### PR TITLE
Add marketing home page (apps/web: Vite + React on Workers)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "web",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["--filter", "@snaveevans/pineapple-web", "dev"],
+      "port": 5173
+    }
+  ]
+}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,8 @@
 name: Deploy
 
-# Auto-deploy the API Worker whenever main advances (i.e. when you merge a PR).
-# Also runnable on demand from the Actions tab.
+# Auto-deploy whenever main advances (i.e. when you merge a PR). Each app
+# (apps/api, apps/web) deploys only when its files — or a shared dependency —
+# changed. Also runnable on demand from the Actions tab, which deploys both.
 on:
   push:
     branches: [main]
@@ -43,8 +44,45 @@ jobs:
           pnpm --filter @snaveevans/pineapple-api openapi:generate
           git diff --exit-code docs/reference/openapi.json
 
-  deploy:
-    needs: verify
+  # Detect which app(s) changed so we only redeploy what moved. Shared changes
+  # (root config, the lockfile, packages/shared, this workflow) fan out to both.
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      api: ${{ steps.filter.outputs.api }}
+      web: ${{ steps.filter.outputs.web }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      # Only meaningful on push (needs a base to diff against). On manual
+      # dispatch this step is skipped and both deploy jobs run via the
+      # event_name guard below.
+      - uses: dorny/paths-filter@v3
+        id: filter
+        if: github.event_name == 'push'
+        with:
+          filters: |
+            shared: &shared
+              - 'pnpm-lock.yaml'
+              - 'package.json'
+              - 'pnpm-workspace.yaml'
+              - 'tsconfig.base.json'
+              - 'tsconfig.json'
+              - 'packages/shared/**'
+              - '.github/workflows/deploy.yml'
+            api:
+              - *shared
+              - 'apps/api/**'
+              - 'migrations/**'
+            web:
+              - *shared
+              - 'apps/web/**'
+
+  deploy-api:
+    needs: [verify, changes]
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.api == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     environment: production
@@ -77,4 +115,40 @@ jobs:
 
       - name: Deploy Worker
         working-directory: apps/api
+        run: pnpm wrangler deploy
+
+  deploy-web:
+    needs: [verify, changes]
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.web == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: production
+    env:
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install pnpm
+        uses: pnpm/action-setup@v5
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Verify Cloudflare credentials are present
+        run: |
+          test -n "$CLOUDFLARE_ACCOUNT_ID"
+          test -n "$CLOUDFLARE_API_TOKEN"
+
+      # Build the SPA (writes the redirect config wrangler deploy reads), then
+      # deploy the Worker that serves it.
+      - name: Build
+        working-directory: apps/web
+        run: pnpm build
+
+      - name: Deploy Worker
+        working-directory: apps/web
         run: pnpm wrangler deploy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,9 @@ everything else.
 
 **Pineapple** — a field-operations app for tracking assets (vehicles,
 properties, equipment) for a two-person team. The backend is a single
-Cloudflare Worker (`apps/api`). There is no frontend yet.
+Cloudflare Worker (`apps/api`). The frontend (`apps/web`) is a Vite + React
+app served by a Cloudflare Worker — it currently hosts the marketing home page
+(see [`apps/web/README.md`](apps/web/README.md)).
 
 ## Stack & runtime constraints
 

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -4,6 +4,19 @@ compatibility_date = "2026-05-21"
 # Better Auth relies on Node APIs (crypto, etc.) on the Workers runtime.
 compatibility_flags = ["nodejs_compat"]
 
+# Production routes on the shared hostname. The API owns /api/* plus its
+# (non-/api) docs + health endpoints; the web Worker (pineapple-web) owns the
+# catch-all /* for the SPA. Cloudflare matches the most specific route, so
+# /api/* and the explicit paths below win over the SPA's /*.
+# Requires the tylerevans.co zone in this Cloudflare account and a proxied DNS
+# record for pineapple.tylerevans.co. Routes are ignored by `wrangler dev`.
+routes = [
+  { pattern = "pineapple.tylerevans.co/api/*", zone_name = "tylerevans.co" },
+  { pattern = "pineapple.tylerevans.co/openapi.json", zone_name = "tylerevans.co" },
+  { pattern = "pineapple.tylerevans.co/reference", zone_name = "tylerevans.co" },
+  { pattern = "pineapple.tylerevans.co/health", zone_name = "tylerevans.co" },
+]
+
 # Auth config is provided as SECRETS (not committed here):
 #   wrangler secret put BETTER_AUTH_SECRET
 #   wrangler secret put GOOGLE_CLIENT_ID

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,0 +1,37 @@
+# @snaveevans/pineapple-web
+
+The FieldOps web frontend — a Vite + React app served by a Cloudflare Worker
+via [`@cloudflare/vite-plugin`](https://developers.cloudflare.com/workers/vite-plugin/).
+Adapted from Cloudflare's `vite-react-template` to fit this pnpm monorepo.
+
+Currently it serves the **Marketing Home** (logged-out landing) page,
+implemented in [`src/marketing/`](src/marketing/) from the Claude Design
+handoff. The design system primitives (`Icon`, `HFStatusPill`, `HFAssetIcon`,
+`HFAssetThumb`) are ported from the FieldOps app prototype and styled by the
+three CSS layers in `src/marketing/styles/` (`hifi.css` + `hifi-assets.css`
+supply the `.hf-*` tokens/components; `marketing.css` is the `.mk-*` layer and
+mirrors the tokens onto `.mk`).
+
+## Layout
+
+```
+index.html              # Vite HTML entry (loads Inter + JetBrains Mono)
+src/main.tsx            # React bootstrap → <MarketingHome />
+src/marketing/          # page, primitives, and CSS
+worker/index.ts         # Worker entry; reserves /api/*, SPA-falls-back otherwise
+vite.config.ts          # react() + cloudflare() plugins
+wrangler.jsonc          # Worker + static-assets config (SPA not_found_handling)
+```
+
+## Commands
+
+```bash
+pnpm --filter @snaveevans/pineapple-web dev         # vite dev server (http://localhost:5173)
+pnpm --filter @snaveevans/pineapple-web build       # production build → dist/
+pnpm --filter @snaveevans/pineapple-web preview      # preview the built worker locally
+pnpm --filter @snaveevans/pineapple-web deploy       # build + wrangler deploy
+```
+
+> Unlike `apps/api`, this app **has a build step** (Vite). It uses Web/DOM
+> standard APIs in the Worker entry, so no `@cloudflare/workers-types` global
+> is pulled in (which would conflict with `lib.dom`).

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>FieldOps — Keep everything you own on schedule</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@snaveevans/pineapple-web",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "deploy": "vite build && wrangler deploy",
+    "type-check": "tsc --noEmit",
+    "cf-typegen": "wrangler types"
+  },
+  "dependencies": {
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
+  },
+  "devDependencies": {
+    "@cloudflare/vite-plugin": "^1.1.0",
+    "@types/react": "^19.1.0",
+    "@types/react-dom": "^19.1.0",
+    "@vitejs/plugin-react": "^4.4.0",
+    "vite": "^6.3.0",
+    "wrangler": "^4.95.0"
+  }
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1,0 +1,8 @@
+/* Global reset for the marketing page. The warm off-white matches the .mk /
+   .hf design-system background token so there's no flash before paint. */
+html,
+body {
+  margin: 0;
+  padding: 0;
+  background: oklch(98% 0.005 85);
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,0 +1,13 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import "./index.css";
+import { MarketingHome } from "./marketing/MarketingHome";
+
+const root = document.getElementById("root");
+if (!root) throw new Error("Root element #root not found");
+
+createRoot(root).render(
+  <StrictMode>
+    <MarketingHome />
+  </StrictMode>,
+);

--- a/apps/web/src/marketing/Icon.tsx
+++ b/apps/web/src/marketing/Icon.tsx
@@ -1,0 +1,218 @@
+import type { CSSProperties, ReactNode } from "react";
+
+// Inline SVG icon set (lucide-style, 1.75 default stroke). Ported verbatim
+// from the FieldOps design system (hifi.jsx) so the marketing page renders
+// pixel-identically to the prototype.
+export type IconName =
+  | "home-nav"
+  | "grid"
+  | "calendar"
+  | "clock"
+  | "truck"
+  | "van"
+  | "home"
+  | "leaf"
+  | "bolt"
+  | "mower"
+  | "wrench"
+  | "pin"
+  | "clock-sm"
+  | "repeat"
+  | "check"
+  | "snooze"
+  | "arrow-right"
+  | "chevron-right"
+  | "bell"
+  | "search"
+  | "plus"
+  | "alert"
+  | "dot"
+  | "filter"
+  | "menu"
+  | "map-pin"
+  | "camera"
+  | "x"
+  | "car"
+  | "info"
+  | "image";
+
+export interface IconProps {
+  name: IconName;
+  size?: number;
+  stroke?: number;
+  color?: string;
+  style?: CSSProperties;
+}
+
+const PATHS: Record<IconName, ReactNode> = {
+  "home-nav": (
+    <>
+      <path d="M3 11 12 3l9 8" />
+      <path d="M5 10v10h14V10" />
+    </>
+  ),
+  grid: (
+    <>
+      <rect x="3" y="3" width="7" height="7" rx="1.5" />
+      <rect x="14" y="3" width="7" height="7" rx="1.5" />
+      <rect x="3" y="14" width="7" height="7" rx="1.5" />
+      <rect x="14" y="14" width="7" height="7" rx="1.5" />
+    </>
+  ),
+  calendar: (
+    <>
+      <rect x="3" y="5" width="18" height="16" rx="2" />
+      <path d="M3 9h18" />
+      <path d="M8 3v4M16 3v4" />
+    </>
+  ),
+  clock: (
+    <>
+      <circle cx="12" cy="12" r="9" />
+      <path d="M12 7v5l3 2" />
+    </>
+  ),
+  truck: (
+    <>
+      <path d="M3 7h11v9H3z" />
+      <path d="M14 10h4l3 3v3h-7" />
+      <circle cx="7" cy="18" r="2" />
+      <circle cx="17" cy="18" r="2" />
+    </>
+  ),
+  van: (
+    <>
+      <path d="M3 7h13v10H3z" />
+      <path d="M16 10h3l2 3v4h-5" />
+      <circle cx="7" cy="18" r="2" />
+      <circle cx="17" cy="18" r="2" />
+    </>
+  ),
+  home: (
+    <>
+      <path d="M4 11 12 4l8 7" />
+      <path d="M6 10v10h12V10" />
+      <path d="M10 20v-5h4v5" />
+    </>
+  ),
+  leaf: (
+    <>
+      <path d="M4 20c0-8 6-14 16-14 0 10-6 16-14 16-2 0-2-2-2-2z" />
+      <path d="M4 20 14 10" />
+    </>
+  ),
+  bolt: <path d="M13 3 5 14h6l-1 7 8-11h-6z" />,
+  mower: (
+    <>
+      <circle cx="6" cy="17" r="3" />
+      <circle cx="17" cy="17" r="3" />
+      <path d="M3 14v-3h12l3-5h3v3l-3 5" />
+    </>
+  ),
+  wrench: <path d="M14 6a4 4 0 0 0 5 5l-9 9a3 3 0 0 1-5-5z" />,
+  pin: (
+    <>
+      <path d="M12 22c4-5 7-9 7-12a7 7 0 0 0-14 0c0 3 3 7 7 12z" />
+      <circle cx="12" cy="10" r="2.5" />
+    </>
+  ),
+  "clock-sm": (
+    <>
+      <circle cx="12" cy="12" r="9" />
+      <path d="M12 7v5l3 2" />
+    </>
+  ),
+  repeat: (
+    <>
+      <path d="M17 3l4 4-4 4" />
+      <path d="M3 11V9a2 2 0 0 1 2-2h16" />
+      <path d="M7 21l-4-4 4-4" />
+      <path d="M21 13v2a2 2 0 0 1-2 2H3" />
+    </>
+  ),
+  check: <path d="M5 13l4 4 10-12" />,
+  snooze: (
+    <>
+      <circle cx="12" cy="13" r="8" />
+      <path d="M9 9h5l-5 6h5" />
+      <path d="M7 3 4 6M17 3l3 3" />
+    </>
+  ),
+  "arrow-right": <path d="M5 12h14M13 6l6 6-6 6" />,
+  "chevron-right": <path d="M9 6l6 6-6 6" />,
+  bell: (
+    <>
+      <path d="M6 16V11a6 6 0 0 1 12 0v5l1.5 2h-15z" />
+      <path d="M10 20a2 2 0 0 0 4 0" />
+    </>
+  ),
+  search: (
+    <>
+      <circle cx="11" cy="11" r="7" />
+      <path d="M21 21l-5-5" />
+    </>
+  ),
+  plus: <path d="M12 5v14M5 12h14" />,
+  alert: (
+    <>
+      <path d="M12 4 2 20h20z" />
+      <path d="M12 10v5M12 18v.5" />
+    </>
+  ),
+  dot: <circle cx="12" cy="12" r="4" />,
+  filter: <path d="M3 5h18l-7 9v6l-4-2v-4z" />,
+  menu: <path d="M4 7h16M4 12h16M4 17h16" />,
+  "map-pin": (
+    <>
+      <path d="M12 22c4-5 7-9 7-12a7 7 0 0 0-14 0c0 3 3 7 7 12z" />
+      <circle cx="12" cy="10" r="2.5" />
+    </>
+  ),
+  camera: (
+    <>
+      <path d="M4 8h3l1.5-2h7L17 8h3v11H4z" />
+      <circle cx="12" cy="13" r="3.5" />
+    </>
+  ),
+  x: <path d="M6 6l12 12M18 6 6 18" />,
+  car: (
+    <>
+      <path d="M5 11l1.5-4h11L19 11" />
+      <path d="M3 16v-3l2-2h14l2 2v3h-3" />
+      <path d="M3 16h3M18 16h3" />
+      <circle cx="8" cy="17" r="2" />
+      <circle cx="16" cy="17" r="2" />
+    </>
+  ),
+  info: (
+    <>
+      <circle cx="12" cy="12" r="9" />
+      <path d="M12 11v5M12 8v.5" />
+    </>
+  ),
+  image: (
+    <>
+      <rect x="3" y="4" width="18" height="16" rx="2" />
+      <circle cx="9" cy="10" r="2" />
+      <path d="m4 19 5-5 4 4 3-3 4 4" />
+    </>
+  ),
+};
+
+export function Icon({ name, size = 16, stroke = 1.75, color = "currentColor", style }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke={color}
+      strokeWidth={stroke}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      style={{ flexShrink: 0, ...style }}
+    >
+      {PATHS[name] ?? <circle cx="12" cy="12" r="9" />}
+    </svg>
+  );
+}

--- a/apps/web/src/marketing/MarketingHome.tsx
+++ b/apps/web/src/marketing/MarketingHome.tsx
@@ -1,0 +1,275 @@
+import { Icon } from "./Icon";
+import { HFAssetIcon, HFAssetThumb, HFStatusPill } from "./hf";
+
+// Stylesheets: the .hf design tokens + asset components first, then the
+// marketing-specific layer (which mirrors the tokens onto .mk so the reused
+// .hf-* pieces resolve outside the app shell).
+import "./styles/hifi.css";
+import "./styles/hifi-assets.css";
+import "./styles/marketing.css";
+
+/* ============ nav ============ */
+function MKNav() {
+  return (
+    <header className="mk-nav">
+      <div className="mk-wrap mk-nav-in">
+        <a className="mk-logo" href="#">
+          <span className="mk-logo-mark">
+            <Icon name="wrench" size={17} color="white" stroke={2} />
+          </span>
+          <span className="mk-logo-text">FieldOps</span>
+        </a>
+        <nav className="mk-nav-links">
+          <a className="mk-nav-link" href="#how">
+            How it works
+          </a>
+        </nav>
+        <div className="mk-nav-cta">
+          <a className="mk-link-quiet" href="#">
+            Log in
+          </a>
+          <a className="mk-btn mk-btn-primary mk-btn-sm" href="#">
+            Get started
+          </a>
+        </div>
+      </div>
+    </header>
+  );
+}
+
+/* ============ hero collage — composed from real app pieces ============ */
+function MKHeroCollage() {
+  return (
+    <div className="mk-collage">
+      <div className="mk-collage-panel" />
+
+      {/* floating "due soon" pill */}
+      <div
+        className="mk-float mk-float-pill hf-pill hf-pill-warn"
+        style={{ boxShadow: "var(--hf-shadow-3)" }}
+      >
+        <Icon name="clock-sm" size={13} stroke={2} />
+        In 2 days
+      </div>
+
+      {/* floating asset card (top-left) */}
+      <div className="mk-float mk-float-card">
+        <div
+          className="hf hf-app"
+          style={{
+            display: "block",
+            height: "auto",
+            overflow: "visible",
+            background: "transparent",
+          }}
+        >
+          <article className="hf-asset-card" style={{ boxShadow: "none", border: 0 }}>
+            <HFAssetThumb asset={{ cat: "lawn", icon: "leaf", status: "soon" }} height={120} />
+            <div className="hf-asset-body">
+              <h3 className="hf-asset-card-name">Riverside Lawn</h3>
+              <div className="hf-asset-card-meta">
+                <span className="hf-mono">LAWN-A</span>
+              </div>
+            </div>
+            <div className="hf-asset-footer">
+              <div className="hf-asset-footer-text">
+                <div className="hf-label-sm">Next</div>
+                <div className="hf-asset-next">Spring fertilizer</div>
+              </div>
+              <HFStatusPill status="ok" due="9 days" />
+            </div>
+          </article>
+        </div>
+      </div>
+
+      {/* floating "next up" detail card (bottom-right) */}
+      <div className="mk-float mk-float-next">
+        <div
+          className="hf"
+          style={{
+            display: "block",
+            height: "auto",
+            overflow: "visible",
+            background: "transparent",
+          }}
+        >
+          <span className="mk-next-eyebrow">
+            <Icon name="arrow-right" size={11} stroke={2.2} />
+            Next up
+          </span>
+          <div className="mk-next-head">
+            <HFAssetIcon asset={{ category: "vehicle", icon: "truck" }} size={42} />
+            <div>
+              <div className="mk-next-name">Ford F-150 · #4</div>
+              <div className="mk-next-sub">48,210 mi</div>
+            </div>
+          </div>
+          <div className="mk-next-svc-lbl">Service due</div>
+          <div className="mk-next-svc">Oil change + tire rotation</div>
+          <div className="mk-next-row">
+            <HFStatusPill status="overdue" due="3 days late" />
+            <button className="hf-btn hf-btn-primary hf-btn-sm">
+              <Icon name="check" size={13} stroke={2.2} />
+              Done
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MKHero() {
+  return (
+    <section className="mk-hero">
+      <div className="mk-wrap mk-hero-in">
+        <div>
+          <span className="mk-eyebrow">
+            <Icon name="truck" size={13} stroke={2} />
+            Built for owner-operators
+          </span>
+          <h1 className="mk-h1">
+            Never miss a <em>service date</em> again.
+          </h1>
+          <p className="mk-lede">
+            FieldOps keeps every truck, property, and tool you own on a maintenance schedule — so
+            you spend less time remembering and more time working.
+          </p>
+          <div className="mk-hero-cta">
+            <a className="mk-btn mk-btn-primary mk-btn-lg" href="#">
+              <Icon name="arrow-right" size={16} stroke={2.2} />
+              Get started
+            </a>
+            <a className="mk-btn mk-btn-ghost mk-btn-lg" href="#how">
+              See how it works
+            </a>
+          </div>
+          <div className="mk-hero-note">
+            <Icon name="check" size={14} color="var(--hf-brand)" stroke={2.4} />
+            Free to start · No card needed · Add your first asset in 2 minutes
+          </div>
+        </div>
+        <MKHeroCollage />
+      </div>
+    </section>
+  );
+}
+
+/* ============ small proof strip ============ */
+function MKStrip() {
+  return (
+    <div className="mk-strip">
+      <div className="mk-wrap mk-strip-in">
+        <span className="mk-strip-text">
+          Tracking <span className="mk-strip-stat">vehicles</span>,{" "}
+          <span className="mk-strip-stat">properties</span>,{" "}
+          <span className="mk-strip-stat">equipment</span> &amp;{" "}
+          <span className="mk-strip-stat">grounds</span> — all in one place, from the truck or the
+          office.
+        </span>
+      </div>
+    </div>
+  );
+}
+
+/* ============ how it works ============ */
+const MK_STEPS = [
+  {
+    n: 1,
+    title: "Add an asset",
+    body: "Vehicle, property, or anything else you maintain. Pick a type and FieldOps asks the right details.",
+  },
+  {
+    n: 2,
+    title: "Set a schedule",
+    body: "Choose how often it needs service — by time or by miles/hours. We track the cadence for you.",
+  },
+  {
+    n: 3,
+    title: "Get reminded",
+    body: "A heads-up lands before each service is due. Mark it done, and the next one's queued automatically.",
+  },
+];
+
+function MKSteps() {
+  return (
+    <section className="mk-section mk-steps-section" id="how">
+      <div className="mk-wrap">
+        <div className="mk-section-head">
+          <div className="mk-kicker">How it works</div>
+          <h2 className="mk-h2">Up and running in three steps</h2>
+          <p>
+            No setup project, no spreadsheets to import. Add your first asset and you're tracking it
+            the same day.
+          </p>
+        </div>
+        <div className="mk-steps">
+          {MK_STEPS.map((s) => (
+            <div className="mk-step" key={s.n}>
+              <div className="mk-step-connector" />
+              <div className="mk-step-num">{s.n}</div>
+              <h3>{s.title}</h3>
+              <p>{s.body}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/* ============ closing CTA ============ */
+function MKCta() {
+  return (
+    <section className="mk-cta-band">
+      <div className="mk-wrap">
+        <div className="mk-cta-box">
+          <h2>Start keeping everything on schedule.</h2>
+          <p>Add your first asset in two minutes. Free to start — no card, no commitment.</p>
+          <div className="mk-hero-cta">
+            <a className="mk-btn mk-btn-primary mk-btn-lg" href="#">
+              <Icon name="arrow-right" size={16} stroke={2.2} />
+              Get started
+            </a>
+            <a className="mk-btn mk-btn-ghost mk-btn-lg" href="#">
+              Log in
+            </a>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function MKFooter() {
+  return (
+    <footer className="mk-footer">
+      <div className="mk-wrap mk-footer-in">
+        <a className="mk-logo" href="#">
+          <span className="mk-logo-mark">
+            <Icon name="wrench" size={16} color="white" stroke={2} />
+          </span>
+          <span className="mk-logo-text">FieldOps</span>
+        </a>
+        <nav className="mk-footer-links">
+          <a href="#how">How it works</a>
+          <a href="#">Log in</a>
+        </nav>
+        <div className="mk-footer-copy">© 2026 FieldOps</div>
+      </div>
+    </footer>
+  );
+}
+
+export function MarketingHome() {
+  return (
+    <div className="mk">
+      <MKNav />
+      <MKHero />
+      <MKStrip />
+      <MKSteps />
+      <MKCta />
+      <MKFooter />
+    </div>
+  );
+}

--- a/apps/web/src/marketing/hf.tsx
+++ b/apps/web/src/marketing/hf.tsx
@@ -1,0 +1,72 @@
+import type { CSSProperties } from "react";
+import { Icon, type IconName } from "./Icon";
+
+// Shared design-system primitives reused by the marketing hero collage,
+// ported from the FieldOps app (hifi.jsx / hifi-assets.jsx). Styling comes
+// from styles/hifi.css + styles/hifi-assets.css.
+
+export type AssetStatus = "overdue" | "soon" | "ok";
+export type AssetCategory = "vehicle" | "equipment" | "property" | "lawn";
+
+const CAT_TINTS: Record<AssetCategory, string> = {
+  vehicle: "var(--hf-tint-vehicle)",
+  equipment: "var(--hf-tint-equip)",
+  property: "var(--hf-tint-prop)",
+  lawn: "var(--hf-tint-lawn)",
+};
+
+const CAT_LABELS: Record<AssetCategory, string> = {
+  vehicle: "Vehicle",
+  equipment: "Equipment",
+  property: "Property",
+  lawn: "Grounds",
+};
+
+const PILL_CONFIG: Record<AssetStatus, { label: string; cls: string; icon: IconName }> = {
+  overdue: { label: "Overdue", cls: "hf-pill hf-pill-bad", icon: "alert" },
+  soon: { label: "Due soon", cls: "hf-pill hf-pill-warn", icon: "clock-sm" },
+  ok: { label: "On track", cls: "hf-pill hf-pill-ok", icon: "check" },
+};
+
+export function HFStatusPill({ status, due }: { status: AssetStatus; due?: string }) {
+  const cfg = PILL_CONFIG[status];
+  return (
+    <span className={cfg.cls}>
+      <Icon name={cfg.icon} size={12} stroke={2} />
+      {due ?? cfg.label}
+    </span>
+  );
+}
+
+export function HFAssetIcon({
+  asset,
+  size = 40,
+}: {
+  asset: { category: AssetCategory; icon: IconName };
+  size?: number;
+}) {
+  const style: CSSProperties = { width: size, height: size, background: CAT_TINTS[asset.category] };
+  return (
+    <div className="hf-asset-icon" style={style}>
+      <Icon name={asset.icon} size={size * 0.55} stroke={1.6} />
+    </div>
+  );
+}
+
+export function HFAssetThumb({
+  asset,
+  height = 132,
+}: {
+  asset: { cat: AssetCategory; icon: IconName; status: AssetStatus };
+  height?: number;
+}) {
+  return (
+    <div className="hf-asset-thumb" data-cat={asset.cat} style={{ height }}>
+      <div className="hf-asset-thumb-icon">
+        <Icon name={asset.icon} size={Math.round(height * 0.36)} stroke={1.4} />
+      </div>
+      <span className="hf-asset-cat-badge">{CAT_LABELS[asset.cat]}</span>
+      <span className="hf-asset-status-dot" data-status={asset.status} />
+    </div>
+  );
+}

--- a/apps/web/src/marketing/styles/hifi-assets.css
+++ b/apps/web/src/marketing/styles/hifi-assets.css
@@ -1,0 +1,496 @@
+/* FieldOps — Hi-Fi Assets styles
+   Extends the .hf design tokens from hifi.css. Adds asset-grid + asset-row
+   + toolbar + add-card. Same container-query contract — desktop card grid
+   collapses to horizontal rows at the mobile breakpoint. */
+
+/* tints per category (used by the thumb background) */
+.hf {
+  --hf-cat-vehicle-bg: oklch(96% 0.025 240);
+  --hf-cat-vehicle-fg: oklch(40% 0.1 240);
+  --hf-cat-equipment-bg: oklch(95% 0.035 60);
+  --hf-cat-equipment-fg: oklch(40% 0.1 60);
+  --hf-cat-property-bg: oklch(95% 0.03 295);
+  --hf-cat-property-fg: oklch(38% 0.1 295);
+  --hf-cat-lawn-bg: oklch(95% 0.04 145);
+  --hf-cat-lawn-fg: oklch(38% 0.1 145);
+}
+
+/* ============ Assets page chrome ============ */
+.hf-assets-page .hf-greeting .hf-h1 {
+  font-size: 26px;
+}
+.hf-stats-tight {
+  gap: 8px;
+}
+
+/* ============ Toolbar (search + chips + view toggle) ============ */
+.hf-assets-toolbar {
+  display: grid;
+  grid-template-columns: minmax(220px, 320px) 1fr auto;
+  align-items: center;
+  gap: 12px;
+}
+
+.hf-search {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: var(--hf-surface);
+  border: 1px solid var(--hf-line);
+  border-radius: 8px;
+  height: 36px;
+}
+.hf-search:focus-within {
+  border-color: var(--hf-ink);
+  box-shadow: 0 0 0 1px var(--hf-ink);
+}
+.hf-search-input {
+  flex: 1;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  font: inherit;
+  font-size: 13px;
+  color: var(--hf-ink);
+}
+.hf-search-input::placeholder {
+  color: var(--hf-ink-faint);
+}
+.hf-kbd {
+  font-family: var(--hf-mono);
+  font-size: 10px;
+  padding: 2px 6px;
+  background: var(--hf-surface-2);
+  border: 1px solid var(--hf-line);
+  border-radius: 4px;
+  color: var(--hf-ink-faint);
+  letter-spacing: 0.04em;
+}
+
+.hf-assets-toolbar .hf-filter-chips {
+  gap: 6px;
+}
+.hf-assets-toolbar-end {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.hf-view-toggle {
+  display: inline-flex;
+  padding: 3px;
+  background: var(--hf-surface);
+  border: 1px solid var(--hf-line);
+  border-radius: 8px;
+  gap: 2px;
+}
+.hf-view-btn {
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  background: transparent;
+  border-radius: 6px;
+  color: var(--hf-ink-soft);
+}
+.hf-view-btn:hover {
+  background: var(--hf-surface-2);
+  color: var(--hf-ink);
+}
+.hf-view-btn.active {
+  background: var(--hf-ink);
+  color: var(--hf-surface);
+}
+
+/* ============ The grid ============ */
+.hf-asset-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+}
+.hf-asset-rows {
+  display: none;
+} /* default: card grid layout */
+
+/* ============ The card ============ */
+.hf-asset-card {
+  background: var(--hf-surface);
+  border: 1px solid var(--hf-line);
+  border-radius: var(--hf-r-lg);
+  overflow: hidden;
+  cursor: pointer;
+  transition:
+    border-color 100ms,
+    box-shadow 120ms,
+    transform 80ms;
+  display: flex;
+  flex-direction: column;
+  box-shadow: var(--hf-shadow-1);
+}
+.hf-asset-card:hover {
+  border-color: oklch(80% 0.012 80);
+  box-shadow: var(--hf-shadow-2);
+  transform: translateY(-1px);
+}
+.hf-asset-card:focus-visible {
+  outline: 2px solid var(--hf-ink);
+  outline-offset: 2px;
+}
+
+/* overdue accent: left edge stripe + tinted thumb fade */
+.hf-asset-card[data-status="overdue"] {
+  border-color: oklch(85% 0.05 28);
+}
+.hf-asset-card[data-status="overdue"]::before {
+  /* the stripe is rendered inside the thumb instead — keep card border subtle */
+}
+
+/* ============ Thumb (category-tinted, icon centered) ============ */
+.hf-asset-thumb {
+  position: relative;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  /* warm pattern background so empty-photo state feels intentional */
+  background: repeating-linear-gradient(135deg, transparent 0 18px, rgba(0, 0, 0, 0.012) 18px 19px);
+}
+.hf-asset-thumb[data-cat="vehicle"] {
+  background-color: var(--hf-cat-vehicle-bg);
+}
+.hf-asset-thumb[data-cat="equipment"] {
+  background-color: var(--hf-cat-equipment-bg);
+}
+.hf-asset-thumb[data-cat="property"] {
+  background-color: var(--hf-cat-property-bg);
+}
+.hf-asset-thumb[data-cat="lawn"] {
+  background-color: var(--hf-cat-lawn-bg);
+}
+
+.hf-asset-thumb-icon {
+  opacity: 0.85;
+}
+.hf-asset-thumb[data-cat="vehicle"] .hf-asset-thumb-icon {
+  color: var(--hf-cat-vehicle-fg);
+}
+.hf-asset-thumb[data-cat="equipment"] .hf-asset-thumb-icon {
+  color: var(--hf-cat-equipment-fg);
+}
+.hf-asset-thumb[data-cat="property"] .hf-asset-thumb-icon {
+  color: var(--hf-cat-property-fg);
+}
+.hf-asset-thumb[data-cat="lawn"] .hf-asset-thumb-icon {
+  color: var(--hf-cat-lawn-fg);
+}
+
+/* category pill in the thumb corner */
+.hf-asset-cat-badge {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  padding: 3px 8px;
+  background: rgba(255, 255, 255, 0.85);
+  border: 1px solid var(--hf-line);
+  border-radius: 999px;
+  font-family: var(--hf-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--hf-ink-soft);
+  backdrop-filter: blur(4px);
+}
+
+/* status dot top-right */
+.hf-asset-status-dot {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  outline: 2px solid var(--hf-surface);
+}
+.hf-asset-status-dot[data-status="overdue"] {
+  background: var(--hf-bad);
+}
+.hf-asset-status-dot[data-status="soon"] {
+  background: var(--hf-warn);
+}
+.hf-asset-status-dot[data-status="ok"] {
+  background: var(--hf-ok);
+}
+
+/* ============ Card body & footer ============ */
+.hf-asset-body {
+  padding: 12px 14px 6px;
+}
+.hf-asset-card-name {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: -0.012em;
+  color: var(--hf-ink);
+  line-height: 1.25;
+  /* clamp to 1 line in the card grid; row card overrides */
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.hf-asset-card-meta {
+  margin-top: 2px;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  flex-wrap: nowrap;
+  font-size: 12px;
+  color: var(--hf-ink-soft);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.hf-asset-card-meta .hf-mono {
+  font-family: var(--hf-mono);
+  font-size: 11.5px;
+  color: var(--hf-ink);
+}
+
+.hf-asset-footer {
+  padding: 8px 14px 14px;
+  margin-top: auto;
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 10px;
+  border-top: 1px dashed var(--hf-line);
+  padding-top: 10px;
+}
+.hf-asset-footer-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  flex: 1;
+}
+.hf-asset-next {
+  font-size: 12.5px;
+  font-weight: 500;
+  color: var(--hf-ink);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.3;
+}
+
+/* ============ Add-asset ghost card ============ */
+.hf-add-card {
+  background:
+    repeating-linear-gradient(135deg, transparent 0 16px, rgba(20, 18, 14, 0.025) 16px 17px),
+    var(--hf-surface);
+  border-style: dashed;
+  box-shadow: none;
+}
+.hf-add-card:hover {
+  background-color: var(--hf-brand-bg);
+  border-color: var(--hf-brand);
+}
+.hf-add-card:hover .hf-add-card-plus {
+  background: var(--hf-brand);
+  color: white;
+  border-color: var(--hf-brand);
+}
+.hf-add-card-inner {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 24px 16px;
+  text-align: center;
+}
+.hf-add-card-plus {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: 1.5px dashed var(--hf-ink-faint);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--hf-ink-soft);
+  background: var(--hf-surface);
+  transition:
+    background 100ms,
+    color 100ms,
+    border-color 100ms;
+}
+.hf-add-card-label {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--hf-ink);
+}
+.hf-add-card-sub {
+  font-size: 11.5px;
+  color: var(--hf-ink-faint);
+  max-width: 180px;
+}
+
+/* ============ Horizontal row card (mobile / list view) ============ */
+.hf-asset-row {
+  display: flex;
+  gap: 12px;
+  background: var(--hf-surface);
+  border: 1px solid var(--hf-line);
+  border-radius: var(--hf-r);
+  padding: 10px;
+  cursor: pointer;
+  align-items: stretch;
+  transition:
+    border-color 100ms,
+    box-shadow 120ms;
+}
+.hf-asset-row:hover {
+  border-color: oklch(80% 0.012 80);
+}
+.hf-asset-row[data-status="overdue"] {
+  border-color: oklch(85% 0.05 28);
+}
+.hf-asset-row .hf-asset-thumb {
+  width: 84px;
+  height: 84px;
+  border-radius: 8px;
+  flex-shrink: 0;
+}
+.hf-asset-row .hf-asset-cat-badge {
+  top: 6px;
+  left: 6px;
+  padding: 1.5px 6px;
+  font-size: 9px;
+}
+.hf-asset-row .hf-asset-status-dot {
+  top: 7px;
+  right: 7px;
+  width: 8px;
+  height: 8px;
+}
+.hf-asset-row-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 8px;
+}
+.hf-asset-row-top {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.hf-asset-row-bot {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 10px;
+}
+.hf-asset-next-mobile {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+  flex: 1;
+}
+.hf-asset-next-text {
+  font-size: 12.5px;
+  color: var(--hf-ink);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.hf-row-add {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 14px;
+  background: transparent;
+  border: 1.5px dashed var(--hf-ink-faint);
+  border-radius: var(--hf-r);
+  color: var(--hf-ink-soft);
+  font-size: 13.5px;
+  font-weight: 600;
+}
+.hf-row-add:hover {
+  color: var(--hf-brand);
+  border-color: var(--hf-brand);
+  background: var(--hf-brand-bg);
+}
+
+/* ===================================================================
+   Responsive — same container-query contract as the home screen
+   =================================================================== */
+
+/* TABLET (≤980px on app container): 3-column grid */
+@container hfmd (max-width: 980px) {
+  .hf-asset-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 12px;
+  }
+  .hf-assets-toolbar {
+    grid-template-columns: 1fr auto;
+    grid-template-areas:
+      "search  end"
+      "chips   chips";
+    row-gap: 10px;
+  }
+  .hf-search {
+    grid-area: search;
+  }
+  .hf-filter-chips {
+    grid-area: chips;
+  }
+  .hf-assets-toolbar-end {
+    grid-area: end;
+  }
+}
+
+/* small TABLET / large MOBILE: 2-column grid */
+@container hfmd (max-width: 720px) {
+  .hf-asset-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+/* MOBILE (≤580px on app container): swap grid for horizontal rows */
+@container hfapp (max-width: 580px) {
+  .hf-assets-page .hf-asset-grid {
+    display: none;
+  }
+  .hf-assets-page .hf-asset-rows {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .hf-assets-toolbar {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      "search"
+      "chips"
+      "end";
+    gap: 10px;
+  }
+  .hf-assets-toolbar-end {
+    justify-content: flex-start;
+  }
+  .hf-view-toggle {
+    display: none;
+  } /* grid/list toggle hides on mobile */
+  .hf-filter-chips {
+    flex-wrap: wrap;
+  }
+}

--- a/apps/web/src/marketing/styles/hifi.css
+++ b/apps/web/src/marketing/styles/hifi.css
@@ -1,0 +1,864 @@
+/* FieldOps — Hi-Fi Master/Detail styles
+   Everything scoped under .hf so it doesn't bleed into the sketchy wireframes.
+   Same container-query contract: container-name "hfapp" on the root,
+   "hfmd" on the master-detail shell. */
+
+.hf {
+  --hf-bg: oklch(98% 0.005 85); /* warm off-white app bg */
+  --hf-surface: oklch(100% 0 0); /* pure white card */
+  --hf-surface-2: oklch(97% 0.005 85); /* faint warm */
+  --hf-ink: oklch(22% 0.015 70); /* darkest text */
+  --hf-ink-soft: oklch(45% 0.012 75);
+  --hf-ink-faint: oklch(60% 0.008 80);
+  --hf-line: oklch(91% 0.006 80); /* hairline borders */
+  --hf-line-soft: oklch(94% 0.005 80);
+
+  /* brand: deep forest green — signals service/health */
+  --hf-brand: oklch(45% 0.1 150);
+  --hf-brand-2: oklch(38% 0.1 150);
+  --hf-brand-bg: oklch(95% 0.025 150);
+
+  /* status */
+  --hf-ok: oklch(50% 0.1 150);
+  --hf-ok-bg: oklch(96% 0.025 150);
+  --hf-warn: oklch(60% 0.13 75);
+  --hf-warn-bg: oklch(96% 0.045 80);
+  --hf-bad: oklch(52% 0.18 28);
+  --hf-bad-bg: oklch(96% 0.025 28);
+
+  /* asset tints */
+  --hf-tint-vehicle: oklch(94% 0.025 240);
+  --hf-tint-equip: oklch(94% 0.035 55);
+  --hf-tint-prop: oklch(94% 0.025 295);
+  --hf-tint-lawn: oklch(94% 0.03 145);
+
+  /* radii / shadows */
+  --hf-r-sm: 6px;
+  --hf-r: 10px;
+  --hf-r-lg: 14px;
+  --hf-shadow-1: 0 1px 2px rgba(20, 18, 14, 0.04), 0 1px 0 rgba(20, 18, 14, 0.03);
+  --hf-shadow-2: 0 4px 12px rgba(20, 18, 14, 0.06), 0 1px 0 rgba(20, 18, 14, 0.03);
+
+  /* fonts */
+  --hf-sans:
+    "Inter", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
+  --hf-mono: "JetBrains Mono", ui-monospace, "SFMono-Regular", Menlo, monospace;
+
+  background: var(--hf-bg);
+  color: var(--hf-ink);
+  font-family: var(--hf-sans);
+  font-size: 14px;
+  line-height: 1.45;
+  letter-spacing: -0.005em;
+  -webkit-font-smoothing: antialiased;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  container-type: inline-size;
+  container-name: hfapp;
+}
+
+.hf * {
+  box-sizing: border-box;
+}
+.hf button {
+  font: inherit;
+  cursor: pointer;
+}
+
+/* ============ TOPBAR ============ */
+.hf-topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 24px;
+  background: var(--hf-surface);
+  border-bottom: 1px solid var(--hf-line);
+  flex-shrink: 0;
+}
+.hf-topbar-left {
+  display: flex;
+  align-items: center;
+  gap: 32px;
+}
+.hf-logo {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.hf-logo-mark {
+  width: 26px;
+  height: 26px;
+  border-radius: 7px;
+  background: var(--hf-ink);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.hf-logo-text {
+  font-weight: 700;
+  font-size: 16px;
+  letter-spacing: -0.015em;
+  color: var(--hf-ink);
+}
+
+.hf-nav-top {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+.hf-nav-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 7px 11px;
+  border-radius: 7px;
+  color: var(--hf-ink-soft);
+  font-size: 13.5px;
+  font-weight: 500;
+  text-decoration: none;
+  cursor: pointer;
+}
+.hf-nav-tab:hover {
+  background: var(--hf-surface-2);
+  color: var(--hf-ink);
+}
+.hf-nav-tab.active {
+  background: var(--hf-ink);
+  color: var(--hf-surface);
+}
+.hf-nav-tab.active:hover {
+  background: var(--hf-ink);
+}
+
+.hf-topbar-right {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.hf-icon-btn {
+  width: 32px;
+  height: 32px;
+  border-radius: 7px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--hf-ink-soft);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+}
+.hf-icon-btn:hover {
+  background: var(--hf-surface-2);
+  color: var(--hf-ink);
+}
+.hf-icon-btn-badge .hf-badge {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  min-width: 14px;
+  height: 14px;
+  padding: 0 3px;
+  background: var(--hf-bad);
+  color: white;
+  border-radius: 7px;
+  font-size: 9px;
+  font-weight: 700;
+  line-height: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1.5px solid var(--hf-surface);
+}
+.hf-avatar {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  background: var(--hf-brand-bg);
+  color: var(--hf-brand-2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  font-size: 13px;
+  margin-left: 6px;
+}
+
+/* ============ MAIN / SHELL ============ */
+.hf-main {
+  flex: 1;
+  min-height: 0;
+  padding: 24px 32px 32px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  container-type: inline-size;
+  container-name: hfmd;
+}
+
+/* ============ GREETING + STATS ============ */
+.hf-greeting {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+.hf-greeting-text {
+  min-width: 0;
+}
+.hf-h1 {
+  margin: 0;
+  font-size: 24px;
+  font-weight: 700;
+  letter-spacing: -0.025em;
+  color: var(--hf-ink);
+  line-height: 1.1;
+}
+.hf-greeting-sub {
+  margin-top: 4px;
+  color: var(--hf-ink-soft);
+  font-size: 13px;
+}
+.hf-stats {
+  display: flex;
+  gap: 8px;
+}
+.hf-stat {
+  min-width: 88px;
+  padding: 10px 14px;
+  border: 1px solid var(--hf-line);
+  border-radius: var(--hf-r);
+  background: var(--hf-surface);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+}
+.hf-stat-val {
+  font-size: 22px;
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: -0.02em;
+}
+.hf-stat-lbl {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--hf-ink-soft);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.hf-stat-bad {
+  background: var(--hf-bad-bg);
+  border-color: oklch(85% 0.04 28);
+}
+.hf-stat-bad .hf-stat-val {
+  color: var(--hf-bad);
+}
+.hf-stat-warn {
+  background: var(--hf-warn-bg);
+  border-color: oklch(88% 0.045 75);
+}
+.hf-stat-warn .hf-stat-val {
+  color: oklch(48% 0.13 75);
+}
+.hf-stat-ok {
+  background: var(--hf-ok-bg);
+  border-color: oklch(88% 0.04 150);
+}
+.hf-stat-ok .hf-stat-val {
+  color: var(--hf-ok);
+}
+
+/* ============ FILTERS ============ */
+.hf-filters {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.hf-filter-chips {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.hf-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 11px;
+  border: 1px solid var(--hf-line);
+  border-radius: 999px;
+  background: var(--hf-surface);
+  color: var(--hf-ink-soft);
+  font-size: 12.5px;
+  font-weight: 500;
+}
+.hf-chip:hover {
+  color: var(--hf-ink);
+  border-color: oklch(85% 0.008 80);
+}
+.hf-chip.active {
+  background: var(--hf-ink);
+  color: var(--hf-surface);
+  border-color: var(--hf-ink);
+}
+.hf-chip.active .hf-chip-count {
+  color: oklch(75% 0.008 80);
+}
+.hf-chip-count {
+  font-family: var(--hf-mono);
+  font-size: 11px;
+  color: var(--hf-ink-faint);
+}
+
+/* ============ GRID ============ */
+.hf-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(0, 1fr);
+  gap: 20px;
+  align-items: start;
+}
+
+/* ============ DETAIL CARD ============ */
+.hf-detail-card {
+  background: var(--hf-surface);
+  border: 1px solid var(--hf-line);
+  border-radius: var(--hf-r-lg);
+  padding: 20px 22px;
+  box-shadow: var(--hf-shadow-1);
+  position: sticky;
+  top: 0;
+}
+.hf-detail-card[data-status="overdue"] {
+  border-color: oklch(82% 0.06 28);
+  background: linear-gradient(to bottom, oklch(98% 0.015 28) 0%, var(--hf-surface) 60%);
+}
+
+.hf-detail-body {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.hf-detail-body[data-compact="true"] {
+  gap: 12px;
+}
+
+.hf-detail-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.hf-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-family: var(--hf-mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--hf-ink-faint);
+}
+
+.hf-asset-row {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+.hf-asset-id {
+  min-width: 0;
+  flex: 1;
+}
+.hf-asset-name {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 600;
+  letter-spacing: -0.022em;
+  color: var(--hf-ink);
+  line-height: 1.2;
+}
+.hf-asset-meta {
+  margin-top: 4px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  font-size: 12.5px;
+  color: var(--hf-ink-soft);
+}
+.hf-asset-meta .hf-mono {
+  font-family: var(--hf-mono);
+  font-size: 12px;
+  color: var(--hf-ink);
+}
+.hf-dot-sep {
+  width: 3px;
+  height: 3px;
+  border-radius: 50%;
+  background: var(--hf-ink-faint);
+}
+
+.hf-divider {
+  height: 1px;
+  background: var(--hf-line);
+}
+
+.hf-service-block {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.hf-label {
+  font-family: var(--hf-mono);
+  font-size: 11px;
+  color: var(--hf-ink-faint);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 500;
+}
+.hf-label-sm {
+  font-family: var(--hf-mono);
+  font-size: 10.5px;
+  color: var(--hf-ink-faint);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.hf-service-name {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--hf-ink);
+  letter-spacing: -0.015em;
+}
+[data-compact="true"] .hf-service-name {
+  font-size: 16px;
+}
+
+.hf-meta-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  padding: 12px 14px;
+  background: var(--hf-surface-2);
+  border-radius: var(--hf-r);
+  border: 1px solid var(--hf-line-soft);
+}
+.hf-meta-item {
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+}
+.hf-meta-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.hf-meta-val {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--hf-ink);
+}
+
+.hf-notes {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.hf-notes-text {
+  margin: 0;
+  padding: 10px 12px;
+  background: var(--hf-surface-2);
+  border: 1px solid var(--hf-line-soft);
+  border-left: 3px solid var(--hf-brand);
+  border-radius: var(--hf-r-sm);
+  font-size: 13px;
+  color: var(--hf-ink-soft);
+  line-height: 1.5;
+}
+
+.hf-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+.hf-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 13px;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 500;
+  border: 1px solid var(--hf-line);
+  background: var(--hf-surface);
+  color: var(--hf-ink);
+  transition:
+    background 100ms,
+    border-color 100ms;
+}
+.hf-btn:hover {
+  background: var(--hf-surface-2);
+}
+.hf-btn-primary {
+  background: var(--hf-ink);
+  color: var(--hf-surface);
+  border-color: var(--hf-ink);
+}
+.hf-btn-primary:hover {
+  background: oklch(28% 0.015 70);
+}
+.hf-btn-secondary {
+  background: var(--hf-surface);
+  border-color: var(--hf-line);
+}
+.hf-btn-ghost {
+  background: transparent;
+  border-color: transparent;
+  color: var(--hf-ink-soft);
+}
+.hf-btn-ghost:hover {
+  background: var(--hf-surface-2);
+  color: var(--hf-ink);
+}
+.hf-btn-end {
+  margin-left: auto;
+}
+.hf-btn-sm {
+  padding: 6px 10px;
+  font-size: 12.5px;
+}
+
+/* ============ QUEUE ============ */
+.hf-queue {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.hf-queue-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  padding: 0 2px;
+}
+.hf-h3 {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+.hf-mono {
+  font-family: var(--hf-mono);
+  font-size: 11.5px;
+}
+.hf-ink-faint {
+  color: var(--hf-ink-faint);
+}
+
+.hf-queue-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.hf-row {
+  background: var(--hf-surface);
+  border: 1px solid var(--hf-line);
+  border-radius: var(--hf-r);
+  cursor: pointer;
+  transition:
+    border-color 100ms,
+    box-shadow 120ms,
+    background 100ms;
+  overflow: hidden;
+}
+.hf-row:hover {
+  border-color: oklch(85% 0.008 80);
+}
+.hf-row.selected {
+  border-color: var(--hf-ink);
+  box-shadow: 0 0 0 1px var(--hf-ink);
+}
+.hf-row[data-status="overdue"] {
+  background: linear-gradient(
+    to right,
+    var(--hf-bad-bg) 0%,
+    var(--hf-bad-bg) 4px,
+    var(--hf-surface) 4px
+  );
+}
+.hf-row[data-status="overdue"].selected {
+  border-color: var(--hf-bad);
+  box-shadow: 0 0 0 1px var(--hf-bad);
+}
+
+.hf-row-summary {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+}
+.hf-row-text {
+  min-width: 0;
+}
+.hf-row-name {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--hf-ink);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.hf-row-sub {
+  font-size: 12px;
+  color: var(--hf-ink-soft);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.hf-row-right {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
+}
+.hf-row-due {
+  font-size: 12px;
+  color: var(--hf-ink-soft);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+.hf-row[data-status="overdue"] .hf-row-due {
+  color: var(--hf-bad);
+  font-weight: 500;
+}
+.hf-status-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+}
+.hf-status-dot[data-status="overdue"] {
+  background: var(--hf-bad);
+}
+.hf-status-dot[data-status="soon"] {
+  background: var(--hf-warn);
+}
+.hf-status-dot[data-status="ok"] {
+  background: var(--hf-ok);
+}
+
+.hf-row-detail {
+  display: none;
+  padding: 0 14px 14px;
+}
+
+/* ============ ASSET ICON ============ */
+.hf-asset-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  color: var(--hf-ink);
+  flex-shrink: 0;
+}
+
+/* ============ STATUS PILLS ============ */
+.hf-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 9px;
+  border-radius: 999px;
+  font-size: 11.5px;
+  font-weight: 500;
+  border: 1px solid transparent;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+.hf-pill-bad {
+  background: var(--hf-bad-bg);
+  color: var(--hf-bad);
+  border-color: oklch(88% 0.045 28);
+}
+.hf-pill-warn {
+  background: var(--hf-warn-bg);
+  color: oklch(45% 0.13 75);
+  border-color: oklch(88% 0.06 75);
+}
+.hf-pill-ok {
+  background: var(--hf-ok-bg);
+  color: var(--hf-ok);
+  border-color: oklch(88% 0.045 150);
+}
+
+/* ============ BOTTOM NAV (mobile only) ============ */
+.hf-nav-bottom {
+  display: none;
+}
+.hf-nav-bottom-tab {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 3px;
+  padding: 8px 4px;
+  color: var(--hf-ink-faint);
+  font-size: 10.5px;
+  font-weight: 500;
+  text-decoration: none;
+}
+.hf-nav-bottom-tab.active {
+  color: var(--hf-ink);
+}
+
+/* ===================================================================
+   RESPONSIVE — same container-query contract as the wireframes
+   =================================================================== */
+
+/* TABLET (560–900px on the app container): tighten the topbar nav to icons
+   only; collapse the meta grid; the layout stays side-by-side. */
+@container hfapp (max-width: 980px) {
+  .hf-topbar-left {
+    gap: 18px;
+  }
+  .hf-nav-label {
+    display: none;
+  }
+  .hf-nav-tab {
+    padding: 7px 9px;
+  }
+  .hf-greeting {
+    flex-direction: row;
+  }
+  .hf-h1 {
+    font-size: 22px;
+  }
+  .hf-stat {
+    min-width: 76px;
+    padding: 8px 12px;
+  }
+}
+
+/* tablet shell: detail card slightly narrower, queue catches more space */
+@container hfmd (max-width: 980px) {
+  .hf-grid {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    gap: 16px;
+  }
+  .hf-asset-name {
+    font-size: 19px;
+  }
+  .hf-service-name {
+    font-size: 16px;
+  }
+  .hf-detail-card {
+    padding: 18px 18px;
+  }
+}
+
+/* MOBILE (max 580px on app container):
+   - top nav tabs hide; bottom tab bar shows
+   - main padding collapses
+   - stats wrap below greeting
+   - grid stacks single-column
+   - the standalone detail card disappears (inline expand instead)
+   - selected row reveals .hf-row-detail inline */
+@container hfapp (max-width: 580px) {
+  .hf-topbar {
+    padding: 10px 14px;
+  }
+  .hf-topbar-left {
+    gap: 0;
+  }
+  .hf-nav-top {
+    display: none;
+  }
+  .hf-nav-bottom {
+    display: flex;
+    background: var(--hf-surface);
+    border-top: 1px solid var(--hf-line);
+    padding: 6px 4px env(safe-area-inset-bottom, 8px);
+    flex-shrink: 0;
+  }
+  .hf-icon-btn {
+    width: 30px;
+    height: 30px;
+  }
+  .hf-main {
+    padding: 14px 14px 18px;
+    gap: 16px;
+  }
+  .hf-greeting {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 12px;
+  }
+  .hf-stats {
+    gap: 6px;
+  }
+  .hf-stat {
+    flex: 1;
+    min-width: 0;
+    padding: 8px 10px;
+  }
+  .hf-stat-val {
+    font-size: 18px;
+  }
+  .hf-h1 {
+    font-size: 20px;
+  }
+  .hf-filters {
+    gap: 8px;
+  }
+  .hf-filter-chips {
+    gap: 5px;
+  }
+  .hf-chip {
+    padding: 5px 9px;
+    font-size: 12px;
+  }
+}
+
+@container hfmd (max-width: 580px) {
+  .hf-grid {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 12px;
+  }
+  .hf-mobile-inline .hf-detail-card {
+    display: none;
+  }
+  .hf-mobile-inline .hf-row.selected .hf-row-detail {
+    display: flex;
+    flex-direction: column;
+    border-top: 1px solid var(--hf-line);
+    padding-top: 14px;
+    margin-top: 4px;
+  }
+  .hf-mobile-inline .hf-row.selected {
+    background: var(--hf-surface);
+  }
+  .hf-mobile-inline .hf-row.selected[data-status="overdue"] {
+    background: linear-gradient(
+      to right,
+      var(--hf-bad-bg) 0%,
+      var(--hf-bad-bg) 4px,
+      var(--hf-surface) 4px
+    );
+  }
+  .hf-row-summary {
+    padding: 12px 14px;
+  }
+  .hf-detail-card {
+    position: static;
+    padding: 16px;
+  }
+}

--- a/apps/web/src/marketing/styles/marketing.css
+++ b/apps/web/src/marketing/styles/marketing.css
@@ -1,0 +1,654 @@
+/* FieldOps — Marketing (logged-out) home page.
+   Built on the .hf design tokens for visual continuity with the app.
+   Token block is mirrored onto .mk so reused .hf-* components (asset cards,
+   status pills) resolve their variables outside the app shell. */
+
+.mk {
+  --hf-bg: oklch(98% 0.005 85);
+  --hf-surface: oklch(100% 0 0);
+  --hf-surface-2: oklch(97% 0.005 85);
+  --hf-ink: oklch(22% 0.015 70);
+  --hf-ink-soft: oklch(45% 0.012 75);
+  --hf-ink-faint: oklch(60% 0.008 80);
+  --hf-line: oklch(91% 0.006 80);
+  --hf-line-soft: oklch(94% 0.005 80);
+  --hf-brand: oklch(45% 0.1 150);
+  --hf-brand-2: oklch(38% 0.1 150);
+  --hf-brand-bg: oklch(95% 0.025 150);
+  --hf-ok: oklch(50% 0.1 150);
+  --hf-ok-bg: oklch(96% 0.025 150);
+  --hf-warn: oklch(60% 0.13 75);
+  --hf-warn-bg: oklch(96% 0.045 80);
+  --hf-bad: oklch(52% 0.18 28);
+  --hf-bad-bg: oklch(96% 0.025 28);
+  --hf-tint-vehicle: oklch(94% 0.025 240);
+  --hf-tint-equip: oklch(94% 0.035 55);
+  --hf-tint-prop: oklch(94% 0.025 295);
+  --hf-tint-lawn: oklch(94% 0.03 145);
+  --hf-cat-vehicle-fg: oklch(40% 0.1 240);
+  --hf-cat-property-fg: oklch(38% 0.1 295);
+  --hf-cat-equipment-fg: oklch(40% 0.1 60);
+  --hf-r-sm: 6px;
+  --hf-r: 10px;
+  --hf-r-lg: 14px;
+  --hf-shadow-1: 0 1px 2px rgba(20, 18, 14, 0.04), 0 1px 0 rgba(20, 18, 14, 0.03);
+  --hf-shadow-2: 0 4px 12px rgba(20, 18, 14, 0.06), 0 1px 0 rgba(20, 18, 14, 0.03);
+  --hf-shadow-3: 0 18px 50px -12px rgba(20, 18, 14, 0.22), 0 6px 16px -8px rgba(20, 18, 14, 0.12);
+  --hf-sans:
+    "Inter", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
+  --hf-mono: "JetBrains Mono", ui-monospace, "SFMono-Regular", Menlo, monospace;
+
+  background: var(--hf-bg);
+  color: var(--hf-ink);
+  font-family: var(--hf-sans);
+  font-size: 16px;
+  line-height: 1.5;
+  letter-spacing: -0.006em;
+  -webkit-font-smoothing: antialiased;
+  min-height: 100vh;
+}
+.mk * {
+  box-sizing: border-box;
+}
+.mk-wrap {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 0 28px;
+}
+
+/* ============ top nav ============ */
+.mk-nav {
+  position: sticky;
+  top: 0;
+  z-index: 40;
+  background: oklch(98% 0.005 85 / 0.82);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid var(--hf-line);
+}
+.mk-nav-in {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 64px;
+}
+.mk-logo {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  text-decoration: none;
+  color: var(--hf-ink);
+}
+.mk-logo-mark {
+  width: 30px;
+  height: 30px;
+  border-radius: 8px;
+  background: var(--hf-ink);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.mk-logo-text {
+  font-weight: 700;
+  font-size: 18px;
+  letter-spacing: -0.02em;
+}
+.mk-nav-links {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.mk-nav-link {
+  padding: 8px 12px;
+  border-radius: 8px;
+  text-decoration: none;
+  color: var(--hf-ink-soft);
+  font-size: 14.5px;
+  font-weight: 500;
+}
+.mk-nav-link:hover {
+  background: var(--hf-surface-2);
+  color: var(--hf-ink);
+}
+.mk-nav-cta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* ============ buttons ============ */
+.mk-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  white-space: nowrap;
+  height: 44px;
+  padding: 0 20px;
+  border-radius: 10px;
+  font-size: 15px;
+  font-weight: 600;
+  font-family: inherit;
+  border: 1px solid transparent;
+  cursor: pointer;
+  text-decoration: none;
+  transition:
+    background 120ms,
+    border-color 120ms,
+    transform 80ms,
+    box-shadow 120ms;
+}
+.mk-btn:active {
+  transform: translateY(1px);
+}
+.mk-btn-primary {
+  background: var(--hf-brand);
+  color: #fff;
+  box-shadow: 0 1px 0 rgba(20, 18, 14, 0.06);
+}
+.mk-btn-primary:hover {
+  background: var(--hf-brand-2);
+}
+.mk-btn-ghost {
+  background: transparent;
+  color: var(--hf-ink);
+  border-color: var(--hf-line);
+}
+.mk-btn-ghost:hover {
+  background: var(--hf-surface);
+  border-color: oklch(82% 0.012 80);
+}
+.mk-btn-sm {
+  height: 38px;
+  padding: 0 15px;
+  font-size: 14px;
+  border-radius: 9px;
+}
+.mk-btn-lg {
+  height: 50px;
+  padding: 0 26px;
+  font-size: 16px;
+  border-radius: 11px;
+}
+.mk-link-quiet {
+  color: var(--hf-ink-soft);
+  font-weight: 500;
+  font-size: 14.5px;
+  text-decoration: none;
+}
+.mk-link-quiet:hover {
+  color: var(--hf-ink);
+}
+
+/* ============ hero ============ */
+.mk-hero {
+  position: relative;
+  overflow: hidden;
+}
+.mk-hero-in {
+  display: grid;
+  grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
+  gap: 56px;
+  align-items: center;
+  padding: 84px 0 92px;
+}
+.mk-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--hf-mono);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--hf-brand-2);
+  padding: 6px 12px;
+  border: 1px solid oklch(88% 0.04 150);
+  border-radius: 999px;
+  background: var(--hf-brand-bg);
+}
+.mk-h1 {
+  margin: 22px 0 0;
+  font-size: 58px;
+  line-height: 1.02;
+  font-weight: 700;
+  letter-spacing: -0.035em;
+  text-wrap: balance;
+}
+.mk-h1 em {
+  font-style: normal;
+  color: var(--hf-brand);
+}
+.mk-lede {
+  margin: 22px 0 0;
+  font-size: 19px;
+  line-height: 1.5;
+  color: var(--hf-ink-soft);
+  max-width: 30em;
+  text-wrap: pretty;
+}
+.mk-hero-cta {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-top: 32px;
+  flex-wrap: wrap;
+}
+.mk-hero-note {
+  margin-top: 16px;
+  font-size: 13.5px;
+  color: var(--hf-ink-faint);
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+/* soft brand blobs behind the hero collage */
+.mk-blob {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(8px);
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+/* ============ hero collage (built from real app components) ============ */
+.mk-collage {
+  position: relative;
+  min-height: 440px;
+}
+.mk-collage-panel {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(120% 90% at 70% 10%, var(--hf-brand-bg) 0%, transparent 55%),
+    radial-gradient(90% 80% at 15% 90%, var(--hf-tint-vehicle) 0%, transparent 50%),
+    var(--hf-surface-2);
+  border: 1px solid var(--hf-line);
+  border-radius: 22px;
+  overflow: hidden;
+}
+.mk-collage-panel::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(
+    135deg,
+    transparent 0 22px,
+    rgba(20, 18, 14, 0.012) 22px 23px
+  );
+}
+.mk-float {
+  position: absolute;
+  background: var(--hf-surface);
+  border: 1px solid var(--hf-line);
+  border-radius: var(--hf-r-lg);
+  box-shadow: var(--hf-shadow-3);
+}
+.mk-float-card {
+  width: 240px;
+  top: 40px;
+  left: 36px;
+  padding: 0;
+  transform: rotate(-2deg);
+}
+.mk-float-next {
+  width: 290px;
+  right: 28px;
+  bottom: 44px;
+  transform: rotate(1.5deg);
+  padding: 16px 18px;
+}
+.mk-float-pill {
+  top: 30px;
+  right: 54px;
+  transform: rotate(3deg);
+  padding: 9px 13px;
+  border-radius: 999px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  font-weight: 600;
+}
+.mk-next-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--hf-mono);
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--hf-ink-faint);
+}
+.mk-next-head {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  margin: 12px 0 12px;
+}
+.mk-next-name {
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+}
+.mk-next-sub {
+  font-size: 12px;
+  color: var(--hf-ink-soft);
+  font-family: var(--hf-mono);
+}
+.mk-next-svc {
+  font-size: 14px;
+  font-weight: 500;
+}
+.mk-next-svc-lbl {
+  font-family: var(--hf-mono);
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--hf-ink-faint);
+  margin-bottom: 3px;
+}
+.mk-next-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-top: 14px;
+}
+
+/* ============ logo strip ============ */
+.mk-strip {
+  border-top: 1px solid var(--hf-line);
+  border-bottom: 1px solid var(--hf-line);
+  background: var(--hf-surface);
+}
+.mk-strip-in {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  padding: 20px 0;
+  text-align: center;
+}
+.mk-strip-text {
+  font-size: 14px;
+  color: var(--hf-ink-soft);
+}
+.mk-strip-stat {
+  font-weight: 700;
+  color: var(--hf-ink);
+}
+
+/* ============ section scaffold ============ */
+.mk-section {
+  padding: 88px 0;
+}
+.mk-section-head {
+  max-width: 640px;
+  margin: 0 auto 52px;
+  text-align: center;
+}
+.mk-kicker {
+  font-family: var(--hf-mono);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--hf-brand-2);
+}
+.mk-h2 {
+  margin: 12px 0 0;
+  font-size: 38px;
+  line-height: 1.08;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  text-wrap: balance;
+}
+.mk-section-head p {
+  margin: 14px 0 0;
+  font-size: 17px;
+  color: var(--hf-ink-soft);
+  line-height: 1.55;
+  text-wrap: pretty;
+}
+
+/* ============ features ============ */
+.mk-features {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+}
+.mk-feature {
+  background: var(--hf-surface);
+  border: 1px solid var(--hf-line);
+  border-radius: var(--hf-r-lg);
+  padding: 26px 24px;
+  box-shadow: var(--hf-shadow-1);
+  transition:
+    box-shadow 140ms,
+    transform 100ms,
+    border-color 120ms;
+}
+.mk-feature:hover {
+  box-shadow: var(--hf-shadow-2);
+  transform: translateY(-2px);
+  border-color: oklch(85% 0.01 80);
+}
+.mk-feature-icon {
+  width: 46px;
+  height: 46px;
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 16px;
+}
+.mk-feature-icon[data-tone="brand"] {
+  background: var(--hf-brand-bg);
+  color: var(--hf-brand-2);
+}
+.mk-feature-icon[data-tone="warn"] {
+  background: var(--hf-warn-bg);
+  color: oklch(45% 0.13 75);
+}
+.mk-feature-icon[data-tone="bad"] {
+  background: var(--hf-bad-bg);
+  color: var(--hf-bad);
+}
+.mk-feature-icon[data-tone="vehicle"] {
+  background: var(--hf-tint-vehicle);
+  color: var(--hf-cat-vehicle-fg);
+}
+.mk-feature h3 {
+  margin: 0 0 7px;
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+}
+.mk-feature p {
+  margin: 0;
+  font-size: 14.5px;
+  color: var(--hf-ink-soft);
+  line-height: 1.55;
+}
+
+/* ============ how it works ============ */
+.mk-steps-section {
+  background: var(--hf-surface);
+  border-top: 1px solid var(--hf-line);
+  border-bottom: 1px solid var(--hf-line);
+}
+.mk-steps {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+  position: relative;
+}
+.mk-step {
+  position: relative;
+}
+.mk-step-num {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: var(--hf-ink);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 16px;
+  font-variant-numeric: tabular-nums;
+  margin-bottom: 18px;
+}
+.mk-step h3 {
+  margin: 0 0 7px;
+  font-size: 19px;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+}
+.mk-step p {
+  margin: 0;
+  font-size: 14.5px;
+  color: var(--hf-ink-soft);
+  line-height: 1.55;
+}
+.mk-step-connector {
+  position: absolute;
+  top: 20px;
+  left: 52px;
+  right: -12px;
+  height: 2px;
+  background: repeating-linear-gradient(90deg, var(--hf-line) 0 6px, transparent 6px 12px);
+}
+.mk-step:last-child .mk-step-connector {
+  display: none;
+}
+
+/* ============ closing CTA ============ */
+.mk-cta-band {
+  padding: 76px 0;
+}
+.mk-cta-box {
+  background:
+    radial-gradient(120% 140% at 85% 0%, var(--hf-brand-bg) 0%, transparent 55%), var(--hf-ink);
+  border-radius: 24px;
+  padding: 56px 56px;
+  text-align: center;
+  position: relative;
+  overflow: hidden;
+}
+.mk-cta-box h2 {
+  margin: 0;
+  font-size: 36px;
+  line-height: 1.1;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  color: #fff;
+  text-wrap: balance;
+}
+.mk-cta-box p {
+  margin: 14px auto 0;
+  max-width: 30em;
+  font-size: 17px;
+  color: oklch(86% 0.01 85);
+  line-height: 1.5;
+}
+.mk-cta-box .mk-hero-cta {
+  justify-content: center;
+  margin-top: 30px;
+}
+.mk-cta-box .mk-btn-ghost {
+  background: transparent;
+  color: #fff;
+  border-color: oklch(100% 0 0 / 0.28);
+}
+.mk-cta-box .mk-btn-ghost:hover {
+  background: oklch(100% 0 0 / 0.08);
+  border-color: oklch(100% 0 0 / 0.5);
+}
+
+/* ============ footer ============ */
+.mk-footer {
+  border-top: 1px solid var(--hf-line);
+  background: var(--hf-surface);
+}
+.mk-footer-in {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 28px 0;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+.mk-footer-links {
+  display: flex;
+  gap: 22px;
+  flex-wrap: wrap;
+}
+.mk-footer-links a {
+  color: var(--hf-ink-soft);
+  text-decoration: none;
+  font-size: 14px;
+}
+.mk-footer-links a:hover {
+  color: var(--hf-ink);
+}
+.mk-footer-copy {
+  font-size: 13px;
+  color: var(--hf-ink-faint);
+}
+
+/* ============ responsive ============ */
+@media (max-width: 920px) {
+  .mk-hero-in {
+    grid-template-columns: 1fr;
+    gap: 40px;
+    padding: 60px 0 64px;
+  }
+  .mk-h1 {
+    font-size: 46px;
+  }
+  .mk-collage {
+    min-height: 380px;
+  }
+  .mk-features,
+  .mk-steps {
+    grid-template-columns: 1fr;
+  }
+  .mk-step-connector {
+    display: none;
+  }
+  .mk-section {
+    padding: 64px 0;
+  }
+}
+@media (max-width: 600px) {
+  .mk-wrap {
+    padding: 0 18px;
+  }
+  .mk-nav-links {
+    display: none;
+  }
+  .mk-h1 {
+    font-size: 38px;
+  }
+  .mk-lede {
+    font-size: 17px;
+  }
+  .mk-h2 {
+    font-size: 30px;
+  }
+  .mk-cta-box {
+    padding: 40px 24px;
+  }
+  .mk-cta-box h2 {
+    font-size: 28px;
+  }
+  .mk-float-card {
+    width: 200px;
+    left: 14px;
+  }
+  .mk-float-next {
+    width: 240px;
+    right: 12px;
+  }
+}

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  // Single project covering the React client, the Worker entry, and the Vite
+  // config. The Worker code uses only Web/DOM-standard APIs (Request/Response/
+  // URL), so a DOM lib covers both client and worker without pulling in
+  // @cloudflare/workers-types (which conflicts with lib.dom).
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "types": [],
+    "resolveJsonModule": true,
+    "noEmit": true
+  },
+  "include": ["src", "worker", "vite.config.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import { cloudflare } from "@cloudflare/vite-plugin";
+
+// Vite + React, bundled and served by a Cloudflare Worker via
+// @cloudflare/vite-plugin. The Worker (worker/index.ts) handles any /api/*
+// routes; everything else falls back to the SPA (see wrangler.jsonc).
+export default defineConfig({
+  plugins: [react(), cloudflare()],
+});

--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -1,0 +1,13 @@
+// Worker entry for the marketing site. Static assets (the built SPA) are
+// served by the runtime ahead of this handler; only unmatched paths reach
+// here. Reserve /api/* for future server routes; everything else is handled
+// by the SPA asset fallback (wrangler.jsonc -> assets.not_found_handling).
+export default {
+  fetch(request: Request): Response {
+    const url = new URL(request.url);
+    if (url.pathname.startsWith("/api/")) {
+      return Response.json({ name: "pineapple-web" });
+    }
+    return new Response(null, { status: 404 });
+  },
+};

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -3,6 +3,11 @@
   "name": "pineapple-web",
   "main": "worker/index.ts",
   "compatibility_date": "2026-05-21",
+  // Production route: the SPA owns the catch-all on the shared hostname.
+  // /api/* (and the API's docs/health paths) are claimed more specifically by
+  // pineapple-api, so they take precedence. Requires the tylerevans.co zone in
+  // this account + a proxied DNS record for pineapple.tylerevans.co.
+  "routes": [{ "pattern": "pineapple.tylerevans.co/*", "zone_name": "tylerevans.co" }],
   // Static assets (the built SPA) are served first; unmatched routes fall
   // through to index.html so client-side routing works.
   "assets": {

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -1,0 +1,14 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "pineapple-web",
+  "main": "worker/index.ts",
+  "compatibility_date": "2026-05-21",
+  // Static assets (the built SPA) are served first; unmatched routes fall
+  // through to index.html so client-side routing works.
+  "assets": {
+    "not_found_handling": "single-page-application",
+  },
+  "observability": {
+    "enabled": true,
+  },
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,10 +55,10 @@ importers:
         version: link:../../packages/shared
       better-auth:
         specifier: ^1.6.11
-        version: 1.6.11(@cloudflare/workers-types@4.20260525.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260525.1)(kysely@0.28.17))(vitest@3.2.4(@types/node@25.9.1)(tsx@4.22.3)(yaml@2.9.0))
+        version: 1.6.11(@cloudflare/workers-types@4.20260525.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260525.1)(kysely@0.28.17))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@3.2.4(@types/node@25.9.1)(tsx@4.22.3)(yaml@2.9.0))
       better-auth-cloudflare:
         specifier: ^0.3.0
-        version: 0.3.0(@better-auth/drizzle-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260525.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260525.1)(kysely@0.28.17)))(@cloudflare/workers-types@4.20260525.1)(better-auth@1.6.11(@cloudflare/workers-types@4.20260525.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260525.1)(kysely@0.28.17))(vitest@3.2.4(@types/node@25.9.1)(tsx@4.22.3)(yaml@2.9.0)))(kysely@0.28.17)
+        version: 0.3.0(@better-auth/drizzle-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260525.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260525.1)(kysely@0.28.17)))(@cloudflare/workers-types@4.20260525.1)(better-auth@1.6.11(@cloudflare/workers-types@4.20260525.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260525.1)(kysely@0.28.17))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@3.2.4(@types/node@25.9.1)(tsx@4.22.3)(yaml@2.9.0)))(kysely@0.28.17)
       hono:
         specifier: ^4.12.0
         version: 4.12.23
