### PR TITLE
Add Asset form page (/app/assets/new)

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -17,6 +17,11 @@ It serves these pages from the Claude Design handoff:
 - **Assets** (`/app/assets`) — [`src/app/AppAssets.tsx`](src/app/AppAssets.tsx) —
   the asset library: a responsive card grid (stacked rows on mobile) with search,
   category filter chips, and a grid/list view toggle.
+- **Add Asset** (`/app/assets/new`) — [`src/app/AppAddAsset.tsx`](src/app/AppAddAsset.tsx) —
+  the add-asset form: a three-bucket type picker (Vehicle / Property / Other)
+  with contextual detail fields, an optional photo dropzone, a deferred
+  "set up a schedule" note, and a sticky save bar. The "Add asset" buttons and
+  the ghost add-card on the Assets page link here; `esc` cancels back.
 
 The authenticated pages share their chrome — the desktop top bar and mobile
 bottom tab bar — via [`src/app/AppChrome.tsx`](src/app/AppChrome.tsx), where the
@@ -25,7 +30,7 @@ nav tabs link between `/app` and `/app/assets`.
 The shared design-system primitives (`Icon`, `HFStatusPill`, `HFAssetIcon`,
 `HFAssetThumb`) are ported from the FieldOps app prototype and live in
 [`src/design/`](src/design/), styled by `design/styles/hifi.css` +
-`hifi-assets.css` (the `.hf-*` tokens/components). Each page adds a thin layer
+`hifi-assets.css` + `hifi-add-asset.css` (the `.hf-*` tokens/components). Each page adds a thin layer
 that mirrors those tokens onto its own scope: `marketing.css` (`.mk`) and
 `auth.css` (`.au`). The `/app` pages render the `.hf` system directly.
 
