### PR TITLE
Wire domain event telemetry and HTTP request telemetry via Analytics Engine

### DIFF
--- a/apps/api/src/api/middleware/technicalTelemetry.test.ts
+++ b/apps/api/src/api/middleware/technicalTelemetry.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { ValidationError } from "@snaveevans/pineapple-shared";
+import { buildApiRequestTelemetryDataPoint } from "./technicalTelemetry.ts";
+
+describe("buildApiRequestTelemetryDataPoint", () => {
+  it("maps successful use-case requests to the documented field order", () => {
+    expect(
+      buildApiRequestTelemetryDataPoint({
+        method: "POST",
+        pathname: "/api/assets",
+        status: 201,
+        durationMs: 42.5,
+        requestSizeBytes: 128,
+        authenticated: true,
+        error: null,
+      }),
+    ).toEqual({
+      indexes: ["CreateAsset"],
+      blobs: ["CreateAsset", "/api/assets", "POST", "2xx", "201", "success", "none", "true", "v1"],
+      doubles: [42.5, 1, 201, 128],
+    });
+  });
+
+  it("normalizes asset ids and records validation failures", () => {
+    expect(
+      buildApiRequestTelemetryDataPoint({
+        method: "GET",
+        pathname: "/api/assets/195d0ef0-47f5-439f-abfd-29f892c9a040",
+        status: 422,
+        durationMs: 3,
+        requestSizeBytes: 0,
+        authenticated: false,
+        error: new ValidationError("Invalid id", "id"),
+      }),
+    ).toEqual({
+      indexes: ["GetAsset"],
+      blobs: [
+        "GetAsset",
+        "/api/assets/{id}",
+        "GET",
+        "4xx",
+        "422",
+        "failure",
+        "ValidationError",
+        "false",
+        "v1",
+      ],
+      doubles: [3, 1, 422, 0],
+    });
+  });
+});

--- a/apps/api/src/api/middleware/technicalTelemetry.ts
+++ b/apps/api/src/api/middleware/technicalTelemetry.ts
@@ -1,0 +1,150 @@
+import type { Context, MiddlewareHandler } from "hono";
+import {
+  ConflictError,
+  ForbiddenError,
+  NotFoundError,
+  UnauthorizedError,
+  ValidationError,
+} from "@snaveevans/pineapple-shared";
+
+export type ApiRequestTelemetryDataPoint = {
+  indexes: string[];
+  blobs: string[];
+  doubles: number[];
+};
+
+export interface ApiRequestTelemetrySink {
+  write(dataPoint: ApiRequestTelemetryDataPoint): void;
+}
+
+type TelemetryVariables = {
+  user?: unknown;
+};
+
+type TelemetryRecord = {
+  method: string;
+  pathname: string;
+  status: number;
+  durationMs: number;
+  requestSizeBytes: number;
+  authenticated: boolean;
+  error: unknown;
+};
+
+type RouteTelemetry = {
+  operation: string;
+  routePattern: string;
+};
+
+export function createTechnicalTelemetryMiddleware<TEnv extends { Variables: TelemetryVariables }>(
+  getSink: (c: Context<TEnv>) => ApiRequestTelemetrySink,
+): MiddlewareHandler<TEnv> {
+  return async (c, next) => {
+    const start = performance.now();
+    let error: unknown = null;
+    let status = 500;
+
+    try {
+      await next();
+      status = c.res.status;
+    } catch (e) {
+      error = e;
+      status = statusFromError(e);
+      throw e;
+    } finally {
+      const url = new URL(c.req.url);
+      const dataPoint = buildApiRequestTelemetryDataPoint({
+        method: c.req.method,
+        pathname: url.pathname,
+        status,
+        durationMs: performance.now() - start,
+        requestSizeBytes: requestSizeBytes(c.req.header("content-length")),
+        authenticated: c.var.user !== undefined,
+        error,
+      });
+
+      try {
+        getSink(c).write(dataPoint);
+      } catch (sinkError) {
+        console.error({ error: sinkError }, "API request telemetry write failed");
+      }
+    }
+  };
+}
+
+export function buildApiRequestTelemetryDataPoint(
+  record: TelemetryRecord,
+): ApiRequestTelemetryDataPoint {
+  const route = routeTelemetry(record.method, record.pathname);
+  return {
+    indexes: [route.operation],
+    blobs: [
+      route.operation,
+      route.routePattern,
+      record.method,
+      statusClass(record.status),
+      String(record.status),
+      outcome(record.status),
+      errorName(record.error),
+      record.authenticated ? "true" : "false",
+      "v1",
+    ],
+    doubles: [record.durationMs, 1, record.status, record.requestSizeBytes],
+  };
+}
+
+function routeTelemetry(method: string, pathname: string): RouteTelemetry {
+  if (pathname.startsWith("/api/auth/")) {
+    return { operation: "Auth", routePattern: "/api/auth/*" };
+  }
+  if (pathname === "/api/assets" && method === "POST") {
+    return { operation: "CreateAsset", routePattern: "/api/assets" };
+  }
+  if (pathname === "/api/assets" && method === "GET") {
+    return { operation: "ListAssets", routePattern: "/api/assets" };
+  }
+  if (/^\/api\/assets\/[^/]+$/.test(pathname) && method === "GET") {
+    return { operation: "GetAsset", routePattern: "/api/assets/{id}" };
+  }
+  if (pathname === "/health" && method === "GET") {
+    return { operation: "Health", routePattern: "/health" };
+  }
+  if (pathname === "/openapi.json" && method === "GET") {
+    return { operation: "OpenApiDocument", routePattern: "/openapi.json" };
+  }
+  if (pathname === "/reference" && method === "GET") {
+    return { operation: "ApiReference", routePattern: "/reference" };
+  }
+  return { operation: "Unknown", routePattern: "Unknown" };
+}
+
+function statusFromError(error: unknown): number {
+  if (error instanceof NotFoundError) return 404;
+  if (error instanceof UnauthorizedError) return 401;
+  if (error instanceof ForbiddenError) return 403;
+  if (error instanceof ValidationError) return 422;
+  if (error instanceof ConflictError) return 409;
+  return 500;
+}
+
+function statusClass(status: number): string {
+  return `${Math.trunc(status / 100)}xx`;
+}
+
+function outcome(status: number): string {
+  if (status >= 500) return "error";
+  if (status >= 400) return "failure";
+  return "success";
+}
+
+function errorName(error: unknown): string {
+  if (error === null) return "none";
+  if (error instanceof Error) return error.constructor.name;
+  return "unknown";
+}
+
+function requestSizeBytes(contentLength: string | undefined): number {
+  if (contentLength === undefined) return 0;
+  const parsed = Number.parseInt(contentLength, 10);
+  return Number.isFinite(parsed) ? parsed : 0;
+}

