### PR TITLE
Documentation system + generated OpenAPI spec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,10 @@ jobs:
 
       - name: Test
         run: pnpm -r test
+
+      # The committed OpenAPI spec must match what the code generates, so the
+      # static file (read by codebase tools) never drifts from the live API.
+      - name: Check OpenAPI spec is up to date
+        run: |
+          pnpm --filter @snaveevans/pineapple-api openapi:generate
+          git diff --exit-code docs/reference/openapi.json

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,6 +38,10 @@ jobs:
         run: pnpm type-check
       - name: Test
         run: pnpm -r test
+      - name: Check OpenAPI spec is up to date
+        run: |
+          pnpm --filter @snaveevans/pineapple-api openapi:generate
+          git diff --exit-code docs/reference/openapi.json
 
   deploy:
     needs: verify

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,7 @@
 dist/
 node_modules/
 pnpm-lock.yaml
+
+# Generated from code by `openapi:generate`; formatting must match the script's
+# output so the CI drift check stays stable. Do not let Prettier reformat it.
+docs/reference/openapi.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,117 @@
+# CLAUDE.md
+
+Orientation for AI agents working in this repo. Read this first; it points to
+everything else.
+
+## What this is
+
+**Pineapple** — a field-operations app for tracking assets (vehicles,
+properties, equipment) for a two-person team. The backend is a single
+Cloudflare Worker (`apps/api`). There is no frontend yet.
+
+## Stack & runtime constraints
+
+- **Cloudflare Workers** runtime (not Node). `nodejs_compat` is on, but treat
+  Node built-ins as unavailable: ESLint **blocks** `fs`, `path`, `http`, `os`,
+  `child_process`, etc. in `apps/api/src/**`. Use WinterCG/Web APIs. (ADR-0006)
+- **No `process.env`** in `apps/api/src/**` — also lint-blocked. Read config
+  from the Worker `env` binding (`c.env.*`), typed in `worker.ts`.
+- **D1 (SQLite)** via the `DB` binding. Migrations in `/migrations`, applied
+  with `wrangler d1 migrations apply pineapple --local|--remote`.
+- **Source-first TypeScript**: no build step. Imports use explicit `.ts`
+  extensions (e.g. `import { User } from "./User.ts"`). Keep that convention.
+- **pnpm workspaces**: `packages/*`, `apps/*`. Package manager pinned via
+  `packageManager` in `package.json` (pnpm 10).
+
+## Architecture — layers & dependency rules (ADR-0003)
+
+Dependencies point inward only. ESLint (`eslint-plugin-boundaries`) enforces
+this; a violation fails `pnpm lint`.
+
+```
+shared  ←  domain  ←  application  ←  infrastructure
+                   ↖  api                ↑
+                       worker.ts (composition root — may import anything)
+```
+
+| Layer (path)                     | May import                  | Holds                                           |
+| -------------------------------- | --------------------------- | ----------------------------------------------- |
+| `packages/shared/**`             | (nothing internal)          | branded IDs, `Result`, `DomainError` subclasses |
+| `apps/api/src/domain/**`         | shared                      | aggregates, value objects, domain events        |
+| `apps/api/src/application/**`    | domain, shared              | use cases, ports (interfaces)                   |
+| `apps/api/src/infrastructure/**` | application, domain, shared | D1 repositories, Better Auth wiring             |
+| `apps/api/src/api/**`            | application, domain, shared | HTTP/Zod schemas, OpenAPI route specs           |
+| `apps/api/src/worker.ts`         | anything                    | composition root: wires deps, defines routes    |
+
+**Key consequence:** the `api/` layer must NOT import `infrastructure/`. Route
+_specs_ (pure schemas) live in `api/`; route _handlers_ that instantiate
+repositories live in `worker.ts`. Keep it that way.
+
+## Conventions
+
+- **Errors:** use cases return `Result<T, DomainError>` (`ok`/`err` from
+  `@snaveevans/pineapple-shared`). HTTP handlers `throw` domain errors; the
+  central `app.onError` in `worker.ts` maps them to status codes via
+  `api/errors.ts`. `DomainError` subclasses: `NotFoundError` (404),
+  `UnauthorizedError` (401), `ForbiddenError` (403), `ValidationError` (422),
+  `ConflictError` (409), `InvariantError` (500). (ADR-0004)
+- **Branded types:** `UserId`, `AssetId`, `Email` are branded — construct via
+  `.from()` / `.generate()`, never raw strings. (ADR-0002)
+- **`exactOptionalPropertyTypes` is on.** Absent ≠ `undefined`. Zod
+  `.optional()` yields `T | undefined`, so casting to domain types at the
+  boundary is sometimes required (see `worker.ts`).
+- **Validation boundary:** Zod validates at the HTTP edge (ADR-0007). The
+  schemas in `api/schemas/` use `z` from `@hono/zod-openapi` and carry
+  `.openapi()` metadata — they are the single source for both validation and
+  the generated API spec.
+
+## API documentation is generated — don't hand-edit the spec
+
+The OpenAPI document is generated from the Zod route specs in
+`apps/api/src/api/openapi.ts`. To change the contract, edit the **specs/schemas**,
+then regenerate:
+
+```bash
+pnpm --filter @snaveevans/pineapple-api openapi:generate
+```
+
+This writes `docs/reference/openapi.json` (committed). CI fails if it's stale.
+The same spec is served live at `GET /openapi.json` with a Scalar UI at
+`/reference`. Never edit `openapi.json` by hand.
+
+## Commands
+
+```bash
+pnpm dev                 # wrangler dev (http://localhost:8787)
+pnpm lint                # eslint (includes layer-boundary + Workers constraints)
+pnpm type-check          # tsc --noEmit across workspace
+pnpm -r test             # vitest (domain tests live in apps/api/src/**)
+pnpm --filter @snaveevans/pineapple-api openapi:generate   # regenerate the spec
+pnpm --filter @snaveevans/pineapple-api wrangler d1 migrations apply pineapple --local
+```
+
+Always run `pnpm lint && pnpm type-check && pnpm -r test` before committing.
+
+## Auth model
+
+Better Auth + Google OAuth runs inside the Worker. It owns the singular tables
+`user`/`session`/`account`/`verification`. The **domain** `User` lives in the
+separate `users` table and is JIT-provisioned by email in
+`infrastructure/auth/BetterAuthResolver.ts`. `/api/auth/*` is handled by Better
+Auth; all other `/api/*` routes require a session (or `DEV_AUTH_EMAIL` locally).
+Secrets (`BETTER_AUTH_SECRET`, `GOOGLE_CLIENT_ID/SECRET`) are Cloudflare Worker
+secrets, never committed.
+
+## Where to look
+
+- **Why** anything is built a certain way → [`docs/decisions/`](docs/decisions/) (ADRs, MADR format)
+- **API contract** → [`docs/reference/api.md`](docs/reference/api.md), `docs/reference/openapi.json`
+- **Data shapes** → [`docs/reference/data-model.md`](docs/reference/data-model.md)
+- **Product features** → [`docs/product/features.md`](docs/product/features.md)
+- **How we document** → [`docs/README.md`](docs/README.md)
+
+## Workflow
+
+Work on a branch, open a PR (CI must pass), merge → auto-deploys to Cloudflare.
+Don't commit to `main` directly. End commit messages with the Co-Authored-By
+trailer.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,15 @@ This writes `docs/reference/openapi.json` (committed). CI fails if it's stale.
 The same spec is served live at `GET /openapi.json` with a Scalar UI at
 `/reference`. Never edit `openapi.json` by hand.
 
