### PR TITLE
Add Assets (card grid) page at /app/assets

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -4,33 +4,45 @@ The FieldOps web frontend — a Vite + React app served by a Cloudflare Worker
 via [`@cloudflare/vite-plugin`](https://developers.cloudflare.com/workers/vite-plugin/).
 Adapted from Cloudflare's `vite-react-template` to fit this pnpm monorepo.
 
-It serves two logged-out pages from the Claude Design handoff:
+It serves these pages from the Claude Design handoff:
 
 - **Marketing Home** (`/`) — [`src/marketing/`](src/marketing/)
 - **Auth Flow** (`/login`) — [`src/auth/`](src/auth/) — Google-first log in /
   sign up (Better Auth, phase 1). Reads `?mode=login|signup` to pick its initial
   screen; the marketing CTAs deep-link with the matching mode.
 
+- **App Home** (`/app`) — [`src/app/AppHome.tsx`](src/app/AppHome.tsx) — the
+  authenticated master/detail home: greeting + fleet stats and an urgency-sorted
+  service queue.
+- **Assets** (`/app/assets`) — [`src/app/AppAssets.tsx`](src/app/AppAssets.tsx) —
+  the asset library: a responsive card grid (stacked rows on mobile) with search,
+  category filter chips, and a grid/list view toggle.
+
+The authenticated pages share their chrome — the desktop top bar and mobile
+bottom tab bar — via [`src/app/AppChrome.tsx`](src/app/AppChrome.tsx), where the
+nav tabs link between `/app` and `/app/assets`.
+
 The shared design-system primitives (`Icon`, `HFStatusPill`, `HFAssetIcon`,
 `HFAssetThumb`) are ported from the FieldOps app prototype and live in
 [`src/design/`](src/design/), styled by `design/styles/hifi.css` +
 `hifi-assets.css` (the `.hf-*` tokens/components). Each page adds a thin layer
 that mirrors those tokens onto its own scope: `marketing.css` (`.mk`) and
-`auth.css` (`.au`).
+`auth.css` (`.au`). The `/app` pages render the `.hf` system directly.
 
 Routing is a single `window.location.pathname` check in
 [`src/main.tsx`](src/main.tsx) — no router dependency. The Worker's SPA
-fallback (see `wrangler.jsonc`) serves `index.html` for any path, so `/login`
-resolves client-side.
+fallback (see `wrangler.jsonc`) serves `index.html` for any path, so `/login`,
+`/app`, and `/app/assets` resolve client-side.
 
 ## Layout
 
 ```
 index.html              # Vite HTML entry (loads Inter + JetBrains Mono)
-src/main.tsx            # React bootstrap + path routing (/ → marketing, /login → auth)
+src/main.tsx            # React bootstrap + path routing (/, /login, /app, /app/assets)
 src/design/             # shared design-system primitives + .hf CSS tokens
 src/marketing/          # Marketing Home page + .mk CSS
 src/auth/               # Auth Flow page (/login) + .au CSS
+src/app/                # Authenticated app: AppHome (/app), AppAssets (/app/assets), AppChrome (shared nav)
 worker/index.ts         # Worker entry; reserves /api/*, SPA-falls-back otherwise
 vite.config.ts          # react() + cloudflare() plugins
 wrangler.jsonc          # Worker + static-assets config (SPA not_found_handling)

--- a/apps/web/src/app/AppAssets.tsx
+++ b/apps/web/src/app/AppAssets.tsx
@@ -1,0 +1,212 @@
+import { Icon, type IconName } from "../design/Icon";
+import { HFAssetThumb, HFStatusPill, type AssetCategory, type AssetStatus } from "../design/hf";
+import { HFTopBar, HFBottomNav } from "./AppChrome";
+
+// FieldOps — Assets (card grid). The authenticated asset library: a header with
+// fleet count + add button, a toolbar (search, category filter chips, grid/list
+// view toggle), and a responsive grid of asset cards that collapses to stacked
+// rows on mobile. Ported from the FieldOps design prototype (Assets.html /
+// hifi-assets.jsx); styling comes from the shared .hf tokens in styles/hifi.css
+// plus the .hf-asset-* scopes in styles/hifi-assets.css.
+import "../design/styles/hifi.css";
+import "../design/styles/hifi-assets.css";
+
+/* ============ data ============ */
+interface Asset {
+  id: string;
+  name: string;
+  cat: AssetCategory;
+  icon: IconName;
+  status: AssetStatus;
+  next: string;
+  due: string;
+  loc: string;
+  meter: string;
+}
+
+const HF_ASSETS_ALL: Asset[] = [
+  { id: "TRK-04", name: "Ford F-150 · #4", cat: "vehicle", icon: "truck", status: "soon", next: "Oil change + tire rotation", due: "2 days", loc: "Lot · Main", meter: "48,210 mi" },
+  { id: "VAN-02", name: "Sprinter Van · #2", cat: "vehicle", icon: "van", status: "ok", next: "Annual state inspection", due: "14 days", loc: "Lot · Main", meter: "82,400 mi" },
+  { id: "TRL-01", name: "16ft Equipment Trailer", cat: "vehicle", icon: "truck", status: "ok", next: "Wheel bearing repack", due: "30 days", loc: "Lot · Back", meter: "—" },
+  { id: "MOWER-A", name: "Toro ZTR Mower", cat: "equipment", icon: "mower", status: "overdue", next: "Blade sharpen + belt check", due: "3 days late", loc: "Shed B", meter: "312 hrs" },
+  { id: "GEN-1", name: "Generac 22kW Generator", cat: "equipment", icon: "bolt", status: "ok", next: "Annual load test + oil", due: "21 days", loc: "12 Oak St", meter: "118 hrs" },
+  { id: "PW-2", name: "Pressure Washer", cat: "equipment", icon: "wrench", status: "ok", next: "Pump oil change", due: "45 days", loc: "Shed A", meter: "84 hrs" },
+  { id: "PROP-12", name: "12 Oak St", cat: "property", icon: "home", status: "soon", next: "Quarterly HVAC inspection", due: "5 days", loc: "Oak St", meter: "—" },
+  { id: "PROP-48", name: "48 Elm Ave", cat: "property", icon: "home", status: "ok", next: "Gutter clean & inspect", due: "60 days", loc: "Elm Ave", meter: "—" },
+  { id: "LAWN-A", name: "Riverside Lawn", cat: "lawn", icon: "leaf", status: "soon", next: "Spring fertilizer treatment", due: "9 days", loc: "Riverside", meter: "—" },
+  { id: "LAWN-B", name: "Park Hedge Row", cat: "lawn", icon: "leaf", status: "ok", next: "Hedge trim & cleanup", due: "25 days", loc: "Park West", meter: "—" },
+];
+
+const HF_CAT_LABELS: Record<AssetCategory, string> = {
+  vehicle: "Vehicle",
+  equipment: "Equipment",
+  property: "Property",
+  lawn: "Grounds",
+};
+
+/* ============ grid card ============ */
+function HFAssetGridCard({ asset }: { asset: Asset }) {
+  return (
+    <article className="hf-asset-card" data-status={asset.status} tabIndex={0}>
+      <HFAssetThumb asset={asset} height={132} />
+      <div className="hf-asset-body">
+        <h3 className="hf-asset-card-name">{asset.name}</h3>
+        <div className="hf-asset-card-meta">
+          <span className="hf-mono">{asset.id}</span>
+          {asset.meter !== "—" && (
+            <>
+              <span className="hf-dot-sep" />
+              <span>{asset.meter}</span>
+            </>
+          )}
+        </div>
+      </div>
+      <div className="hf-asset-footer">
+        <div className="hf-asset-footer-text">
+          <div className="hf-label-sm">Next</div>
+          <div className="hf-asset-next">{asset.next}</div>
+        </div>
+        <HFStatusPill status={asset.status} due={asset.due} />
+      </div>
+    </article>
+  );
+}
+
+/* horizontal row card — used on mobile */
+function HFAssetRowCard({ asset }: { asset: Asset }) {
+  return (
+    <article className="hf-asset-row" data-status={asset.status} tabIndex={0}>
+      <HFAssetThumb asset={asset} height={84} />
+      <div className="hf-asset-row-body">
+        <div className="hf-asset-row-top">
+          <h3 className="hf-asset-card-name">{asset.name}</h3>
+          <div className="hf-asset-card-meta">
+            <span className="hf-mono">{asset.id}</span>
+            <span className="hf-dot-sep" />
+            <span>{HF_CAT_LABELS[asset.cat]}</span>
+          </div>
+        </div>
+        <div className="hf-asset-row-bot">
+          <div className="hf-asset-next-mobile">
+            <span className="hf-label-sm">Next</span>
+            <span className="hf-asset-next-text">{asset.next}</span>
+          </div>
+          <HFStatusPill status={asset.status} due={asset.due} />
+        </div>
+      </div>
+    </article>
+  );
+}
+
+/* ============ add-asset ghost card (slots into the grid) ============ */
+function HFAddCard() {
+  return (
+    <article className="hf-asset-card hf-add-card" tabIndex={0}>
+      <div className="hf-add-card-inner">
+        <div className="hf-add-card-plus">
+          <Icon name="plus" size={20} stroke={2} />
+        </div>
+        <div className="hf-add-card-label">Add an asset</div>
+        <div className="hf-add-card-sub">Vehicle, equipment, property, grounds…</div>
+      </div>
+    </article>
+  );
+}
+
+/* ============ toolbar: search + filter chips + view toggle ============ */
+function HFAssetsToolbar({
+  activeCat = "all",
+  activeView = "grid",
+}: {
+  activeCat?: string;
+  activeView?: "grid" | "list";
+}) {
+  const cats = [
+    { id: "all", label: "All", count: HF_ASSETS_ALL.length },
+    { id: "vehicle", label: "Vehicles", count: HF_ASSETS_ALL.filter((a) => a.cat === "vehicle").length },
+    { id: "equipment", label: "Equipment", count: HF_ASSETS_ALL.filter((a) => a.cat === "equipment").length },
+    { id: "property", label: "Properties", count: HF_ASSETS_ALL.filter((a) => a.cat === "property").length },
+    { id: "lawn", label: "Grounds", count: HF_ASSETS_ALL.filter((a) => a.cat === "lawn").length },
+  ];
+  const views: { id: "grid" | "list"; icon: IconName }[] = [
+    { id: "grid", icon: "grid" },
+    { id: "list", icon: "menu" },
+  ];
+  return (
+    <div className="hf-assets-toolbar">
+      <div className="hf-search">
+        <Icon name="search" size={15} color="var(--hf-ink-faint)" />
+        <input className="hf-search-input" placeholder="Search assets, IDs, locations…" />
+        <kbd className="hf-kbd">⌘ K</kbd>
+      </div>
+      <div className="hf-filter-chips">
+        {cats.map((c) => (
+          <button key={c.id} className={`hf-chip ${activeCat === c.id ? "active" : ""}`}>
+            {c.label}
+            <span className="hf-chip-count">{c.count}</span>
+          </button>
+        ))}
+      </div>
+      <div className="hf-assets-toolbar-end">
+        <div className="hf-view-toggle">
+          {views.map((v) => (
+            <button key={v.id} className={`hf-view-btn ${activeView === v.id ? "active" : ""}`} title={v.id}>
+              <Icon name={v.icon} size={15} />
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ============ header ============ */
+function HFAssetsHeader() {
+  return (
+    <div className="hf-greeting">
+      <div className="hf-greeting-text">
+        <h1 className="hf-h1">Assets</h1>
+        <div className="hf-greeting-sub">{HF_ASSETS_ALL.length} things you take care of</div>
+      </div>
+      <div className="hf-stats hf-stats-tight">
+        <button className="hf-btn hf-btn-primary">
+          <Icon name="plus" size={14} stroke={2.2} />
+          Add asset
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/* ============ main: assets card grid (responsive) ============ */
+export function AppAssets() {
+  // The add-card slots in at the END of the grid so the "+" stays discoverable
+  // inline; the stacked rows (mobile) get their own add button at the bottom.
+  return (
+    <div className="hf hf-app hf-assets-page">
+      <HFTopBar activeNav="assets" />
+      <main className="hf-main hf-shell">
+        <HFAssetsHeader />
+        <HFAssetsToolbar activeCat="all" activeView="grid" />
+
+        <div className="hf-asset-grid">
+          {HF_ASSETS_ALL.map((a) => (
+            <HFAssetGridCard key={a.id} asset={a} />
+          ))}
+          <HFAddCard />
+        </div>
+
+        <div className="hf-asset-rows">
+          {HF_ASSETS_ALL.map((a) => (
+            <HFAssetRowCard key={a.id} asset={a} />
+          ))}
+          <button className="hf-row-add">
+            <Icon name="plus" size={16} stroke={2} />
+            Add an asset
+          </button>
+        </div>
+      </main>
+      <HFBottomNav activeNav="assets" />
+    </div>
+  );
+}

--- a/apps/web/src/app/AppChrome.tsx
+++ b/apps/web/src/app/AppChrome.tsx
@@ -1,0 +1,78 @@
+import { Icon, type IconName } from "../design/Icon";
+import { Brandmark } from "../design/Brandmark";
+
+// Shared authenticated-app chrome: the desktop top bar and the mobile bottom
+// tab bar. Ported from the FieldOps prototype (hifi.jsx). Both the Home
+// (master/detail) and Assets pages render this, so nav lives here. Tabs that
+// have a real page carry an href; placeholders (Schedule, History) don't.
+
+export type AppNav = "home" | "assets" | "schedule" | "history";
+
+interface NavItem {
+  id: AppNav;
+  label: string;
+  icon: IconName;
+  href?: string;
+}
+
+const HF_NAV: NavItem[] = [
+  { id: "home", label: "Home", icon: "home-nav", href: "/app" },
+  { id: "assets", label: "Assets", icon: "grid", href: "/app/assets" },
+  { id: "schedule", label: "Schedule", icon: "calendar" },
+  { id: "history", label: "History", icon: "clock" },
+];
+
+export function HFTopBar({ activeNav = "home" }: { activeNav?: AppNav }) {
+  return (
+    <header className="hf-topbar">
+      <div className="hf-topbar-left">
+        <div className="hf-logo">
+          <div className="hf-logo-mark">
+            <Brandmark size={15} color="white" />
+          </div>
+          <span className="hf-logo-text">FieldOps</span>
+        </div>
+        <nav className="hf-nav-top">
+          {HF_NAV.map((n) => (
+            <a
+              key={n.id}
+              href={n.href}
+              className={`hf-nav-tab ${n.id === activeNav ? "active" : ""}`}
+              title={n.label}
+            >
+              <Icon name={n.icon} size={16} />
+              <span className="hf-nav-label">{n.label}</span>
+            </a>
+          ))}
+        </nav>
+      </div>
+      <div className="hf-topbar-right">
+        <button className="hf-icon-btn" title="Search">
+          <Icon name="search" size={16} />
+        </button>
+        <button className="hf-icon-btn hf-icon-btn-badge" title="Notifications">
+          <Icon name="bell" size={16} />
+          <span className="hf-badge">3</span>
+        </button>
+        <div className="hf-avatar">J</div>
+      </div>
+    </header>
+  );
+}
+
+export function HFBottomNav({ activeNav = "home" }: { activeNav?: AppNav }) {
+  return (
+    <nav className="hf-nav-bottom">
+      {HF_NAV.map((n) => (
+        <a
+          key={n.id}
+          href={n.href}
+          className={`hf-nav-bottom-tab ${n.id === activeNav ? "active" : ""}`}
+        >
+          <Icon name={n.icon} size={20} stroke={n.id === activeNav ? 2 : 1.5} />
+          <span>{n.label}</span>
+        </a>
+      ))}
+    </nav>
+  );
+}

--- a/apps/web/src/app/AppHome.tsx
+++ b/apps/web/src/app/AppHome.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { Icon, type IconName } from "../design/Icon";
-import { Brandmark } from "../design/Brandmark";
 import { HFAssetIcon, HFStatusPill, type AssetCategory, type AssetStatus } from "../design/hf";
+import { HFTopBar, HFBottomNav } from "./AppChrome";
 
 // FieldOps — Home (Master / Detail). The authenticated app shell: a top bar,
 // greeting + fleet stats, category filters, and a master/detail grid (detail
@@ -137,19 +137,6 @@ const HF_ASSETS: Asset[] = [
   },
 ];
 
-interface NavItem {
-  id: string;
-  label: string;
-  icon: IconName;
-}
-
-const HF_NAV: NavItem[] = [
-  { id: "home", label: "Home", icon: "home-nav" },
-  { id: "assets", label: "Assets", icon: "grid" },
-  { id: "schedule", label: "Schedule", icon: "calendar" },
-  { id: "history", label: "History", icon: "clock" },
-];
-
 /* ============ detail body (shared by hero card + inline expand) ============ */
 function HFDetailBody({
   asset,
@@ -250,58 +237,6 @@ function HFDetailBody({
         )}
       </div>
     </div>
-  );
-}
-
-/* ============ top bar ============ */
-function HFTopBar({ activeNav = "home" }: { activeNav?: string }) {
-  return (
-    <header className="hf-topbar">
-      <div className="hf-topbar-left">
-        <div className="hf-logo">
-          <div className="hf-logo-mark">
-            <Brandmark size={15} color="white" />
-          </div>
-          <span className="hf-logo-text">FieldOps</span>
-        </div>
-        <nav className="hf-nav-top">
-          {HF_NAV.map((n) => (
-            <a
-              key={n.id}
-              className={`hf-nav-tab ${n.id === activeNav ? "active" : ""}`}
-              title={n.label}
-            >
-              <Icon name={n.icon} size={16} />
-              <span className="hf-nav-label">{n.label}</span>
-            </a>
-          ))}
-        </nav>
-      </div>
-      <div className="hf-topbar-right">
-        <button className="hf-icon-btn" title="Search">
-          <Icon name="search" size={16} />
-        </button>
-        <button className="hf-icon-btn hf-icon-btn-badge" title="Notifications">
-          <Icon name="bell" size={16} />
-          <span className="hf-badge">3</span>
-        </button>
-        <div className="hf-avatar">J</div>
-      </div>
-    </header>
-  );
-}
-
-/* ============ bottom tab bar (mobile only) ============ */
-function HFBottomNav({ activeNav = "home" }: { activeNav?: string }) {
-  return (
-    <nav className="hf-nav-bottom">
-      {HF_NAV.map((n) => (
-        <a key={n.id} className={`hf-nav-bottom-tab ${n.id === activeNav ? "active" : ""}`}>
-          <Icon name={n.icon} size={20} stroke={n.id === activeNav ? 2 : 1.5} />
-          <span>{n.label}</span>
-        </a>
-      ))}
-    </nav>
   );
 }
 

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -4,15 +4,18 @@ import "./index.css";
 import { MarketingHome } from "./marketing/MarketingHome";
 import { AuthFlow } from "./auth/AuthFlow";
 import { AppHome } from "./app/AppHome";
+import { AppAssets } from "./app/AppAssets";
 
 // Minimal path-based routing. The Worker serves index.html for any unmatched
 // path (wrangler.jsonc -> assets.not_found_handling: "single-page-application"),
 // so /login and /app resolve here; everything else renders the marketing home.
 // /login reads ?mode=login|signup to pick its initial screen (set by the
-// marketing CTAs); /app is the authenticated master/detail home.
+// marketing CTAs); /app is the authenticated master/detail home and
+// /app/assets is the asset library (card grid).
 function App() {
   const path = window.location.pathname;
   if (path === "/login") return <AuthFlow />;
+  if (path === "/app/assets") return <AppAssets />;
   if (path === "/app") return <AppHome />;
   return <MarketingHome />;
 }


### PR DESCRIPTION
## Summary

Implements the **Assets** page from the FieldOps Claude Design handoff (`Assets.html` / `hifi-assets.jsx`), wired at `/app/assets`.

- **Assets page** ([`AppAssets.tsx`](apps/web/src/app/AppAssets.tsx)) — responsive asset card grid: category-tinted thumbnails, status dots + pills, ID/meter meta, "Next" service, and an add-asset ghost card. Toolbar with search (⌘K), 5 category filter chips with counts, and a grid/list view toggle. Collapses to stacked row cards on mobile.
- **Shared chrome** ([`AppChrome.tsx`](apps/web/src/app/AppChrome.tsx)) — extracted `HFTopBar` + `HFBottomNav` so Home and Assets share one nav. The Home/Assets tabs now carry `href`s and actually navigate. [`AppHome.tsx`](apps/web/src/app/AppHome.tsx) drops its duplicated nav code to use it.
- **Routing** — added `/app/assets` to the `window.location.pathname` switch in [`main.tsx`](apps/web/src/main.tsx).
- **Docs** — documented the `/app` and `/app/assets` pages in the web [README](apps/web/README.md) (the `/app` Home page was previously undocumented too).

The `.hf` design system (CSS tokens, `Icon`, `Brandmark`, `HFStatusPill`, `HFAssetThumb`, `hifi-assets.css`) was already ported by the prior Master Detail PR, so this reuses it directly.

## Verification

- `pnpm lint`, `pnpm type-check`, `pnpm -r test` (6 passed), and the web production build all pass.
- Verified in-browser: desktop card grid (10 cards + add card, chips with counts, search, view toggle, no console errors) and mobile (390px) stacked rows with the bottom tab bar; the desktop tabs/view-toggle hide on mobile. Home↔Assets nav round-trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)