--- a/apps/api/src/application/ports/EventBus.ts
+++ b/apps/api/src/application/ports/EventBus.ts
@@ -1,0 +1,12 @@
+import type { DomainEvent } from "../../domain/events/DomainEvent.ts";
+
+export interface DomainEventHandler<TEvent extends DomainEvent = DomainEvent> {
+  readonly eventType: TEvent["type"];
+  handle(event: TEvent): void | Promise<void>;
+}
+
+export interface EventBus {
+  publish(event: DomainEvent): Promise<void>;
+  publishAll(events: readonly DomainEvent[]): Promise<void>;
+  subscribe<TEvent extends DomainEvent>(handler: DomainEventHandler<TEvent>): void;
+}

--- a/apps/api/src/application/usecases/CreateAsset.test.ts
+++ b/apps/api/src/application/usecases/CreateAsset.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { UserId } from "@snaveevans/pineapple-shared";
+import { CreateAsset } from "./CreateAsset.ts";
+import type { EventBus } from "../ports/EventBus.ts";
+import type { Asset } from "../../domain/asset/Asset.ts";
+import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
+import type { AssetCreated } from "../../domain/asset/events/AssetCreated.ts";
+import type { DomainEvent } from "../../domain/events/DomainEvent.ts";
+
+class RecordingAssetRepository implements AssetRepository {
+  saved: Asset | null = null;
+
+  findById(): Promise<Asset | null> {
+    return Promise.resolve(null);
+  }
+
+  findByOwner(): Promise<Asset[]> {
+    return Promise.resolve([]);
+  }
+
+  save(asset: Asset): Promise<void> {
+    this.saved = asset;
+    return Promise.resolve();
+  }
+}
+
+class RecordingEventBus implements EventBus {
+  readonly events: DomainEvent[] = [];
+
+  publish(event: DomainEvent): Promise<void> {
+    this.events.push(event);
+    return Promise.resolve();
+  }
+
+  publishAll(events: readonly DomainEvent[]): Promise<void> {
+    for (const event of events) {
+      this.events.push(event);
+    }
+    return Promise.resolve();
+  }
+
+  subscribe(): void {}
+}
+
+describe("CreateAsset", () => {
+  it("publishes AssetCreated after saving the asset", async () => {
+    const repo = new RecordingAssetRepository();
+    const eventBus = new RecordingEventBus();
+    const ownerId = UserId.generate();
+
+    const result = await new CreateAsset(repo, eventBus).execute({
+      ownerId,
+      name: "My Truck",
+      metadata: { kind: "vehicle", make: "Ram", model: "2500", year: 2016 },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(repo.saved).not.toBeNull();
+    expect(eventBus.events).toHaveLength(1);
+
+    const event = eventBus.events[0] as AssetCreated | undefined;
+    expect(event).toMatchObject({
+      type: "AssetCreated",
+      ownerId,
+      assetType: "vehicle",
+      assetModelYear: 2016,
+    });
+    expect(repo.saved?.pullEvents()).toHaveLength(0);
+  });
+});

--- a/apps/api/src/application/usecases/CreateAsset.ts
+++ b/apps/api/src/application/usecases/CreateAsset.ts
@@ -10,6 +10,7 @@ import {
 import { Asset } from "../../domain/asset/Asset.ts";
 import type { AssetMetadata } from "../../domain/asset/AssetMetadata.ts";
 import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
+import type { EventBus } from "../ports/EventBus.ts";
 
 export type CreateAssetCommand = {
   ownerId: UserId;
@@ -18,7 +19,10 @@ export type CreateAssetCommand = {
 };
 
 export class CreateAsset {
-  constructor(private readonly assets: AssetRepository) {}
+  constructor(
+    private readonly assets: AssetRepository,
+    private readonly eventBus: EventBus,
+  ) {}
 
   async execute(cmd: CreateAssetCommand): Promise<Result<AssetId, DomainError>> {
     try {
@@ -28,7 +32,7 @@ export class CreateAsset {
         metadata: cmd.metadata,
       });
       await this.assets.save(asset);
-      asset.pullEvents(); // drain — no EventBus consumer yet
+      await this.eventBus.publishAll(asset.pullEvents());
       return ok(asset.id);
     } catch (e) {
       if (e instanceof DomainErrorClass) return err(e);

--- a/apps/api/src/domain/asset/Asset.test.ts
+++ b/apps/api/src/domain/asset/Asset.test.ts
@@ -16,6 +16,7 @@ describe("Asset", () => {
     const events = asset.pullEvents();
     expect(events).toHaveLength(1);
     expect(events[0]?.type).toBe("AssetCreated");
+    expect(events[0]).toMatchObject({ assetType: "vehicle", assetModelYear: 2016 });
 
     // Second pull returns empty — events are drained
     expect(asset.pullEvents()).toHaveLength(0);

--- a/apps/api/src/domain/asset/Asset.ts
+++ b/apps/api/src/domain/asset/Asset.ts
@@ -37,7 +37,14 @@ export class Asset {
       now,
       now,
     );
-    asset._domainEvents.push(AssetCreated(asset.id, asset.ownerId));
+    asset._domainEvents.push(
+      AssetCreated({
+        assetId: asset.id,
+        ownerId: asset.ownerId,
+        assetType: asset.type,
+        ...(asset.metadata.kind === "vehicle" ? { assetModelYear: asset.metadata.year } : {}),
+      }),
+    );
     return asset;
   }
 

--- a/apps/api/src/domain/asset/events/AssetCreated.ts
+++ b/apps/api/src/domain/asset/events/AssetCreated.ts
@@ -1,15 +1,25 @@
 import type { AssetId, UserId } from "@snaveevans/pineapple-shared";
+import type { AssetType } from "../AssetType.ts";
 import type { DomainEvent } from "../../events/DomainEvent";
 
 export type AssetCreated = DomainEvent & {
   type: "AssetCreated";
   assetId: AssetId;
   ownerId: UserId;
+  assetType: AssetType;
+  assetModelYear?: number;
 };
 
-export const AssetCreated = (assetId: AssetId, ownerId: UserId): AssetCreated => ({
+export const AssetCreated = (props: {
+  assetId: AssetId;
+  ownerId: UserId;
+  assetType: AssetType;
+  assetModelYear?: number;
+}): AssetCreated => ({
   type: "AssetCreated",
-  assetId,
-  ownerId,
+  assetId: props.assetId,
+  ownerId: props.ownerId,
+  assetType: props.assetType,
+  ...(props.assetModelYear !== undefined ? { assetModelYear: props.assetModelYear } : {}),
   occurredAt: new Date(),
 });

--- a/apps/api/src/infrastructure/events/InMemoryEventBus.test.ts
+++ b/apps/api/src/infrastructure/events/InMemoryEventBus.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from "vitest";
+import { InMemoryEventBus } from "./InMemoryEventBus.ts";
+import type { DomainEvent } from "../../domain/events/DomainEvent.ts";
+
+describe("InMemoryEventBus", () => {
+  const event: DomainEvent = {
+    type: "AssetCreated",
+    occurredAt: new Date("2026-05-29T12:00:00.000Z"),
+  };
+
+  it("publishes events to matching handlers", async () => {
+    const bus = new InMemoryEventBus();
+    const received: DomainEvent[] = [];
+
+    bus.subscribe({
+      eventType: "AssetCreated",
+      handle: (published) => {
+        received.push(published);
+      },
+    });
+
+    await bus.publish(event);
+
+    expect(received).toEqual([event]);
+  });
+
+  it("isolates handler failures from publishers and other handlers", async () => {
+    const bus = new InMemoryEventBus();
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const received: DomainEvent[] = [];
+
+    bus.subscribe({
+      eventType: "AssetCreated",
+      handle: () => {
+        throw new Error("telemetry failed");
+      },
+    });
+    bus.subscribe({
+      eventType: "AssetCreated",
+      handle: (published) => {
+        received.push(published);
+      },
+    });
+
+    await expect(bus.publish(event)).resolves.toBeUndefined();
+
+    expect(received).toEqual([event]);
+    expect(consoleError).toHaveBeenCalledOnce();
+    consoleError.mockRestore();
+  });
+});

--- a/apps/api/src/infrastructure/events/InMemoryEventBus.ts
+++ b/apps/api/src/infrastructure/events/InMemoryEventBus.ts
@@ -1,0 +1,31 @@
+import type { DomainEventHandler, EventBus } from "../../application/ports/EventBus.ts";
+import type { DomainEvent } from "../../domain/events/DomainEvent.ts";
+
+export class InMemoryEventBus implements EventBus {
+  readonly #handlers = new Map<string, DomainEventHandler[]>();
+
+  subscribe<TEvent extends DomainEvent>(handler: DomainEventHandler<TEvent>): void {
+    const handlers = this.#handlers.get(handler.eventType) ?? [];
+    handlers.push(handler);
+    this.#handlers.set(handler.eventType, handlers);
+  }
+
+  async publish(event: DomainEvent): Promise<void> {
+    const handlers = this.#handlers.get(event.type) ?? [];
+    await Promise.all(
+      handlers.map(async (handler) => {
+        try {
+          await handler.handle(event);
+        } catch (error) {
+          console.error({ eventType: event.type, error }, "Domain event handler failed");
+        }
+      }),
+    );
+  }
+
+  async publishAll(events: readonly DomainEvent[]): Promise<void> {
+    for (const event of events) {
+      await this.publish(event);
+    }
+  }
+}

--- a/apps/api/src/infrastructure/telemetry/AnalyticsEngineTelemetrySink.ts
+++ b/apps/api/src/infrastructure/telemetry/AnalyticsEngineTelemetrySink.ts
@@ -1,0 +1,21 @@
+export type TelemetryDataPoint = {
+  indexes: string[];
+  blobs: string[];
+  doubles: number[];
+};
+
+export interface TelemetrySink {
+  write(dataPoint: TelemetryDataPoint): void;
+}
+
+export class AnalyticsEngineTelemetrySink implements TelemetrySink {
+  constructor(private readonly dataset: AnalyticsEngineDataset) {}
+
+  write(dataPoint: TelemetryDataPoint): void {
+    try {
+      this.dataset.writeDataPoint(dataPoint);
+    } catch (error) {
+      console.error({ error }, "Analytics Engine telemetry write failed");
+    }
+  }
+}

--- a/apps/api/src/infrastructure/telemetry/asset/AssetCreatedTelemetryHandler.test.ts
+++ b/apps/api/src/infrastructure/telemetry/asset/AssetCreatedTelemetryHandler.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { AssetId, UserId } from "@snaveevans/pineapple-shared";
+import {
+  AssetCreatedTelemetryHandler,
+  mapAssetCreatedTelemetry,
+} from "./AssetCreatedTelemetryHandler.ts";
+import type { TelemetryDataPoint, TelemetrySink } from "../AnalyticsEngineTelemetrySink.ts";
+import type { AssetCreated } from "../../../domain/asset/events/AssetCreated.ts";
+
+describe("AssetCreatedTelemetryHandler", () => {
+  const event: AssetCreated = {
+    type: "AssetCreated",
+    assetId: AssetId.from("195d0ef0-47f5-439f-abfd-29f892c9a040"),
+    ownerId: UserId.from("7d914909-c903-41a4-a13a-82cbd0f61851"),
+    assetType: "vehicle",
+    assetModelYear: 2016,
+    occurredAt: new Date("2026-05-29T12:00:00.000Z"),
+  };
+
+  it("maps AssetCreated to the documented Analytics Engine field order", () => {
+    expect(mapAssetCreatedTelemetry(event)).toEqual({
+      indexes: [event.ownerId],
+      blobs: [
+        "AssetCreated",
+        "Asset",
+        event.assetId,
+        event.ownerId,
+        "vehicle",
+        event.ownerId,
+        "CreateAsset",
+        "v1",
+        "success",
+      ],
+      doubles: [1, event.occurredAt.getTime(), 2016],
+    });
+  });
+
+  it("writes mapped data points to the sink", () => {
+    const writes: TelemetryDataPoint[] = [];
+    const sink: TelemetrySink = {
+      write: (dataPoint) => {
+        writes.push(dataPoint);
+      },
+    };
+
+    new AssetCreatedTelemetryHandler(sink).handle(event);
+
+    expect(writes).toEqual([mapAssetCreatedTelemetry(event)]);
+  });
+});

--- a/apps/api/src/infrastructure/telemetry/asset/AssetCreatedTelemetryHandler.ts
+++ b/apps/api/src/infrastructure/telemetry/asset/AssetCreatedTelemetryHandler.ts
@@ -1,0 +1,31 @@
+import type { DomainEventHandler } from "../../../application/ports/EventBus.ts";
+import type { AssetCreated } from "../../../domain/asset/events/AssetCreated.ts";
+import type { TelemetryDataPoint, TelemetrySink } from "../AnalyticsEngineTelemetrySink.ts";
+
+export function mapAssetCreatedTelemetry(event: AssetCreated): TelemetryDataPoint {
+  return {
+    indexes: [event.ownerId],
+    blobs: [
+      event.type,
+      "Asset",
+      event.assetId,
+      event.ownerId,
+      event.assetType,
+      event.ownerId,
+      "CreateAsset",
+      "v1",
+      "success",
+    ],
+    doubles: [1, event.occurredAt.getTime(), event.assetModelYear ?? 0],
+  };
+}
+
+export class AssetCreatedTelemetryHandler implements DomainEventHandler<AssetCreated> {
+  readonly eventType = "AssetCreated" as const;
+
+  constructor(private readonly sink: TelemetrySink) {}
+
+  handle(event: AssetCreated): void {
+    this.sink.write(mapAssetCreatedTelemetry(event));
+  }
+}

--- a/apps/api/src/infrastructure/telemetry/registerDomainTelemetry.ts
+++ b/apps/api/src/infrastructure/telemetry/registerDomainTelemetry.ts
@@ -1,0 +1,11 @@
+import type { EventBus } from "../../application/ports/EventBus.ts";
+import { AnalyticsEngineTelemetrySink } from "./AnalyticsEngineTelemetrySink.ts";
+import { AssetCreatedTelemetryHandler } from "./asset/AssetCreatedTelemetryHandler.ts";
+
+export function registerDomainTelemetry(deps: {
+  eventBus: EventBus;
+  assetDomainDataset: AnalyticsEngineDataset;
+}): void {
+  const assetDomainSink = new AnalyticsEngineTelemetrySink(deps.assetDomainDataset);
+  deps.eventBus.subscribe(new AssetCreatedTelemetryHandler(assetDomainSink));
+}

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -12,14 +12,19 @@ import { D1UserRepository } from "./infrastructure/persistence/D1UserRepository.
 import { D1AssetRepository } from "./infrastructure/persistence/D1AssetRepository.ts";
 import { createAuth, type Auth, type AuthEnv } from "./infrastructure/auth/auth.ts";
 import { BetterAuthResolver } from "./infrastructure/auth/BetterAuthResolver.ts";
+import { InMemoryEventBus } from "./infrastructure/events/InMemoryEventBus.ts";
+import { AnalyticsEngineTelemetrySink } from "./infrastructure/telemetry/AnalyticsEngineTelemetrySink.ts";
+import { registerDomainTelemetry } from "./infrastructure/telemetry/registerDomainTelemetry.ts";
 
 // Application
 import { CreateAsset } from "./application/usecases/CreateAsset.ts";
 import { GetAsset } from "./application/usecases/GetAsset.ts";
 import { ListAssets } from "./application/usecases/ListAssets.ts";
+import type { EventBus } from "./application/ports/EventBus.ts";
 
 // API layer
 import { toHttpError } from "./api/errors.ts";
+import { createTechnicalTelemetryMiddleware } from "./api/middleware/technicalTelemetry.ts";
 import {
   createAssetRoute,
   getAssetRoute,
@@ -32,12 +37,15 @@ import type { AssetResponseSchema } from "./api/schemas/assetSchemas.ts";
 import type { z } from "@hono/zod-openapi";
 
 type Bindings = AuthEnv & {
+  ASSET_DOMAIN_TELEMETRY: AnalyticsEngineDataset;
+  API_REQUEST_TELEMETRY: AnalyticsEngineDataset;
   /** Local dev only — set in .dev.vars, never in wrangler.toml. Bypasses the Better Auth session check. */
   DEV_AUTH_EMAIL?: string;
 };
 type Variables = { user: User; auth: Auth };
+type AppEnv = { Bindings: Bindings; Variables: Variables };
 
-const app = new OpenAPIHono<{ Bindings: Bindings; Variables: Variables }>({
+const app = new OpenAPIHono<AppEnv>({
   // Validation failures (body/params) → 422 in our standard error shape.
   defaultHook: (result, c) => {
     if (!result.success) {
@@ -61,6 +69,13 @@ app.onError((err, c) => {
 
 registerOpenApiComponents(app.openAPIRegistry);
 
+app.use(
+  "*",
+  createTechnicalTelemetryMiddleware<AppEnv>(
+    (c) => new AnalyticsEngineTelemetrySink(c.env.API_REQUEST_TELEMETRY),
+  ),
+);
+
 // ── Serializers ────────────────────────────────────────────────────────────
 
 function serializeAsset(asset: Asset): z.infer<typeof AssetResponseSchema> {
@@ -73,6 +88,15 @@ function serializeAsset(asset: Asset): z.infer<typeof AssetResponseSchema> {
     createdAt: asset.createdAt.toISOString(),
     updatedAt: asset.updatedAt.toISOString(),
   };
+}
+
+function createEventBus(c: Context<AppEnv>): EventBus {
+  const eventBus = new InMemoryEventBus();
+  registerDomainTelemetry({
+    eventBus,
+    assetDomainDataset: c.env.ASSET_DOMAIN_TELEMETRY,
+  });
+  return eventBus;
 }
 
 // ── Public routes (no auth) ──────────────────────────────────────────────────
@@ -131,7 +155,7 @@ app.use("/api/*", async (c, next) => {
 app.openapi(createAssetRoute, async (c) => {
   const user = c.get("user");
   const { name, metadata } = c.req.valid("json");
-  const result = await new CreateAsset(new D1AssetRepository(c.env.DB)).execute({
+  const result = await new CreateAsset(new D1AssetRepository(c.env.DB), createEventBus(c)).execute({
     ownerId: user.id,
     name,
     // Cast: Zod's `.optional()` yields `T | undefined` but the domain type uses

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -4,6 +4,10 @@ compatibility_date = "2026-05-21"
 # Better Auth relies on Node APIs (crypto, etc.) on the Workers runtime.
 compatibility_flags = ["nodejs_compat"]
 
+[observability]
+enabled = true
+head_sampling_rate = 1
+
 # Production routes on the shared hostname. The API owns /api/* plus its
 # (non-/api) docs + health endpoints; the web Worker (pineapple-web) owns the
 # catch-all /* for the SPA. Cloudflare matches the most specific route, so
@@ -30,3 +34,11 @@ database_id = "9187de54-a0ee-49c4-8d84-954df8010366"
 # Tracked migrations (applied via `wrangler d1 migrations apply`). Path is
 # relative to this config file -> repo-root /migrations.
 migrations_dir = "../../migrations"
+
+[[analytics_engine_datasets]]
+binding = "ASSET_DOMAIN_TELEMETRY"
+dataset = "pineapple_asset_domain_events"
+
+[[analytics_engine_datasets]]
+binding = "API_REQUEST_TELEMETRY"
+dataset = "pineapple_api_request_events"

--- a/docs/telemetry-plan.md
+++ b/docs/telemetry-plan.md
@@ -1,0 +1,216 @@
+# Domain Telemetry Plan
+
+## 1. Summary
+
+Pineapple records two telemetry streams: domain telemetry derived from domain
+events, and technical telemetry derived from HTTP/runtime behavior. Domain
+telemetry answers business questions such as how many assets were created by
+type, while technical telemetry answers operational questions such as p95
+latency for `CreateAsset`. The domain layer remains pure: aggregates raise
+business events, application use cases publish them after persistence, and
+infrastructure subscribers translate them into telemetry writes. Cloudflare
+Workers Analytics Engine is the primary custom telemetry sink because it is a
+Worker-native high-cardinality time-series store with non-blocking writes and
+SQL queries.
+
+References: [Analytics Engine](https://developers.cloudflare.com/analytics/analytics-engine/),
+[Get started](https://developers.cloudflare.com/analytics/analytics-engine/get-started/),
+[limits](https://developers.cloudflare.com/analytics/analytics-engine/limits/),
+[sampling](https://developers.cloudflare.com/analytics/analytics-engine/sampling/),
+and [Workers Logs](https://developers.cloudflare.com/workers/observability/logs/workers-logs/).
+
+## 2. Architecture Decision
+
+Telemetry belongs outside `domain/`. Domain events carry business facts needed
+by downstream consumers; for example, `AssetCreated` carries `assetId`,
+`ownerId`, `assetType`, optional `assetModelYear`, and `occurredAt`, not
+Analytics Engine field positions.
+
+The application layer owns the `EventBus` and `DomainEventHandler` ports. Use
+cases save aggregates, pull events, and publish them after successful
+persistence. They do not know whether a subscriber writes telemetry,
+notifications, projections, or nothing.
+
+Cloudflare-specific telemetry lives in `infrastructure/telemetry/`. That layer
+contains Analytics Engine sinks, domain event subscribers, mappers, and safe
+write wrappers. `worker.ts` is the composition root that binds Analytics Engine
+datasets to subscribers.
+
+Technical telemetry is API/runtime instrumentation. It lives as injectable Hono
+middleware in `api/middleware/technicalTelemetry.ts` and depends only on a sink
+shape. `worker.ts` supplies the Analytics Engine implementation.
+
+## 3. Analytics Engine Schema Per Event Type
+
+Use separate datasets for domain and technical telemetry so ordered Analytics
+Engine fields keep stable meanings.
+
+### `pineapple_asset_domain_events`
+
+Binding: `ASSET_DOMAIN_TELEMETRY`  
+Index: `owner_id`
+
+| Event          | Blobs                                                                                                                           | Doubles                                      | Answers                                  |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- | ---------------------------------------- |
+| `AssetCreated` | `event_type`, `aggregate_type`, `asset_id`, `owner_id`, `asset_type`, `actor_id`, `source_use_case`, `schema_version`, `result` | `count`, `event_time_ms`, `asset_model_year` | Asset creation counts by week/type/owner |
+
+Example question: "How many assets were created this week by type?"
+
+```sql
+SELECT
+  blob5 AS asset_type,
+  SUM(_sample_interval * double1) AS assets_created
+FROM pineapple_asset_domain_events
+WHERE blob1 = 'AssetCreated'
+  AND timestamp >= NOW() - INTERVAL '7' DAY
+GROUP BY asset_type
+ORDER BY assets_created DESC
+```
+
+### Future `pineapple_maintenance_domain_events`
+
+Binding: `MAINTENANCE_DOMAIN_TELEMETRY`  
+Index: `owner_id`
+
+| Event                 | Blobs                                                                                                                                              | Doubles                                                                         | Answers                                                 |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| `MaintenanceRecorded` | `event_type`, `aggregate_type`, `maintenance_id`, `owner_id`, `asset_id`, `asset_type`, `maintenance_type`, `actor_id`, `schema_version`, `result` | `count`, `event_time_ms`, `cost_cents`, `downtime_minutes`, `odometer_or_hours` | Maintenance volume/cost/downtime by asset/type/category |
+
+### `pineapple_api_request_events`
+
+Binding: `API_REQUEST_TELEMETRY`  
+Index: `operation`
+
+| Event       | Blobs                                                                                                                             | Doubles                                                            | Answers                                                    |
+| ----------- | --------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ | ---------------------------------------------------------- |
+| API request | `operation`, `route_pattern`, `method`, `status_class`, `status_code`, `outcome`, `error_name`, `authenticated`, `schema_version` | `duration_ms`, `count`, `status_code_number`, `request_size_bytes` | Request volume, error rates, p95 latency by route/use case |
+
+Example question: "What is the p95 latency of `CreateAsset`?"
+
+```sql
+SELECT quantileExactWeighted(0.95)(double1, _sample_interval) AS p95_ms
+FROM pineapple_api_request_events
+WHERE blob1 = 'CreateAsset'
+  AND timestamp >= NOW() - INTERVAL '1' DAY
+```
+
+Analytics Engine constraints to preserve in future schemas:
+
+- Up to 20 blobs, 20 doubles, and one index per `writeDataPoint`.
+- Total blob payload per data point must remain under 16 KB.
+- The index must be 96 bytes or less.
+- A Worker invocation can write at most 250 data points.
+- Query counts, sums, averages, and quantiles must account for
+  `_sample_interval`.
+- Retention is three months; use D1 outbox, R2, Logpush, or an external
+  observability stack for exact replay or longer retention.
+
+## 4. Extensibility Pattern With A Concrete Template
+
+Naming conventions:
+
+- Domain event files: `domain/<aggregate>/events/<PastTenseEvent>.ts`
+- Telemetry handlers:
+  `infrastructure/telemetry/<aggregate>/<EventName>TelemetryHandler.ts`
+- Dataset bindings: `<AGGREGATE>_DOMAIN_TELEMETRY`
+- Dataset names: `pineapple_<aggregate>_domain_events`
+- Event type strings: exact event name, for example `AssetCreated`
+
+Checklist for a new feature:
+
+1. Add or update the domain event with business dimensions needed by
+   non-domain consumers.
+2. Publish pulled events from the use case after persistence through
+   `EventBus`.
+3. Add a telemetry mapper and handler under
+   `infrastructure/telemetry/<aggregate>/`.
+4. Register the handler in `registerDomainTelemetry(...)` from `worker.ts`.
+5. Add mapper tests proving the ordered blobs/doubles match this document.
+6. Update this document with the new event row.
+
+Template:
+
+```ts
+export class AssetCreatedTelemetryHandler implements DomainEventHandler<AssetCreated> {
+  readonly eventType = "AssetCreated" as const;
+
+  constructor(private readonly sink: TelemetrySink) {}
+
+  handle(event: AssetCreated): void {
+    this.sink.write({
+      indexes: [event.ownerId],
+      blobs: [
+        event.type,
+        "Asset",
+        event.assetId,
+        event.ownerId,
+        event.assetType,
+        event.ownerId,
+        "CreateAsset",
+        "v1",
+        "success",
+      ],
+      doubles: [1, event.occurredAt.getTime(), event.assetModelYear ?? 0],
+    });
+  }
+}
+```
+
+Sinks and the in-memory bus must isolate failures. Telemetry write failures are
+logged but never thrown back into the use case.
+
+## 5. Technical Telemetry Approach
+
+`createTechnicalTelemetryMiddleware` wraps the Worker routes and emits one
+Analytics Engine data point per request. It captures normalized route pattern,
+operation, method, final status, status class, success/failure/error outcome,
+error class, authenticated state when available, request size, and duration via
+`performance.now()`.
+
+Route normalization:
+
+| Request               | Operation     | Route pattern      |
+| --------------------- | ------------- | ------------------ |
+| `POST /api/assets`    | `CreateAsset` | `/api/assets`      |
+| `GET /api/assets`     | `ListAssets`  | `/api/assets`      |
+| `GET /api/assets/:id` | `GetAsset`    | `/api/assets/{id}` |
+| `/api/auth/*`         | `Auth`        | `/api/auth/*`      |
+| unknown               | `Unknown`     | `Unknown`          |
+
+Workers Logs are enabled with `[observability] enabled = true` for invocation
+logs, uncaught exceptions, CPU time, wall time, and debugging. Analytics Engine
+is for custom aggregate queries; Workers Logs, Logpush, R2, or an external
+observability stack should be used for troubleshooting and longer forensic
+workflows.
+
+## 6. Anti-Patterns To Avoid
+
+- Do not import Cloudflare bindings, Hono, Analytics Engine, or telemetry sinks
+  from `domain/` or application use cases.
+- Do not create business telemetry directly from HTTP payloads when it should
+  come from domain events.
+- Do not re-query D1 inside telemetry handlers to recover fields that should be
+  part of the event payload.
+- Do not await Analytics Engine writes in the request path or let telemetry
+  failures fail a use case.
+- Do not use request IDs, asset IDs, or random UUIDs as Analytics Engine indexes
+  by default; index by the stable query partition, usually `ownerId` for domain
+  events and `operation` for request telemetry.
+- Do not put PII or sensitive operational details in blobs: emails, asset names,
+  addresses, VINs, serial numbers, secrets, cookies, or raw request bodies.
+- Do not use Analytics Engine as an audit log, replay log, exact billing ledger,
+  or long-term event store.
+
+## 7. Implementation Order
+
+1. Add the `EventBus` application port, in-memory infrastructure bus, and safe
+   handler registration.
+2. Update `AssetCreated` to include asset telemetry dimensions and publish it
+   from `CreateAsset` after `D1AssetRepository.save`.
+3. Add `ASSET_DOMAIN_TELEMETRY` and `API_REQUEST_TELEMETRY` bindings in
+   `apps/api/wrangler.toml`.
+4. Add Analytics Engine sink wrappers and the `AssetCreatedTelemetryHandler`.
+5. Add technical telemetry middleware and wire it in `worker.ts`.
+6. Add tests for event publication, telemetry mapping, handler failure
+   isolation, and middleware data point construction.
+7. Run `pnpm lint`, `pnpm type-check`, and `pnpm -r test`.


### PR DESCRIPTION
## Summary

- Introduces an `EventBus` application port with an `InMemoryEventBus` infrastructure implementation; `CreateAsset` now publishes `AssetCreated` after persistence
- Adds domain telemetry: `AssetCreatedTelemetryHandler` maps `AssetCreated` events to the `pineapple_asset_domain_events` Analytics Engine dataset, enabling queries like "how many assets created this week by type?"
- Adds technical telemetry: a Hono middleware captures per-request metrics (operation, route, method, status, duration, auth state, error class) and writes to the `pineapple_api_request_events` dataset, enabling p95 latency and error-rate queries per route
- Enables Workers built-in observability (`[observability] enabled = true`) for invocation logs and uncaught exceptions
- Adds `docs/telemetry-plan.md` documenting the two-stream architecture, Analytics Engine field schemas, extensibility pattern, and anti-patterns

## Test plan

- [ ] `pnpm lint` passes
- [ ] `pnpm type-check` passes
- [ ] `pnpm -r test` — 13 tests pass (InMemoryEventBus, technicalTelemetry middleware, AssetCreatedTelemetryHandler, CreateAsset use case, Asset domain)
- [ ] After deploy: verify `pineapple_asset_domain_events` and `pineapple_api_request_events` datasets appear in the Cloudflare Analytics Engine dashboard
- [ ] Create an asset via the API and confirm a data point is written to `pineapple_asset_domain_events`

🤖 Generated with [Claude Code](https://claude.com/claude-code)