+**`openapi.json` is the single source of truth for API contracts.** Do not
+duplicate field names, types, validation rules, or metadata shapes in
+`docs/reference/data-model.md` or anywhere else. `data-model.md` covers only
+what the spec cannot express: domain entities not exposed via HTTP (e.g.
+`User`), internal fields hidden from API responses (e.g. `ownerId`), branded
+value objects, domain events, and storage/table mapping. If you find yourself
+writing a field table that mirrors a spec schema, stop — link to the spec
+instead.
+
 ## Commands
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,0 +1,90 @@
+# Pineapple
+
+Field-operations app for tracking **assets** — vehicles, properties, and
+equipment — and the work done around them. Built for a two-person team, on a
+stack that stays cheap and fast at small scale and is disciplined enough to grow.
+
+> **New here? Pick your door.** This README is the human overview. If you're an
+> AI agent, start with [`CLAUDE.md`](CLAUDE.md). For everything else, see the
+> [documentation map](#documentation) below.
+
+## Tech stack
+
+| Concern        | Choice                                              |
+| -------------- | --------------------------------------------------- |
+| Runtime        | Cloudflare Workers (`nodejs_compat`)                |
+| Database       | Cloudflare D1 (SQLite) with tracked migrations      |
+| HTTP framework | Hono + `@hono/zod-openapi`                          |
+| Auth           | Better Auth + Google OAuth                          |
+| Validation     | Zod (the same schemas generate the OpenAPI spec)    |
+| Language       | TypeScript, source-first (no build step), strict    |
+| Monorepo       | pnpm workspaces                                     |
+| Architecture   | Domain-Driven Design with enforced layer boundaries |
+
+## Quickstart
+
+```bash
+pnpm install
+
+# Run the API locally (http://localhost:8787)
+pnpm dev
+
+# Apply the database schema to your local D1
+pnpm --filter @snaveevans/pineapple-api wrangler d1 migrations apply pineapple --local
+
+# Quality gates (what CI runs)
+pnpm lint
+pnpm type-check
+pnpm -r test
+```
+
+Local secrets live in `apps/api/.dev.vars` (gitignored). Set `DEV_AUTH_EMAIL`
+there to bypass the login flow during development. See
+[`docs/guides/getting-started.md`](docs/guides/getting-started.md) for the full
+setup, including Google OAuth.
+
+## Project structure
+
+```
+apps/api/             The Cloudflare Worker (the whole backend today)
+  src/
+    domain/           Aggregates, value objects, domain events  (no deps)
+    application/      Use cases + ports                         (depends on domain)
+    infrastructure/   D1 repositories, Better Auth wiring       (depends on application)
+    api/              HTTP schemas + OpenAPI specs              (depends on application)
+    worker.ts         Composition root — wires everything, defines routes
+  scripts/            Build-time tooling (OpenAPI generation)
+packages/shared/      Cross-cutting primitives: branded IDs, Result, errors
+migrations/           D1 SQL migrations (tracked by wrangler)
+docs/                 All documentation (see below)
+```
+
+Dependencies only ever point inward (`shared ← domain ← application ←
+infrastructure`); `worker.ts` is the one place allowed to touch every layer.
+ESLint enforces this — see [ADR-0003](docs/decisions/0003-monorepo-layer-architecture-and-dependency-rules.md).
+
+## Documentation
+
+Docs are organized by **what you need**, not by who you are. Start with the row
+that matches your goal:
+
+| You want to…                                 | Read                                                               |
+| -------------------------------------------- | ------------------------------------------------------------------ |
+| Call the API from a UI                       | [`docs/reference/api.md`](docs/reference/api.md) + the live spec¹  |
+| Know what data exists (fields, types, enums) | [`docs/reference/data-model.md`](docs/reference/data-model.md)     |
+| Understand what the product does             | [`docs/product/features.md`](docs/product/features.md)             |
+| See what's planned / where to improve        | [`docs/product/roadmap.md`](docs/product/roadmap.md)               |
+| Run, test, or deploy the project             | [`docs/guides/getting-started.md`](docs/guides/getting-started.md) |
+| Understand _why_ something is built a way    | [`docs/decisions/`](docs/decisions/) (ADRs)                        |
+| Understand how we document (the method)      | [`docs/README.md`](docs/README.md)                                 |
+
+¹ The OpenAPI spec is committed at
+[`docs/reference/openapi.json`](docs/reference/openapi.json) and served live at
+`GET /openapi.json`, with interactive docs at `/reference`.
+
+## Deployment
+
+Merging to `main` auto-deploys the Worker via GitHub Actions (migrations are
+applied first, then `wrangler deploy`). See
+[ADR-0006](docs/decisions/0006-deployment-platform.md) and
+[`docs/guides/getting-started.md`](docs/guides/getting-started.md#deployment).

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,17 +8,21 @@
     "deploy": "wrangler deploy",
     "type-check": "tsc --noEmit",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "openapi:generate": "tsx scripts/generate-openapi.ts"
   },
   "dependencies": {
+    "@hono/zod-openapi": "^0.19.10",
+    "@scalar/hono-api-reference": "^0.10.19",
     "@snaveevans/pineapple-shared": "workspace:*",
     "better-auth": "^1.6.11",
     "better-auth-cloudflare": "^0.3.0",
-    "hono": "^4.0.0",
+    "hono": "^4.12.0",
     "zod": "^3.0.0"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.0.0",
+    "tsx": "^4.19.0",
     "vitest": "^3.0.0",
     "wrangler": "^4.95.0"
   }

--- a/apps/api/scripts/generate-openapi.ts
+++ b/apps/api/scripts/generate-openapi.ts
@@ -1,0 +1,18 @@
+// Emits the static OpenAPI document to docs/reference/openapi.json.
+//
+// Run via `pnpm --filter @snaveevans/pineapple-api openapi:generate` (tsx).
+// CI regenerates and fails if the committed file drifts from the code, so the
+// static spec — what codebase-reading tools (e.g. Claude design) see — always
+// matches the live API served at /openapi.json.
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { getApiDocument } from "../src/api/openapi.ts";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const outPath = resolve(here, "../../../docs/reference/openapi.json");
+
+mkdirSync(dirname(outPath), { recursive: true });
+writeFileSync(outPath, JSON.stringify(getApiDocument(), null, 2) + "\n");
+
+console.log(`Wrote ${outPath}`);

--- a/apps/api/src/api/openapi.ts
+++ b/apps/api/src/api/openapi.ts
@@ -1,0 +1,169 @@
+import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
+import {
+  AssetIdParamSchema,
+  AssetListResponseSchema,
+  AssetResponseSchema,
+  CreateAssetBodySchema,
+  CreatedAssetResponseSchema,
+  ErrorResponseSchema,
+  HealthResponseSchema,
+} from "./schemas/assetSchemas.ts";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// OpenAPI route specs (metadata only — no handlers, no infrastructure).
+//
+// These are the single source of truth for the API contract. worker.ts binds
+// real handlers to them via `app.openapi(spec, handler)`; the generate script
+// and the runtime `/openapi.json` endpoint both render them. Because there are
+// no handlers here, this file stays inside the api-layer boundary (it never
+// imports infrastructure).
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Document-level metadata shared by the runtime endpoint and the static file. */
+export const openApiConfig = {
+  openapi: "3.0.0" as const,
+  info: {
+    title: "Pineapple API",
+    version: "0.1.0",
+    description:
+      "Field-operations API for managing assets (vehicles, properties, " +
+      "equipment). Authentication is handled by Better Auth + Google OAuth; " +
+      "send the session cookie obtained from `/api/auth/*` with requests to " +
+      "protected `/api/*` routes.",
+  },
+  servers: [
+    { url: "http://localhost:8787", description: "Local dev (wrangler)" },
+    {
+      url: "https://pineapple-api.tylerjevans.workers.dev",
+      description: "Production",
+    },
+  ],
+  tags: [
+    { name: "System", description: "Health and meta endpoints" },
+    { name: "Assets", description: "Create and read assets owned by the caller" },
+  ],
+};
+
+const cookieAuth = { cookieAuth: [] as string[] };
+
+export const healthRoute = createRoute({
+  method: "get",
+  path: "/health",
+  tags: ["System"],
+  summary: "Liveness check",
+  description: "Returns ok when the Worker is serving. No authentication.",
+  responses: {
+    200: {
+      description: "Service is healthy",
+      content: { "application/json": { schema: HealthResponseSchema } },
+    },
+  },
+});
+
+export const createAssetRoute = createRoute({
+  method: "post",
+  path: "/api/assets",
+  tags: ["Assets"],
+  summary: "Create an asset",
+  security: [cookieAuth],
+  request: {
+    body: {
+      required: true,
+      content: { "application/json": { schema: CreateAssetBodySchema } },
+    },
+  },
+  responses: {
+    201: {
+      description: "Asset created",
+      content: { "application/json": { schema: CreatedAssetResponseSchema } },
+    },
+    401: {
+      description: "Not authenticated",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    422: {
+      description: "Validation failed",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
+export const listAssetsRoute = createRoute({
+  method: "get",
+  path: "/api/assets",
+  tags: ["Assets"],
+  summary: "List my assets",
+  description: "Returns the caller's active (non-archived) assets.",
+  security: [cookieAuth],
+  responses: {
+    200: {
+      description: "The caller's assets",
+      content: { "application/json": { schema: AssetListResponseSchema } },
+    },
+    401: {
+      description: "Not authenticated",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
+export const getAssetRoute = createRoute({
+  method: "get",
+  path: "/api/assets/{id}",
+  tags: ["Assets"],
+  summary: "Get an asset by id",
+  security: [cookieAuth],
+  request: { params: AssetIdParamSchema },
+  responses: {
+    200: {
+      description: "The asset",
+      content: { "application/json": { schema: AssetResponseSchema } },
+    },
+    401: {
+      description: "Not authenticated",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    403: {
+      description: "The asset belongs to another user",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    404: {
+      description: "No such asset",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
+/**
+ * Register shared OpenAPI components (security schemes) on a registry.
+ * Keyed off the registry type (not the app's Env) so it works for both the
+ * runtime app and the doc-only builder regardless of their generics.
+ */
+export function registerOpenApiComponents(registry: OpenAPIHono["openAPIRegistry"]): void {
+  registry.registerComponent("securitySchemes", "cookieAuth", {
+    type: "apiKey",
+    in: "cookie",
+    name: "better-auth.session_token",
+    description:
+      "Better Auth session cookie, set after completing the Google OAuth " +
+      "flow at `/api/auth/sign-in/social?provider=google`.",
+  });
+}
+
+/**
+ * Build the OpenAPI document from the route specs alone, with throwaway
+ * handlers (never invoked — the doc derives from the specs). Used by the
+ * generate script (static file) and re-used by the runtime endpoint, so both
+ * render identical output from one source.
+ */
+export function getApiDocument() {
+  const doc = new OpenAPIHono();
+  // Handlers are required by `openapi()` but never run during generation.
+  const stub = (() => new Response(null, { status: 501 })) as never;
+  doc.openapi(healthRoute, stub);
+  doc.openapi(createAssetRoute, stub);
+  doc.openapi(listAssetsRoute, stub);
+  doc.openapi(getAssetRoute, stub);
+  registerOpenApiComponents(doc.openAPIRegistry);
+  return doc.getOpenAPIDocument(openApiConfig);
+}

--- a/apps/api/src/api/schemas/assetSchemas.ts
+++ b/apps/api/src/api/schemas/assetSchemas.ts
@@ -1,45 +1,111 @@
-import { z } from "zod";
+// Import `z` from @hono/zod-openapi (not "zod") so schemas carry `.openapi()`
+// metadata. This is the single source of truth for both runtime validation
+// AND the generated OpenAPI spec — change a rule here and the docs follow.
+import { z } from "@hono/zod-openapi";
+import { ASSET_TYPES } from "../../domain/asset/AssetType.ts";
 
-const VehicleMetadataSchema = z.object({
-  kind: z.literal("vehicle"),
-  make: z.string().min(1, "Make is required"),
-  model: z.string().min(1, "Model is required"),
-  year: z
-    .number()
-    .int()
-    .min(1900, "Year must be 1900 or later")
-    .max(new Date().getFullYear() + 1, "Year is too far in the future"),
-  vin: z.string().length(17, "VIN must be exactly 17 characters").optional(),
-});
+// ── Asset metadata (discriminated by `kind`) ─────────────────────────────────
 
-const PropertyMetadataSchema = z.object({
-  kind: z.literal("property"),
-  nickname: z.string().optional(),
-  address: z.object({
-    street: z.string().min(1, "Street is required"),
-    city: z.string().min(1, "City is required"),
-    state: z.string().min(1, "State is required"),
-    postalCode: z.string().min(1, "Postal code is required"),
-    country: z.string().min(1, "Country is required"),
+const VehicleMetadataSchema = z
+  .object({
+    kind: z.literal("vehicle"),
+    make: z.string().min(1, "Make is required").openapi({ example: "Ram" }),
+    model: z.string().min(1, "Model is required").openapi({ example: "2500" }),
+    year: z
+      .number()
+      .int()
+      .min(1900, "Year must be 1900 or later")
+      .max(new Date().getFullYear() + 1, "Year is too far in the future")
+      .openapi({ example: 2016 }),
+    vin: z
+      .string()
+      .length(17, "VIN must be exactly 17 characters")
+      .optional()
+      .openapi({ example: "1C6RR7LT4GS123456" }),
+  })
+  .openapi("VehicleMetadata");
+
+const PropertyMetadataSchema = z
+  .object({
+    kind: z.literal("property"),
+    nickname: z.string().optional().openapi({ example: "Lake cabin" }),
+    address: z
+      .object({
+        street: z.string().min(1, "Street is required"),
+        city: z.string().min(1, "City is required"),
+        state: z.string().min(1, "State is required"),
+        postalCode: z.string().min(1, "Postal code is required"),
+        country: z.string().min(1, "Country is required"),
+      })
+      .openapi("Address"),
+  })
+  .openapi("PropertyMetadata");
+
+const EquipmentMetadataSchema = z
+  .object({
+    kind: z.literal("equipment"),
+    manufacturer: z.string().optional().openapi({ example: "Honda" }),
+    modelNumber: z.string().optional().openapi({ example: "EU2200i" }),
+    serialNumber: z.string().optional().openapi({ example: "EAMT-1234567" }),
+  })
+  .openapi("EquipmentMetadata");
+
+export const AssetMetadataSchema = z
+  .discriminatedUnion("kind", [
+    VehicleMetadataSchema,
+    PropertyMetadataSchema,
+    EquipmentMetadataSchema,
+  ])
+  .openapi("AssetMetadata");
+
+// ── Requests ─────────────────────────────────────────────────────────────────
+
+export const CreateAssetBodySchema = z
+  .object({
+    name: z.string().min(1, "Name is required").openapi({ example: "My Truck" }),
+    metadata: AssetMetadataSchema,
+  })
+  .openapi("CreateAssetBody");
+
+export type CreateAssetBody = z.infer<typeof CreateAssetBodySchema>;
+
+export const AssetIdParamSchema = z.object({
+  id: z.string().openapi({
+    param: { name: "id", in: "path" },
+    example: "195d0ef0-47f5-439f-abfd-29f892c9a040",
   }),
 });
 
-const EquipmentMetadataSchema = z.object({
-  kind: z.literal("equipment"),
-  manufacturer: z.string().optional(),
-  modelNumber: z.string().optional(),
-  serialNumber: z.string().optional(),
-});
+// ── Responses ──────────────────────────────────────────────────────────────
 
-const AssetMetadataSchema = z.discriminatedUnion("kind", [
-  VehicleMetadataSchema,
-  PropertyMetadataSchema,
-  EquipmentMetadataSchema,
-]);
+/** Serialized asset, matching `serializeAsset` in worker.ts. */
+export const AssetResponseSchema = z
+  .object({
+    id: z.string().openapi({ example: "195d0ef0-47f5-439f-abfd-29f892c9a040" }),
+    name: z.string().openapi({ example: "My Truck" }),
+    type: z.enum(ASSET_TYPES).openapi({ example: "vehicle" }),
+    metadata: AssetMetadataSchema,
+    archivedAt: z.string().datetime().nullable().openapi({ example: null }),
+    createdAt: z.string().datetime().openapi({ example: "2026-05-29T03:25:24.887Z" }),
+    updatedAt: z.string().datetime().openapi({ example: "2026-05-29T03:25:24.887Z" }),
+  })
+  .openapi("Asset");
 
-export const CreateAssetBodySchema = z.object({
-  name: z.string().min(1, "Name is required"),
-  metadata: AssetMetadataSchema,
-});
+export const AssetListResponseSchema = z
+  .object({ assets: z.array(AssetResponseSchema) })
+  .openapi("AssetListResponse");
 
-export type CreateAssetBody = z.infer<typeof CreateAssetBodySchema>;
+export const CreatedAssetResponseSchema = z
+  .object({
+    id: z.string().openapi({ example: "195d0ef0-47f5-439f-abfd-29f892c9a040" }),
+  })
+  .openapi("CreatedAsset");
+
+export const ErrorResponseSchema = z
+  .object({
+    error: z.string().openapi({ example: "Asset not found" }),
+    field: z.string().optional().openapi({ example: "metadata.year" }),
+  })
+  .openapi("Error");
+
+export const HealthResponseSchema = z.object({ status: z.literal("ok") }).openapi("Health");

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -1,6 +1,8 @@
-import { Hono, type Context } from "hono";
+import { OpenAPIHono } from "@hono/zod-openapi";
+import { Scalar } from "@scalar/hono-api-reference";
 import { cors } from "hono/cors";
-import { AssetId, ValidationError, DomainError } from "@snaveevans/pineapple-shared";
+import type { Context } from "hono";
+import { AssetId, DomainError } from "@snaveevans/pineapple-shared";
 import type { User } from "./domain/identity/User.ts";
 import type { Asset } from "./domain/asset/Asset.ts";
 import type { AssetMetadata } from "./domain/asset/AssetMetadata.ts";
@@ -18,7 +20,16 @@ import { ListAssets } from "./application/usecases/ListAssets.ts";
 
 // API layer
 import { toHttpError } from "./api/errors.ts";
-import { CreateAssetBodySchema } from "./api/schemas/assetSchemas.ts";
+import {
+  createAssetRoute,
+  getAssetRoute,
+  healthRoute,
+  listAssetsRoute,
+  openApiConfig,
+  registerOpenApiComponents,
+} from "./api/openapi.ts";
+import type { AssetResponseSchema } from "./api/schemas/assetSchemas.ts";
+import type { z } from "@hono/zod-openapi";
 
 type Bindings = AuthEnv & {
   /** Local dev only — set in .dev.vars, never in wrangler.toml. Bypasses the Better Auth session check. */
@@ -26,11 +37,33 @@ type Bindings = AuthEnv & {
 };
 type Variables = { user: User; auth: Auth };
 
-const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+const app = new OpenAPIHono<{ Bindings: Bindings; Variables: Variables }>({
+  // Validation failures (body/params) → 422 in our standard error shape.
+  defaultHook: (result, c) => {
+    if (!result.success) {
+      const issue = result.error.issues[0];
+      const field = issue?.path.length ? issue.path.join(".") : undefined;
+      return c.json(
+        { error: issue?.message ?? "Validation failed", ...(field ? { field } : {}) },
+        422,
+      );
+    }
+  },
+});
+
+// Centralized error handling: domain errors → their HTTP status; anything
+// else → 500. Handlers and middleware just `throw` and this maps it.
+app.onError((err, c) => {
+  if (err instanceof DomainError) return toHttpError(c as Context, err);
+  console.error(err);
+  return c.json({ error: "Internal Server Error" }, 500);
+});
+
+registerOpenApiComponents(app.openAPIRegistry);
 
 // ── Serializers ────────────────────────────────────────────────────────────
 
-function serializeAsset(asset: Asset) {
+function serializeAsset(asset: Asset): z.infer<typeof AssetResponseSchema> {
   return {
     id: asset.id,
     name: asset.name,
@@ -42,14 +75,17 @@ function serializeAsset(asset: Asset) {
   };
 }
 
-// ── Routes ─────────────────────────────────────────────────────────────────
+// ── Public routes (no auth) ──────────────────────────────────────────────────
 
-// GET /health — no auth required
-app.get("/health", (c) => c.json({ status: "ok" }));
+app.openapi(healthRoute, (c) => c.json({ status: "ok" } as const, 200));
+
+// Machine-readable spec + interactive docs.
+app.doc("/openapi.json", openApiConfig);
+app.get("/reference", Scalar({ url: "/openapi.json" }));
+
+// ── Better Auth ───────────────────────────────────────────────────────────
 
 // CORS for the Better Auth endpoints (browser hits these with credentials).
-// Reflect the request origin for now — tighten to the deployed web origin
-// once the UI lands.
 app.use(
   "/api/auth/**",
   cors({
@@ -62,75 +98,64 @@ app.use(
 
 // Build a per-request Better Auth instance (baseURL must match the incoming
 // origin for OAuth callbacks/cookies to work) and stash it on the context.
-app.use("*", async (c, next) => {
+app.use("/api/*", async (c, next) => {
   const auth = createAuth(c.env, new URL(c.req.url).origin);
   c.set("auth", auth);
   await next();
 });
 
-// Mount all Better Auth routes: sign-in/out, OAuth callbacks, session, etc.
-// e.g. GET /api/auth/sign-in/social?provider=google
+// Mount all Better Auth routes (sign-in/out, OAuth callbacks, session).
 app.on(["GET", "POST"], "/api/auth/*", (c) => c.get("auth").handler(c.req.raw));
 
-// Auth gate for the application API. Resolves (and JIT-provisions) the domain
-// User from the Better Auth session; maps auth failures to clean HTTP errors.
+// ── Auth gate for the application API ────────────────────────────────────────
+
+// Resolves (and JIT-provisions) the domain User from the Better Auth session.
+// Thrown auth errors propagate to app.onError above.
 app.use("/api/*", async (c, next) => {
   const resolver = new BetterAuthResolver(
     c.get("auth"),
     new D1UserRepository(c.env.DB),
     c.env.DEV_AUTH_EMAIL,
   );
-  try {
-    const user = await resolver.resolve(c.req.raw);
-    c.set("user", user);
-  } catch (e) {
-    // Cast to the base Context: this middleware's generic Input is `any`,
-    // which `no-unsafe-argument` rejects; toHttpError only needs the base type.
-    if (e instanceof DomainError) return toHttpError(c as Context, e);
-    throw e;
-  }
+  const user = await resolver.resolve(c.req.raw);
+  c.set("user", user);
   await next();
 });
 
-// POST /api/assets — create a new asset
-app.post("/api/assets", async (c) => {
+// ── Asset endpoints ──────────────────────────────────────────────────────────
+
+app.openapi(createAssetRoute, async (c) => {
   const user = c.get("user");
-  const body = await c.req.json<unknown>().catch(() => null);
-  const parsed = CreateAssetBodySchema.safeParse(body);
-  if (!parsed.success) {
-    const issue = parsed.error.issues[0];
-    return toHttpError(c, new ValidationError(issue?.message ?? "Invalid request body"));
-  }
+  const { name, metadata } = c.req.valid("json");
   const result = await new CreateAsset(new D1AssetRepository(c.env.DB)).execute({
     ownerId: user.id,
-    name: parsed.data.name,
-    // Cast needed: Zod's .optional() produces `T | undefined` but the domain
-    // type uses exactOptionalPropertyTypes (absent ≠ explicitly undefined).
-    metadata: parsed.data.metadata as AssetMetadata,
+    name,
+    // Cast: Zod's `.optional()` yields `T | undefined` but the domain type uses
+    // exactOptionalPropertyTypes (absent ≠ explicitly undefined).
+    metadata: metadata as AssetMetadata,
   });
-  if (!result.ok) return toHttpError(c, result.error);
+  if (!result.ok) throw result.error;
   return c.json({ id: result.value }, 201);
 });
 
-// GET /api/assets — list my assets (active only)
-app.get("/api/assets", async (c) => {
+app.openapi(listAssetsRoute, async (c) => {
   const user = c.get("user");
   const result = await new ListAssets(new D1AssetRepository(c.env.DB)).execute({
     ownerId: user.id,
   });
-  if (!result.ok) return toHttpError(c, result.error);
-  return c.json({ assets: result.value.map(serializeAsset) });
+  if (!result.ok) throw result.error;
+  return c.json({ assets: result.value.map(serializeAsset) }, 200);
 });
 
-// GET /api/assets/:id — get a single asset by ID
-app.get("/api/assets/:id", async (c) => {
+app.openapi(getAssetRoute, async (c) => {
   const user = c.get("user");
+  const { id } = c.req.valid("param");
   const result = await new GetAsset(new D1AssetRepository(c.env.DB)).execute({
-    assetId: AssetId.from(c.req.param("id")),
+    assetId: AssetId.from(id),
     requesterId: user.id,
   });
-  if (!result.ok) return toHttpError(c, result.error);
-  return c.json(serializeAsset(result.value));
+  if (!result.ok) throw result.error;
+  return c.json(serializeAsset(result.value), 200);
 });
 
 export default app;

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,74 @@
+# Documentation
+
+How Pineapple documents itself, and where each kind of knowledge lives. The
+guiding rule:
+
+> **Each fact has one home; everything else links to it.** Where a fact can be
+> derived from code, the docs are _generated_ from code so they cannot drift.
+
+This keeps documentation trustworthy for both humans and the AI agents that read
+this repo.
+
+## The doc types
+
+| Type            | Lives in                                 | Source of truth                 | Primarily serves           |
+| --------------- | ---------------------------------------- | ------------------------------- | -------------------------- |
+| Front door      | `README.md`, `CLAUDE.md`                 | hand-written                    | newcomers · AI agents      |
+| Decisions (ADR) | `docs/decisions/`                        | hand-written                    | engineers (the _why_)      |
+| API reference   | `docs/reference/api.md` + `openapi.json` | **generated from Zod**          | UI/integration devs · LLMs |
+| Data model      | `docs/reference/data-model.md`           | hand-written, mirrors `domain/` | designers · devs           |
+| Product         | `docs/product/`                          | hand-written                    | PM · marketing             |
+| Guides          | `docs/guides/`                           | hand-written                    | operators · contributors   |
+
+### Who reads what
+
+- **UI / integration developer** → `reference/api.md` and the live spec
+  (`/openapi.json`, `/reference`); `reference/data-model.md` for field details.
+- **Designer** → `reference/data-model.md` (what data and which enums exist) and
+  `product/features.md` (what flows are possible).
+- **Product manager** → `product/features.md` (what we have) and
+  `product/roadmap.md` (gaps & opportunities).
+- **Marketing** → `product/features.md` (benefit-framed capability list).
+- **AI agent** → `CLAUDE.md` is the hub; everything is linked and, where
+  possible, machine-readable.
+
+## Conventions
+
+**Every doc starts with a header** so a reader (or model) instantly knows what
+it is and whether to trust it:
+
+```markdown
+> **Audience:** UI developers · **Purpose:** how to call the API ·
+> **Source of truth:** generated from `apps/api/src/api/` · **Last reviewed:** 2026-05-29
+```
+
+For generated docs, "Source of truth" names the code; for hand-written docs it
+says `this file`. Update **Last reviewed** when you touch a hand-written doc.
+
+**Indexes are maintained by hand.** `docs/decisions/README.md` keeps the ADR
+index; the root `README.md` keeps the doc map. When you add a doc, add the link.
+
+**Prose over cleverness.** Short sentences, concrete examples, real values.
+Assume the reader is competent but new to _this_ project.
+
+## The generated API spec
+
+`docs/reference/openapi.json` is produced from the Zod route specs in
+`apps/api/src/api/openapi.ts`:
+
+```bash
+pnpm --filter @snaveevans/pineapple-api openapi:generate
+```
+
+Do not hand-edit it. CI regenerates and fails the build if the committed file
+differs from what the code produces, so the static file (read by codebase
+tools) always matches the live `/openapi.json`. See
+[ADR-0008](decisions/0008-documentation-method.md) for the rationale.
+
+## Adding a new doc
+
+1. Put it under the right type directory above.
+2. Add the header block.
+3. Link it from the root `README.md` doc map (and `CLAUDE.md` if agents need it).
+4. If it documents a significant, hard-to-reverse choice, write an ADR instead
+   of (or alongside) the doc — see [`docs/decisions/README.md`](decisions/README.md).

--- a/docs/decisions/0008-documentation-method.md
+++ b/docs/decisions/0008-documentation-method.md
@@ -1,0 +1,65 @@
+# Documentation method
+
+- Status: accepted
+- Date: 2026-05-29
+
+## Context and Problem Statement
+
+The project had good Architecture Decision Records (the _why_) but nothing
+describing the _what_ and _how_: no API reference, no data-model description, no
+product/feature overview, and no front door for either humans or the AI agents
+that increasingly read and modify this repo.
+
+The documentation needs to serve several audiences at once — a UI developer who
+needs the API contract, a designer who needs to know what data exists, a product
+manager and marketing who need to know what the product does — without each
+fact being copied into multiple places where copies rot. It must be equally
+useful to an LLM, which means machine-readable where possible and discoverable
+from a single entry point.
+
+## Decision Drivers
+
+- Documentation must not drift from the code — stale docs are worse than none
+- One fact should have exactly one home; everything else links to it
+- Must serve multiple audiences (dev, designer, PM, marketing) and LLMs
+- An LLM should be able to orient itself and find anything from one entry point
+- Low maintenance burden for a two-person team
+
+## Considered Options
+
+- **Layered docs with a generated API spec** — a small set of doc types
+  organized by purpose, with the API reference generated from the Zod schemas
+  and committed as a static artifact, fronted by `README.md` (humans) and
+  `CLAUDE.md` (agents)
+- **Hand-written Markdown for everything**, including the API reference
+- **External docs site / wiki** (e.g. a hosted docs platform)
+
+## Decision Outcome
+
+Chosen option: **Layered docs with a generated API spec**, because it is the
+only option that defends against drift on the highest-churn surface (the API)
+while keeping everything in-repo and discoverable. Docs live under `docs/`
+organized by purpose (`reference/`, `product/`, `guides/`, `decisions/`), with
+`README.md` and `CLAUDE.md` as the two front doors. The OpenAPI spec is
+generated from the Zod route specs, served at `/openapi.json` (+ a Scalar UI at
+`/reference`), and committed to `docs/reference/openapi.json` with a CI check
+that fails if it is stale. The method itself is documented in
+[`docs/README.md`](../README.md).
+
+### Positive Consequences
+
+- The API contract cannot silently drift: the schemas are the single source for
+  validation _and_ documentation, and CI enforces the committed copy
+- The committed `openapi.json` is readable by codebase-aware tools (e.g. Claude
+  design) without running anything, while the same spec is reachable by URL
+- Clear per-audience entry points; one hub (`CLAUDE.md`) for agents
+- Everything stays in version control, reviewed alongside code
+
+### Negative Consequences
+
+- Hand-written docs (data model, product, guides) still require discipline to
+  keep current; the per-doc "Last reviewed" header is the only guard
+- Generating the spec adds a build dependency (`@hono/zod-openapi`, `tsx`) and a
+  CI step
+- Route handlers and route specs are split (specs in `api/`, handlers in
+  `worker.ts`) to satisfy layer boundaries — a minor indirection

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -59,3 +59,4 @@ Use [`0000-template.md`](0000-template.md) as your starting point.
 | [0005](0005-repository-contract.md)                              | Repository contract                              | accepted |
 | [0006](0006-deployment-platform.md)                              | Deployment platform                              | accepted |
 | [0007](0007-api-validation-boundary.md)                          | API validation boundary                          | accepted |
+| [0008](0008-documentation-method.md)                             | Documentation method                             | accepted |

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -1,0 +1,112 @@
+# Getting Started
+
+> **Audience:** contributors & operators · **Purpose:** run, test, and deploy
+> Pineapple · **Source of truth:** this file · **Last reviewed:** 2026-05-29
+
+## Prerequisites
+
+- Node.js 22+
+- pnpm 10 (pinned via `packageManager`; `corepack enable` will provide it)
+- A Cloudflare account (for deploy) and `wrangler` (installed as a dev dep)
+
+## 1. Install
+
+```bash
+pnpm install
+```
+
+## 2. Local database
+
+Apply migrations to your local D1 instance:
+
+```bash
+cd apps/api
+pnpm wrangler d1 migrations apply pineapple --local
+```
+
+## 3. Local secrets (`apps/api/.dev.vars`)
+
+This file is **gitignored** — never commit it. Minimum for local development:
+
+```ini
+# Any long random string locally: `openssl rand -base64 32`
+BETTER_AUTH_SECRET=dev-only-change-me
+
+# Leave blank until you set up Google OAuth (step 5)
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+
+# Dev bypass: treat every request as this user, skipping the login flow.
+# Remove it to exercise the real Google session flow. NEVER set in production.
+DEV_AUTH_EMAIL=you@example.com
+```
+
+## 4. Run
+
+```bash
+pnpm dev        # from repo root → http://localhost:8787
+```
+
+Try it:
+
+```bash
+curl http://localhost:8787/health                 # {"status":"ok"}
+open http://localhost:8787/reference              # interactive API docs
+curl http://localhost:8787/api/assets             # works via DEV_AUTH_EMAIL bypass
+```
+
+## 5. Google OAuth (for the real login flow)
+
+1. Google Cloud Console → **APIs & Services → Credentials → Create OAuth client
+   ID** → type **Web application**.
+2. **Authorized redirect URIs:**
+   - `http://localhost:8787/api/auth/callback/google`
+   - `https://<your-prod-domain>/api/auth/callback/google`
+3. Put the client ID/secret in `.dev.vars` (local) and as Worker secrets (prod,
+   step 7). Then sign in via
+   `http://localhost:8787/api/auth/sign-in/social?provider=google`.
+
+## 6. Quality gates
+
+Run these before every commit (CI runs the same):
+
+```bash
+pnpm lint
+pnpm type-check
+pnpm -r test
+
+# If you changed API schemas/routes, regenerate the committed spec:
+pnpm --filter @snaveevans/pineapple-api openapi:generate
+```
+
+## 7. Deployment
+
+Deployment is automatic: **merging to `main`** runs CI, applies pending D1
+migrations to production, then `wrangler deploy`s the Worker (see
+[ADR-0006](../decisions/0006-deployment-platform.md) and the workflows in
+`.github/workflows/`).
+
+**One-time setup:**
+
+- **GitHub Actions secrets** (the deploy credential): `CLOUDFLARE_API_TOKEN`
+  (token with _Workers Scripts: Edit_ + _D1: Edit_) and `CLOUDFLARE_ACCOUNT_ID`.
+  Set with `gh secret set <NAME> --repo <owner>/<repo>`.
+- **Worker runtime secrets** (the app needs these at runtime — set once in
+  Cloudflare, they persist across deploys and never go in GitHub):
+
+  ```bash
+  cd apps/api
+  pnpm wrangler secret put BETTER_AUTH_SECRET
+  pnpm wrangler secret put GOOGLE_CLIENT_ID
+  pnpm wrangler secret put GOOGLE_CLIENT_SECRET
+  ```
+
+> **Two kinds of secrets, two homes.** The Cloudflare _API token_ lives in
+> GitHub and lets CI deploy. The _OAuth/runtime_ secrets live in Cloudflare and
+> are read by the running Worker. They never mix.
+
+## Branch workflow
+
+Work on a branch → open a PR → CI must pass → merge → auto-deploy. `main` is
+protected (PR required, CI required, you can merge your own PRs). Don't push to
+`main` directly.

--- a/docs/product/features.md
+++ b/docs/product/features.md
@@ -1,0 +1,62 @@
+# Features
+
+> **Audience:** product & marketing · **Purpose:** what Pineapple can do today,
+> framed by the value it delivers · **Source of truth:** this file ·
+> **Last reviewed:** 2026-05-29
+
+Pineapple helps a small team keep track of their **assets** — the vehicles,
+properties, and equipment they operate — in one place. This page lists what
+ships **today**. For what's next, see the [roadmap](roadmap.md).
+
+> **Status legend:** ✅ available · 🟡 partial (data modeled, not yet exposed)
+
+## Capabilities
+
+### ✅ Sign in with Google
+
+One-tap sign-in with a Google account — no passwords to create or remember.
+Accounts are created automatically on first sign-in. _Benefit: zero-friction
+onboarding; nothing to manage._
+
+### ✅ Track three kinds of assets
+
+Add and view **vehicles**, **properties**, and **equipment**, each with details
+that fit the kind:
+
+- **Vehicles** — make, model, year, and (optionally) VIN.
+- **Properties** — a full address plus an optional nickname.
+- **Equipment** — manufacturer, model number, and serial number.
+
+_Benefit: the right fields for each asset type, instead of a one-size-fits-all
+form._
+
+### ✅ Private by owner
+
+Each person sees only their own assets. There's no accidental cross-visibility.
+_Benefit: personal inventories stay personal._
+
+### ✅ API-first, fully documented
+
+Every capability is a clean HTTP API with an always-current, interactive spec
+(OpenAPI / Scalar). _Benefit: a UI, a mobile app, or an automation can be built
+against it immediately, and the docs never lie._
+
+### 🟡 Archiving
+
+Assets carry an "archived" state, and active-only listing already excludes
+archived items — but there's no button to archive yet. _Coming via an update
+endpoint (see roadmap)._
+
+## What it's for
+
+The north star is **field operations**: not just an inventory, but a record of
+the work done around each asset over time. Today's release nails the foundation
+— a trustworthy, private, typed asset registry with an open API. The work log,
+attachments, and a UI build on top of it.
+
+## Not yet available
+
+To set expectations honestly, these are **not** in today's build (they're on the
+[roadmap](roadmap.md)): a web/mobile UI, editing or deleting assets, search and
+filtering, photos/attachments, work/maintenance logs, sharing between users, and
+notifications.

--- a/docs/product/roadmap.md
+++ b/docs/product/roadmap.md
@@ -1,0 +1,41 @@
+# Roadmap
+
+> **Audience:** product · **Purpose:** gaps and opportunities, roughly ordered ·
+> **Source of truth:** this file · **Last reviewed:** 2026-05-29
+
+Direction, not commitment. Reflects where the product can grow from today's
+[feature set](features.md). Order is a rough priority, not a schedule.
+
+## Near term — complete the core loop
+
+- **Web UI.** The biggest gap: everything today is API-only. A front end (likely
+  Cloudflare Pages, referencing the existing high-fidelity designs) turns the API
+  into a usable product.
+- **Edit, archive, delete assets.** The data model already supports archiving;
+  expose `PATCH`/archive/`DELETE` endpoints and wire the UI to them.
+- **Search & filter.** Filter assets by type, and search by name/details, as
+  inventories grow.
+
+## Mid term — the "operations" in field operations
+
+- **Work / maintenance log.** A timeline of work done on each asset (services,
+  repairs, inspections) — the core differentiator beyond a static registry.
+- **Photos & attachments.** Per-asset images and documents (e.g. titles,
+  receipts) stored in Cloudflare R2.
+- **Reminders & notifications.** Service-due and inspection reminders (e.g.
+  registration renewal, maintenance intervals).
+
+## Longer term — collaboration & insight
+
+- **Sharing.** Let team members share or co-manage specific assets, with
+  appropriate permissions (today everything is strictly per-owner).
+- **Reporting.** Summaries across assets — costs over time, upcoming work,
+  fleet/property overviews.
+- **Import/export.** Bulk-load existing inventories and export records.
+
+## How to propose a change
+
+For a significant, hard-to-reverse technical choice, write an
+[ADR](../decisions/README.md). For product/feature ideas, add them here and link
+any supporting design or API work. Use the [feature list](features.md) to check
+what already exists before proposing.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1,0 +1,103 @@
+# API Reference
+
+> **Audience:** UI & integration developers, LLMs · **Purpose:** how to call the
+> Pineapple API · **Source of truth:** generated from `apps/api/src/api/` —
+> the exhaustive contract is [`openapi.json`](openapi.json)
+
+This page is the narrative guide. For the precise, machine-readable contract
+(every field, type, and status code), use the OpenAPI spec:
+
+- **Static spec (in repo):** [`docs/reference/openapi.json`](openapi.json)
+- **Live spec:** `GET /openapi.json`
+- **Interactive docs (Scalar):** open `/reference` in a browser
+- Local base URL: `http://localhost:8787` · Production: `https://pineapple-api.tylerjevans.workers.dev`
+
+The spec is generated from the Zod schemas, so it never drifts from the running
+code. If this prose and the spec disagree, the spec wins.
+
+## Authentication
+
+Auth is **Better Auth + Google OAuth**, handled inside the Worker under
+`/api/auth/*`. Every other `/api/*` route requires an authenticated session.
+
+**Flow:**
+
+1. Send the user to `GET /api/auth/sign-in/social?provider=google`.
+2. Better Auth redirects to Google, then back to
+   `/api/auth/callback/google`, and sets a **session cookie**
+   (`better-auth.session_token`).
+3. The browser includes that cookie automatically on subsequent `/api/*`
+   requests. (Send credentials: `fetch(url, { credentials: "include" })`.)
+4. `GET /api/auth/get-session` returns the current session, or `null` if signed
+   out.
+
+The API maps the session to a domain user by email, creating the user on first
+sign-in. There is no separate "register" step.
+
+> **Local development:** set `DEV_AUTH_EMAIL` in `apps/api/.dev.vars` to bypass
+> the session check entirely — every request is treated as that user. Never set
+> it in production. See [getting-started](../guides/getting-started.md).
+
+## Endpoints
+
+| Method | Path               | Auth | Description                              |
+| ------ | ------------------ | ---- | ---------------------------------------- |
+| GET    | `/health`          | no   | Liveness check                           |
+| GET    | `/openapi.json`    | no   | The OpenAPI spec                         |
+| GET    | `/reference`       | no   | Interactive API docs (Scalar)            |
+| `*`    | `/api/auth/*`      | —    | Better Auth (sign-in, callback, session) |
+| POST   | `/api/assets`      | yes  | Create an asset                          |
+| GET    | `/api/assets`      | yes  | List the caller's active assets          |
+| GET    | `/api/assets/{id}` | yes  | Get one asset the caller owns            |
+
+See [`data-model.md`](data-model.md) for the shape of an asset and its metadata
+variants.
+
+### Example: create an asset
+
+```http
+POST /api/assets
+Content-Type: application/json
+
+{
+  "name": "My Truck",
+  "metadata": { "kind": "vehicle", "make": "Ram", "model": "2500", "year": 2016 }
+}
+```
+
+```http
+201 Created
+{ "id": "195d0ef0-47f5-439f-abfd-29f892c9a040" }
+```
+
+## Errors
+
+All errors share one JSON shape:
+
+```json
+{ "error": "human-readable message", "field": "metadata.year" }
+```
+
+`field` is present only for validation errors. Status codes:
+
+| Status | Meaning                                     |
+| ------ | ------------------------------------------- |
+| 401    | Not authenticated (no/expired session)      |
+| 403    | Authenticated, but the resource isn't yours |
+| 404    | Resource not found                          |
+| 409    | Conflict (e.g. uniqueness violation)        |
+| 422    | Request body/params failed validation       |
+| 500    | Unexpected server error                     |
+
+These map directly to the domain error types (see
+[ADR-0004](../decisions/0004-error-handling-strategy.md)). Structural validation
+(shape/types) happens at the HTTP edge via Zod; business-rule validation lives
+in the domain (see [ADR-0007](../decisions/0007-api-validation-boundary.md)).
+
+## Conventions
+
+- All request and response bodies are JSON.
+- IDs are UUID strings.
+- Timestamps are ISO-8601 UTC strings (e.g. `2026-05-29T03:25:24.887Z`).
+- `GET /api/assets` returns only **active** assets (archived ones are excluded).
+- You can only read assets you own; requesting another user's asset returns 403.

--- a/docs/reference/data-model.md
+++ b/docs/reference/data-model.md
@@ -1,0 +1,128 @@
+# Data Model
+
+> **Audience:** designers & developers · **Purpose:** what data exists, with what
+> fields, types, and rules · **Source of truth:** this file, mirroring
+> `apps/api/src/domain/` · **Last reviewed:** 2026-05-29
+
+What entities Pineapple stores, the fields on each, and the rules they must
+satisfy. Designers: this is the menu of data you can build flows around.
+Developers: the field-level contract behind the [API](api.md).
+
+## Entities at a glance
+
+```
+User 1 ──< owns >── * Asset
+```
+
+A **User** owns many **Assets**. An asset always belongs to exactly one user,
+and a user only ever sees their own assets.
+
+## User
+
+The identity of a person using Pineapple.
+
+| Field       | Type            | Notes                                  |
+| ----------- | --------------- | -------------------------------------- |
+| `id`        | UserId (UUID)   | Stable identifier, generated on create |
+| `email`     | Email           | Unique; how sign-in maps to a user     |
+| `createdAt` | timestamp (ISO) | When the user first signed in          |
+
+Users are **provisioned automatically** on first Google sign-in — there is no
+separate registration. Identity (login, sessions) is managed by Better Auth in
+its own tables; this `User` is the domain-facing record keyed by email. See
+[the auth model](../../CLAUDE.md#auth-model).
+
+## Asset
+
+A thing the team tracks. The asset has common fields plus a `metadata` object
+whose shape depends on its `kind`.
+
+| Field        | Type                | Notes                                   |
+| ------------ | ------------------- | --------------------------------------- |
+| `id`         | AssetId (UUID)      | Generated on create                     |
+| `ownerId`    | UserId              | The owning user; immutable              |
+| `name`       | string              | Required, non-blank (trimmed)           |
+| `type`       | AssetType enum      | Derived from `metadata.kind`; immutable |
+| `metadata`   | AssetMetadata       | Type-specific details (see below)       |
+| `archivedAt` | timestamp \| `null` | Set when archived; `null` means active  |
+| `createdAt`  | timestamp (ISO)     | Creation time                           |
+| `updatedAt`  | timestamp (ISO)     | Last modification time                  |
+
+**AssetType** is one of: `vehicle`, `property`, `equipment`. It mirrors
+`metadata.kind` — there is no asset whose `type` disagrees with its metadata.
+
+## Asset metadata (by kind)
+
+`metadata` is a discriminated union on `kind`. Exactly one shape applies per
+asset.
+
+### `vehicle`
+
+| Field   | Type        | Required | Rule                                |
+| ------- | ----------- | -------- | ----------------------------------- |
+| `kind`  | `"vehicle"` | yes      | discriminator                       |
+| `make`  | string      | yes      | non-blank (e.g. `"Ram"`)            |
+| `model` | string      | yes      | non-blank (e.g. `"2500"`)           |
+| `year`  | integer     | yes      | between 1900 and next calendar year |
+| `vin`   | string      | no       | exactly 17 characters when present  |
+
+### `property`
+
+| Field      | Type         | Required | Rule                            |
+| ---------- | ------------ | -------- | ------------------------------- |
+| `kind`     | `"property"` | yes      | discriminator                   |
+| `nickname` | string       | no       | free text (e.g. `"Lake cabin"`) |
+| `address`  | Address      | yes      | all subfields required          |
+
+**Address:** `street`, `city`, `state`, `postalCode`, `country` — all strings,
+all required and non-blank.
+
+### `equipment`
+
+| Field          | Type          | Required | Rule          |
+| -------------- | ------------- | -------- | ------------- |
+| `kind`         | `"equipment"` | yes      | discriminator |
+| `manufacturer` | string        | no       | free text     |
+| `modelNumber`  | string        | no       | free text     |
+| `serialNumber` | string        | no       | free text     |
+
+> Validation runs in two places (by design — [ADR-0007](../decisions/0007-api-validation-boundary.md)):
+> Zod checks shape/types at the HTTP edge (→ 422), and the domain re-checks
+> business rules so invariants hold no matter who calls. The rules above are the
+> domain rules; the [OpenAPI spec](openapi.json) encodes the same constraints.
+
+## Value objects
+
+These are **branded** types, not raw strings — constructed via `.from()` /
+`.generate()` and validated on creation (see
+[ADR-0002](../decisions/0002-use-tactical-ddd-patterns-for-the-domain-layer.md)).
+
+| Type      | Backed by   | Notes                        |
+| --------- | ----------- | ---------------------------- |
+| `UserId`  | UUID string | `.generate()` for new users  |
+| `AssetId` | UUID string | `.generate()` for new assets |
+| `Email`   | string      | validated email format       |
+
+## Domain events
+
+Aggregates raise events when something significant happens. Today:
+
+| Event          | Raised when         | Carries            |
+| -------------- | ------------------- | ------------------ |
+| `AssetCreated` | an asset is created | the new asset's id |
+
+There is no event bus yet — events are drained and dropped after persistence.
+This is the seam where future side effects (notifications, projections) will
+attach.
+
+## Storage mapping
+
+| Domain concept     | D1 table                                     | Notes                                                                  |
+| ------------------ | -------------------------------------------- | ---------------------------------------------------------------------- |
+| `User`             | `users`                                      | `metadata` stored as JSON text on assets                               |
+| `Asset`            | `assets`                                     | `metadata` is a JSON string column                                     |
+| Auth (Better Auth) | `user`, `session`, `account`, `verification` | **singular** names; auth infra, separate from the domain `users` table |
+
+Timestamps are stored as ISO-8601 strings. Schema lives in
+[`/migrations`](../../migrations) and is applied with
+`wrangler d1 migrations apply`.

--- a/docs/reference/data-model.md
+++ b/docs/reference/data-model.md
@@ -1,12 +1,6 @@
 # Data Model
 
-> **Audience:** designers & developers · **Purpose:** what data exists, with what
-> fields, types, and rules · **Source of truth:** this file, mirroring
-> `apps/api/src/domain/` · **Last reviewed:** 2026-05-29
-
-What entities Pineapple stores, the fields on each, and the rules they must
-satisfy. Designers: this is the menu of data you can build flows around.
-Developers: the field-level contract behind the [API](api.md).
+> **Audience:** designers & developers · **Purpose:** domain concepts, relationships, and storage details not captured by the API contract · **See also:** [`openapi.json`](openapi.json) for field-level types and validation rules
 
 ## Entities at a glance
 
@@ -34,62 +28,14 @@ its own tables; this `User` is the domain-facing record keyed by email. See
 
 ## Asset
 
-A thing the team tracks. The asset has common fields plus a `metadata` object
-whose shape depends on its `kind`.
+Field shapes and validation rules live in the [OpenAPI spec](openapi.json)
+(`Asset`, `AssetMetadata`, `VehicleMetadata`, `PropertyMetadata`,
+`EquipmentMetadata`, `Address`). Domain-only details:
 
-| Field        | Type                | Notes                                   |
-| ------------ | ------------------- | --------------------------------------- |
-| `id`         | AssetId (UUID)      | Generated on create                     |
-| `ownerId`    | UserId              | The owning user; immutable              |
-| `name`       | string              | Required, non-blank (trimmed)           |
-| `type`       | AssetType enum      | Derived from `metadata.kind`; immutable |
-| `metadata`   | AssetMetadata       | Type-specific details (see below)       |
-| `archivedAt` | timestamp \| `null` | Set when archived; `null` means active  |
-| `createdAt`  | timestamp (ISO)     | Creation time                           |
-| `updatedAt`  | timestamp (ISO)     | Last modification time                  |
-
-**AssetType** is one of: `vehicle`, `property`, `equipment`. It mirrors
-`metadata.kind` — there is no asset whose `type` disagrees with its metadata.
-
-## Asset metadata (by kind)
-
-`metadata` is a discriminated union on `kind`. Exactly one shape applies per
-asset.
-
-### `vehicle`
-
-| Field   | Type        | Required | Rule                                |
-| ------- | ----------- | -------- | ----------------------------------- |
-| `kind`  | `"vehicle"` | yes      | discriminator                       |
-| `make`  | string      | yes      | non-blank (e.g. `"Ram"`)            |
-| `model` | string      | yes      | non-blank (e.g. `"2500"`)           |
-| `year`  | integer     | yes      | between 1900 and next calendar year |
-| `vin`   | string      | no       | exactly 17 characters when present  |
-
-### `property`
-
-| Field      | Type         | Required | Rule                            |
-| ---------- | ------------ | -------- | ------------------------------- |
-| `kind`     | `"property"` | yes      | discriminator                   |
-| `nickname` | string       | no       | free text (e.g. `"Lake cabin"`) |
-| `address`  | Address      | yes      | all subfields required          |
-
-**Address:** `street`, `city`, `state`, `postalCode`, `country` — all strings,
-all required and non-blank.
-
-### `equipment`
-
-| Field          | Type          | Required | Rule          |
-| -------------- | ------------- | -------- | ------------- |
-| `kind`         | `"equipment"` | yes      | discriminator |
-| `manufacturer` | string        | no       | free text     |
-| `modelNumber`  | string        | no       | free text     |
-| `serialNumber` | string        | no       | free text     |
-
-> Validation runs in two places (by design — [ADR-0007](../decisions/0007-api-validation-boundary.md)):
-> Zod checks shape/types at the HTTP edge (→ 422), and the domain re-checks
-> business rules so invariants hold no matter who calls. The rules above are the
-> domain rules; the [OpenAPI spec](openapi.json) encodes the same constraints.
+- **`ownerId`** — the owning `UserId`; set on creation and immutable. Not
+  exposed in the API response.
+- **`type`** mirrors `metadata.kind` — there is no asset whose `type`
+  disagrees with its metadata. Both are immutable after creation.
 
 ## Value objects
 
@@ -119,7 +65,7 @@ attach.
 
 | Domain concept     | D1 table                                     | Notes                                                                  |
 | ------------------ | -------------------------------------------- | ---------------------------------------------------------------------- |
-| `User`             | `users`                                      | `metadata` stored as JSON text on assets                               |
+| `User`             | `users`                                      |                                                                        |
 | `Asset`            | `assets`                                     | `metadata` is a JSON string column                                     |
 | Auth (Better Auth) | `user`, `session`, `account`, `verification` | **singular** names; auth infra, separate from the domain `users` table |
 

--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -1,0 +1,482 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Pineapple API",
+    "version": "0.1.0",
+    "description": "Field-operations API for managing assets (vehicles, properties, equipment). Authentication is handled by Better Auth + Google OAuth; send the session cookie obtained from `/api/auth/*` with requests to protected `/api/*` routes."
+  },
+  "servers": [
+    {
+      "url": "http://localhost:8787",
+      "description": "Local dev (wrangler)"
+    },
+    {
+      "url": "https://pineapple-api.tylerjevans.workers.dev",
+      "description": "Production"
+    }
+  ],
+  "tags": [
+    {
+      "name": "System",
+      "description": "Health and meta endpoints"
+    },
+    {
+      "name": "Assets",
+      "description": "Create and read assets owned by the caller"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "cookieAuth": {
+        "type": "apiKey",
+        "in": "cookie",
+        "name": "better-auth.session_token",
+        "description": "Better Auth session cookie, set after completing the Google OAuth flow at `/api/auth/sign-in/social?provider=google`."
+      }
+    },
+    "schemas": {
+      "Health": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "ok"
+            ]
+          }
+        },
+        "required": [
+          "status"
+        ]
+      },
+      "CreatedAsset": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "example": "195d0ef0-47f5-439f-abfd-29f892c9a040"
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
+      "Error": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string",
+            "example": "Asset not found"
+          },
+          "field": {
+            "type": "string",
+            "example": "metadata.year"
+          }
+        },
+        "required": [
+          "error"
+        ]
+      },
+      "VehicleMetadata": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": [
+              "vehicle"
+            ]
+          },
+          "make": {
+            "type": "string",
+            "minLength": 1,
+            "example": "Ram"
+          },
+          "model": {
+            "type": "string",
+            "minLength": 1,
+            "example": "2500"
+          },
+          "year": {
+            "type": "integer",
+            "minimum": 1900,
+            "maximum": 2027,
+            "example": 2016
+          },
+          "vin": {
+            "type": "string",
+            "minLength": 17,
+            "maxLength": 17,
+            "example": "1C6RR7LT4GS123456"
+          }
+        },
+        "required": [
+          "kind",
+          "make",
+          "model",
+          "year"
+        ]
+      },
+      "Address": {
+        "type": "object",
+        "properties": {
+          "street": {
+            "type": "string",
+            "minLength": 1
+          },
+          "city": {
+            "type": "string",
+            "minLength": 1
+          },
+          "state": {
+            "type": "string",
+            "minLength": 1
+          },
+          "postalCode": {
+            "type": "string",
+            "minLength": 1
+          },
+          "country": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "street",
+          "city",
+          "state",
+          "postalCode",
+          "country"
+        ]
+      },
+      "PropertyMetadata": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": [
+              "property"
+            ]
+          },
+          "nickname": {
+            "type": "string",
+            "example": "Lake cabin"
+          },
+          "address": {
+            "$ref": "#/components/schemas/Address"
+          }
+        },
+        "required": [
+          "kind",
+          "address"
+        ]
+      },
+      "EquipmentMetadata": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": [
+              "equipment"
+            ]
+          },
+          "manufacturer": {
+            "type": "string",
+            "example": "Honda"
+          },
+          "modelNumber": {
+            "type": "string",
+            "example": "EU2200i"
+          },
+          "serialNumber": {
+            "type": "string",
+            "example": "EAMT-1234567"
+          }
+        },
+        "required": [
+          "kind"
+        ]
+      },
+      "AssetMetadata": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/VehicleMetadata"
+          },
+          {
+            "$ref": "#/components/schemas/PropertyMetadata"
+          },
+          {
+            "$ref": "#/components/schemas/EquipmentMetadata"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "kind",
+          "mapping": {
+            "vehicle": "#/components/schemas/VehicleMetadata",
+            "property": "#/components/schemas/PropertyMetadata",
+            "equipment": "#/components/schemas/EquipmentMetadata"
+          }
+        }
+      },
+      "CreateAssetBody": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "example": "My Truck"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/AssetMetadata"
+          }
+        },
+        "required": [
+          "name",
+          "metadata"
+        ]
+      },
+      "Asset": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "example": "195d0ef0-47f5-439f-abfd-29f892c9a040"
+          },
+          "name": {
+            "type": "string",
+            "example": "My Truck"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "vehicle",
+              "property",
+              "equipment"
+            ],
+            "example": "vehicle"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/AssetMetadata"
+          },
+          "archivedAt": {
+            "type": "string",
+            "nullable": true,
+            "format": "date-time",
+            "example": null
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2026-05-29T03:25:24.887Z"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2026-05-29T03:25:24.887Z"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "type",
+          "metadata",
+          "archivedAt",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "AssetListResponse": {
+        "type": "object",
+        "properties": {
+          "assets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Asset"
+            }
+          }
+        },
+        "required": [
+          "assets"
+        ]
+      }
+    },
+    "parameters": {}
+  },
+  "paths": {
+    "/health": {
+      "get": {
+        "tags": [
+          "System"
+        ],
+        "summary": "Liveness check",
+        "description": "Returns ok when the Worker is serving. No authentication.",
+        "responses": {
+          "200": {
+            "description": "Service is healthy",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Health"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/assets": {
+      "post": {
+        "tags": [
+          "Assets"
+        ],
+        "summary": "Create an asset",
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateAssetBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Asset created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreatedAsset"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Assets"
+        ],
+        "summary": "List my assets",
+        "description": "Returns the caller's active (non-archived) assets.",
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The caller's assets",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssetListResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/assets/{id}": {
+      "get": {
+        "tags": [
+          "Assets"
+        ],
+        "summary": "Get an asset by id",
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "example": "195d0ef0-47f5-439f-abfd-29f892c9a040"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The asset",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Asset"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The asset belongs to another user",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No such asset",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -42,7 +42,8 @@ const BLOCKED_IMPORTS = BLOCKED_NODE_BUILTINS.flatMap((name) => [
 
 export default tseslint.config(
   // ── Global ignores ───────────────────────────────────────────────────────
-  { ignores: ["**/dist/**", "**/node_modules/**", "**/.wrangler/**"] },
+  // scripts/ are Node tooling (build-time), outside the Workers tsconfig.
+  { ignores: ["**/dist/**", "**/node_modules/**", "**/.wrangler/**", "**/scripts/**"] },
 
   // ── Layer boundary enforcement (ADR-0003) ────────────────────────────────
   // Elements map file paths → logical layer names.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,21 +40,27 @@ importers:
         version: 8.59.4(eslint@9.39.4)(typescript@5.9.3)
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@22.19.19)(yaml@2.9.0)
+        version: 3.2.4(@types/node@22.19.19)(tsx@4.22.3)(yaml@2.9.0)
 
   apps/api:
     dependencies:
+      '@hono/zod-openapi':
+        specifier: ^0.19.10
+        version: 0.19.10(hono@4.12.23)(zod@3.25.76)
+      '@scalar/hono-api-reference':
+        specifier: ^0.10.19
+        version: 0.10.19(hono@4.12.23)
       '@snaveevans/pineapple-shared':
         specifier: workspace:*
         version: link:../../packages/shared
       better-auth:
         specifier: ^1.6.11
-        version: 1.6.11(@cloudflare/workers-types@4.20260525.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260525.1)(kysely@0.28.17))(vitest@3.2.4(@types/node@25.9.1)(yaml@2.9.0))
+        version: 1.6.11(@cloudflare/workers-types@4.20260525.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260525.1)(kysely@0.28.17))(vitest@3.2.4(@types/node@25.9.1)(tsx@4.22.3)(yaml@2.9.0))
       better-auth-cloudflare:
         specifier: ^0.3.0
-        version: 0.3.0(@better-auth/drizzle-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260525.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260525.1)(kysely@0.28.17)))(@cloudflare/workers-types@4.20260525.1)(better-auth@1.6.11(@cloudflare/workers-types@4.20260525.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260525.1)(kysely@0.28.17))(vitest@3.2.4(@types/node@25.9.1)(yaml@2.9.0)))(kysely@0.28.17)
+        version: 0.3.0(@better-auth/drizzle-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260525.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260525.1)(kysely@0.28.17)))(@cloudflare/workers-types@4.20260525.1)(better-auth@1.6.11(@cloudflare/workers-types@4.20260525.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260525.1)(kysely@0.28.17))(vitest@3.2.4(@types/node@25.9.1)(tsx@4.22.3)(yaml@2.9.0)))(kysely@0.28.17)
       hono:
-        specifier: ^4.0.0
+        specifier: ^4.12.0
         version: 4.12.23
       zod:
         specifier: ^3.0.0
@@ -63,9 +69,12 @@ importers:
       '@cloudflare/workers-types':
         specifier: ^4.0.0
         version: 4.20260525.1
+      tsx:
+        specifier: ^4.19.0
+        version: 4.22.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@25.9.1)(yaml@2.9.0)
+        version: 3.2.4(@types/node@25.9.1)(tsx@4.22.3)(yaml@2.9.0)
       wrangler:
         specifier: ^4.95.0
         version: 4.95.0(@cloudflare/workers-types@4.20260525.1)
@@ -73,6 +82,11 @@ importers:
   packages/shared: {}
 
 packages:
+
+  '@asteasolutions/zod-to-openapi@7.3.4':
+    resolution: {integrity: sha512-/2rThQ5zPi9OzVwes6U7lK1+Yvug0iXu25olp7S0XsYmOqnyMfxH7gdSQjn/+DSOHRg7wnotwGJSyL+fBKdnEA==}
+    peerDependencies:
+      zod: ^3.20.2
 
   '@better-auth/core@1.6.11':
     resolution: {integrity: sha512-LrwidLCV8azdMGjvtwp30nj9tIv1BwI3VhtC0UaGSjQkAVWw4bN42I8qwbxRziPeSQoj+zUVkOpxZzAWBDARtQ==}
@@ -222,6 +236,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.0':
+    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.27.3':
     resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
     engines: {node: '>=18'}
@@ -230,6 +250,12 @@ packages:
 
   '@esbuild/android-arm64@0.27.7':
     resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.0':
+    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -246,6 +272,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.0':
+    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.27.3':
     resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
     engines: {node: '>=18'}
@@ -254,6 +286,12 @@ packages:
 
   '@esbuild/android-x64@0.27.7':
     resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.0':
+    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -270,6 +308,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.0':
+    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.27.3':
     resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
     engines: {node: '>=18'}
@@ -278,6 +322,12 @@ packages:
 
   '@esbuild/darwin-x64@0.27.7':
     resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.0':
+    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -294,6 +344,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.27.3':
     resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
     engines: {node: '>=18'}
@@ -302,6 +358,12 @@ packages:
 
   '@esbuild/freebsd-x64@0.27.7':
     resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.0':
+    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -318,6 +380,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.0':
+    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.27.3':
     resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
     engines: {node: '>=18'}
@@ -326,6 +394,12 @@ packages:
 
   '@esbuild/linux-arm@0.27.7':
     resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.0':
+    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -342,6 +416,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.0':
+    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.27.3':
     resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
     engines: {node: '>=18'}
@@ -350,6 +430,12 @@ packages:
 
   '@esbuild/linux-loong64@0.27.7':
     resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.0':
+    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -366,6 +452,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.0':
+    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.27.3':
     resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
     engines: {node: '>=18'}
@@ -374,6 +466,12 @@ packages:
 
   '@esbuild/linux-ppc64@0.27.7':
     resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.0':
+    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -390,6 +488,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.0':
+    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.27.3':
     resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
     engines: {node: '>=18'}
@@ -398,6 +502,12 @@ packages:
 
   '@esbuild/linux-s390x@0.27.7':
     resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.0':
+    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -414,6 +524,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.0':
+    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.27.3':
     resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
     engines: {node: '>=18'}
@@ -422,6 +538,12 @@ packages:
 
   '@esbuild/netbsd-arm64@0.27.7':
     resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -438,6 +560,12 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.28.0':
+    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.27.3':
     resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
     engines: {node: '>=18'}
@@ -446,6 +574,12 @@ packages:
 
   '@esbuild/openbsd-arm64@0.27.7':
     resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -462,6 +596,12 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.0':
+    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.27.3':
     resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
     engines: {node: '>=18'}
@@ -470,6 +610,12 @@ packages:
 
   '@esbuild/openharmony-arm64@0.27.7':
     resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -486,6 +632,12 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.28.0':
+    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.27.3':
     resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
     engines: {node: '>=18'}
@@ -494,6 +646,12 @@ packages:
 
   '@esbuild/win32-arm64@0.27.7':
     resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.0':
+    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -510,6 +668,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.0':
+    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.27.3':
     resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
     engines: {node: '>=18'}
@@ -518,6 +682,12 @@ packages:
 
   '@esbuild/win32-x64@0.27.7':
     resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.0':
+    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -559,6 +729,19 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@hono/zod-openapi@0.19.10':
+    resolution: {integrity: sha512-dpoS6DenvoJyvxtQ7Kd633FRZ/Qf74+4+o9s+zZI8pEqnbjdF/DtxIib08WDpCaWabMEJOL5TXpMgNEZvb7hpA==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      hono: '>=4.3.6'
+      zod: '>=3.0.0'
+
+  '@hono/zod-validator@0.7.6':
+    resolution: {integrity: sha512-Io1B6d011Gj1KknV4rXYz4le5+5EubcWEU/speUjuw9XMMIaP3n78yXLhjd2A3PXaXaUwEAluOiAyLqhBEJgsw==}
+    peerDependencies:
+      hono: '>=3.9.0'
+      zod: ^3.25.0 || ^4.0.0
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -901,6 +1084,32 @@ packages:
     resolution: {integrity: sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==}
     cpu: [x64]
     os: [win32]
+
+  '@scalar/client-side-rendering@0.1.12':
+    resolution: {integrity: sha512-prwHK4ozTU268BHZ/5OstoKB23JSidDuvddAOp0bVz9c29ZxsyzzxPtPcVgF7X16LiZnS1OzY030FoDCM+iC9Q==}
+    engines: {node: '>=22'}
+
+  '@scalar/helpers@0.8.0':
+    resolution: {integrity: sha512-gmOC6VravNB9VDl6wnt/GOj4K/hn48tj5bpW4AM4MhH8Ubil6uu7g1DSoKHwltu8Ks79KEtR6JmOrROi9R7jaQ==}
+    engines: {node: '>=22'}
+
+  '@scalar/hono-api-reference@0.10.19':
+    resolution: {integrity: sha512-6EfwN/lfPvePzAxe9UE8fr/ZuAAqS6ttUwQu9JTgk2Xl/clicaVVSOc0gyGt+8GLXdysoNinjZ74we8xqNWyCA==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      hono: ^4.12.5
+
+  '@scalar/schemas@0.3.2':
+    resolution: {integrity: sha512-iadXBgJ02XUU5C5s6/xh/PmGLzUPd7X8upXIvPWBXDcQ4FHACNgkG8PPZ/beYM8UPDDkTUPM3ygEs0G6jKwGjQ==}
+    engines: {node: '>=22'}
+
+  '@scalar/types@0.12.2':
+    resolution: {integrity: sha512-EzLkubCb7xioiTm9eYnmn/032akaq4kkrrdclgV2uezwtniR8ErQICjhMl2AjBWL6nstHiFZ9RnPZm2Z2/KM0Q==}
+    engines: {node: '>=22'}
+
+  '@scalar/validation@0.6.0':
+    resolution: {integrity: sha512-tpmmG+/xRE2Kn9RpflU3AIyZv08v10+E1ZrJCx7z6+/91zHVxy0M73kC1LT4/8PbYNt85ywyC8+n+D99JdMcGA==}
+    engines: {node: '>=20'}
 
   '@sindresorhus/is@7.2.0':
     resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
@@ -1355,6 +1564,11 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  esbuild@0.28.0:
+    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
@@ -1707,6 +1921,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@5.1.11:
+    resolution: {integrity: sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+
   nanostores@1.3.0:
     resolution: {integrity: sha512-XPUa/jz+P1oJvN9VBxw4L9MtdFfaH3DAryqPssqhb2kXjmb9npz0dly6rCsgFWOPr4Yg9mTfM3MDZgZZ+7A3lA==}
     engines: {node: ^20.0.0 || >=22.0.0}
@@ -1720,6 +1939,9 @@ packages:
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
+
+  openapi3-ts@4.5.0:
+    resolution: {integrity: sha512-jaL+HgTq2Gj5jRcfdutgRGLosCy/hT8sQf6VOy+P+g36cZOjI1iukdPnijC+4CmeRzg/jEllJUboEic2FhxhtQ==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -1917,6 +2139,10 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
@@ -1960,9 +2186,18 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.22.3:
+    resolution: {integrity: sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  type-fest@5.6.0:
+    resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
+    engines: {node: '>=20'}
 
   typescript-eslint@8.59.4:
     resolution: {integrity: sha512-Rw6+44QNFaXtgHSjPy+Kw8hrJniMYzR85E9yLmOLcfZ91/rz+JXQbDTCmc6ccxMPY6K6PgAq26f0JCBfR7LIPQ==}
@@ -2145,6 +2380,11 @@ packages:
 
 snapshots:
 
+  '@asteasolutions/zod-to-openapi@7.3.4(zod@3.25.76)':
+    dependencies:
+      openapi3-ts: 4.5.0
+      zod: 3.25.76
+
   '@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260525.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)':
     dependencies:
       '@better-auth/utils': 0.4.0
@@ -2254,10 +2494,16 @@ snapshots:
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
   '@esbuild/android-arm64@0.27.3':
     optional: true
 
   '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.0':
     optional: true
 
   '@esbuild/android-arm@0.27.3':
@@ -2266,10 +2512,16 @@ snapshots:
   '@esbuild/android-arm@0.27.7':
     optional: true
 
+  '@esbuild/android-arm@0.28.0':
+    optional: true
+
   '@esbuild/android-x64@0.27.3':
     optional: true
 
   '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.28.0':
     optional: true
 
   '@esbuild/darwin-arm64@0.27.3':
@@ -2278,10 +2530,16 @@ snapshots:
   '@esbuild/darwin-arm64@0.27.7':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
   '@esbuild/darwin-x64@0.27.3':
     optional: true
 
   '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.0':
     optional: true
 
   '@esbuild/freebsd-arm64@0.27.3':
@@ -2290,10 +2548,16 @@ snapshots:
   '@esbuild/freebsd-arm64@0.27.7':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
   '@esbuild/freebsd-x64@0.27.3':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.0':
     optional: true
 
   '@esbuild/linux-arm64@0.27.3':
@@ -2302,10 +2566,16 @@ snapshots:
   '@esbuild/linux-arm64@0.27.7':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
   '@esbuild/linux-arm@0.27.3':
     optional: true
 
   '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.0':
     optional: true
 
   '@esbuild/linux-ia32@0.27.3':
@@ -2314,10 +2584,16 @@ snapshots:
   '@esbuild/linux-ia32@0.27.7':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
   '@esbuild/linux-loong64@0.27.3':
     optional: true
 
   '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.0':
     optional: true
 
   '@esbuild/linux-mips64el@0.27.3':
@@ -2326,10 +2602,16 @@ snapshots:
   '@esbuild/linux-mips64el@0.27.7':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
   '@esbuild/linux-ppc64@0.27.3':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.0':
     optional: true
 
   '@esbuild/linux-riscv64@0.27.3':
@@ -2338,10 +2620,16 @@ snapshots:
   '@esbuild/linux-riscv64@0.27.7':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
   '@esbuild/linux-s390x@0.27.3':
     optional: true
 
   '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.0':
     optional: true
 
   '@esbuild/linux-x64@0.27.3':
@@ -2350,10 +2638,16 @@ snapshots:
   '@esbuild/linux-x64@0.27.7':
     optional: true
 
+  '@esbuild/linux-x64@0.28.0':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.27.3':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/netbsd-x64@0.27.3':
@@ -2362,10 +2656,16 @@ snapshots:
   '@esbuild/netbsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.27.3':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/openbsd-x64@0.27.3':
@@ -2374,10 +2674,16 @@ snapshots:
   '@esbuild/openbsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.27.3':
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.0':
     optional: true
 
   '@esbuild/sunos-x64@0.27.3':
@@ -2386,10 +2692,16 @@ snapshots:
   '@esbuild/sunos-x64@0.27.7':
     optional: true
 
+  '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
   '@esbuild/win32-arm64@0.27.3':
     optional: true
 
   '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.0':
     optional: true
 
   '@esbuild/win32-ia32@0.27.3':
@@ -2398,10 +2710,16 @@ snapshots:
   '@esbuild/win32-ia32@0.27.7':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
   '@esbuild/win32-x64@0.27.3':
     optional: true
 
   '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.0':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4)':
@@ -2449,6 +2767,19 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       levn: 0.4.1
+
+  '@hono/zod-openapi@0.19.10(hono@4.12.23)(zod@3.25.76)':
+    dependencies:
+      '@asteasolutions/zod-to-openapi': 7.3.4(zod@3.25.76)
+      '@hono/zod-validator': 0.7.6(hono@4.12.23)(zod@3.25.76)
+      hono: 4.12.23
+      openapi3-ts: 4.5.0
+      zod: 3.25.76
+
+  '@hono/zod-validator@0.7.6(hono@4.12.23)(zod@3.25.76)':
+    dependencies:
+      hono: 4.12.23
+      zod: 3.25.76
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -2664,6 +2995,33 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.4':
     optional: true
 
+  '@scalar/client-side-rendering@0.1.12':
+    dependencies:
+      '@scalar/schemas': 0.3.2
+      '@scalar/types': 0.12.2
+      '@scalar/validation': 0.6.0
+
+  '@scalar/helpers@0.8.0': {}
+
+  '@scalar/hono-api-reference@0.10.19(hono@4.12.23)':
+    dependencies:
+      '@scalar/client-side-rendering': 0.1.12
+      hono: 4.12.23
+
+  '@scalar/schemas@0.3.2':
+    dependencies:
+      '@scalar/helpers': 0.8.0
+      '@scalar/validation': 0.6.0
+
+  '@scalar/types@0.12.2':
+    dependencies:
+      '@scalar/helpers': 0.8.0
+      nanoid: 5.1.11
+      type-fest: 5.6.0
+      zod: 4.4.3
+
+  '@scalar/validation@0.6.0': {}
+
   '@sindresorhus/is@7.2.0': {}
 
   '@speed-highlight/core@1.2.15': {}
@@ -2791,13 +3149,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.3(@types/node@22.19.19)(yaml@2.9.0))':
+  '@vitest/mocker@3.2.4(vite@7.3.3(@types/node@22.19.19)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.3(@types/node@22.19.19)(yaml@2.9.0)
+      vite: 7.3.3(@types/node@22.19.19)(tsx@4.22.3)(yaml@2.9.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -2858,11 +3216,11 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  better-auth-cloudflare@0.3.0(@better-auth/drizzle-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260525.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260525.1)(kysely@0.28.17)))(@cloudflare/workers-types@4.20260525.1)(better-auth@1.6.11(@cloudflare/workers-types@4.20260525.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260525.1)(kysely@0.28.17))(vitest@3.2.4(@types/node@25.9.1)(yaml@2.9.0)))(kysely@0.28.17):
+  better-auth-cloudflare@0.3.0(@better-auth/drizzle-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260525.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260525.1)(kysely@0.28.17)))(@cloudflare/workers-types@4.20260525.1)(better-auth@1.6.11(@cloudflare/workers-types@4.20260525.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260525.1)(kysely@0.28.17))(vitest@3.2.4(@types/node@25.9.1)(tsx@4.22.3)(yaml@2.9.0)))(kysely@0.28.17):
     dependencies:
       '@better-auth/drizzle-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260525.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260525.1)(kysely@0.28.17))
       '@cloudflare/workers-types': 4.20260525.1
-      better-auth: 1.6.11(@cloudflare/workers-types@4.20260525.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260525.1)(kysely@0.28.17))(vitest@3.2.4(@types/node@25.9.1)(yaml@2.9.0))
+      better-auth: 1.6.11(@cloudflare/workers-types@4.20260525.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260525.1)(kysely@0.28.17))(vitest@3.2.4(@types/node@25.9.1)(tsx@4.22.3)(yaml@2.9.0))
       drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260525.1)(kysely@0.28.17)
       mime: 4.1.0
       zod: 4.4.3
@@ -2896,7 +3254,7 @@ snapshots:
       - sql.js
       - sqlite3
 
-  better-auth@1.6.11(@cloudflare/workers-types@4.20260525.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260525.1)(kysely@0.28.17))(vitest@3.2.4(@types/node@25.9.1)(yaml@2.9.0)):
+  better-auth@1.6.11(@cloudflare/workers-types@4.20260525.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260525.1)(kysely@0.28.17))(vitest@3.2.4(@types/node@25.9.1)(tsx@4.22.3)(yaml@2.9.0)):
     dependencies:
       '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260525.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/drizzle-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260525.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260525.1)(kysely@0.28.17))