@@ -79,6 +79,34 @@ importers:
         specifier: ^4.95.0
         version: 4.95.0(@cloudflare/workers-types@4.20260525.1)
 
+  apps/web:
+    dependencies:
+      react:
+        specifier: ^19.1.0
+        version: 19.2.6
+      react-dom:
+        specifier: ^19.1.0
+        version: 19.2.6(react@19.2.6)
+    devDependencies:
+      '@cloudflare/vite-plugin':
+        specifier: ^1.1.0
+        version: 1.39.0(vite@6.4.2(@types/node@25.9.1)(tsx@4.22.3)(yaml@2.9.0))(workerd@1.20260526.1)(wrangler@4.95.0)
+      '@types/react':
+        specifier: ^19.1.0
+        version: 19.2.15
+      '@types/react-dom':
+        specifier: ^19.1.0
+        version: 19.2.3(@types/react@19.2.15)
+      '@vitejs/plugin-react':
+        specifier: ^4.4.0
+        version: 4.7.0(vite@6.4.2(@types/node@25.9.1)(tsx@4.22.3)(yaml@2.9.0))
+      vite:
+        specifier: ^6.3.0
+        version: 6.4.2(@types/node@25.9.1)(tsx@4.22.3)(yaml@2.9.0)
+      wrangler:
+        specifier: ^4.95.0
+        version: 4.95.0(@cloudflare/workers-types@4.20260525.1)
+
   packages/shared: {}
 
 packages:
