### PR TITLE
[codex] Add React Router to web app

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -34,16 +34,19 @@ The shared design-system primitives (`Icon`, `HFStatusPill`, `HFAssetIcon`,
 that mirrors those tokens onto its own scope: `marketing.css` (`.mk`) and
 `auth.css` (`.au`). The `/app` pages render the `.hf` system directly.
 
-Routing is a single `window.location.pathname` check in
-[`src/main.tsx`](src/main.tsx) — no router dependency. The Worker's SPA
-fallback (see `wrangler.jsonc`) serves `index.html` for any path, so `/login`,
-`/app`, and `/app/assets` resolve client-side.
+Routing uses React Router Data Mode. [`src/router.tsx`](src/router.tsx) owns the
+route tree and [`src/routes.ts`](src/routes.ts) exports shared path helpers for
+route-aware links and navigation. The Worker's SPA fallback (see
+`wrangler.jsonc`) serves `index.html` for any path, so direct loads of `/login`,
+`/app`, `/app/assets`, and `/app/assets/new` resolve client-side.
 
 ## Layout
 
 ```
 index.html              # Vite HTML entry (loads Inter + JetBrains Mono)
-src/main.tsx            # React bootstrap + path routing (/, /login, /app, /app/assets, /app/assets/new)
+src/main.tsx            # React bootstrap + RouterProvider
+src/router.tsx          # React Router route tree (/, /login, /app, /app/assets, /app/assets/new)
+src/routes.ts           # shared route paths/path builders
 src/design/             # shared design-system primitives + .hf CSS tokens
 src/marketing/          # Marketing Home page + .mk CSS
 src/auth/               # Auth Flow page (/login) + .au CSS

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,7 +13,8 @@
   },
   "dependencies": {
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-router": "^7.16.0"
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.1.0",

--- a/apps/web/src/app/AppAddAsset.tsx
+++ b/apps/web/src/app/AppAddAsset.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState, type ReactNode } from "react";
+import { Link, useNavigate } from "react-router";
 import { Icon, type IconName } from "../design/Icon";
 import { HFTopBar } from "./AppChrome";
+import { paths } from "../routes";
 
 // FieldOps — Add Asset. A focused single-page form on the .hf design system:
 // a three-bucket type picker (Vehicle / Property / Other), contextual detail
@@ -15,8 +17,6 @@ import "../design/styles/hifi-add-asset.css";
 
 type AssetType = "vehicle" | "property" | "other";
 type Subtype = "lawn" | "power-tool" | "appliance" | "hvac" | "generator" | "other";
-
-const ASSETS_HREF = "/app/assets";
 
 /* ============ field primitives ============ */
 function HFField({
@@ -344,27 +344,28 @@ function HFAddAssetFields({
 export function AppAddAsset({ initialType = "vehicle" }: { initialType?: AssetType }) {
   const [type, setType] = useState<AssetType>(initialType);
   const [subtype, setSubtype] = useState<Subtype>("lawn");
+  const navigate = useNavigate();
 
   // Esc cancels back to the asset library — mirrors the breadcrumb's hint.
   useEffect(() => {
     document.title = "FieldOps — Add Asset";
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") window.location.href = ASSETS_HREF;
+      if (e.key === "Escape") navigate(paths.assets);
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, []);
+  }, [navigate]);
 
   const cancel = () => {
-    window.location.href = ASSETS_HREF;
+    navigate(paths.assets);
   };
 
   return (
     <div className="hf hf-app hf-aa-page">
-      <HFTopBar activeNav="assets" />
+      <HFTopBar />
 
       <div className="hf-aa-crumb">
-        <a href={ASSETS_HREF}>Assets</a>
+        <Link to={paths.assets}>Assets</Link>
         <span className="hf-aa-crumb-sep">
           <Icon name="chevron-right" size={13} />
         </span>

--- a/apps/web/src/app/AppAssets.tsx
+++ b/apps/web/src/app/AppAssets.tsx
@@ -1,6 +1,9 @@
+import { useEffect } from "react";
+import { Link } from "react-router";
 import { Icon, type IconName } from "../design/Icon";
 import { HFAssetThumb, HFStatusPill, type AssetCategory, type AssetStatus } from "../design/hf";
 import { HFTopBar, HFBottomNav } from "./AppChrome";
+import { paths } from "../routes";
 
 // FieldOps — Assets (card grid). The authenticated asset library: a header with
 // fleet count + add button, a toolbar (search, category filter chips, grid/list
@@ -101,13 +104,7 @@ function HFAssetRowCard({ asset }: { asset: Asset }) {
 /* ============ add-asset ghost card (slots into the grid) ============ */
 function HFAddCard() {
   return (
-    <article
-      className="hf-asset-card hf-add-card"
-      tabIndex={0}
-      onClick={() => {
-        window.location.href = "/app/assets/new";
-      }}
-    >
+    <Link to={paths.addAsset} className="hf-asset-card hf-add-card">
       <div className="hf-add-card-inner">
         <div className="hf-add-card-plus">
           <Icon name="plus" size={20} stroke={2} />
@@ -115,7 +112,7 @@ function HFAddCard() {
         <div className="hf-add-card-label">Add an asset</div>
         <div className="hf-add-card-sub">Vehicle, equipment, property, grounds…</div>
       </div>
-    </article>
+    </Link>
   );
 }
 
@@ -175,15 +172,10 @@ function HFAssetsHeader() {
         <div className="hf-greeting-sub">{HF_ASSETS_ALL.length} things you take care of</div>
       </div>
       <div className="hf-stats hf-stats-tight">
-        <button
-          className="hf-btn hf-btn-primary"
-          onClick={() => {
-            window.location.href = "/app/assets/new";
-          }}
-        >
+        <Link className="hf-btn hf-btn-primary" to={paths.addAsset}>
           <Icon name="plus" size={14} stroke={2.2} />
           Add asset
-        </button>
+        </Link>
       </div>
     </div>
   );
@@ -191,11 +183,15 @@ function HFAssetsHeader() {
 
 /* ============ main: assets card grid (responsive) ============ */
 export function AppAssets() {
+  useEffect(() => {
+    document.title = "FieldOps — Assets";
+  }, []);
+
   // The add-card slots in at the END of the grid so the "+" stays discoverable
   // inline; the stacked rows (mobile) get their own add button at the bottom.
   return (
     <div className="hf hf-app hf-assets-page">
-      <HFTopBar activeNav="assets" />
+      <HFTopBar />
       <main className="hf-main hf-shell">
         <HFAssetsHeader />
         <HFAssetsToolbar activeCat="all" activeView="grid" />
@@ -211,18 +207,13 @@ export function AppAssets() {
           {HF_ASSETS_ALL.map((a) => (
             <HFAssetRowCard key={a.id} asset={a} />
           ))}
-          <button
-            className="hf-row-add"
-            onClick={() => {
-              window.location.href = "/app/assets/new";
-            }}
-          >
+          <Link className="hf-row-add" to={paths.addAsset}>
             <Icon name="plus" size={16} stroke={2} />
             Add an asset
-          </button>
+          </Link>
         </div>
       </main>
-      <HFBottomNav activeNav="assets" />
+      <HFBottomNav />
     </div>
   );
 }

--- a/apps/web/src/app/AppChrome.tsx
+++ b/apps/web/src/app/AppChrome.tsx
@@ -1,10 +1,12 @@
+import { NavLink } from "react-router";
 import { Icon, type IconName } from "../design/Icon";
 import { Brandmark } from "../design/Brandmark";
+import { paths } from "../routes";
 
 // Shared authenticated-app chrome: the desktop top bar and the mobile bottom
 // tab bar. Ported from the FieldOps prototype (hifi.jsx). Both the Home
 // (master/detail) and Assets pages render this, so nav lives here. Tabs that
-// have a real page carry an href; placeholders (Schedule, History) don't.
+// have a real page carry a route; placeholders (Schedule, History) don't.
 
 export type AppNav = "home" | "assets" | "schedule" | "history";
 
@@ -12,17 +14,18 @@ interface NavItem {
   id: AppNav;
   label: string;
   icon: IconName;
-  href?: string;
+  to?: string;
+  end?: boolean;
 }
 
 const HF_NAV: NavItem[] = [
-  { id: "home", label: "Home", icon: "home-nav", href: "/app" },
-  { id: "assets", label: "Assets", icon: "grid", href: "/app/assets" },
+  { id: "home", label: "Home", icon: "home-nav", to: paths.appHome, end: true },
+  { id: "assets", label: "Assets", icon: "grid", to: paths.assets },
   { id: "schedule", label: "Schedule", icon: "calendar" },
   { id: "history", label: "History", icon: "clock" },
 ];
 
-export function HFTopBar({ activeNav = "home" }: { activeNav?: AppNav }) {
+export function HFTopBar() {
   return (
     <header className="hf-topbar">
       <div className="hf-topbar-left">
@@ -33,17 +36,25 @@ export function HFTopBar({ activeNav = "home" }: { activeNav?: AppNav }) {
           <span className="hf-logo-text">FieldOps</span>
         </div>
         <nav className="hf-nav-top">
-          {HF_NAV.map((n) => (
-            <a
-              key={n.id}
-              href={n.href}
-              className={`hf-nav-tab ${n.id === activeNav ? "active" : ""}`}
-              title={n.label}
-            >
-              <Icon name={n.icon} size={16} />
-              <span className="hf-nav-label">{n.label}</span>
-            </a>
-          ))}
+          {HF_NAV.map((n) =>
+            n.to ? (
+              <NavLink
+                key={n.id}
+                to={n.to}
+                end={n.end ?? false}
+                className={({ isActive }) => `hf-nav-tab ${isActive ? "active" : ""}`}
+                title={n.label}
+              >
+                <Icon name={n.icon} size={16} />
+                <span className="hf-nav-label">{n.label}</span>
+              </NavLink>
+            ) : (
+              <span key={n.id} className="hf-nav-tab" title={n.label} aria-disabled="true">
+                <Icon name={n.icon} size={16} />
+                <span className="hf-nav-label">{n.label}</span>
+              </span>
+            ),
+          )}
         </nav>
       </div>
       <div className="hf-topbar-right">
@@ -60,19 +71,31 @@ export function HFTopBar({ activeNav = "home" }: { activeNav?: AppNav }) {
   );
 }
 
-export function HFBottomNav({ activeNav = "home" }: { activeNav?: AppNav }) {
+export function HFBottomNav() {
   return (
     <nav className="hf-nav-bottom">
-      {HF_NAV.map((n) => (
-        <a
-          key={n.id}
-          href={n.href}
-          className={`hf-nav-bottom-tab ${n.id === activeNav ? "active" : ""}`}
-        >
-          <Icon name={n.icon} size={20} stroke={n.id === activeNav ? 2 : 1.5} />
-          <span>{n.label}</span>
-        </a>
-      ))}
+      {HF_NAV.map((n) =>
+        n.to ? (
+          <NavLink
+            key={n.id}
+            to={n.to}
+            end={n.end ?? false}
+            className={({ isActive }) => `hf-nav-bottom-tab ${isActive ? "active" : ""}`}
+          >
+            {({ isActive }) => (
+              <>
+                <Icon name={n.icon} size={20} stroke={isActive ? 2 : 1.5} />
+                <span>{n.label}</span>
+              </>
+            )}
+          </NavLink>
+        ) : (
+          <span key={n.id} className="hf-nav-bottom-tab" aria-disabled="true">
+            <Icon name={n.icon} size={20} stroke={1.5} />
+            <span>{n.label}</span>
+          </span>
+        ),
+      )}
     </nav>
   );
 }

--- a/apps/web/src/app/AppHome.tsx
+++ b/apps/web/src/app/AppHome.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Icon, type IconName } from "../design/Icon";
 import { HFAssetIcon, HFStatusPill, type AssetCategory, type AssetStatus } from "../design/hf";
 import { HFTopBar, HFBottomNav } from "./AppChrome";
@@ -281,6 +281,10 @@ export function AppHome({ mobileMode = "inline" }: { mobileMode?: "inline" }) {
   const [selId, setSelId] = useState(sorted[0]?.id ?? "");
   const selected = HF_ASSETS.find((a) => a.id === selId) ?? sorted[0];
   const isNextUp = selId === sorted[0]?.id;
+
+  useEffect(() => {
+    document.title = "FieldOps — Home";
+  }, []);
 
   if (!selected) return null;
 

--- a/apps/web/src/auth/AuthFlow.tsx
+++ b/apps/web/src/auth/AuthFlow.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useState } from "react";
+import { Link, useNavigate } from "react-router";
 import { Icon } from "../design/Icon";
 import { Brandmark } from "../design/Brandmark";
 import { HFAssetIcon, HFAssetThumb } from "../design/hf";
+import { paths } from "../routes";
 
 // Stylesheets: the .hf design tokens + asset components first, then the
 // auth-specific layer (which mirrors the tokens onto .au so the reused .hf-*
@@ -112,12 +114,12 @@ function AuthCollage() {
 function AuthBrand() {
   return (
     <div className="au-brand">
-      <a className="au-brand-logo" href="/">
+      <Link className="au-brand-logo" to={paths.home}>
         <span className="au-brand-mark">
           <Brandmark size={17} color="white" />
         </span>
         <span className="au-brand-name">FieldOps</span>
-      </a>
+      </Link>
       <div className="au-brand-content">
         <div className="au-brand-body">
           <h2 className="au-brand-h2">Keep everything you own on schedule.</h2>
@@ -151,12 +153,12 @@ function AuthCard({
   const isSignup = mode === "signup";
   return (
     <div className="au-card">
-      <a className="au-card-logo" href="/">
+      <Link className="au-card-logo" to={paths.home}>
         <span className="au-brand-mark">
           <Icon name="wrench" size={16} color="white" stroke={2} />
         </span>
         <span className="au-brand-name">FieldOps</span>
-      </a>
+      </Link>
 
       <div className="au-eyebrow">{isSignup ? "Get started" : "Welcome back"}</div>
       <h1 className="au-h1">{isSignup ? "Create your account" : "Log in to FieldOps"}</h1>
@@ -242,9 +244,9 @@ function AuthSignedIn({
         {user.name ? ` (${user.email})` : ""}.
       </p>
       <div className="au-hero-cta" style={{ display: "flex", gap: 12, marginTop: 24 }}>
-        <a className="au-google" style={{ width: "auto", padding: "0 20px" }} href="/app">
+        <Link className="au-google" style={{ width: "auto", padding: "0 20px" }} to={paths.appHome}>
           Go to FieldOps
-        </a>
+        </Link>
       </div>
       <button className="au-redirect-cancel" onClick={onSignOut}>
         Sign out
@@ -255,6 +257,7 @@ function AuthSignedIn({
 
 /* ============ page ============ */
 export function AuthFlow() {
+  const navigate = useNavigate();
   // mode: "login" | "signup" ; phase: "form" | "redirect"
   // initial mode comes from ?mode= so marketing CTAs can deep-link the right screen
   const initialMode: Mode =
@@ -303,7 +306,7 @@ export function AuthFlow() {
       credentials: "include",
     }).finally(() => {
       // Logged out → send them to the marketing home.
-      window.location.href = "/";
+      navigate(paths.home);
     });
   };
 

--- a/apps/web/src/auth/AuthFlow.tsx
+++ b/apps/web/src/auth/AuthFlow.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Link, useNavigate } from "react-router";
+import { Link, useSearchParams } from "react-router";
 import { Icon } from "../design/Icon";
 import { Brandmark } from "../design/Brandmark";
 import { HFAssetIcon, HFAssetThumb } from "../design/hf";
@@ -257,11 +257,10 @@ function AuthSignedIn({
 
 /* ============ page ============ */
 export function AuthFlow() {
-  const navigate = useNavigate();
   // mode: "login" | "signup" ; phase: "form" | "redirect"
   // initial mode comes from ?mode= so marketing CTAs can deep-link the right screen
-  const initialMode: Mode =
-    new URLSearchParams(window.location.search).get("mode") === "signup" ? "signup" : "login";
+  const [searchParams] = useSearchParams();
+  const initialMode: Mode = searchParams.get("mode") === "signup" ? "signup" : "login";
   const [mode, setMode] = useState<Mode>(initialMode);
   const [phase, setPhase] = useState<Phase>("form");
   // undefined = still checking; null = logged out; object = logged in
@@ -305,8 +304,9 @@ export function AuthFlow() {
       body: "{}",
       credentials: "include",
     }).finally(() => {
-      // Logged out → send them to the marketing home.
-      navigate(paths.home);
+      // Logged out → full-page reload to the marketing home so any in-memory
+      // session state is wiped, not just unmounted.
+      window.location.href = paths.home;
     });
   };
 

--- a/apps/web/src/design/styles/hifi-assets.css
+++ b/apps/web/src/design/styles/hifi-assets.css
@@ -293,6 +293,8 @@
     var(--hf-surface);
   border-style: dashed;
   box-shadow: none;
+  color: inherit;
+  text-decoration: none;
 }
 .hf-add-card:hover {
   background-color: var(--hf-brand-bg);
@@ -424,6 +426,7 @@
   color: var(--hf-ink-soft);
   font-size: 13.5px;
   font-weight: 600;
+  text-decoration: none;
 }
 .hf-row-add:hover {
   color: var(--hf-brand);

--- a/apps/web/src/design/styles/hifi.css
+++ b/apps/web/src/design/styles/hifi.css
@@ -497,6 +497,7 @@
   border: 1px solid var(--hf-line);
   background: var(--hf-surface);
   color: var(--hf-ink);
+  text-decoration: none;
   transition:
     background 100ms,
     border-color 100ms;

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,33 +1,14 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import { RouterProvider } from "react-router";
 import "./index.css";
-import { MarketingHome } from "./marketing/MarketingHome";
-import { AuthFlow } from "./auth/AuthFlow";
-import { AppHome } from "./app/AppHome";
-import { AppAssets } from "./app/AppAssets";
-import { AppAddAsset } from "./app/AppAddAsset";
-
-// Minimal path-based routing. The Worker serves index.html for any unmatched
-// path (wrangler.jsonc -> assets.not_found_handling: "single-page-application"),
-// so /login and /app resolve here; everything else renders the marketing home.
-// /login reads ?mode=login|signup to pick its initial screen (set by the
-// marketing CTAs); /app is the authenticated master/detail home,
-// /app/assets is the asset library (card grid), and /app/assets/new is the
-// add-asset form.
-function App() {
-  const path = window.location.pathname;
-  if (path === "/login") return <AuthFlow />;
-  if (path === "/app/assets/new") return <AppAddAsset />;
-  if (path === "/app/assets") return <AppAssets />;
-  if (path === "/app") return <AppHome />;
-  return <MarketingHome />;
-}
+import { router } from "./router";
 
 const root = document.getElementById("root");
 if (!root) throw new Error("Root element #root not found");
 
 createRoot(root).render(
   <StrictMode>
-    <App />
+    <RouterProvider router={router} />
   </StrictMode>,
 );

--- a/apps/web/src/marketing/MarketingHome.tsx
+++ b/apps/web/src/marketing/MarketingHome.tsx
@@ -1,6 +1,9 @@
+import { useEffect } from "react";
+import { Link } from "react-router";
 import { Icon } from "../design/Icon";
 import { Brandmark } from "../design/Brandmark";
 import { HFAssetIcon, HFAssetThumb, HFStatusPill } from "../design/hf";
+import { paths } from "../routes";
 
 // Stylesheets: the .hf design tokens + asset components first, then the
 // marketing-specific layer (which mirrors the tokens onto .mk so the reused
@@ -11,32 +14,32 @@ import "./styles/marketing.css";
 
 // Auth entry points. "Get started" deep-links to the sign-up screen, "Log in"
 // to the login screen; the auth page reads ?mode= to pick its initial state.
-const SIGNUP_HREF = "/login?mode=signup";
-const LOGIN_HREF = "/login?mode=login";
+const SIGNUP_HREF = paths.login("signup");
+const LOGIN_HREF = paths.login("login");
 
 /* ============ nav ============ */
 function MKNav() {
   return (
     <header className="mk-nav">
       <div className="mk-wrap mk-nav-in">
-        <a className="mk-logo" href="#">
+        <Link className="mk-logo" to={paths.home}>
           <span className="mk-logo-mark">
             <Brandmark size={17} color="white" />
           </span>
           <span className="mk-logo-text">FieldOps</span>
-        </a>
+        </Link>
         <nav className="mk-nav-links">
           <a className="mk-nav-link" href="#how">
             How it works
           </a>
         </nav>
         <div className="mk-nav-cta">
-          <a className="mk-link-quiet" href={LOGIN_HREF}>
+          <Link className="mk-link-quiet" to={LOGIN_HREF}>
             Log in
-          </a>
-          <a className="mk-btn mk-btn-primary mk-btn-sm" href={SIGNUP_HREF}>
+          </Link>
+          <Link className="mk-btn mk-btn-primary mk-btn-sm" to={SIGNUP_HREF}>
             Get started
-          </a>
+          </Link>
         </div>
       </div>
     </header>
@@ -142,10 +145,10 @@ function MKHero() {
             you spend less time remembering and more time working.
           </p>
           <div className="mk-hero-cta">
-            <a className="mk-btn mk-btn-primary mk-btn-lg" href={SIGNUP_HREF}>
+            <Link className="mk-btn mk-btn-primary mk-btn-lg" to={SIGNUP_HREF}>
               <Icon name="arrow-right" size={16} stroke={2.2} />
               Get started
-            </a>
+            </Link>
             <a className="mk-btn mk-btn-ghost mk-btn-lg" href="#how">
               See how it works
             </a>
@@ -233,13 +236,13 @@ function MKCta() {
           <h2>Start keeping everything on schedule.</h2>
           <p>Add your first asset in two minutes. Free to start — no card, no commitment.</p>
           <div className="mk-hero-cta">
-            <a className="mk-btn mk-btn-primary mk-btn-lg" href={SIGNUP_HREF}>
+            <Link className="mk-btn mk-btn-primary mk-btn-lg" to={SIGNUP_HREF}>
               <Icon name="arrow-right" size={16} stroke={2.2} />
               Get started
-            </a>
-            <a className="mk-btn mk-btn-ghost mk-btn-lg" href={LOGIN_HREF}>
+            </Link>
+            <Link className="mk-btn mk-btn-ghost mk-btn-lg" to={LOGIN_HREF}>
               Log in
-            </a>
+            </Link>
           </div>
         </div>
       </div>
@@ -251,15 +254,15 @@ function MKFooter() {
   return (
     <footer className="mk-footer">
       <div className="mk-wrap mk-footer-in">
-        <a className="mk-logo" href="#">
+        <Link className="mk-logo" to={paths.home}>
           <span className="mk-logo-mark">
             <Icon name="wrench" size={16} color="white" stroke={2} />
           </span>
           <span className="mk-logo-text">FieldOps</span>
-        </a>
+        </Link>
         <nav className="mk-footer-links">
           <a href="#how">How it works</a>
-          <a href={LOGIN_HREF}>Log in</a>
+          <Link to={LOGIN_HREF}>Log in</Link>
         </nav>
         <div className="mk-footer-copy">© 2026 FieldOps</div>
       </div>
@@ -268,6 +271,10 @@ function MKFooter() {
 }
 
 export function MarketingHome() {
+  useEffect(() => {
+    document.title = "FieldOps — Keep everything you own on schedule";
+  }, []);
+
   return (
     <div className="mk">
       <MKNav />

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1,0 +1,18 @@
+import { createBrowserRouter } from "react-router";
+import { AuthFlow } from "./auth/AuthFlow";
+import { AppAddAsset } from "./app/AppAddAsset";
+import { AppAssets } from "./app/AppAssets";
+import { AppHome } from "./app/AppHome";
+import { MarketingHome } from "./marketing/MarketingHome";
+import { paths, routePaths } from "./routes";
+
+export { paths };
+
+export const router = createBrowserRouter([
+  { path: routePaths.home, element: <MarketingHome /> },
+  { path: routePaths.login, element: <AuthFlow /> },
+  { path: routePaths.appHome, element: <AppHome /> },
+  { path: routePaths.assets, element: <AppAssets /> },
+  { path: routePaths.addAsset, element: <AppAddAsset /> },
+  { path: "*", element: <MarketingHome /> },
+]);

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -4,9 +4,7 @@ import { AppAddAsset } from "./app/AppAddAsset";
 import { AppAssets } from "./app/AppAssets";
 import { AppHome } from "./app/AppHome";
 import { MarketingHome } from "./marketing/MarketingHome";
-import { paths, routePaths } from "./routes";
-
-export { paths };
+import { routePaths } from "./routes";
 
 export const router = createBrowserRouter([
   { path: routePaths.home, element: <MarketingHome /> },
@@ -14,5 +12,7 @@ export const router = createBrowserRouter([
   { path: routePaths.appHome, element: <AppHome /> },
   { path: routePaths.assets, element: <AppAssets /> },
   { path: routePaths.addAsset, element: <AppAddAsset /> },
+  // TODO: unknown routes currently fall back to the marketing home. Design a
+  // real not-found / 404 experience and route it here.
   { path: "*", element: <MarketingHome /> },
 ]);

--- a/apps/web/src/routes.ts
+++ b/apps/web/src/routes.ts
@@ -1,0 +1,17 @@
+export type LoginMode = "login" | "signup";
+
+export const routePaths = {
+  home: "/",
+  login: "/login",
+  appHome: "/app",
+  assets: "/app/assets",
+  addAsset: "/app/assets/new",
+} as const;
+
+export const paths = {
+  home: routePaths.home,
+  login: (mode?: LoginMode) => (mode ? `${routePaths.login}?mode=${mode}` : routePaths.login),
+  appHome: routePaths.appHome,
+  assets: routePaths.assets,
+  addAsset: routePaths.addAsset,
+} as const;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       react-dom:
         specifier: ^19.1.0
         version: 19.2.6(react@19.2.6)
+      react-router:
+        specifier: ^7.16.0
+        version: 7.16.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ^1.1.0
@@ -2383,6 +2386,16 @@ packages:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
 
+  react-router@7.16.0:
+    resolution: {integrity: sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
   react@19.2.6:
     resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
     engines: {node: '>=0.10.0'}
@@ -2445,6 +2458,9 @@ packages:
     resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   set-cookie-parser@3.1.0:
     resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
@@ -4651,6 +4667,14 @@ snapshots:
 
   react-refresh@0.17.0: {}
 
+  react-router@7.16.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+    dependencies:
+      cookie: 1.1.1
+      react: 19.2.6
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      react-dom: 19.2.6(react@19.2.6)
+
   react@19.2.6: {}
 
   resolve-from@4.0.0: {}
@@ -4724,6 +4748,8 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.8.0: {}
+
+  set-cookie-parser@2.7.2: {}
 
   set-cookie-parser@3.1.0: {}
 


### PR DESCRIPTION
## Summary

- Add React Router Data Mode to the web app and replace the manual pathname switch.
- Centralize route paths and path builders for app, auth, marketing, and asset flows.
- Convert internal navigation to `Link`, `NavLink`, and `useNavigate` while keeping OAuth as a full external redirect.
- Keep the Cloudflare SPA fallback unchanged and document the new route structure.

## Impact

The app can now grow beyond the current hand-rolled route switch without full-page internal navigations. App chrome derives active state from the current route, and route-level document titles prevent stale titles during SPA navigation.

## Validation

- `pnpm lint`
- `pnpm type-check`
- `pnpm -r test`
- `pnpm --filter @snaveevans/pineapple-web build`
- Browser smoke test for `/app`, `/app/assets`, `/app/assets/new`, Escape cancel, `/login?mode=signup`, and unknown-route fallback.