@@ -2917,7 +3275,7 @@ snapshots:
       zod: 4.4.3
     optionalDependencies:
       drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260525.1)(kysely@0.28.17)
-      vitest: 3.2.4(@types/node@25.9.1)(yaml@2.9.0)
+      vitest: 3.2.4(@types/node@25.9.1)(tsx@4.22.3)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
@@ -3083,6 +3441,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.7
       '@esbuild/win32-ia32': 0.27.7
       '@esbuild/win32-x64': 0.27.7
+
+  esbuild@0.28.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.0
+      '@esbuild/android-arm': 0.28.0
+      '@esbuild/android-arm64': 0.28.0
+      '@esbuild/android-x64': 0.28.0
+      '@esbuild/darwin-arm64': 0.28.0
+      '@esbuild/darwin-x64': 0.28.0
+      '@esbuild/freebsd-arm64': 0.28.0
+      '@esbuild/freebsd-x64': 0.28.0
+      '@esbuild/linux-arm': 0.28.0
+      '@esbuild/linux-arm64': 0.28.0
+      '@esbuild/linux-ia32': 0.28.0
+      '@esbuild/linux-loong64': 0.28.0
+      '@esbuild/linux-mips64el': 0.28.0
+      '@esbuild/linux-ppc64': 0.28.0
+      '@esbuild/linux-riscv64': 0.28.0
+      '@esbuild/linux-s390x': 0.28.0
+      '@esbuild/linux-x64': 0.28.0
+      '@esbuild/netbsd-arm64': 0.28.0
+      '@esbuild/netbsd-x64': 0.28.0
+      '@esbuild/openbsd-arm64': 0.28.0
+      '@esbuild/openbsd-x64': 0.28.0
+      '@esbuild/openharmony-arm64': 0.28.0
+      '@esbuild/sunos-x64': 0.28.0
+      '@esbuild/win32-arm64': 0.28.0
+      '@esbuild/win32-ia32': 0.28.0
+      '@esbuild/win32-x64': 0.28.0
 
   escape-string-regexp@4.0.0: {}
 