@@ -87,6 +115,89 @@ packages:
     resolution: {integrity: sha512-/2rThQ5zPi9OzVwes6U7lK1+Yvug0iXu25olp7S0XsYmOqnyMfxH7gdSQjn/+DSOHRg7wnotwGJSyL+fBKdnEA==}
     peerDependencies:
       zod: ^3.20.2
+
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.29.7':
+    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-transform-react-jsx-self@7.29.7':
+    resolution: {integrity: sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7':
+    resolution: {integrity: sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.7':
+    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+    engines: {node: '>=6.9.0'}
 
   '@better-auth/core@1.6.11':
     resolution: {integrity: sha512-LrwidLCV8azdMGjvtwp30nj9tIv1BwI3VhtC0UaGSjQkAVWw4bN42I8qwbxRziPeSQoj+zUVkOpxZzAWBDARtQ==}
@@ -184,6 +295,12 @@ packages:
       workerd:
         optional: true
 
+  '@cloudflare/vite-plugin@1.39.0':
+    resolution: {integrity: sha512-AHC+KSR+3dtGu7Ab7I0Ode4Whx12TxMEmiZt7w+Fc3/2wYNByIzbb6cndWZ78tnveFdO1xhNLv1YaNngxGtOPg==}
+    peerDependencies:
+      vite: ^6.1.0 || ^7.0.0 || ^8.0.0
+      wrangler: ^4.95.0
+
   '@cloudflare/workerd-darwin-64@1.20260526.1':
     resolution: {integrity: sha512-/pR3GH3gfv0PUp7DjI8v0aAIDOqFwibq4bg5xT7TZgcVdBV/cJQWckdXCMqiRtHiawLwogUX00EIOINkYJ1Zqg==}
     engines: {node: '>=16'}
@@ -224,6 +341,12 @@ packages:
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.27.3':
     resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
     engines: {node: '>=18'}
@@ -242,6 +365,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.27.3':
     resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
     engines: {node: '>=18'}
@@ -258,6 +387,12 @@ packages:
     resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.27.3':
@@ -278,6 +413,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.27.3':
     resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
     engines: {node: '>=18'}
@@ -296,6 +437,12 @@ packages:
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.27.3':
     resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
     engines: {node: '>=18'}
@@ -312,6 +459,12 @@ packages:
     resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.27.3':
@@ -332,6 +485,12 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.27.3':
     resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
     engines: {node: '>=18'}
@@ -348,6 +507,12 @@ packages:
     resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.27.3':
@@ -368,6 +533,12 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.27.3':
     resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
     engines: {node: '>=18'}
@@ -384,6 +555,12 @@ packages:
     resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.27.3':
@@ -404,6 +581,12 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.27.3':
     resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
     engines: {node: '>=18'}
@@ -420,6 +603,12 @@ packages:
     resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.27.3':
@@ -440,6 +629,12 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.27.3':
     resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
     engines: {node: '>=18'}
@@ -456,6 +651,12 @@ packages:
     resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.27.3':
@@ -476,6 +677,12 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.27.3':
     resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
     engines: {node: '>=18'}
@@ -492,6 +699,12 @@ packages:
     resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.27.3':
@@ -512,6 +725,12 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.27.3':
     resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
     engines: {node: '>=18'}
@@ -530,6 +749,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-arm64@0.27.3':
     resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
     engines: {node: '>=18'}
@@ -546,6 +771,12 @@ packages:
     resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.27.3':
@@ -566,6 +797,12 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-arm64@0.27.3':
     resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
     engines: {node: '>=18'}
@@ -582,6 +819,12 @@ packages:
     resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.27.3':
@@ -602,6 +845,12 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/openharmony-arm64@0.27.3':
     resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
     engines: {node: '>=18'}
@@ -619,6 +868,12 @@ packages:
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
 
   '@esbuild/sunos-x64@0.27.3':
     resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
@@ -638,6 +893,12 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.27.3':
     resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
     engines: {node: '>=18'}
@@ -656,6 +917,12 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.27.3':
     resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
     engines: {node: '>=18'}
@@ -672,6 +939,12 @@ packages:
     resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.27.3':
@@ -916,12 +1189,21 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
@@ -946,6 +1228,9 @@ packages:
 
   '@poppinss/exception@1.2.3':
     resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
+
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
   '@rollup/rollup-android-arm-eabi@4.60.4':
     resolution: {integrity: sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==}
@@ -1121,6 +1406,18 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -1141,6 +1438,14 @@ packages:
 
   '@types/node@25.9.1':
     resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
+
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.15':
+    resolution: {integrity: sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==}
 
   '@typescript-eslint/eslint-plugin@8.59.4':
     resolution: {integrity: sha512-PegsU+XfyJJNjd4+u/k6f9yTyp0lEXXiPopUNobZcIAUJFGICFLN+sP0Rb3JehVmiij1Ph0dFGYqODoRo/2+6A==}
@@ -1200,6 +1505,12 @@ packages:
   '@typescript-eslint/visitor-keys@8.59.4':
     resolution: {integrity: sha512-U3gxVaDVnuZKhSspW/MzMxE1kq7zOdc072FcSNoqA1I9p8HyKbBFfEHoWckBAMgNMph4MamwS5iTVzFmrnt8TQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
@@ -1272,6 +1583,11 @@ packages:
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
+
+  baseline-browser-mapping@2.10.32:
+    resolution: {integrity: sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
 
   better-auth-cloudflare@0.3.0:
     resolution: {integrity: sha512-u0TrMbFhHNL2IFzkCbCQYyA/beeBSivdL+vfrNywYnsVrQO1qT5CC/yKhnRdrkwXLeNi9tCeoSwWoygTMSl0Yg==}
@@ -1364,6 +1680,11 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
@@ -1371,6 +1692,9 @@ packages:
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
+
+  caniuse-lite@1.0.30001793:
+    resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
 
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
@@ -1402,6 +1726,9 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
@@ -1409,6 +1736,9 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
@@ -1533,6 +1863,9 @@ packages:
       sqlite3:
         optional: true
 
+  electron-to-chromium@1.5.364:
+    resolution: {integrity: sha512-G/dYE3+AYhyHwzTwg8UbnXf7zqMERYh7l2jJ3QujhFsH8agSYwtnGAR2aZ7f0AakIKJXd5En/Hre4igIUrdlYw==}
+
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
@@ -1554,6 +1887,11 @@ packages:
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   esbuild@0.27.3:
     resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
     engines: {node: '>=18'}
@@ -1568,6 +1906,10 @@ packages:
     resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -1735,6 +2077,10 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
   get-east-asian-width@1.6.0:
     resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
     engines: {node: '>=18'}
@@ -1828,11 +2174,19 @@ packages:
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
     hasBin: true
 
   json-buffer@3.0.1:
@@ -1843,6 +2197,11 @@ packages:
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -1881,6 +2240,9 @@ packages:
 
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -1935,6 +2297,10 @@ packages:
 
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
+
+  node-releases@2.0.46:
+    resolution: {integrity: sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==}
+    engines: {node: '>=18'}
 
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
@@ -2008,6 +2374,19 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  react-dom@19.2.6:
+    resolution: {integrity: sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==}
+    peerDependencies:
+      react: ^19.2.6
+
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.2.6:
+    resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
+    engines: {node: '>=0.10.0'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -2054,6 +2433,13 @@ packages:
 
   rou3@0.7.12:
     resolution: {integrity: sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
 
   semver@7.8.0:
     resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
@@ -2229,6 +2615,12 @@ packages:
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
 
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
@@ -2236,6 +2628,46 @@ packages:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
+
+  vite@6.4.2:
+    resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
 
   vite@7.3.3:
     resolution: {integrity: sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==}
@@ -2357,6 +2789,9 @@ packages:
       utf-8-validate:
         optional: true
 
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
@@ -2384,6 +2819,118 @@ snapshots:
     dependencies:
       openapi3-ts: 4.5.0
       zod: 3.25.76
+
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.7': {}
+
+  '@babel/core@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.7':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.29.7':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.29.7': {}
+
+  '@babel/helper-module-imports@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.29.7': {}
+
+  '@babel/helper-string-parser@7.29.7': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/helper-validator-option@7.29.7': {}
+
+  '@babel/helpers@7.29.7':
+    dependencies:
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/traverse@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260525.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)':
     dependencies:
@@ -2462,6 +3009,19 @@ snapshots:
     optionalDependencies:
       workerd: 1.20260526.1
 
+  '@cloudflare/vite-plugin@1.39.0(vite@6.4.2(@types/node@25.9.1)(tsx@4.22.3)(yaml@2.9.0))(workerd@1.20260526.1)(wrangler@4.95.0)':
+    dependencies:
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260526.1)
+      miniflare: 4.20260526.0
+      unenv: 2.0.0-rc.24
+      vite: 6.4.2(@types/node@25.9.1)(tsx@4.22.3)(yaml@2.9.0)
+      wrangler: 4.95.0(@cloudflare/workers-types@4.20260525.1)
+      ws: 8.20.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - workerd
+
   '@cloudflare/workerd-darwin-64@1.20260526.1':
     optional: true
 
@@ -2488,6 +3048,9 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
   '@esbuild/aix-ppc64@0.27.3':
     optional: true
 
@@ -2495,6 +3058,9 @@ snapshots:
     optional: true
 
   '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
     optional: true
 
   '@esbuild/android-arm64@0.27.3':
@@ -2506,6 +3072,9 @@ snapshots:
   '@esbuild/android-arm64@0.28.0':
     optional: true
 
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
   '@esbuild/android-arm@0.27.3':
     optional: true
 
@@ -2513,6 +3082,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm@0.28.0':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
     optional: true
 
   '@esbuild/android-x64@0.27.3':
@@ -2524,6 +3096,9 @@ snapshots:
   '@esbuild/android-x64@0.28.0':
     optional: true
 
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
   '@esbuild/darwin-arm64@0.27.3':
     optional: true
 
@@ -2531,6 +3106,9 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
     optional: true
 
   '@esbuild/darwin-x64@0.27.3':
@@ -2542,6 +3120,9 @@ snapshots:
   '@esbuild/darwin-x64@0.28.0':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.27.3':
     optional: true
 
@@ -2549,6 +3130,9 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.3':
@@ -2560,6 +3144,9 @@ snapshots:
   '@esbuild/freebsd-x64@0.28.0':
     optional: true
 
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
   '@esbuild/linux-arm64@0.27.3':
     optional: true
 
@@ -2567,6 +3154,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
     optional: true
 
   '@esbuild/linux-arm@0.27.3':
@@ -2578,6 +3168,9 @@ snapshots:
   '@esbuild/linux-arm@0.28.0':
     optional: true
 
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
   '@esbuild/linux-ia32@0.27.3':
     optional: true
 
@@ -2585,6 +3178,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
     optional: true
 
   '@esbuild/linux-loong64@0.27.3':
@@ -2596,6 +3192,9 @@ snapshots:
   '@esbuild/linux-loong64@0.28.0':
     optional: true
 
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
   '@esbuild/linux-mips64el@0.27.3':
     optional: true
 
@@ -2603,6 +3202,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.3':
@@ -2614,6 +3216,9 @@ snapshots:
   '@esbuild/linux-ppc64@0.28.0':
     optional: true
 
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
   '@esbuild/linux-riscv64@0.27.3':
     optional: true
 
@@ -2621,6 +3226,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
     optional: true
 
   '@esbuild/linux-s390x@0.27.3':
@@ -2632,6 +3240,9 @@ snapshots:
   '@esbuild/linux-s390x@0.28.0':
     optional: true
 
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
   '@esbuild/linux-x64@0.27.3':
     optional: true
 
@@ -2639,6 +3250,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-x64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.3':
@@ -2650,6 +3264,9 @@ snapshots:
   '@esbuild/netbsd-arm64@0.28.0':
     optional: true
 
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/netbsd-x64@0.27.3':
     optional: true
 
@@ -2657,6 +3274,9 @@ snapshots:
     optional: true
 
   '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.3':
@@ -2668,6 +3288,9 @@ snapshots:
   '@esbuild/openbsd-arm64@0.28.0':
     optional: true
 
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/openbsd-x64@0.27.3':
     optional: true
 
@@ -2675,6 +3298,9 @@ snapshots:
     optional: true
 
   '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.3':
@@ -2686,6 +3312,9 @@ snapshots:
   '@esbuild/openharmony-arm64@0.28.0':
     optional: true
 
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
   '@esbuild/sunos-x64@0.27.3':
     optional: true
 
@@ -2693,6 +3322,9 @@ snapshots:
     optional: true
 
   '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
     optional: true
 
   '@esbuild/win32-arm64@0.27.3':
@@ -2704,6 +3336,9 @@ snapshots:
   '@esbuild/win32-arm64@0.28.0':
     optional: true
 
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
   '@esbuild/win32-ia32@0.27.3':
     optional: true
 
@@ -2711,6 +3346,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
     optional: true
 
   '@esbuild/win32-x64@0.27.3':
@@ -2893,9 +3531,24 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
   '@jridgewell/resolve-uri@3.1.2': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@jridgewell/trace-mapping@0.3.9':
     dependencies:
@@ -2919,6 +3572,8 @@ snapshots:
       supports-color: 10.2.2
 
   '@poppinss/exception@1.2.3': {}
+
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rollup/rollup-android-arm-eabi@4.60.4':
     optional: true
@@ -3028,6 +3683,27 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.7
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -3049,6 +3725,14 @@ snapshots:
     dependencies:
       undici-types: 7.24.6
     optional: true
+
+  '@types/react-dom@19.2.3(@types/react@19.2.15)':
+    dependencies:
+      '@types/react': 19.2.15
+
+  '@types/react@19.2.15':
+    dependencies:
+      csstype: 3.2.3
 
   '@typescript-eslint/eslint-plugin@8.59.4(@typescript-eslint/parser@8.59.4(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)':
     dependencies:
@@ -3141,6 +3825,18 @@ snapshots:
       '@typescript-eslint/types': 8.59.4
       eslint-visitor-keys: 5.0.1
 
+  '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@25.9.1)(tsx@4.22.3)(yaml@2.9.0))':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 6.4.2(@types/node@25.9.1)(tsx@4.22.3)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitest/expect@3.2.4':
     dependencies:
       '@types/chai': 5.2.3
@@ -3216,11 +3912,13 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  better-auth-cloudflare@0.3.0(@better-auth/drizzle-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260525.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260525.1)(kysely@0.28.17)))(@cloudflare/workers-types@4.20260525.1)(better-auth@1.6.11(@cloudflare/workers-types@4.20260525.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260525.1)(kysely@0.28.17))(vitest@3.2.4(@types/node@25.9.1)(tsx@4.22.3)(yaml@2.9.0)))(kysely@0.28.17):
+  baseline-browser-mapping@2.10.32: {}
+
+  better-auth-cloudflare@0.3.0(@better-auth/drizzle-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260525.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260525.1)(kysely@0.28.17)))(@cloudflare/workers-types@4.20260525.1)(better-auth@1.6.11(@cloudflare/workers-types@4.20260525.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260525.1)(kysely@0.28.17))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@3.2.4(@types/node@25.9.1)(tsx@4.22.3)(yaml@2.9.0)))(kysely@0.28.17):
     dependencies:
       '@better-auth/drizzle-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260525.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260525.1)(kysely@0.28.17))
       '@cloudflare/workers-types': 4.20260525.1