@@ -38,7 +43,7 @@ fallback (see `wrangler.jsonc`) serves `index.html` for any path, so `/login`,
 
 ```
 index.html              # Vite HTML entry (loads Inter + JetBrains Mono)
-src/main.tsx            # React bootstrap + path routing (/, /login, /app, /app/assets)
+src/main.tsx            # React bootstrap + path routing (/, /login, /app, /app/assets, /app/assets/new)
 src/design/             # shared design-system primitives + .hf CSS tokens
 src/marketing/          # Marketing Home page + .mk CSS
 src/auth/               # Auth Flow page (/login) + .au CSS

--- a/apps/web/src/app/AppAddAsset.tsx
+++ b/apps/web/src/app/AppAddAsset.tsx
@@ -1,0 +1,445 @@
+import { useEffect, useState, type ReactNode } from "react";
+import { Icon, type IconName } from "../design/Icon";
+import { HFTopBar } from "./AppChrome";
+
+// FieldOps — Add Asset. A focused single-page form on the .hf design system:
+// a three-bucket type picker (Vehicle / Property / Other), contextual detail
+// fields that reveal based on the chosen type/subtype, an optional photo
+// dropzone, a deferred "set up a schedule" note, and a sticky save bar. Ported
+// from the FieldOps design prototype (Add Asset.html / hifi-add-asset.jsx);
+// styling comes from the shared .hf tokens in styles/hifi.css + hifi-assets.css
+// plus the .hf-aa-* scopes in styles/hifi-add-asset.css.
+import "../design/styles/hifi.css";
+import "../design/styles/hifi-assets.css";
+import "../design/styles/hifi-add-asset.css";
+
+type AssetType = "vehicle" | "property" | "other";
+type Subtype = "lawn" | "power-tool" | "appliance" | "hvac" | "generator" | "other";
+
+const ASSETS_HREF = "/app/assets";
+
+/* ============ field primitives ============ */
+function HFField({
+  label,
+  required,
+  optional,
+  hint,
+  children,
+}: {
+  label: string;
+  required?: boolean | undefined;
+  optional?: boolean | undefined;
+  hint?: string | undefined;
+  children: ReactNode;
+}) {
+  return (
+    <div className="hf-field">
+      <label className="hf-field-label">
+        {label}
+        {required && <span className="hf-field-req">*</span>}
+        {optional && <span className="hf-field-opt">optional</span>}
+        {hint && <span className="hf-field-hint">{hint}</span>}
+      </label>
+      {children}
+    </div>
+  );
+}
+
+function HFTextField({
+  label,
+  required,
+  optional,
+  hint,
+  placeholder,
+  mono,
+  defaultValue,
+}: {
+  label: string;
+  required?: boolean | undefined;
+  optional?: boolean | undefined;
+  hint?: string | undefined;
+  placeholder?: string | undefined;
+  mono?: boolean | undefined;
+  defaultValue?: string | undefined;
+}) {
+  return (
+    <HFField label={label} required={required} optional={optional} hint={hint}>
+      <input
+        className={`hf-input ${mono ? "hf-mono-input" : ""}`}
+        placeholder={placeholder}
+        defaultValue={defaultValue}
+      />
+    </HFField>
+  );
+}
+
+function HFSelectField({
+  label,
+  required,
+  optional,
+  hint,
+  options,
+  defaultValue,
+}: {
+  label: string;
+  required?: boolean | undefined;
+  optional?: boolean | undefined;
+  hint?: string | undefined;
+  options: string[];
+  defaultValue?: string | undefined;
+}) {
+  return (
+    <HFField label={label} required={required} optional={optional} hint={hint}>
+      <select className="hf-select" defaultValue={defaultValue}>
+        {options.map((o) => (
+          <option key={o} value={o}>
+            {o}
+          </option>
+        ))}
+      </select>
+    </HFField>
+  );
+}
+
+/* ============ type picker ============ */
+const HF_TYPES: { id: AssetType; icon: IconName; name: string; desc: string }[] = [
+  { id: "vehicle", icon: "car", name: "Vehicle", desc: "Cars, trucks, vans, trailers" },
+  { id: "property", icon: "home", name: "Property", desc: "Homes, land, rentals & what's on them" },
+  { id: "other", icon: "wrench", name: "Other", desc: "Tools, HVAC, generators, appliances" },
+];
+
+function HFTypePicker({
+  value,
+  onChange,
+}: {
+  value: AssetType;
+  onChange: (v: AssetType) => void;
+}) {
+  return (
+    <div className="hf-aa-types" role="radiogroup" aria-label="Asset type">
+      {HF_TYPES.map((t) => (
+        <button
+          key={t.id}
+          type="button"
+          role="radio"
+          aria-checked={value === t.id}
+          className={`hf-type-card ${value === t.id ? "selected" : ""}`}
+          onClick={() => onChange(t.id)}
+        >
+          <span className="hf-type-radio" />
+          <span className="hf-type-icon" data-cat={t.id}>
+            <Icon name={t.icon} size={19} stroke={1.7} />
+          </span>
+          <span className="hf-type-text">
+            <span className="hf-type-name">{t.name}</span>
+            <span className="hf-type-desc">{t.desc}</span>
+          </span>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+/* ============ subtype chips (within "Other") ============ */
+const HF_SUBTYPES: { id: Subtype; glyph: IconName; label: string }[] = [
+  { id: "lawn", glyph: "leaf", label: "Lawn equipment" },
+  { id: "power-tool", glyph: "wrench", label: "Power tool" },
+  { id: "appliance", glyph: "grid", label: "Appliance" },
+  { id: "hvac", glyph: "home", label: "HVAC" },
+  { id: "generator", glyph: "bolt", label: "Generator" },
+  { id: "other", glyph: "dot", label: "Something else" },
+];
+
+function HFSubtypeChips({
+  value,
+  onChange,
+}: {
+  value: Subtype;
+  onChange: (v: Subtype) => void;
+}) {
+  return (
+    <div className="hf-aa-chips">
+      {HF_SUBTYPES.map((s) => (
+        <button
+          key={s.id}
+          type="button"
+          className={`hf-subchip ${value === s.id ? "selected" : ""}`}
+          onClick={() => onChange(s.id)}
+        >
+          <span className="hf-subchip-glyph">
+            <Icon name={s.glyph} size={13} stroke={1.8} />
+          </span>
+          {s.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+/* ============ photo dropzone ============ */
+function HFDropzone() {
+  return (
+    <div className="hf-dropzone">
+      <div className="hf-dropzone-icon">
+        <Icon name="camera" size={18} color="var(--hf-ink-soft)" />
+      </div>
+      <div className="hf-dropzone-label">Add photo</div>
+      <div className="hf-dropzone-sub">drag or click</div>
+    </div>
+  );
+}
+
+/* ============ contextual detail sections ============ */
+function HFVehicleFields() {
+  return (
+    <div className="hf-aa-section">
+      <div className="hf-aa-section-head">
+        <span className="hf-aa-section-title">Vehicle details</span>
+        <span className="hf-aa-section-hint">helps with service reminders</span>
+      </div>
+      <div className="hf-field-row">
+        <HFTextField label="Make" required placeholder="Ford" />
+        <HFTextField label="Model" required placeholder="F-150" />
+        <HFTextField label="Year" required placeholder="2022" mono />
+      </div>
+      <HFTextField
+        label="VIN"
+        optional
+        hint="enables warranty lookups"
+        placeholder="1FTFW1E50NFA12345"
+        mono
+      />
+    </div>
+  );
+}
+
+function HFPropertyFields() {
+  return (
+    <div className="hf-aa-section">
+      <div className="hf-aa-section-head">
+        <span className="hf-aa-section-title">Property details</span>
+        <span className="hf-aa-section-hint">at least street, city & state</span>
+      </div>
+      <HFTextField
+        label="Nickname"
+        optional
+        hint="handy when you own multiples"
+        placeholder="Main house, Cabin…"
+      />
+      <HFTextField label="Street" required placeholder="12 Oak St, Apt 4" />
+      <div className="hf-field-row">
+        <HFTextField label="City" required placeholder="Portland" />
+        <HFSelectField label="State" required options={["OR", "WA", "CA", "ID", "NV", "AZ"]} />
+        <HFTextField label="Postal" required placeholder="97204" mono />
+      </div>
+    </div>
+  );
+}
+
+function HFOtherFields({
+  subtype,
+  onSubtype,
+}: {
+  subtype: Subtype;
+  onSubtype: (v: Subtype) => void;
+}) {
+  return (
+    <div className="hf-aa-section">
+      <div className="hf-aa-section-head">
+        <span className="hf-aa-section-title">Details</span>
+        <span className="hf-aa-section-hint">all optional — fill what you know</span>
+      </div>
+      <HFField label="What is it?" hint="picks the right service reminders">
+        <HFSubtypeChips value={subtype} onChange={onSubtype} />
+      </HFField>
+      <div className="hf-field-row">
+        <HFTextField
+          label="Manufacturer"
+          placeholder={
+            subtype === "lawn"
+              ? "Toro"
+              : subtype === "hvac"
+                ? "Carrier"
+                : subtype === "generator"
+                  ? "Generac"
+                  : "Brand"
+          }
+        />
+        <HFTextField label="Model number" placeholder="MX5060" mono />
+      </div>
+      <HFTextField label="Serial number" optional hint="useful for warranty" placeholder="SN-298471-A" mono />
+      {subtype === "lawn" && (
+        <div className="hf-field-row">
+          <HFTextField label="Engine hours" optional hint="schedules oil changes" placeholder="124" mono />
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* maps current type → name placeholder + follow-up label */
+function namePlaceholder(type: AssetType, subtype: Subtype): string {
+  if (type === "vehicle") return "Ford F-150 · #4";
+  if (type === "property") return "12 Oak St";
+  if (subtype === "lawn") return "Toro ZTR Mower";
+  if (subtype === "hvac") return "Rooftop AC unit";
+  if (subtype === "generator") return "Generac 22kW";
+  return "Pressure washer";
+}
+
+function followLabel(type: AssetType, subtype: Subtype): string {
+  if (type === "vehicle") return "vehicle";
+  if (type === "property") return "property";
+  if (subtype === "lawn") return "equipment";
+  if (subtype === "hvac") return "unit";
+  return "asset";
+}
+
+/* ============ shared field-stack ============ */
+function HFAddAssetFields({
+  type,
+  setType,
+  subtype,
+  setSubtype,
+  showHeaderHint,
+}: {
+  type: AssetType;
+  setType: (v: AssetType) => void;
+  subtype: Subtype;
+  setSubtype: (v: Subtype) => void;
+  showHeaderHint?: boolean | undefined;
+}) {
+  return (
+    <>
+      {/* TYPE */}
+      <div className="hf-aa-section">
+        <HFField
+          label="Asset type"
+          required
+          hint={showHeaderHint ? "three buckets — pick what fits" : undefined}
+        >
+          <HFTypePicker value={type} onChange={setType} />
+        </HFField>
+      </div>
+
+      {/* NAME */}
+      <HFTextField
+        label="Asset name"
+        required
+        hint="how you'll recognize it"
+        placeholder={namePlaceholder(type, subtype)}
+      />
+
+      <div className="hf-aa-rule" />
+
+      {/* CONTEXTUAL FIELDS */}
+      {type === "vehicle" && <HFVehicleFields />}
+      {type === "property" && <HFPropertyFields />}
+      {type === "other" && <HFOtherFields subtype={subtype} onSubtype={setSubtype} />}
+    </>
+  );
+}
+
+/* ============ main: full-page add-asset form (responsive) ============ */
+export function AppAddAsset({ initialType = "vehicle" }: { initialType?: AssetType }) {
+  const [type, setType] = useState<AssetType>(initialType);
+  const [subtype, setSubtype] = useState<Subtype>("lawn");
+
+  // Esc cancels back to the asset library — mirrors the breadcrumb's hint.
+  useEffect(() => {
+    document.title = "FieldOps — Add Asset";
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") window.location.href = ASSETS_HREF;
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  const cancel = () => {
+    window.location.href = ASSETS_HREF;
+  };
+
+  return (
+    <div className="hf hf-app hf-aa-page">
+      <HFTopBar activeNav="assets" />
+
+      <div className="hf-aa-crumb">
+        <a href={ASSETS_HREF}>Assets</a>
+        <span className="hf-aa-crumb-sep">
+          <Icon name="chevron-right" size={13} />
+        </span>
+        <span className="hf-aa-crumb-here">Add asset</span>
+        <span className="hf-aa-crumb-esc">
+          <kbd>esc</kbd> to cancel
+        </span>
+      </div>
+
+      <div className="hf-aa-body">
+        <div className="hf-aa-col">
+          <div className="hf-aa-head">
+            <h1>Add an asset</h1>
+            <p>
+              Track anything that needs regular service — pick a type and we'll ask the right
+              details.
+            </p>
+          </div>
+
+          <HFAddAssetFields
+            type={type}
+            setType={setType}
+            subtype={subtype}
+            setSubtype={setSubtype}
+            showHeaderHint
+          />
+
+          <div className="hf-aa-rule" />
+
+          {/* PHOTO */}
+          <div className="hf-photo-row">
+            <div className="hf-photo-text">
+              <label className="hf-field-label">
+                Photo <span className="hf-field-opt">optional</span>
+              </label>
+              <div className="hf-photo-sub">
+                Helps you spot it in the grid. If you skip it, we'll use a category icon — you can
+                add or change this anytime.
+              </div>
+            </div>
+            <HFDropzone />
+          </div>
+
+          {/* NEXT STEP */}
+          <div className="hf-aa-next">
+            <div className="hf-aa-next-icon">
+              <Icon name="calendar" size={17} stroke={1.8} />
+            </div>
+            <div className="hf-aa-next-text">
+              <div className="hf-aa-next-title">Next: set up a service schedule</div>
+              <div className="hf-aa-next-sub">
+                After saving, we'll ask when this {followLabel(type, subtype)} needs its next
+                service.
+              </div>
+            </div>
+            <Icon name="arrow-right" size={18} color="var(--hf-brand-2)" />
+          </div>
+        </div>
+      </div>
+
+      {/* STICKY SAVE BAR */}
+      <div className="hf-aa-footer">
+        <div className="hf-aa-footer-note">
+          Fields marked <span className="hf-field-req">*</span> are required
+        </div>
+        <div className="hf-aa-footer-actions">
+          <button className="hf-btn hf-btn-secondary hf-btn-lg" onClick={cancel}>
+            Cancel
+          </button>
+          <button className="hf-btn hf-btn-primary hf-btn-lg">
+            <Icon name="check" size={15} stroke={2.2} />
+            Save asset
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/AppAssets.tsx
+++ b/apps/web/src/app/AppAssets.tsx
@@ -101,7 +101,13 @@ function HFAssetRowCard({ asset }: { asset: Asset }) {
 /* ============ add-asset ghost card (slots into the grid) ============ */
 function HFAddCard() {
   return (
-    <article className="hf-asset-card hf-add-card" tabIndex={0}>
+    <article
+      className="hf-asset-card hf-add-card"
+      tabIndex={0}
+      onClick={() => {
+        window.location.href = "/app/assets/new";
+      }}
+    >
       <div className="hf-add-card-inner">
         <div className="hf-add-card-plus">
           <Icon name="plus" size={20} stroke={2} />
@@ -169,7 +175,12 @@ function HFAssetsHeader() {
         <div className="hf-greeting-sub">{HF_ASSETS_ALL.length} things you take care of</div>
       </div>
       <div className="hf-stats hf-stats-tight">
-        <button className="hf-btn hf-btn-primary">
+        <button
+          className="hf-btn hf-btn-primary"
+          onClick={() => {
+            window.location.href = "/app/assets/new";
+          }}
+        >
           <Icon name="plus" size={14} stroke={2.2} />
           Add asset
         </button>
@@ -200,7 +211,12 @@ export function AppAssets() {
           {HF_ASSETS_ALL.map((a) => (
             <HFAssetRowCard key={a.id} asset={a} />
           ))}
-          <button className="hf-row-add">
+          <button
+            className="hf-row-add"
+            onClick={() => {
+              window.location.href = "/app/assets/new";
+            }}
+          >
             <Icon name="plus" size={16} stroke={2} />
             Add an asset
           </button>

--- a/apps/web/src/design/styles/hifi-add-asset.css
+++ b/apps/web/src/design/styles/hifi-add-asset.css
@@ -1,0 +1,592 @@
+/* FieldOps — Hi-Fi Add Asset form
+   Extends the .hf tokens from hifi.css. Single-page form with a 3-type
+   picker (Vehicle / Property / Other), contextual detail fields, optional
+   photo, and a sticky save bar. Mobile collapses to a bottom-sheet shell.
+   Same container-query contract — container-name "hfapp" on the root. */
+
+/* ============ page shell ============ */
+.hf-aa-page {
+  background: var(--hf-bg);
+}
+
+/* breadcrumb strip under the topbar */
+.hf-aa-crumb {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 32px;
+  font-size: 12.5px;
+  color: var(--hf-ink-soft);
+  border-bottom: 1px solid var(--hf-line);
+  background: var(--hf-surface);
+  flex-shrink: 0;
+}
+.hf-aa-crumb a {
+  color: var(--hf-ink-soft);
+  text-decoration: none;
+}
+.hf-aa-crumb a:hover {
+  color: var(--hf-ink);
+}
+.hf-aa-crumb-sep {
+  color: var(--hf-ink-faint);
+}
+.hf-aa-crumb-here {
+  color: var(--hf-ink);
+  font-weight: 500;
+}
+.hf-aa-crumb-esc {
+  margin-left: auto;
+}
+.hf-aa-crumb-esc kbd {
+  font-family: var(--hf-mono);
+  font-size: 10px;
+  padding: 2px 6px;
+  background: var(--hf-surface-2);
+  border: 1px solid var(--hf-line);
+  border-radius: 4px;
+  color: var(--hf-ink-faint);
+}
+
+/* scroll body — centered column */
+.hf-aa-body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 28px 32px 40px;
+}
+.hf-aa-col {
+  width: 100%;
+  max-width: 680px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+/* ============ page header ============ */
+.hf-aa-head h1 {
+  margin: 0;
+  font-size: 26px;
+  font-weight: 700;
+  letter-spacing: -0.025em;
+  color: var(--hf-ink);
+  line-height: 1.15;
+}
+.hf-aa-head p {
+  margin: 6px 0 0;
+  font-size: 14px;
+  color: var(--hf-ink-soft);
+  line-height: 1.45;
+}
+
+/* ============ field section scaffold ============ */
+.hf-aa-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.hf-aa-section-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+.hf-aa-section-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--hf-ink);
+  letter-spacing: -0.01em;
+}
+.hf-aa-section-hint {
+  font-size: 12px;
+  color: var(--hf-ink-faint);
+}
+
+.hf-aa-rule {
+  height: 1px;
+  background: var(--hf-line);
+}
+
+/* ============ field group ============ */
+.hf-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+.hf-field-label {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  font-size: 12.5px;
+  font-weight: 500;
+  color: var(--hf-ink);
+}
+.hf-field-req {
+  color: var(--hf-bad);
+  font-weight: 600;
+}
+.hf-field-opt {
+  font-family: var(--hf-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--hf-ink-faint);
+}
+.hf-field-hint {
+  font-size: 11.5px;
+  color: var(--hf-ink-faint);
+  margin-left: auto;
+}
+
+.hf-input,
+.hf-select {
+  width: 100%;
+  height: 40px;
+  padding: 0 12px;
+  border: 1px solid var(--hf-line);
+  border-radius: 8px;
+  background: var(--hf-surface);
+  color: var(--hf-ink);
+  font: inherit;
+  font-size: 14px;
+  outline: 0;
+  transition:
+    border-color 100ms,
+    box-shadow 100ms;
+}
+.hf-input::placeholder {
+  color: var(--hf-ink-faint);
+}
+.hf-input:hover,
+.hf-select:hover {
+  border-color: oklch(85% 0.008 80);
+}
+.hf-input:focus,
+.hf-select:focus {
+  border-color: var(--hf-brand);
+  box-shadow: 0 0 0 3px var(--hf-brand-bg);
+}
+.hf-input.hf-mono-input {
+  font-family: var(--hf-mono);
+  font-size: 13px;
+  letter-spacing: 0.01em;
+}
+
+.hf-select {
+  appearance: none;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%239a958c' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><path d='M6 9l6 6 6-6'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
+  padding-right: 34px;
+  cursor: pointer;
+}
+
+.hf-field-row {
+  display: flex;
+  gap: 12px;
+}
+.hf-field-row > .hf-field {
+  flex: 1;
+}
+
+/* ============ type picker (3 radio cards) ============ */
+.hf-aa-types {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+}
+.hf-type-card {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  padding: 12px 13px;
+  border: 1px solid var(--hf-line);
+  border-radius: var(--hf-r);
+  background: var(--hf-surface);
+  text-align: left;
+  cursor: pointer;
+  position: relative;
+  transition:
+    border-color 100ms,
+    box-shadow 120ms,
+    background 100ms;
+}
+.hf-type-card:hover {
+  border-color: oklch(82% 0.012 80);
+  box-shadow: var(--hf-shadow-1);
+}
+.hf-type-card.selected {
+  border-color: var(--hf-brand);
+  box-shadow: 0 0 0 1px var(--hf-brand);
+  background: var(--hf-brand-bg);
+}
+.hf-type-radio {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 1.5px solid var(--hf-ink-faint);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  background: var(--hf-surface);
+  transition: border-color 100ms;
+}
+.hf-type-card.selected .hf-type-radio {
+  border-color: var(--hf-brand);
+}
+.hf-type-card.selected .hf-type-radio::after {
+  content: "";
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--hf-brand);
+}
+.hf-type-icon {
+  width: 34px;
+  height: 34px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+.hf-type-icon[data-cat="vehicle"] {
+  background: var(--hf-tint-vehicle);
+  color: var(--hf-cat-vehicle-fg);
+}
+.hf-type-icon[data-cat="property"] {
+  background: var(--hf-tint-prop);
+  color: var(--hf-cat-property-fg);
+}
+.hf-type-icon[data-cat="other"] {
+  background: var(--hf-tint-equip);
+  color: var(--hf-cat-equipment-fg);
+}
+.hf-type-text {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+.hf-type-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--hf-ink);
+  letter-spacing: -0.01em;
+}
+.hf-type-desc {
+  font-size: 11.5px;
+  color: var(--hf-ink-soft);
+  line-height: 1.3;
+}
+
+/* ============ subtype chips (inside "Other") ============ */
+.hf-aa-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+.hf-subchip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 12px;
+  border: 1px solid var(--hf-line);
+  border-radius: 999px;
+  background: var(--hf-surface);
+  color: var(--hf-ink-soft);
+  font-size: 12.5px;
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    border-color 100ms,
+    background 100ms,
+    color 100ms;
+}
+.hf-subchip:hover {
+  border-color: oklch(82% 0.012 80);
+  color: var(--hf-ink);
+}
+.hf-subchip.selected {
+  background: var(--hf-ink);
+  color: var(--hf-surface);
+  border-color: var(--hf-ink);
+}
+.hf-subchip.selected .hf-subchip-glyph {
+  opacity: 1;
+}
+.hf-subchip-glyph {
+  display: inline-flex;
+  opacity: 0.7;
+}
+
+/* ============ photo dropzone ============ */
+.hf-photo-row {
+  display: flex;
+  gap: 16px;
+  align-items: stretch;
+}
+.hf-photo-text {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  justify-content: center;
+}
+.hf-photo-text .hf-field-label {
+  margin-bottom: 2px;
+}
+.hf-photo-sub {
+  font-size: 12px;
+  color: var(--hf-ink-soft);
+  line-height: 1.45;
+}
+.hf-dropzone {
+  width: 132px;
+  flex-shrink: 0;
+  border: 1.5px dashed var(--hf-ink-faint);
+  border-radius: var(--hf-r);
+  background:
+    repeating-linear-gradient(135deg, transparent 0 16px, rgba(20, 18, 14, 0.02) 16px 17px),
+    var(--hf-surface-2);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 16px 12px;
+  color: var(--hf-ink-soft);
+  cursor: pointer;
+  transition:
+    border-color 100ms,
+    background 100ms,
+    color 100ms;
+}
+.hf-dropzone:hover {
+  border-color: var(--hf-brand);
+  color: var(--hf-brand);
+  background: var(--hf-brand-bg);
+}
+.hf-dropzone-icon {
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  background: var(--hf-surface);
+  border: 1px solid var(--hf-line);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.hf-dropzone-label {
+  font-size: 12px;
+  font-weight: 600;
+  text-align: center;
+  line-height: 1.3;
+}
+.hf-dropzone-sub {
+  font-size: 10.5px;
+  color: var(--hf-ink-faint);
+}
+
+/* ============ deferred next-step note ============ */
+.hf-aa-next {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 16px;
+  border: 1px solid var(--hf-line);
+  border-left: 3px solid var(--hf-brand);
+  border-radius: var(--hf-r);
+  background: var(--hf-brand-bg);
+}
+.hf-aa-next-icon {
+  width: 34px;
+  height: 34px;
+  border-radius: 8px;
+  background: var(--hf-surface);
+  border: 1px solid oklch(88% 0.04 150);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--hf-brand-2);
+  flex-shrink: 0;
+}
+.hf-aa-next-text {
+  flex: 1;
+  min-width: 0;
+}
+.hf-aa-next-title {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--hf-ink);
+}
+.hf-aa-next-sub {
+  font-size: 12px;
+  color: var(--hf-ink-soft);
+  margin-top: 1px;
+}
+
+/* ============ sticky save bar ============ */
+.hf-aa-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 32px;
+  border-top: 1px solid var(--hf-line);
+  background: var(--hf-surface);
+  flex-shrink: 0;
+}
+.hf-aa-footer-note {
+  font-size: 12px;
+  color: var(--hf-ink-faint);
+}
+.hf-aa-footer-note .hf-field-req {
+  font-weight: 600;
+}
+.hf-aa-footer-actions {
+  display: flex;
+  gap: 8px;
+}
+.hf-btn-lg {
+  height: 40px;
+  padding: 0 18px;
+  font-size: 13.5px;
+}
+
+/* ===================================================================
+   MOBILE — bottom-sheet shell
+   =================================================================== */
+.hf-sheet-scrim {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  background: var(--hf-bg);
+  overflow: hidden;
+}
+.hf-sheet-bg {
+  position: absolute;
+  inset: 0;
+  padding: 16px;
+  opacity: 0.5;
+  pointer-events: none;
+}
+.hf-sheet-bg-h1 {
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--hf-ink-faint);
+  margin: 0;
+}
+.hf-sheet-bg-sub {
+  font-size: 12px;
+  color: var(--hf-ink-faint);
+  margin-top: 2px;
+}
+.hf-sheet-dim {
+  position: absolute;
+  inset: 0;
+  background: rgba(20, 18, 14, 0.28);
+}
+
+.hf-sheet {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 93%;
+  background: var(--hf-surface);
+  border-top-left-radius: 20px;
+  border-top-right-radius: 20px;
+  box-shadow: 0 -8px 30px rgba(20, 18, 14, 0.18);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.hf-sheet-grab {
+  display: flex;
+  justify-content: center;
+  padding: 9px 0 5px;
+}
+.hf-sheet-grab span {
+  width: 38px;
+  height: 4px;
+  border-radius: 2px;
+  background: var(--hf-line);
+}
+.hf-sheet-head {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  padding: 4px 16px 12px;
+  border-bottom: 1px solid var(--hf-line);
+}
+.hf-sheet-head-title {
+  font-size: 15px;
+  font-weight: 600;
+  text-align: center;
+  color: var(--hf-ink);
+}
+.hf-sheet-cancel {
+  font-size: 13px;
+  color: var(--hf-ink-soft);
+  justify-self: start;
+  background: none;
+  border: 0;
+  padding: 0;
+}
+.hf-sheet-body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+.hf-sheet-foot {
+  display: flex;
+  gap: 10px;
+  padding: 12px 16px calc(12px + env(safe-area-inset-bottom, 8px));
+  border-top: 1px solid var(--hf-line);
+}
+.hf-sheet-foot .hf-btn {
+  flex: 1;
+  justify-content: center;
+  height: 44px;
+}
+.hf-sheet-foot .hf-btn-primary {
+  flex: 1.5;
+}
+
+/* mobile type grid: stack the 3 cards full-width */
+.hf-sheet .hf-aa-types {
+  grid-template-columns: 1fr;
+  gap: 8px;
+}
+.hf-sheet .hf-type-desc {
+  display: none;
+}
+
+/* ===================================================================
+   RESPONSIVE — container queries on hfapp
+   =================================================================== */
+@container hfapp (max-width: 720px) {
+  .hf-aa-body {
+    padding: 22px 18px 32px;
+  }
+  .hf-aa-crumb {
+    padding: 10px 18px;
+  }
+  .hf-aa-footer {
+    padding: 12px 18px;
+  }
+  .hf-aa-types {
+    grid-template-columns: 1fr;
+  }
+  .hf-type-desc {
+    display: block;
+  }
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -5,16 +5,19 @@ import { MarketingHome } from "./marketing/MarketingHome";
 import { AuthFlow } from "./auth/AuthFlow";
 import { AppHome } from "./app/AppHome";
 import { AppAssets } from "./app/AppAssets";
+import { AppAddAsset } from "./app/AppAddAsset";
 
 // Minimal path-based routing. The Worker serves index.html for any unmatched
 // path (wrangler.jsonc -> assets.not_found_handling: "single-page-application"),
 // so /login and /app resolve here; everything else renders the marketing home.
 // /login reads ?mode=login|signup to pick its initial screen (set by the
-// marketing CTAs); /app is the authenticated master/detail home and
-// /app/assets is the asset library (card grid).
+// marketing CTAs); /app is the authenticated master/detail home,
+// /app/assets is the asset library (card grid), and /app/assets/new is the
+// add-asset form.
 function App() {
   const path = window.location.pathname;
   if (path === "/login") return <AuthFlow />;
+  if (path === "/app/assets/new") return <AppAddAsset />;
   if (path === "/app/assets") return <AppAssets />;
   if (path === "/app") return <AppHome />;
   return <MarketingHome />;


### PR DESCRIPTION
## Summary

Ports the FieldOps **Add Asset** design handoff into the web app as a new authenticated page at `/app/assets/new`.

- **New page** `apps/web/src/app/AppAddAsset.tsx` — a focused single-page form:
  - three-bucket **type picker** (Vehicle / Property / Other)
  - **contextual detail fields** that reveal per type, and per subtype within "Other" (e.g. "Engine hours" for lawn equipment); the asset-name placeholder adapts too
  - optional **photo dropzone**
  - deferred **"set up a service schedule"** note
  - sticky **save bar**
- **New styles** `apps/web/src/design/styles/hifi-add-asset.css` — ported from the prototype's `hifi-add-asset.css`, extending the shared `.hf` tokens.
- **Routing** — `main.tsx` maps `/app/assets/new` → `AppAddAsset`.
- **Entry points** — the Assets page "Add asset" header button, the ghost add-card, and the mobile row-add button all navigate to the new route.
- **Cancel** — `esc` and the Cancel buttons return to `/app/assets`.
- Documented the page/route in `apps/web/README.md`.

## Verification

- `pnpm lint` ✅ and `pnpm type-check` ✅ pass clean.
- Rendered in the live Vite preview — pixel-faithful to the handoff. Confirmed Vehicle/Property/Other field-switching, subtype-driven fields, the mobile responsive layout (type cards stack full-width), and round-trip navigation from the Assets page and back via `esc`. No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)