@@ -3429,6 +3816,8 @@ snapshots:
 
   nanoid@3.3.12: {}
 
+  nanoid@5.1.11: {}
+
   nanostores@1.3.0: {}
 
   natural-compare@1.4.0: {}
@@ -3438,6 +3827,10 @@ snapshots:
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
+
+  openapi3-ts@4.5.0:
+    dependencies:
+      yaml: 2.9.0
 
   optionator@0.9.4:
     dependencies:
@@ -3650,6 +4043,8 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  tagged-tag@1.0.0: {}
+
   tapable@2.3.3: {}
 
   tinybench@2.9.0: {}
@@ -3680,9 +4075,19 @@ snapshots:
   tslib@2.8.1:
     optional: true
 
+  tsx@4.22.3:
+    dependencies:
+      esbuild: 0.28.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-fest@5.6.0:
+    dependencies:
+      tagged-tag: 1.0.0
 
   typescript-eslint@8.59.4(eslint@9.39.4)(typescript@5.9.3):
     dependencies:
@@ -3715,13 +4120,13 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  vite-node@3.2.4(@types/node@22.19.19)(yaml@2.9.0):
+  vite-node@3.2.4(@types/node@22.19.19)(tsx@4.22.3)(yaml@2.9.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.3(@types/node@22.19.19)(yaml@2.9.0)
+      vite: 7.3.3(@types/node@22.19.19)(tsx@4.22.3)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -3736,13 +4141,13 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@3.2.4(@types/node@25.9.1)(yaml@2.9.0):
+  vite-node@3.2.4(@types/node@25.9.1)(tsx@4.22.3)(yaml@2.9.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.3(@types/node@25.9.1)(yaml@2.9.0)
+      vite: 7.3.3(@types/node@25.9.1)(tsx@4.22.3)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -3757,7 +4162,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.3(@types/node@22.19.19)(yaml@2.9.0):
+  vite@7.3.3(@types/node@22.19.19)(tsx@4.22.3)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -3768,9 +4173,10 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.19
       fsevents: 2.3.3
+      tsx: 4.22.3
       yaml: 2.9.0
 
-  vite@7.3.3(@types/node@25.9.1)(yaml@2.9.0):
+  vite@7.3.3(@types/node@25.9.1)(tsx@4.22.3)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -3781,13 +4187,14 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.9.1
       fsevents: 2.3.3
+      tsx: 4.22.3
       yaml: 2.9.0
 
-  vitest@3.2.4(@types/node@22.19.19)(yaml@2.9.0):
+  vitest@3.2.4(@types/node@22.19.19)(tsx@4.22.3)(yaml@2.9.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.3(@types/node@22.19.19)(yaml@2.9.0))
+      '@vitest/mocker': 3.2.4(vite@7.3.3(@types/node@22.19.19)(tsx@4.22.3)(yaml@2.9.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -3805,8 +4212,8 @@ snapshots:
       tinyglobby: 0.2.16
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.3(@types/node@22.19.19)(yaml@2.9.0)
-      vite-node: 3.2.4(@types/node@22.19.19)(yaml@2.9.0)
+      vite: 7.3.3(@types/node@22.19.19)(tsx@4.22.3)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@22.19.19)(tsx@4.22.3)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.19
@@ -3824,11 +4231,11 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.2.4(@types/node@25.9.1)(yaml@2.9.0):
+  vitest@3.2.4(@types/node@25.9.1)(tsx@4.22.3)(yaml@2.9.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.3(@types/node@22.19.19)(yaml@2.9.0))
+      '@vitest/mocker': 3.2.4(vite@7.3.3(@types/node@22.19.19)(tsx@4.22.3)(yaml@2.9.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -3846,8 +4253,8 @@ snapshots:
       tinyglobby: 0.2.16
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.3(@types/node@25.9.1)(yaml@2.9.0)
-      vite-node: 3.2.4(@types/node@25.9.1)(yaml@2.9.0)
+      vite: 7.3.3(@types/node@25.9.1)(tsx@4.22.3)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@25.9.1)(tsx@4.22.3)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.1
@@ -3918,8 +4325,7 @@ snapshots:
 
   ws@8.20.1: {}
 
-  yaml@2.9.0:
-    optional: true
+  yaml@2.9.0: {}
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
Establishes a consistent, audience-oriented documentation method (ADR-0008) and makes the API self-documenting.

## API is now self-documenting
- API contract generated from the Zod schemas via `@hono/zod-openapi` — single source of truth for validation **and** docs
- Served live at `GET /openapi.json` + interactive Scalar UI at `/reference`
- Committed static spec at `docs/reference/openapi.json`, with a **CI drift check** so the file codebase-tools read always matches the live API
- `worker.ts` refactored to `OpenAPIHono`: handlers bound to specs, centralized `onError` domain-error mapping, 422 validation via `defaultHook`

## Documentation system (organized by need, not role)
- **`README.md`** (human front door) + **`CLAUDE.md`** (AI-agent orientation hub)
- **`docs/README.md`** — the documentation method itself
- **`docs/reference/`** — `api.md` (narrative over the spec) + `data-model.md` (entities, fields, enums, rules)
- **`docs/product/`** — `features.md` + `roadmap.md` (PM/marketing)
- **`docs/guides/getting-started.md`** — run/test/deploy + the two-secret model
- **ADR-0008** records the method; index updated

## Per-persona map
UI dev → `api.md` + spec · Designer → `data-model.md` · PM/marketing → `product/` · LLM → `CLAUDE.md`

Verified: lint, type-check, tests, OpenAPI drift check, and a local smoke test (`/openapi.json`, `/reference`, asset CRUD, 422 validation) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)