-      better-auth: 1.6.11(@cloudflare/workers-types@4.20260525.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260525.1)(kysely@0.28.17))(vitest@3.2.4(@types/node@25.9.1)(tsx@4.22.3)(yaml@2.9.0))
+      better-auth: 1.6.11(@cloudflare/workers-types@4.20260525.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260525.1)(kysely@0.28.17))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@3.2.4(@types/node@25.9.1)(tsx@4.22.3)(yaml@2.9.0))
       drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260525.1)(kysely@0.28.17)
       mime: 4.1.0
       zod: 4.4.3
@@ -3254,7 +3952,7 @@ snapshots:
       - sql.js
       - sqlite3
 
-  better-auth@1.6.11(@cloudflare/workers-types@4.20260525.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260525.1)(kysely@0.28.17))(vitest@3.2.4(@types/node@25.9.1)(tsx@4.22.3)(yaml@2.9.0)):
+  better-auth@1.6.11(@cloudflare/workers-types@4.20260525.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260525.1)(kysely@0.28.17))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@3.2.4(@types/node@25.9.1)(tsx@4.22.3)(yaml@2.9.0)):
     dependencies:
       '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260525.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/drizzle-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260525.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260525.1)(kysely@0.28.17))
@@ -3275,6 +3973,8 @@ snapshots:
       zod: 4.4.3
     optionalDependencies:
       drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260525.1)(kysely@0.28.17)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
       vitest: 3.2.4(@types/node@25.9.1)(tsx@4.22.3)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
@@ -3304,9 +4004,19 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.32
+      caniuse-lite: 1.0.30001793
+      electron-to-chromium: 1.5.364
+      node-releases: 2.0.46
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
   cac@6.7.14: {}
 
   callsites@3.1.0: {}
+
+  caniuse-lite@1.0.30001793: {}
 
   chai@5.3.3:
     dependencies:
@@ -3340,6 +4050,8 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  convert-source-map@2.0.0: {}
+
   cookie@1.1.1: {}
 
   cross-spawn@7.0.6:
@@ -3347,6 +4059,8 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  csstype@3.2.3: {}
 
   debug@3.2.7:
     dependencies:
@@ -3369,6 +4083,8 @@ snapshots:
       '@cloudflare/workers-types': 4.20260525.1
       kysely: 0.28.17
 
+  electron-to-chromium@1.5.364: {}
+
   emoji-regex@10.6.0: {}
 
   enhanced-resolve@5.22.0:
@@ -3383,6 +4099,35 @@ snapshots:
   es-errors@1.3.0: {}
 
   es-module-lexer@1.7.0: {}
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
 
   esbuild@0.27.3:
     optionalDependencies:
@@ -3470,6 +4215,8 @@ snapshots:
       '@esbuild/win32-arm64': 0.28.0
       '@esbuild/win32-ia32': 0.28.0
       '@esbuild/win32-x64': 0.28.0
+
+  escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -3647,6 +4394,8 @@ snapshots:
 
   function-bind@1.1.2: {}
 
+  gensync@1.0.0-beta.2: {}
+
   get-east-asian-width@1.6.0: {}
 
   get-tsconfig@4.14.0:
@@ -3719,17 +4468,23 @@ snapshots:
 
   jose@6.2.3: {}
 
+  js-tokens@4.0.0: {}
+
   js-tokens@9.0.1: {}
 
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
 
+  jsesc@3.1.0: {}
+
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
+
+  json5@2.2.3: {}
 
   keyv@4.5.4:
     dependencies:
@@ -3777,6 +4532,10 @@ snapshots:
 
   loupe@3.2.1: {}
 
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -3823,6 +4582,8 @@ snapshots:
   natural-compare@1.4.0: {}
 
   neo-async@2.6.2: {}
+
+  node-releases@2.0.46: {}
 
   onetime@7.0.0:
     dependencies:
@@ -3882,6 +4643,15 @@ snapshots:
   prettier@3.8.3: {}
 
   punycode@2.3.1: {}
+
+  react-dom@19.2.6(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+      scheduler: 0.27.0
+
+  react-refresh@0.17.0: {}
+
+  react@19.2.6: {}
 
   resolve-from@4.0.0: {}
 
@@ -3948,6 +4718,10 @@ snapshots:
       rosie-skills-linux-x64: 0.6.4
 
   rou3@0.7.12: {}
+
+  scheduler@0.27.0: {}
+
+  semver@6.3.1: {}
 
   semver@7.8.0: {}
 
@@ -4116,6 +4890,12 @@ snapshots:
     dependencies:
       pathe: 2.0.3
 
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
@@ -4126,7 +4906,7 @@ snapshots:
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.3(@types/node@22.19.19)(tsx@4.22.3)(yaml@2.9.0)
+      vite: 6.4.2(@types/node@22.19.19)(tsx@4.22.3)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -4147,7 +4927,7 @@ snapshots:
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.3(@types/node@25.9.1)(tsx@4.22.3)(yaml@2.9.0)
+      vite: 6.4.2(@types/node@25.9.1)(tsx@4.22.3)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -4161,6 +4941,34 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  vite@6.4.2(@types/node@22.19.19)(tsx@4.22.3)(yaml@2.9.0):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rollup: 4.60.4
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 22.19.19
+      fsevents: 2.3.3
+      tsx: 4.22.3
+      yaml: 2.9.0
+
+  vite@6.4.2(@types/node@25.9.1)(tsx@4.22.3)(yaml@2.9.0):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rollup: 4.60.4
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 25.9.1
+      fsevents: 2.3.3
+      tsx: 4.22.3
+      yaml: 2.9.0
 
   vite@7.3.3(@types/node@22.19.19)(tsx@4.22.3)(yaml@2.9.0):
     dependencies:
@@ -4324,6 +5132,8 @@ snapshots:
       strip-ansi: 7.2.0
 
   ws@8.20.1: {}
+
+  yallist@3.1.1: {}
 
   yaml@2.9.0: {}
 


### PR DESCRIPTION
## What

Implements the **Marketing Home** design from the Claude Design handoff as a new `apps/web` package, adapting Cloudflare's `vite-react-template` into this pnpm monorepo. This is the repo's first frontend.

The page is served by a Cloudflare Worker via `@cloudflare/vite-plugin`: the Worker reserves `/api/*` for future routes and falls back to the SPA (`index.html`) for everything else.

## Highlights

- **`apps/web/src/marketing/MarketingHome.tsx`** — reproduces what the prototype's `MarketingApp` actually renders: nav, hero with the floating asset/next-up collage, proof strip, "how it works" steps, dark CTA band, and footer.
- Design-system primitives (`Icon`, `HFStatusPill`, `HFAssetIcon`, `HFAssetThumb`) ported to typed TSX; the three CSS layers (`hifi.css`, `hifi-assets.css`, `marketing.css`) copied verbatim for pixel parity.
- The Worker entry uses only Web/DOM-standard APIs, so client + worker share one tsconfig without pulling in `@cloudflare/workers-types` (which conflicts with `lib.dom`).
- Updated `CLAUDE.md` ("no frontend yet" → points at `apps/web`) and added `apps/web/README.md`.

## Note on scope

The prototype *defines* a `MKFeatures` section but `MarketingApp` doesn't render it — the user had removed it from the composition. I matched the rendered output and left it out; easy to add back if wanted.

## Verification

- `pnpm lint`, `pnpm type-check` (all 4 packages), `pnpm -r test`, `pnpm format:check`, and `vite build` all pass.
- Rendered and visually verified at desktop and mobile widths — no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)