### PR TITLE
[codex] Harden API and authenticated asset flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ pnpm type-check
 pnpm -r test
 ```
 
-Local secrets live in `apps/api/.dev.vars` (gitignored). Set `DEV_AUTH_EMAIL`
-there to bypass the login flow during development. See
+Local secrets live in `apps/api/.dev.vars` (gitignored). Set
+`DEV_AUTH_BYPASS_ENABLED=true` and `DEV_AUTH_EMAIL` there to bypass the login
+flow during local development. See
 [`docs/guides/getting-started.md`](docs/guides/getting-started.md) for the full
 setup, including Google OAuth.
 

--- a/apps/api/.dev.vars.example
+++ b/apps/api/.dev.vars.example
@@ -22,4 +22,6 @@ GOOGLE_CLIENT_SECRET=""
 DEV_WEB_ORIGIN="http://localhost:5173"
 
 # Optional: bypass auth locally by hardcoding a session email (skips Google).
+# Both values are required and only work with the loopback BETTER_AUTH_URL above.
+# DEV_AUTH_BYPASS_ENABLED="true"
 # DEV_AUTH_EMAIL="you@example.com"

--- a/apps/api/src/api/authSecurity.test.ts
+++ b/apps/api/src/api/authSecurity.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+  getAllowedApiCorsOrigin,
+  getTrustedDevWebOrigins,
+  resolveDevAuthEmail,
+} from "./authSecurity.ts";
+
+describe("auth security policy", () => {
+  it("allows the configured auth origin and loopback development web origins", () => {
+    expect(
+      getAllowedApiCorsOrigin(
+        "http://localhost:5173",
+        "http://localhost:8787",
+        "http://localhost:5173",
+      ),
+    ).toBe("http://localhost:5173");
+    expect(
+      getAllowedApiCorsOrigin("https://pineapple.tylerevans.co", "https://pineapple.tylerevans.co"),
+    ).toBe("https://pineapple.tylerevans.co");
+  });
+
+  it("rejects arbitrary and non-loopback development origins", () => {
+    expect(
+      getAllowedApiCorsOrigin(
+        "https://evil.example",
+        "https://pineapple.tylerevans.co",
+        "https://evil.example",
+      ),
+    ).toBeUndefined();
+    expect(getTrustedDevWebOrigins("http://localhost:8787", "https://evil.example")).toEqual([]);
+  });
+
+  it("requires an explicit loopback-only opt-in for the authentication bypass", () => {
+    expect(
+      resolveDevAuthEmail({
+        baseURL: "http://localhost:8787",
+        email: "dev@example.com",
+        enabled: "true",
+      }),
+    ).toBe("dev@example.com");
+    expect(() =>
+      resolveDevAuthEmail({
+        baseURL: "https://pineapple.tylerevans.co",
+        email: "dev@example.com",
+        enabled: "true",
+      }),
+    ).toThrow("Invalid local authentication bypass configuration");
+    expect(() =>
+      resolveDevAuthEmail({
+        baseURL: "http://localhost:8787",
+        email: "dev@example.com",
+        enabled: undefined,
+      }),
+    ).toThrow("Invalid local authentication bypass configuration");
+  });
+});

--- a/apps/api/src/api/authSecurity.ts
+++ b/apps/api/src/api/authSecurity.ts
@@ -1,0 +1,55 @@
+import { InvariantError } from "@snaveevans/pineapple-shared";
+
+export function getAuthBaseURL(requestURL: string, configuredBaseURL?: string): string {
+  return configuredBaseURL ?? new URL(requestURL).origin;
+}
+
+export function isLoopbackOrigin(value: string): boolean {
+  try {
+    const { hostname, origin } = new URL(value);
+    return (
+      origin === value &&
+      (hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]")
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function getTrustedDevWebOrigins(baseURL: string, configuredOrigins?: string): string[] {
+  if (!isLoopbackOrigin(baseURL)) return [];
+  return (
+    configuredOrigins
+      ?.split(",")
+      .map((origin) => origin.trim())
+      .filter((origin) => isLoopbackOrigin(origin)) ?? []
+  );
+}
+
+export function getAllowedApiCorsOrigin(
+  requestOrigin: string,
+  baseURL: string,
+  configuredDevOrigins?: string,
+): string | undefined {
+  const allowedOrigins = new Set([
+    new URL(baseURL).origin,
+    ...getTrustedDevWebOrigins(baseURL, configuredDevOrigins),
+  ]);
+  return allowedOrigins.has(requestOrigin) ? requestOrigin : undefined;
+}
+
+export function resolveDevAuthEmail({
+  enabled,
+  email,
+  baseURL,
+}: {
+  enabled: string | undefined;
+  email: string | undefined;
+  baseURL: string;
+}): string | undefined {
+  if (enabled === undefined && email === undefined) return undefined;
+  if (enabled !== "true" || !email || !isLoopbackOrigin(baseURL)) {
+    throw new InvariantError("Invalid local authentication bypass configuration");
+  }
+  return email;
+}

--- a/apps/api/src/api/errors.test.ts
+++ b/apps/api/src/api/errors.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+import { InvariantError, ValidationError } from "@snaveevans/pineapple-shared";
+import { toHttpError } from "./errors.ts";
+
+describe("toHttpError", () => {
+  it("hides invariant details from the response", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const app = new Hono();
+    app.get("/", (c) => toHttpError(c, new InvariantError("sensitive implementation detail")));
+
+    const response = await app.request("/");
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({ error: "Internal Server Error" });
+    expect(consoleError).toHaveBeenCalledOnce();
+    consoleError.mockRestore();
+  });
+
+  it("keeps validation details for callers", async () => {
+    const app = new Hono();
+    app.get("/", (c) => toHttpError(c, new ValidationError("Name is required", "name")));
+
+    const response = await app.request("/");
+
+    expect(response.status).toBe(422);
+    await expect(response.json()).resolves.toEqual({ error: "Name is required", field: "name" });
+  });
+});

--- a/apps/api/src/api/errors.ts
+++ b/apps/api/src/api/errors.ts
@@ -6,6 +6,7 @@ import {
   ValidationError,
   ConflictError,
   UnauthorizedError,
+  InvariantError,
 } from "@snaveevans/pineapple-shared";
 
 /**
@@ -25,6 +26,11 @@ export function toHttpError(c: Context, error: DomainError): Response {
             : error instanceof ConflictError
               ? 409
               : 500;
+
+  if (status === 500 || error instanceof InvariantError) {
+    console.error(error);
+    return c.json({ error: "Internal Server Error" }, 500);
+  }
 
   const body: Record<string, unknown> = { error: error.message };
   if (error instanceof ValidationError && error.field) {

--- a/apps/api/src/api/middleware/createAssetBodyLimit.test.ts
+++ b/apps/api/src/api/middleware/createAssetBodyLimit.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { Hono } from "hono";
+import { CREATE_ASSET_BODY_MAX_BYTES, createAssetBodyLimit } from "./createAssetBodyLimit.ts";
+
+describe("createAssetBodyLimit", () => {
+  it("rejects JSON request bodies larger than 16 KiB", async () => {
+    const app = new Hono();
+    app.use("*", createAssetBodyLimit);
+    app.post("/", (c) => c.json({ ok: true }));
+
+    const response = await app.request("/", {
+      method: "POST",
+      body: "a".repeat(CREATE_ASSET_BODY_MAX_BYTES + 1),
+    });
+
+    expect(response.status).toBe(413);
+    await expect(response.json()).resolves.toEqual({
+      error: "Request body exceeds the 16 KiB limit",
+    });
+  });
+});

--- a/apps/api/src/api/middleware/createAssetBodyLimit.ts
+++ b/apps/api/src/api/middleware/createAssetBodyLimit.ts
@@ -1,0 +1,8 @@
+import { bodyLimit } from "hono/body-limit";
+
+export const CREATE_ASSET_BODY_MAX_BYTES = 16 * 1024;
+
+export const createAssetBodyLimit = bodyLimit({
+  maxSize: CREATE_ASSET_BODY_MAX_BYTES,
+  onError: (c) => c.json({ error: "Request body exceeds the 16 KiB limit" }, 413),
+});

--- a/apps/api/src/api/openapi.test.ts
+++ b/apps/api/src/api/openapi.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { getApiDocument } from "./openapi.ts";
+
+describe("OpenAPI document", () => {
+  it("reflects asset validation limits and hardened responses", () => {
+    const document = getApiDocument();
+
+    expect(document.components?.schemas?.["CreateAssetBody"]).toMatchObject({
+      properties: {
+        name: { minLength: 1, maxLength: 120 },
+      },
+    });
+    expect(document.components?.schemas?.["VehicleMetadata"]).toMatchObject({
+      properties: {
+        make: { minLength: 1, maxLength: 64 },
+        model: { minLength: 1, maxLength: 64 },
+        vin: {
+          minLength: 17,
+          maxLength: 17,
+          pattern: "^[A-HJ-NPR-Z0-9]{17}$",
+        },
+      },
+    });
+    expect(document.paths["/api/assets"]?.post?.responses).toHaveProperty("413");
+    expect(document.paths["/api/assets"]?.post?.responses).toHaveProperty("429");
+    expect(document.paths["/api/assets/{id}"]?.get?.responses).not.toHaveProperty("403");
+  });
+});

--- a/apps/api/src/api/openapi.ts
+++ b/apps/api/src/api/openapi.ts
@@ -65,6 +65,8 @@ export const createAssetRoute = createRoute({
   path: "/api/assets",
   tags: ["Assets"],
   summary: "Create an asset",
+  description:
+    "Creates an asset owned by the caller. The JSON request body must not exceed 16 KiB.",
   security: [cookieAuth],
   request: {
     body: {
@@ -79,6 +81,24 @@ export const createAssetRoute = createRoute({
     },
     401: {
       description: "Not authenticated",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    409: {
+      description: "Active asset quota reached",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    413: {
+      description: "Request body exceeds 16 KiB",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    429: {
+      description: "Write rate limit exceeded",
+      headers: {
+        "Retry-After": {
+          description: "Seconds until the caller should retry",
+          schema: { type: "string" },
+        },
+      },
       content: { "application/json": { schema: ErrorResponseSchema } },
     },
     422: {
@@ -104,6 +124,16 @@ export const listAssetsRoute = createRoute({
       description: "Not authenticated",
       content: { "application/json": { schema: ErrorResponseSchema } },
     },
+    429: {
+      description: "Read rate limit exceeded",
+      headers: {
+        "Retry-After": {
+          description: "Seconds until the caller should retry",
+          schema: { type: "string" },
+        },
+      },
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
   },
 });
 
@@ -123,12 +153,18 @@ export const getAssetRoute = createRoute({
       description: "Not authenticated",
       content: { "application/json": { schema: ErrorResponseSchema } },
     },
-    403: {
-      description: "The asset belongs to another user",
-      content: { "application/json": { schema: ErrorResponseSchema } },
-    },
     404: {
       description: "No such asset",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    429: {
+      description: "Read rate limit exceeded",
+      headers: {
+        "Retry-After": {
+          description: "Seconds until the caller should retry",
+          schema: { type: "string" },
+        },
+      },
       content: { "application/json": { schema: ErrorResponseSchema } },
     },
   },

--- a/apps/api/src/api/schemas/assetSchemas.ts
+++ b/apps/api/src/api/schemas/assetSchemas.ts
@@ -2,6 +2,7 @@
 // metadata. This is the single source of truth for both runtime validation
 // AND the generated OpenAPI spec — change a rule here and the docs follow.
 import { z } from "@hono/zod-openapi";
+import { ASSET_FIELD_LIMITS, VIN_PATTERN } from "../../domain/asset/AssetConstraints.ts";
 import { ASSET_TYPES } from "../../domain/asset/AssetType.ts";
 
 // ── Asset metadata (discriminated by `kind`) ─────────────────────────────────
@@ -9,8 +10,18 @@ import { ASSET_TYPES } from "../../domain/asset/AssetType.ts";
 const VehicleMetadataSchema = z
   .object({
     kind: z.literal("vehicle"),
-    make: z.string().min(1, "Make is required").openapi({ example: "Ram" }),
-    model: z.string().min(1, "Model is required").openapi({ example: "2500" }),
+    make: z
+      .string()
+      .trim()
+      .min(1, "Make is required")
+      .max(ASSET_FIELD_LIMITS.vehicleMake)
+      .openapi({ example: "Ram" }),
+    model: z
+      .string()
+      .trim()
+      .min(1, "Model is required")
+      .max(ASSET_FIELD_LIMITS.vehicleModel)
+      .openapi({ example: "2500" }),
     year: z
       .number()
       .int()
@@ -20,6 +31,7 @@ const VehicleMetadataSchema = z
     vin: z
       .string()
       .length(17, "VIN must be exactly 17 characters")
+      .regex(VIN_PATTERN, "VIN must use VIN-safe characters")
       .optional()
       .openapi({ example: "1C6RR7LT4GS123456" }),
   })
@@ -28,14 +40,31 @@ const VehicleMetadataSchema = z
 const PropertyMetadataSchema = z
   .object({
     kind: z.literal("property"),
-    nickname: z.string().optional().openapi({ example: "Lake cabin" }),
+    nickname: z
+      .string()
+      .trim()
+      .max(ASSET_FIELD_LIMITS.propertyNickname)
+      .optional()
+      .openapi({ example: "Lake cabin" }),
     address: z
       .object({
-        street: z.string().min(1, "Street is required"),
-        city: z.string().min(1, "City is required"),
-        state: z.string().min(1, "State is required"),
-        postalCode: z.string().min(1, "Postal code is required"),
-        country: z.string().min(1, "Country is required"),
+        street: z
+          .string()
+          .trim()
+          .min(1, "Street is required")
+          .max(ASSET_FIELD_LIMITS.propertyStreet),
+        city: z.string().trim().min(1, "City is required").max(ASSET_FIELD_LIMITS.propertyCity),
+        state: z.string().trim().min(1, "State is required").max(ASSET_FIELD_LIMITS.propertyState),
+        postalCode: z
+          .string()
+          .trim()
+          .min(1, "Postal code is required")
+          .max(ASSET_FIELD_LIMITS.propertyPostalCode),
+        country: z
+          .string()
+          .trim()
+          .min(1, "Country is required")
+          .max(ASSET_FIELD_LIMITS.propertyCountry),
       })
       .openapi("Address"),
   })
@@ -44,9 +73,24 @@ const PropertyMetadataSchema = z
 const EquipmentMetadataSchema = z
   .object({
     kind: z.literal("equipment"),
-    manufacturer: z.string().optional().openapi({ example: "Honda" }),
-    modelNumber: z.string().optional().openapi({ example: "EU2200i" }),
-    serialNumber: z.string().optional().openapi({ example: "EAMT-1234567" }),
+    manufacturer: z
+      .string()
+      .trim()
+      .max(ASSET_FIELD_LIMITS.equipmentManufacturer)
+      .optional()
+      .openapi({ example: "Honda" }),
+    modelNumber: z
+      .string()
+      .trim()
+      .max(ASSET_FIELD_LIMITS.equipmentModelNumber)
+      .optional()
+      .openapi({ example: "EU2200i" }),
+    serialNumber: z
+      .string()
+      .trim()
+      .max(ASSET_FIELD_LIMITS.equipmentSerialNumber)
+      .optional()
+      .openapi({ example: "EAMT-1234567" }),
   })
   .openapi("EquipmentMetadata");
 
@@ -62,7 +106,12 @@ export const AssetMetadataSchema = z
 
 export const CreateAssetBodySchema = z
   .object({
-    name: z.string().min(1, "Name is required").openapi({ example: "My Truck" }),
+    name: z
+      .string()
+      .trim()
+      .min(1, "Name is required")
+      .max(ASSET_FIELD_LIMITS.name)
+      .openapi({ example: "My Truck" }),
     metadata: AssetMetadataSchema,
   })
   .openapi("CreateAssetBody");

--- a/apps/api/src/application/usecases/CreateAsset.test.ts
+++ b/apps/api/src/application/usecases/CreateAsset.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { UserId } from "@snaveevans/pineapple-shared";
-import { CreateAsset } from "./CreateAsset.ts";
+import { CreateAsset, MAX_ACTIVE_ASSETS_PER_USER } from "./CreateAsset.ts";
 import type { EventBus } from "../ports/EventBus.ts";
 import type { Asset } from "../../domain/asset/Asset.ts";
 import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
@@ -9,6 +9,7 @@ import type { DomainEvent } from "../../domain/events/DomainEvent.ts";
 
 class RecordingAssetRepository implements AssetRepository {
   saved: Asset | null = null;
+  activeAssetCount = 0;
 
   findById(): Promise<Asset | null> {
     return Promise.resolve(null);
@@ -16,6 +17,10 @@ class RecordingAssetRepository implements AssetRepository {
 
   findByOwner(): Promise<Asset[]> {
     return Promise.resolve([]);
+  }
+
+  countActiveByOwner(): Promise<number> {
+    return Promise.resolve(this.activeAssetCount);
   }
 
   save(asset: Asset): Promise<void> {
@@ -66,5 +71,22 @@ describe("CreateAsset", () => {
       assetModelYear: 2016,
     });
     expect(repo.saved?.pullEvents()).toHaveLength(0);
+  });
+
+  it("rejects creation after the active asset quota is reached", async () => {
+    const repo = new RecordingAssetRepository();
+    repo.activeAssetCount = MAX_ACTIVE_ASSETS_PER_USER;
+
+    const result = await new CreateAsset(repo, new RecordingEventBus()).execute({
+      ownerId: UserId.generate(),
+      name: "My Truck",
+      metadata: { kind: "vehicle", make: "Ram", model: "2500", year: 2016 },
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: { message: "Active asset limit reached" },
+    });
+    expect(repo.saved).toBeNull();
   });
 });

--- a/apps/api/src/application/usecases/CreateAsset.ts
+++ b/apps/api/src/application/usecases/CreateAsset.ts
@@ -1,5 +1,6 @@
 import {
   type AssetId,
+  ConflictError,
   type DomainError,
   DomainError as DomainErrorClass,
   ok,
@@ -11,6 +12,8 @@ import { Asset } from "../../domain/asset/Asset.ts";
 import type { AssetMetadata } from "../../domain/asset/AssetMetadata.ts";
 import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
 import type { EventBus } from "../ports/EventBus.ts";
+
+export const MAX_ACTIVE_ASSETS_PER_USER = 500;
 
 export type CreateAssetCommand = {
   ownerId: UserId;
@@ -26,6 +29,10 @@ export class CreateAsset {
 
   async execute(cmd: CreateAssetCommand): Promise<Result<AssetId, DomainError>> {
     try {
+      const activeAssetCount = await this.assets.countActiveByOwner(cmd.ownerId);
+      if (activeAssetCount >= MAX_ACTIVE_ASSETS_PER_USER) {
+        return err(new ConflictError("Active asset limit reached"));
+      }
       const asset = Asset.create({
         ownerId: cmd.ownerId,
         name: cmd.name,

--- a/apps/api/src/application/usecases/GetAsset.test.ts
+++ b/apps/api/src/application/usecases/GetAsset.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { UserId } from "@snaveevans/pineapple-shared";
+import { Asset } from "../../domain/asset/Asset.ts";
+import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
+import { GetAsset } from "./GetAsset.ts";
+
+class SingleAssetRepository implements AssetRepository {
+  constructor(private readonly asset: Asset) {}
+
+  findById(): Promise<Asset> {
+    return Promise.resolve(this.asset);
+  }
+
+  findByOwner(): Promise<Asset[]> {
+    return Promise.resolve([this.asset]);
+  }
+
+  countActiveByOwner(): Promise<number> {
+    return Promise.resolve(1);
+  }
+
+  save(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+describe("GetAsset", () => {
+  it("returns not found when the asset belongs to a different user", async () => {
+    const asset = Asset.create({
+      ownerId: UserId.generate(),
+      name: "Truck",
+      metadata: { kind: "vehicle", make: "Ram", model: "2500", year: 2016 },
+    });
+
+    const result = await new GetAsset(new SingleAssetRepository(asset)).execute({
+      assetId: asset.id,
+      requesterId: UserId.generate(),
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: { message: "Asset not found" },
+    });
+  });
+});

--- a/apps/api/src/application/usecases/GetAsset.ts
+++ b/apps/api/src/application/usecases/GetAsset.ts
@@ -3,7 +3,6 @@ import {
   type DomainError,
   DomainError as DomainErrorClass,
   NotFoundError,
-  ForbiddenError,
   ok,
   err,
   type Result,
@@ -24,7 +23,7 @@ export class GetAsset {
     try {
       const asset = await this.assets.findById(query.assetId);
       if (!asset) return err(new NotFoundError("Asset not found"));
-      if (asset.ownerId !== query.requesterId) return err(new ForbiddenError("Access denied"));
+      if (asset.ownerId !== query.requesterId) return err(new NotFoundError("Asset not found"));
       return ok(asset);
     } catch (e) {
       if (e instanceof DomainErrorClass) return err(e);

--- a/apps/api/src/domain/asset/Asset.test.ts
+++ b/apps/api/src/domain/asset/Asset.test.ts
@@ -33,6 +33,12 @@ describe("Asset", () => {
     );
   });
 
+  it("rejects overlong names", () => {
+    expect(() => Asset.create({ ownerId, name: "a".repeat(121), metadata: validVehicle })).toThrow(
+      ValidationError,
+    );
+  });
+
   it("rejects invalid vehicle year", () => {
     expect(() =>
       Asset.create({ ownerId, name: "Old Truck", metadata: { ...validVehicle, year: 1800 } }),
@@ -45,6 +51,16 @@ describe("Asset", () => {
         ownerId,
         name: "Truck",
         metadata: { ...validVehicle, vin: "TOOSHORT" },
+      }),
+    ).toThrow(ValidationError);
+  });
+
+  it("rejects VIN characters that are not VIN-safe", () => {
+    expect(() =>
+      Asset.create({
+        ownerId,
+        name: "Truck",
+        metadata: { ...validVehicle, vin: "1C6RR7LT4GS12345I" },
       }),
     ).toThrow(ValidationError);
   });

--- a/apps/api/src/domain/asset/Asset.ts
+++ b/apps/api/src/domain/asset/Asset.ts
@@ -3,6 +3,7 @@ import { validateMetadata, type AssetMetadata } from "./AssetMetadata";
 import type { AssetType } from "./AssetType";
 import type { DomainEvent } from "../events/DomainEvent";
 import { AssetCreated } from "./events/AssetCreated";
+import { ASSET_FIELD_LIMITS } from "./AssetConstraints";
 
 export class Asset {
   private _domainEvents: DomainEvent[] = [];
@@ -24,6 +25,12 @@ export class Asset {
   static create(props: { ownerId: UserId; name: string; metadata: AssetMetadata }): Asset {
     if (!props.name?.trim()) {
       throw new ValidationError("Asset name is required", "name");
+    }
+    if (props.name.trim().length > ASSET_FIELD_LIMITS.name) {
+      throw new ValidationError(
+        `Asset name must be ${ASSET_FIELD_LIMITS.name} characters or fewer`,
+        "name",
+      );
     }
     validateMetadata(props.metadata);
 
@@ -70,6 +77,12 @@ export class Asset {
 
   rename(name: string): void {
     if (!name?.trim()) throw new ValidationError("Name required", "name");
+    if (name.trim().length > ASSET_FIELD_LIMITS.name) {
+      throw new ValidationError(
+        `Asset name must be ${ASSET_FIELD_LIMITS.name} characters or fewer`,
+        "name",
+      );
+    }
     this.name = name.trim();
     this.updatedAt = new Date();
   }

--- a/apps/api/src/domain/asset/AssetConstraints.ts
+++ b/apps/api/src/domain/asset/AssetConstraints.ts
@@ -1,0 +1,17 @@
+export const ASSET_FIELD_LIMITS = {
+  name: 120,
+  vehicleMake: 64,
+  vehicleModel: 64,
+  propertyNickname: 80,
+  propertyStreet: 160,
+  propertyCity: 80,
+  propertyState: 80,
+  propertyCountry: 80,
+  propertyPostalCode: 20,
+  equipmentManufacturer: 80,
+  equipmentModelNumber: 80,
+  equipmentSerialNumber: 80,
+} as const;
+
+/** VINs exclude I, O, and Q to avoid ambiguous characters. */
+export const VIN_PATTERN = /^[A-HJ-NPR-Z0-9]{17}$/;

--- a/apps/api/src/domain/asset/AssetMetadata.ts
+++ b/apps/api/src/domain/asset/AssetMetadata.ts
@@ -1,4 +1,5 @@
 import { ValidationError } from "@snaveevans/pineapple-shared";
+import { ASSET_FIELD_LIMITS, VIN_PATTERN } from "./AssetConstraints";
 
 export type AssetMetadata = VehicleMetadata | PropertyMetadata | EquipmentMetadata;
 
@@ -31,22 +32,41 @@ export type Address = {
   country: string;
 };
 
+function assertMaxLength(
+  value: string | undefined,
+  maxLength: number,
+  field: string,
+  label: string,
+): void {
+  if (value !== undefined && value.length > maxLength) {
+    throw new ValidationError(`${label} must be ${maxLength} characters or fewer`, field);
+  }
+}
+
 export function validateMetadata(metadata: AssetMetadata): void {
   switch (metadata.kind) {
     case "vehicle": {
       if (!metadata.make?.trim()) throw new ValidationError("Make required", "metadata.make");
       if (!metadata.model?.trim()) throw new ValidationError("Model required", "metadata.model");
+      assertMaxLength(metadata.make, ASSET_FIELD_LIMITS.vehicleMake, "metadata.make", "Make");
+      assertMaxLength(metadata.model, ASSET_FIELD_LIMITS.vehicleModel, "metadata.model", "Model");
       const currentYear = new Date().getFullYear();
       if (metadata.year < 1900 || metadata.year > currentYear + 1) {
         throw new ValidationError("Invalid year", "metadata.year");
       }
-      if (metadata.vin !== undefined && metadata.vin.length !== 17) {
-        throw new ValidationError("VIN must be 17 characters", "metadata.vin");
+      if (metadata.vin !== undefined && !VIN_PATTERN.test(metadata.vin)) {
+        throw new ValidationError("VIN must be 17 VIN-safe characters", "metadata.vin");
       }
       return;
     }
     case "property": {
       const a = metadata.address;
+      assertMaxLength(
+        metadata.nickname,
+        ASSET_FIELD_LIMITS.propertyNickname,
+        "metadata.nickname",
+        "Nickname",
+      );
       if (!a.street?.trim())
         throw new ValidationError("Street required", "metadata.address.street");
       if (!a.city?.trim()) throw new ValidationError("City required", "metadata.address.city");
@@ -55,9 +75,47 @@ export function validateMetadata(metadata: AssetMetadata): void {
         throw new ValidationError("Postal code required", "metadata.address.postalCode");
       if (!a.country?.trim())
         throw new ValidationError("Country required", "metadata.address.country");
+      assertMaxLength(
+        a.street,
+        ASSET_FIELD_LIMITS.propertyStreet,
+        "metadata.address.street",
+        "Street",
+      );
+      assertMaxLength(a.city, ASSET_FIELD_LIMITS.propertyCity, "metadata.address.city", "City");
+      assertMaxLength(a.state, ASSET_FIELD_LIMITS.propertyState, "metadata.address.state", "State");
+      assertMaxLength(
+        a.postalCode,
+        ASSET_FIELD_LIMITS.propertyPostalCode,
+        "metadata.address.postalCode",
+        "Postal code",
+      );
+      assertMaxLength(
+        a.country,
+        ASSET_FIELD_LIMITS.propertyCountry,
+        "metadata.address.country",
+        "Country",
+      );
       return;
     }
     case "equipment":
+      assertMaxLength(
+        metadata.manufacturer,
+        ASSET_FIELD_LIMITS.equipmentManufacturer,
+        "metadata.manufacturer",
+        "Manufacturer",
+      );
+      assertMaxLength(
+        metadata.modelNumber,
+        ASSET_FIELD_LIMITS.equipmentModelNumber,
+        "metadata.modelNumber",
+        "Model number",
+      );
+      assertMaxLength(
+        metadata.serialNumber,
+        ASSET_FIELD_LIMITS.equipmentSerialNumber,
+        "metadata.serialNumber",
+        "Serial number",
+      );
       return;
   }
 }

--- a/apps/api/src/domain/asset/AssetRepository.ts
+++ b/apps/api/src/domain/asset/AssetRepository.ts
@@ -4,5 +4,6 @@ import type { Asset } from "./Asset";
 export interface AssetRepository {
   findById(id: AssetId): Promise<Asset | null>;
   findByOwner(ownerId: UserId): Promise<Asset[]>;
+  countActiveByOwner(ownerId: UserId): Promise<number>;
   save(asset: Asset): Promise<void>;
 }

--- a/apps/api/src/infrastructure/auth/auth.ts
+++ b/apps/api/src/infrastructure/auth/auth.ts
@@ -1,6 +1,18 @@
 import { betterAuth, type BetterAuthOptions } from "better-auth";
 import { withCloudflare } from "better-auth-cloudflare";
 
+function isLoopbackOrigin(value: string): boolean {
+  try {
+    const { hostname, origin } = new URL(value);
+    return (
+      origin === value &&
+      (hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]")
+    );
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Environment needed to construct a runtime Better Auth instance.
  * Values come from wrangler bindings (`c.env`) — never `process.env`,
@@ -67,10 +79,11 @@ export function createAuth(env?: AuthEnv, baseURL?: string) {
 
   // Dev-only: trust the web app's separate dev origin (e.g. localhost:5173).
   // Better Auth always trusts baseURL; this adds the cross-port frontend.
-  const devOrigins =
-    env?.DEV_WEB_ORIGIN?.split(",")
-      .map((o) => o.trim())
-      .filter(Boolean) ?? [];
+  const devOrigins = isLoopbackOrigin(baseURL ?? "")
+    ? (env?.DEV_WEB_ORIGIN?.split(",")
+        .map((o) => o.trim())
+        .filter((origin) => isLoopbackOrigin(origin)) ?? [])
+    : [];
 
   const options: BetterAuthOptions = {
     ...(baseURL ? { baseURL } : {}),

--- a/apps/api/src/infrastructure/persistence/D1AssetRepository.ts
+++ b/apps/api/src/infrastructure/persistence/D1AssetRepository.ts
@@ -37,6 +37,14 @@ export class D1AssetRepository implements AssetRepository {
     return result.results.map((row) => this.#rowToAsset(row));
   }
 
+  async countActiveByOwner(ownerId: UserId): Promise<number> {
+    const row = await this.db
+      .prepare("SELECT COUNT(*) AS count FROM assets WHERE owner_id = ? AND archived_at IS NULL")
+      .bind(ownerId)
+      .first<{ count: number }>();
+    return row?.count ?? 0;
+  }
+
   async save(asset: Asset): Promise<void> {
     await this.db
       .prepare(

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -1,7 +1,8 @@
 import { OpenAPIHono } from "@hono/zod-openapi";
 import { Scalar } from "@scalar/hono-api-reference";
 import { cors } from "hono/cors";
-import type { Context } from "hono";
+import { secureHeaders } from "hono/secure-headers";
+import type { Context, Next } from "hono";
 import { AssetId, DomainError } from "@snaveevans/pineapple-shared";
 import type { User } from "./domain/identity/User.ts";
 import type { Asset } from "./domain/asset/Asset.ts";
@@ -25,6 +26,12 @@ import type { EventBus } from "./application/ports/EventBus.ts";
 // API layer
 import { toHttpError } from "./api/errors.ts";
 import { createTechnicalTelemetryMiddleware } from "./api/middleware/technicalTelemetry.ts";
+import { createAssetBodyLimit } from "./api/middleware/createAssetBodyLimit.ts";
+import {
+  getAllowedApiCorsOrigin,
+  getAuthBaseURL,
+  resolveDevAuthEmail,
+} from "./api/authSecurity.ts";
 import {
   createAssetRoute,
   getAssetRoute,
@@ -41,6 +48,10 @@ type Bindings = AuthEnv & {
   API_REQUEST_TELEMETRY: AnalyticsEngineDataset;
   /** Local dev only — set in .dev.vars, never in wrangler.toml. Bypasses the Better Auth session check. */
   DEV_AUTH_EMAIL?: string;
+  /** Local dev only — must be exactly "true" before DEV_AUTH_EMAIL is honored. */
+  DEV_AUTH_BYPASS_ENABLED?: string;
+  ASSET_WRITE_RATE_LIMITER: RateLimit;
+  ASSET_READ_RATE_LIMITER: RateLimit;
 };
 type Variables = { user: User; auth: Auth };
 type AppEnv = { Bindings: Bindings; Variables: Variables };
@@ -59,6 +70,8 @@ const app = new OpenAPIHono<AppEnv>({
   },
 });
 
+const ASSET_RATE_LIMIT_RETRY_AFTER_SECONDS = 60;
+
 // Centralized error handling: domain errors → their HTTP status; anything
 // else → 500. Handlers and middleware just `throw` and this maps it.
 app.onError((err, c) => {
@@ -68,6 +81,22 @@ app.onError((err, c) => {
 });
 
 registerOpenApiComponents(app.openAPIRegistry);
+
+app.use(
+  "*",
+  secureHeaders({
+    // Approved local development CORS needs to remain usable for API responses.
+    crossOriginOpenerPolicy: false,
+    crossOriginResourcePolicy: false,
+    permissionsPolicy: {
+      camera: [],
+      geolocation: [],
+      microphone: [],
+    },
+    referrerPolicy: "no-referrer",
+    xFrameOptions: "DENY",
+  }),
+);
 
 app.use(
   "*",
@@ -109,11 +138,19 @@ app.get("/reference", Scalar({ url: "/openapi.json" }));
 
 // ── Better Auth ───────────────────────────────────────────────────────────
 
-// CORS for the Better Auth endpoints (browser hits these with credentials).
+// Credentialed browser API calls are same-origin in production and explicitly
+// allowlisted by loopback origin in local development.
 app.use(
-  "/api/auth/**",
+  "/api/*",
   cors({
-    origin: (origin) => origin,
+    origin: (origin, c) => {
+      const env = c.env as Bindings;
+      return getAllowedApiCorsOrigin(
+        origin,
+        getAuthBaseURL(c.req.url, env.BETTER_AUTH_URL),
+        env.DEV_WEB_ORIGIN,
+      );
+    },
     allowHeaders: ["Content-Type", "Authorization"],
     allowMethods: ["GET", "POST", "OPTIONS"],
     credentials: true,
@@ -126,13 +163,26 @@ app.use(
 // request URL is the production route host, not localhost); otherwise derive
 // it from the incoming request (correct in production).
 app.use("/api/*", async (c, next) => {
-  const baseURL = c.env.BETTER_AUTH_URL ?? new URL(c.req.url).origin;
+  const baseURL = getAuthBaseURL(c.req.url, c.env.BETTER_AUTH_URL);
   const auth = createAuth(c.env, baseURL);
   c.set("auth", auth);
   await next();
 });
 
-// Mount all Better Auth routes (sign-in/out, OAuth callbacks, session).
+// The local bypass also needs a session-shaped response so the web router can
+// exercise protected screens without Google credentials.
+app.get("/api/auth/get-session", (c) => {
+  const baseURL = getAuthBaseURL(c.req.url, c.env.BETTER_AUTH_URL);
+  const devEmail = resolveDevAuthEmail({
+    baseURL,
+    email: c.env.DEV_AUTH_EMAIL,
+    enabled: c.env.DEV_AUTH_BYPASS_ENABLED,
+  });
+  if (devEmail) return c.json({ user: { email: devEmail, name: null } });
+  return c.get("auth").handler(c.req.raw);
+});
+
+// Mount all other Better Auth routes (sign-in/out and OAuth callbacks).
 app.on(["GET", "POST"], "/api/auth/*", (c) => c.get("auth").handler(c.req.raw));
 
 // ── Auth gate for the application API ────────────────────────────────────────
@@ -140,10 +190,15 @@ app.on(["GET", "POST"], "/api/auth/*", (c) => c.get("auth").handler(c.req.raw));
 // Resolves (and JIT-provisions) the domain User from the Better Auth session.
 // Thrown auth errors propagate to app.onError above.
 app.use("/api/*", async (c, next) => {
+  const baseURL = getAuthBaseURL(c.req.url, c.env.BETTER_AUTH_URL);
   const resolver = new BetterAuthResolver(
     c.get("auth"),
     new D1UserRepository(c.env.DB),
-    c.env.DEV_AUTH_EMAIL,
+    resolveDevAuthEmail({
+      baseURL,
+      email: c.env.DEV_AUTH_EMAIL,
+      enabled: c.env.DEV_AUTH_BYPASS_ENABLED,
+    }),
   );
   const user = await resolver.resolve(c.req.raw);
   c.set("user", user);
@@ -151,6 +206,29 @@ app.use("/api/*", async (c, next) => {
 });
 
 // ── Asset endpoints ──────────────────────────────────────────────────────────
+
+app.use("/api/assets", createAssetBodyLimit);
+
+async function enforceAssetRateLimit(c: Context<AppEnv>, next: Next) {
+  const limiter =
+    c.req.method === "POST"
+      ? c.env.ASSET_WRITE_RATE_LIMITER
+      : c.req.method === "GET"
+        ? c.env.ASSET_READ_RATE_LIMITER
+        : undefined;
+  if (!limiter) return next();
+
+  const { success } = await limiter.limit({ key: c.get("user").id });
+  if (!success) {
+    return c.json({ error: "Too many requests" }, 429, {
+      "Retry-After": String(ASSET_RATE_LIMIT_RETRY_AFTER_SECONDS),
+    });
+  }
+  return next();
+}
+
+app.use("/api/assets", enforceAssetRateLimit);
+app.use("/api/assets/*", enforceAssetRateLimit);
 
 app.openapi(createAssetRoute, async (c) => {
   const user = c.get("user");

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -4,10 +4,6 @@ compatibility_date = "2026-05-21"
 # Better Auth relies on Node APIs (crypto, etc.) on the Workers runtime.
 compatibility_flags = ["nodejs_compat"]
 
-[observability]
-enabled = true
-head_sampling_rate = 1
-
 # Production routes on the shared hostname. The API owns /api/* plus its
 # (non-/api) docs + health endpoints; the web Worker (pineapple-web) owns the
 # catch-all /* for the SPA. Cloudflare matches the most specific route, so
@@ -20,6 +16,10 @@ routes = [
   { pattern = "pineapple.tylerevans.co/reference", zone_name = "tylerevans.co" },
   { pattern = "pineapple.tylerevans.co/health", zone_name = "tylerevans.co" },
 ]
+
+[observability]
+enabled = true
+head_sampling_rate = 1
 
 # Auth config is provided as SECRETS (not committed here):
 #   wrangler secret put BETTER_AUTH_SECRET
@@ -42,3 +42,13 @@ dataset = "pineapple_asset_domain_events"
 [[analytics_engine_datasets]]
 binding = "API_REQUEST_TELEMETRY"
 dataset = "pineapple_api_request_events"
+
+[[ratelimits]]
+name = "ASSET_WRITE_RATE_LIMITER"
+namespace_id = "1001"
+simple = { limit = 10, period = 60 }
+
+[[ratelimits]]
+name = "ASSET_READ_RATE_LIMITER"
+namespace_id = "1002"
+simple = { limit = 120, period = 60 }

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,3 +1,3 @@
-# Copy to .env.local for local dev. Base URL of the API Worker.
-# In production web + API share a hostname, so leave empty (same-origin).
+# Copy to .env.development.local for local dev. Base URL of the API Worker.
+# Production builds reject this value because web + API share a hostname.
 VITE_API_URL=http://localhost:8787

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -19,7 +19,7 @@ It serves these pages from the Claude Design handoff:
   category filter chips, and a grid/list view toggle.
 - **Add Asset** (`/app/assets/new`) — [`src/app/AppAddAsset.tsx`](src/app/AppAddAsset.tsx) —
   the add-asset form: a three-bucket type picker (Vehicle / Property / Other)
-  with contextual detail fields, an optional photo dropzone, a deferred
+  with contextual detail fields, a disabled future photo control, a deferred
   "set up a schedule" note, and a sticky save bar. The "Add asset" buttons and
   the ghost add-card on the Assets page link here; `esc` cancels back.
 
@@ -64,6 +64,10 @@ pnpm --filter @snaveevans/pineapple-web build       # production build → dist/
 pnpm --filter @snaveevans/pineapple-web preview      # preview the built worker locally
 pnpm --filter @snaveevans/pineapple-web deploy       # build + wrangler deploy
 ```
+
+Copy `.env.example` to `.env.development.local` for local API calls. Production
+builds reject `VITE_API_URL` because the deployed web app uses same-origin API
+requests.
 
 > Unlike `apps/api`, this app **has a build step** (Vite). It uses Web/DOM
 > standard APIs in the Worker entry, so no `@cloudflare/workers-types` global

--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -1,0 +1,6 @@
+/*
+  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'; upgrade-insecure-requests
+  Permissions-Policy: camera=(), microphone=(), geolocation=()
+  Referrer-Policy: strict-origin-when-cross-origin
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -1,0 +1,91 @@
+const API_BASE = import.meta.env.VITE_API_URL ?? "";
+
+export type SessionUser = { email: string; name?: string | null };
+
+export type CreateAssetPayload =
+  | {
+      name: string;
+      metadata: { kind: "vehicle"; make: string; model: string; year: number; vin?: string };
+    }
+  | {
+      name: string;
+      metadata: {
+        kind: "property";
+        nickname?: string;
+        address: {
+          street: string;
+          city: string;
+          state: string;
+          postalCode: string;
+          country: string;
+        };
+      };
+    }
+  | {
+      name: string;
+      metadata: {
+        kind: "equipment";
+        manufacturer?: string;
+        modelNumber?: string;
+        serialNumber?: string;
+      };
+    };
+
+type ApiErrorBody = { error?: string; field?: string };
+
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly field?: string,
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
+async function throwApiError(response: Response): Promise<never> {
+  const body = (await response.json().catch(() => null)) as ApiErrorBody | null;
+  throw new ApiError(body?.error ?? "Request failed", response.status, body?.field);
+}
+
+export async function getSession(): Promise<SessionUser | null> {
+  const response = await fetch(`${API_BASE}/api/auth/get-session`, { credentials: "include" });
+  if (!response.ok) return throwApiError(response);
+  const body = (await response.json()) as { user?: SessionUser } | null;
+  return body?.user ?? null;
+}
+
+export async function startGoogleSignIn(callbackURL: string, errorCallbackURL: string) {
+  const response = await fetch(`${API_BASE}/api/auth/sign-in/social`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify({ provider: "google", callbackURL, errorCallbackURL }),
+  });
+  if (!response.ok) return throwApiError(response);
+  const body = (await response.json()) as { url?: string };
+  if (!body.url) throw new Error("Sign-in response is missing the redirect URL");
+  window.location.href = body.url;
+}
+
+export async function signOut() {
+  const response = await fetch(`${API_BASE}/api/auth/sign-out`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    credentials: "include",
+    body: "{}",
+  });
+  if (!response.ok) return throwApiError(response);
+}
+
+export async function createAsset(payload: CreateAssetPayload): Promise<{ id: string }> {
+  const response = await fetch(`${API_BASE}/api/assets`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify(payload),
+  });
+  if (!response.ok) return throwApiError(response);
+  return (await response.json()) as { id: string };
+}

--- a/apps/web/src/app/AppAddAsset.tsx
+++ b/apps/web/src/app/AppAddAsset.tsx
@@ -1,7 +1,21 @@
-import { useEffect, useState, type ReactNode } from "react";
+import {
+  useEffect,
+  useState,
+  type FormEvent,
+  type HTMLInputTypeAttribute,
+  type ReactNode,
+} from "react";
 import { Link, useNavigate } from "react-router";
+import { createAsset } from "../api/client";
 import { Icon, type IconName } from "../design/Icon";
 import { HFTopBar } from "./AppChrome";
+import {
+  ADD_ASSET_FIELD_LIMITS,
+  buildCreateAssetPayload,
+  EMPTY_ADD_ASSET_FORM,
+  type AddAssetFormValues,
+  type AssetType,
+} from "./addAssetPayload";
 import { paths } from "../routes";
 
 // FieldOps — Add Asset. A focused single-page form on the .hf design system:
@@ -15,7 +29,6 @@ import "../design/styles/hifi.css";
 import "../design/styles/hifi-assets.css";
 import "../design/styles/hifi-add-asset.css";
 
-type AssetType = "vehicle" | "property" | "other";
 type Subtype = "lawn" | "power-tool" | "appliance" | "hvac" | "generator" | "other";
 
 /* ============ field primitives ============ */
@@ -52,7 +65,14 @@ function HFTextField({
   hint,
   placeholder,
   mono,
-  defaultValue,
+  value,
+  onChange,
+  maxLength,
+  inputMode,
+  pattern,
+  type,
+  min,
+  max,
 }: {
   label: string;
   required?: boolean | undefined;
@@ -60,14 +80,29 @@ function HFTextField({
   hint?: string | undefined;
   placeholder?: string | undefined;
   mono?: boolean | undefined;
-  defaultValue?: string | undefined;
+  value: string;
+  onChange: (value: string) => void;
+  maxLength?: number | undefined;
+  inputMode?: "numeric" | "text" | undefined;
+  pattern?: string | undefined;
+  type?: HTMLInputTypeAttribute | undefined;
+  min?: number | undefined;
+  max?: number | undefined;
 }) {
   return (
     <HFField label={label} required={required} optional={optional} hint={hint}>
       <input
         className={`hf-input ${mono ? "hf-mono-input" : ""}`}
         placeholder={placeholder}
-        defaultValue={defaultValue}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        required={required}
+        maxLength={maxLength}
+        inputMode={inputMode}
+        pattern={pattern}
+        type={type}
+        min={min}
+        max={max}
       />
     </HFField>
   );
@@ -79,18 +114,25 @@ function HFSelectField({
   optional,
   hint,
   options,
-  defaultValue,
+  value,
+  onChange,
 }: {
   label: string;
   required?: boolean | undefined;
   optional?: boolean | undefined;
   hint?: string | undefined;
   options: string[];
-  defaultValue?: string | undefined;
+  value: string;
+  onChange: (value: string) => void;
 }) {
   return (
     <HFField label={label} required={required} optional={optional} hint={hint}>
-      <select className="hf-select" defaultValue={defaultValue}>
+      <select
+        className="hf-select"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        required={required}
+      >
         {options.map((o) => (
           <option key={o} value={o}>
             {o}
@@ -108,13 +150,7 @@ const HF_TYPES: { id: AssetType; icon: IconName; name: string; desc: string }[] 
   { id: "other", icon: "wrench", name: "Other", desc: "Tools, HVAC, generators, appliances" },
 ];
 
-function HFTypePicker({
-  value,
-  onChange,
-}: {
-  value: AssetType;
-  onChange: (v: AssetType) => void;
-}) {
+function HFTypePicker({ value, onChange }: { value: AssetType; onChange: (v: AssetType) => void }) {
   return (
     <div className="hf-aa-types" role="radiogroup" aria-label="Asset type">
       {HF_TYPES.map((t) => (
@@ -150,13 +186,7 @@ const HF_SUBTYPES: { id: Subtype; glyph: IconName; label: string }[] = [
   { id: "other", glyph: "dot", label: "Something else" },
 ];
 
-function HFSubtypeChips({
-  value,
-  onChange,
-}: {
-  value: Subtype;
-  onChange: (v: Subtype) => void;
-}) {
+function HFSubtypeChips({ value, onChange }: { value: Subtype; onChange: (v: Subtype) => void }) {
   return (
     <div className="hf-aa-chips">
       {HF_SUBTYPES.map((s) => (
@@ -179,18 +209,23 @@ function HFSubtypeChips({
 /* ============ photo dropzone ============ */
 function HFDropzone() {
   return (
-    <div className="hf-dropzone">
+    <button className="hf-dropzone" type="button" disabled title="Photo uploads are coming soon">
       <div className="hf-dropzone-icon">
         <Icon name="camera" size={18} color="var(--hf-ink-soft)" />
       </div>
       <div className="hf-dropzone-label">Add photo</div>
-      <div className="hf-dropzone-sub">drag or click</div>
-    </div>
+      <div className="hf-dropzone-sub">coming soon</div>
+    </button>
   );
 }
 
 /* ============ contextual detail sections ============ */
-function HFVehicleFields() {
+type SetField = <K extends keyof AddAssetFormValues>(
+  field: K,
+  value: AddAssetFormValues[K],
+) => void;
+
+function HFVehicleFields({ values, setField }: { values: AddAssetFormValues; setField: SetField }) {
   return (
     <div className="hf-aa-section">
       <div className="hf-aa-section-head">
@@ -198,9 +233,34 @@ function HFVehicleFields() {
         <span className="hf-aa-section-hint">helps with service reminders</span>
       </div>
       <div className="hf-field-row">
-        <HFTextField label="Make" required placeholder="Ford" />
-        <HFTextField label="Model" required placeholder="F-150" />
-        <HFTextField label="Year" required placeholder="2022" mono />
+        <HFTextField
+          label="Make"
+          required
+          placeholder="Ford"
+          value={values.vehicleMake}
+          onChange={(value) => setField("vehicleMake", value)}
+          maxLength={ADD_ASSET_FIELD_LIMITS.vehicleMake}
+        />
+        <HFTextField
+          label="Model"
+          required
+          placeholder="F-150"
+          value={values.vehicleModel}
+          onChange={(value) => setField("vehicleModel", value)}
+          maxLength={ADD_ASSET_FIELD_LIMITS.vehicleModel}
+        />
+        <HFTextField
+          label="Year"
+          required
+          placeholder="2022"
+          mono
+          type="number"
+          inputMode="numeric"
+          min={1900}
+          max={new Date().getFullYear() + 1}
+          value={values.vehicleYear}
+          onChange={(value) => setField("vehicleYear", value)}
+        />
       </div>
       <HFTextField
         label="VIN"
@@ -208,12 +268,22 @@ function HFVehicleFields() {
         hint="enables warranty lookups"
         placeholder="1FTFW1E50NFA12345"
         mono
+        value={values.vin}
+        onChange={(value) => setField("vin", value.toUpperCase())}
+        maxLength={ADD_ASSET_FIELD_LIMITS.vin}
+        pattern="[A-HJ-NPR-Z0-9]{17}"
       />
     </div>
   );
 }
 
-function HFPropertyFields() {
+function HFPropertyFields({
+  values,
+  setField,
+}: {
+  values: AddAssetFormValues;
+  setField: SetField;
+}) {
   return (
     <div className="hf-aa-section">
       <div className="hf-aa-section-head">
@@ -225,12 +295,43 @@ function HFPropertyFields() {
         optional
         hint="handy when you own multiples"
         placeholder="Main house, Cabin…"
+        value={values.propertyNickname}
+        onChange={(value) => setField("propertyNickname", value)}
+        maxLength={ADD_ASSET_FIELD_LIMITS.propertyNickname}
       />
-      <HFTextField label="Street" required placeholder="12 Oak St, Apt 4" />
+      <HFTextField
+        label="Street"
+        required
+        placeholder="12 Oak St, Apt 4"
+        value={values.propertyStreet}
+        onChange={(value) => setField("propertyStreet", value)}
+        maxLength={ADD_ASSET_FIELD_LIMITS.propertyStreet}
+      />
       <div className="hf-field-row">
-        <HFTextField label="City" required placeholder="Portland" />
-        <HFSelectField label="State" required options={["OR", "WA", "CA", "ID", "NV", "AZ"]} />
-        <HFTextField label="Postal" required placeholder="97204" mono />
+        <HFTextField
+          label="City"
+          required
+          placeholder="Portland"
+          value={values.propertyCity}
+          onChange={(value) => setField("propertyCity", value)}
+          maxLength={ADD_ASSET_FIELD_LIMITS.propertyCity}
+        />
+        <HFSelectField
+          label="State"
+          required
+          options={["OR", "WA", "CA", "ID", "NV", "AZ"]}
+          value={values.propertyState}
+          onChange={(value) => setField("propertyState", value)}
+        />
+        <HFTextField
+          label="Postal"
+          required
+          placeholder="97204"
+          mono
+          value={values.propertyPostalCode}
+          onChange={(value) => setField("propertyPostalCode", value)}
+          maxLength={ADD_ASSET_FIELD_LIMITS.propertyPostalCode}
+        />
       </div>
     </div>
   );
@@ -239,9 +340,13 @@ function HFPropertyFields() {
 function HFOtherFields({
   subtype,
   onSubtype,
+  values,
+  setField,
 }: {
   subtype: Subtype;
   onSubtype: (v: Subtype) => void;
+  values: AddAssetFormValues;
+  setField: SetField;
 }) {
   return (
     <div className="hf-aa-section">
@@ -264,15 +369,29 @@ function HFOtherFields({
                   ? "Generac"
                   : "Brand"
           }
+          value={values.equipmentManufacturer}
+          onChange={(value) => setField("equipmentManufacturer", value)}
+          maxLength={ADD_ASSET_FIELD_LIMITS.equipmentManufacturer}
         />
-        <HFTextField label="Model number" placeholder="MX5060" mono />
+        <HFTextField
+          label="Model number"
+          placeholder="MX5060"
+          mono
+          value={values.equipmentModelNumber}
+          onChange={(value) => setField("equipmentModelNumber", value)}
+          maxLength={ADD_ASSET_FIELD_LIMITS.equipmentModelNumber}
+        />
       </div>
-      <HFTextField label="Serial number" optional hint="useful for warranty" placeholder="SN-298471-A" mono />
-      {subtype === "lawn" && (
-        <div className="hf-field-row">
-          <HFTextField label="Engine hours" optional hint="schedules oil changes" placeholder="124" mono />
-        </div>
-      )}
+      <HFTextField
+        label="Serial number"
+        optional
+        hint="useful for warranty"
+        placeholder="SN-298471-A"
+        mono
+        value={values.equipmentSerialNumber}
+        onChange={(value) => setField("equipmentSerialNumber", value)}
+        maxLength={ADD_ASSET_FIELD_LIMITS.equipmentSerialNumber}
+      />
     </div>
   );
 }
@@ -301,12 +420,16 @@ function HFAddAssetFields({
   setType,
   subtype,
   setSubtype,
+  values,
+  setField,
   showHeaderHint,
 }: {
   type: AssetType;
   setType: (v: AssetType) => void;
   subtype: Subtype;
   setSubtype: (v: Subtype) => void;
+  values: AddAssetFormValues;
+  setField: SetField;
   showHeaderHint?: boolean | undefined;
 }) {
   return (
@@ -328,14 +451,24 @@ function HFAddAssetFields({
         required
         hint="how you'll recognize it"
         placeholder={namePlaceholder(type, subtype)}
+        value={values.name}
+        onChange={(value) => setField("name", value)}
+        maxLength={ADD_ASSET_FIELD_LIMITS.name}
       />
 
       <div className="hf-aa-rule" />
 
       {/* CONTEXTUAL FIELDS */}
-      {type === "vehicle" && <HFVehicleFields />}
-      {type === "property" && <HFPropertyFields />}
-      {type === "other" && <HFOtherFields subtype={subtype} onSubtype={setSubtype} />}
+      {type === "vehicle" && <HFVehicleFields values={values} setField={setField} />}
+      {type === "property" && <HFPropertyFields values={values} setField={setField} />}
+      {type === "other" && (
+        <HFOtherFields
+          subtype={subtype}
+          onSubtype={setSubtype}
+          values={values}
+          setField={setField}
+        />
+      )}
     </>
   );
 }
@@ -344,6 +477,9 @@ function HFAddAssetFields({
 export function AppAddAsset({ initialType = "vehicle" }: { initialType?: AssetType }) {
   const [type, setType] = useState<AssetType>(initialType);
   const [subtype, setSubtype] = useState<Subtype>("lawn");
+  const [values, setValues] = useState<AddAssetFormValues>(EMPTY_ADD_ASSET_FORM);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
   const navigate = useNavigate();
 
   // Esc cancels back to the asset library — mirrors the breadcrumb's hint.
@@ -358,6 +494,23 @@ export function AppAddAsset({ initialType = "vehicle" }: { initialType?: AssetTy
 
   const cancel = () => {
     navigate(paths.assets);
+  };
+
+  const setField: SetField = (field, value) => {
+    setValues((current) => ({ ...current, [field]: value }));
+  };
+
+  const save = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSaving(true);
+    setSaveError(null);
+    try {
+      await createAsset(buildCreateAssetPayload(type, values));
+      navigate(paths.assets);
+    } catch (error) {
+      setSaveError(error instanceof Error ? error.message : "Unable to save asset");
+      setSaving(false);
+    }
   };
 
   return (
@@ -375,7 +528,7 @@ export function AppAddAsset({ initialType = "vehicle" }: { initialType?: AssetTy
         </span>
       </div>
 
-      <div className="hf-aa-body">
+      <form id="add-asset-form" className="hf-aa-body" onSubmit={save}>
         <div className="hf-aa-col">
           <div className="hf-aa-head">
             <h1>Add an asset</h1>
@@ -390,8 +543,16 @@ export function AppAddAsset({ initialType = "vehicle" }: { initialType?: AssetTy
             setType={setType}
             subtype={subtype}
             setSubtype={setSubtype}
+            values={values}
+            setField={setField}
             showHeaderHint
           />
+
+          {saveError && (
+            <div className="hf-aa-error" role="alert">
+              {saveError}
+            </div>
+          )}
 
           <div className="hf-aa-rule" />
 
@@ -402,8 +563,7 @@ export function AppAddAsset({ initialType = "vehicle" }: { initialType?: AssetTy
                 Photo <span className="hf-field-opt">optional</span>
               </label>
               <div className="hf-photo-sub">
-                Helps you spot it in the grid. If you skip it, we'll use a category icon — you can
-                add or change this anytime.
+                Photo uploads are not available yet. Saved assets use a category icon.
               </div>
             </div>
             <HFDropzone />
@@ -424,7 +584,7 @@ export function AppAddAsset({ initialType = "vehicle" }: { initialType?: AssetTy
             <Icon name="arrow-right" size={18} color="var(--hf-brand-2)" />
           </div>
         </div>
-      </div>
+      </form>
 
       {/* STICKY SAVE BAR */}
       <div className="hf-aa-footer">
@@ -432,12 +592,17 @@ export function AppAddAsset({ initialType = "vehicle" }: { initialType?: AssetTy
           Fields marked <span className="hf-field-req">*</span> are required
         </div>
         <div className="hf-aa-footer-actions">
-          <button className="hf-btn hf-btn-secondary hf-btn-lg" onClick={cancel}>
+          <button className="hf-btn hf-btn-secondary hf-btn-lg" type="button" onClick={cancel}>
             Cancel
           </button>
-          <button className="hf-btn hf-btn-primary hf-btn-lg">
+          <button
+            className="hf-btn hf-btn-primary hf-btn-lg"
+            type="submit"
+            form="add-asset-form"
+            disabled={saving}
+          >
             <Icon name="check" size={15} stroke={2.2} />
-            Save asset
+            {saving ? "Saving..." : "Save asset"}
           </button>
         </div>
       </div>

--- a/apps/web/src/app/addAssetPayload.test.ts
+++ b/apps/web/src/app/addAssetPayload.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { buildCreateAssetPayload, EMPTY_ADD_ASSET_FORM } from "./addAssetPayload";
+
+describe("buildCreateAssetPayload", () => {
+  it("normalizes a vehicle payload and uppercases its VIN", () => {
+    expect(
+      buildCreateAssetPayload("vehicle", {
+        ...EMPTY_ADD_ASSET_FORM,
+        name: "  Truck  ",
+        vehicleMake: " Ram ",
+        vehicleModel: " 2500 ",
+        vehicleYear: "2016",
+        vin: "1c6rr7lt4gs123456",
+      }),
+    ).toEqual({
+      name: "Truck",
+      metadata: {
+        kind: "vehicle",
+        make: "Ram",
+        model: "2500",
+        year: 2016,
+        vin: "1C6RR7LT4GS123456",
+      },
+    });
+  });
+
+  it("maps the UI other bucket to equipment metadata", () => {
+    expect(
+      buildCreateAssetPayload("other", {
+        ...EMPTY_ADD_ASSET_FORM,
+        name: " Generator ",
+        equipmentManufacturer: " Honda ",
+      }),
+    ).toEqual({
+      name: "Generator",
+      metadata: { kind: "equipment", manufacturer: "Honda" },
+    });
+  });
+});

--- a/apps/web/src/app/addAssetPayload.ts
+++ b/apps/web/src/app/addAssetPayload.ts
@@ -1,0 +1,106 @@
+import type { CreateAssetPayload } from "../api/client";
+
+export type AssetType = "vehicle" | "property" | "other";
+
+export const ADD_ASSET_FIELD_LIMITS = {
+  name: 120,
+  vehicleMake: 64,
+  vehicleModel: 64,
+  vin: 17,
+  propertyNickname: 80,
+  propertyStreet: 160,
+  propertyCity: 80,
+  propertyState: 80,
+  propertyPostalCode: 20,
+  equipmentManufacturer: 80,
+  equipmentModelNumber: 80,
+  equipmentSerialNumber: 80,
+} as const;
+
+export type AddAssetFormValues = {
+  name: string;
+  vehicleMake: string;
+  vehicleModel: string;
+  vehicleYear: string;
+  vin: string;
+  propertyNickname: string;
+  propertyStreet: string;
+  propertyCity: string;
+  propertyState: string;
+  propertyPostalCode: string;
+  equipmentManufacturer: string;
+  equipmentModelNumber: string;
+  equipmentSerialNumber: string;
+};
+
+export const EMPTY_ADD_ASSET_FORM: AddAssetFormValues = {
+  name: "",
+  vehicleMake: "",
+  vehicleModel: "",
+  vehicleYear: "",
+  vin: "",
+  propertyNickname: "",
+  propertyStreet: "",
+  propertyCity: "",
+  propertyState: "OR",
+  propertyPostalCode: "",
+  equipmentManufacturer: "",
+  equipmentModelNumber: "",
+  equipmentSerialNumber: "",
+};
+
+function optional(value: string): string | undefined {
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+export function buildCreateAssetPayload(
+  type: AssetType,
+  values: AddAssetFormValues,
+): CreateAssetPayload {
+  const name = values.name.trim();
+  if (type === "vehicle") {
+    const year = Number(values.vehicleYear);
+    const vin = optional(values.vin.toUpperCase());
+    if (!Number.isInteger(year)) throw new Error("Enter a valid vehicle year");
+    return {
+      name,
+      metadata: {
+        kind: "vehicle",
+        make: values.vehicleMake.trim(),
+        model: values.vehicleModel.trim(),
+        year,
+        ...(vin ? { vin } : {}),
+      },
+    };
+  }
+  if (type === "property") {
+    const nickname = optional(values.propertyNickname);
+    return {
+      name,
+      metadata: {
+        kind: "property",
+        ...(nickname ? { nickname } : {}),
+        address: {
+          street: values.propertyStreet.trim(),
+          city: values.propertyCity.trim(),
+          state: values.propertyState.trim(),
+          postalCode: values.propertyPostalCode.trim(),
+          country: "US",
+        },
+      },
+    };
+  }
+  const manufacturer = optional(values.equipmentManufacturer);
+  const modelNumber = optional(values.equipmentModelNumber);
+  const serialNumber = optional(values.equipmentSerialNumber);
+  return {
+    name,
+    metadata: {
+      kind: "equipment",
+      ...(manufacturer ? { manufacturer } : {}),
+      ...(modelNumber ? { modelNumber } : {}),
+      ...(serialNumber ? { serialNumber } : {}),
+    },
+  };
+}

--- a/apps/web/src/auth/AuthFlow.tsx
+++ b/apps/web/src/auth/AuthFlow.tsx
@@ -3,6 +3,8 @@ import { Link, useSearchParams } from "react-router";
 import { Icon } from "../design/Icon";
 import { Brandmark } from "../design/Brandmark";
 import { HFAssetIcon, HFAssetThumb } from "../design/hf";
+import { getSession, signOut, startGoogleSignIn, type SessionUser } from "../api/client";
+import { loginPath, safeAppPath } from "./redirects";
 import { paths } from "../routes";
 
 // Stylesheets: the .hf design tokens + asset components first, then the
@@ -14,32 +16,6 @@ import "./styles/auth.css";
 
 type Mode = "login" | "signup";
 type Phase = "form" | "redirect";
-
-// Where the Better Auth endpoints live. In dev the API runs on its own port
-// (set VITE_API_URL=http://localhost:8787); in production web + API share a
-// hostname so the default empty base = same-origin /api/auth/*.
-const API_BASE = import.meta.env.VITE_API_URL ?? "";
-
-type SessionUser = { email: string; name?: string | null } | null;
-
-/** Kick off Better Auth's Google OAuth. Resolves the consent URL then navigates. */
-async function startGoogleSignIn() {
-  const res = await fetch(`${API_BASE}/api/auth/sign-in/social`, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    credentials: "include",
-    body: JSON.stringify({
-      provider: "google",
-      // Return to /login so the page can confirm the session was established.
-      callbackURL: `${window.location.origin}/login`,
-      errorCallbackURL: `${window.location.origin}/login?error=google`,
-    }),
-  });
-  if (!res.ok) throw new Error(`sign-in/social failed: ${res.status}`);
-  const data = (await res.json()) as { url?: string };
-  if (!data.url) throw new Error("sign-in/social returned no redirect url");
-  window.location.href = data.url;
-}
 
 /** official Google "G" mark for the sign-in button */
 function GoogleG({ size = 18 }: { size?: number }) {
@@ -228,9 +204,11 @@ function AuthRedirect({ mode, onCancel }: { mode: Mode; onCancel: () => void }) 
 /* ============ signed-in confirmation (post-OAuth return) ============ */
 function AuthSignedIn({
   user,
+  next,
   onSignOut,
 }: {
   user: { email: string; name?: string | null };
+  next: string;
   onSignOut: () => void;
 }) {
   return (
@@ -244,7 +222,7 @@ function AuthSignedIn({
         {user.name ? ` (${user.email})` : ""}.
       </p>
       <div className="au-hero-cta" style={{ display: "flex", gap: 12, marginTop: 24 }}>
-        <Link className="au-google" style={{ width: "auto", padding: "0 20px" }} to={paths.appHome}>
+        <Link className="au-google" style={{ width: "auto", padding: "0 20px" }} to={next}>
           Go to FieldOps
         </Link>
       </div>
@@ -261,10 +239,11 @@ export function AuthFlow() {
   // initial mode comes from ?mode= so marketing CTAs can deep-link the right screen
   const [searchParams] = useSearchParams();
   const initialMode: Mode = searchParams.get("mode") === "signup" ? "signup" : "login";
+  const next = safeAppPath(searchParams.get("next"));
   const [mode, setMode] = useState<Mode>(initialMode);
   const [phase, setPhase] = useState<Phase>("form");
   // undefined = still checking; null = logged out; object = logged in
-  const [session, setSession] = useState<SessionUser | undefined>(undefined);
+  const [session, setSession] = useState<SessionUser | null | undefined>(undefined);
 
   useEffect(() => {
     document.title = "FieldOps — Sign in";
@@ -273,10 +252,9 @@ export function AuthFlow() {
   // On load (and after returning from Google) check whether a session exists.
   useEffect(() => {
     let cancelled = false;
-    fetch(`${API_BASE}/api/auth/get-session`, { credentials: "include" })
-      .then((r) => (r.ok ? r.json() : null))
-      .then((data: { user?: SessionUser } | null) => {
-        if (!cancelled) setSession(data?.user ?? null);
+    getSession()
+      .then((user) => {
+        if (!cancelled) setSession(user);
       })
       .catch(() => {
         if (!cancelled) setSession(null);
@@ -288,26 +266,24 @@ export function AuthFlow() {
 
   const onGoogle = () => {
     setPhase("redirect");
-    startGoogleSignIn().catch((err) => {
+    const callbackURL = `${window.location.origin}${loginPath({ next })}`;
+    const errorCallbackURL = `${window.location.origin}${loginPath({ next, error: "google" })}`;
+    startGoogleSignIn(callbackURL, errorCallbackURL).catch((err: unknown) => {
       console.error(err);
       setPhase("form");
     });
   };
 
   const onSignOut = () => {
-    // Better Auth's /sign-out requires a JSON content-type AND a (non-empty)
-    // JSON body — without the header it 415s, with the header but an empty body
-    // it 500s on JSON.parse. Send "{}". The response clears the session cookies.
-    fetch(`${API_BASE}/api/auth/sign-out`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: "{}",
-      credentials: "include",
-    }).finally(() => {
-      // Logged out → full-page reload to the marketing home so any in-memory
-      // session state is wiped, not just unmounted.
-      window.location.href = paths.home;
-    });
+    void signOut()
+      .catch((error: unknown) => {
+        console.error(error);
+      })
+      .finally(() => {
+        // Logged out → full-page reload to the marketing home so any in-memory
+        // session state is wiped, not just unmounted.
+        window.location.href = paths.home;
+      });
   };
 
   return (
@@ -316,7 +292,7 @@ export function AuthFlow() {
         <AuthBrand />
         <div className="au-form-side">
           {session ? (
-            <AuthSignedIn user={session} onSignOut={onSignOut} />
+            <AuthSignedIn user={session} next={next} onSignOut={onSignOut} />
           ) : phase === "redirect" ? (
             <AuthRedirect mode={mode} onCancel={() => setPhase("form")} />
           ) : (

--- a/apps/web/src/auth/redirects.test.ts
+++ b/apps/web/src/auth/redirects.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { loginPath, safeAppPath } from "./redirects";
+
+describe("safeAppPath", () => {
+  it("keeps internal app destinations", () => {
+    expect(safeAppPath("/app/assets/new?from=grid#form")).toBe("/app/assets/new?from=grid#form");
+  });
+
+  it("falls back for external, protocol-relative, and non-app destinations", () => {
+    expect(safeAppPath("https://evil.example/app")).toBe("/app");
+    expect(safeAppPath("//evil.example/app")).toBe("/app");
+    expect(safeAppPath("/app/../login")).toBe("/app");
+  });
+
+  it("encodes the sanitized destination in the login path", () => {
+    expect(loginPath({ next: "//evil.example/app" })).toBe("/login?next=%2Fapp");
+  });
+});

--- a/apps/web/src/auth/redirects.ts
+++ b/apps/web/src/auth/redirects.ts
@@ -1,0 +1,31 @@
+import { routePaths } from "../routes";
+
+export function safeAppPath(candidate?: string | null): string {
+  if (!candidate || !candidate.startsWith("/") || candidate.startsWith("//")) {
+    return routePaths.appHome;
+  }
+
+  const base = "https://fieldops.invalid";
+  const url = new URL(candidate, base);
+  if (
+    url.origin !== base ||
+    (url.pathname !== routePaths.appHome && !url.pathname.startsWith("/app/"))
+  ) {
+    return routePaths.appHome;
+  }
+  return `${url.pathname}${url.search}${url.hash}`;
+}
+
+export function loginPath({
+  next,
+  error,
+}: {
+  next?: string;
+  error?: string;
+} = {}): string {
+  const search = new URLSearchParams();
+  if (next !== undefined) search.set("next", safeAppPath(next));
+  if (error) search.set("error", error);
+  const query = search.toString();
+  return query ? `${routePaths.login}?${query}` : routePaths.login;
+}

--- a/apps/web/src/design/styles/hifi-add-asset.css
+++ b/apps/web/src/design/styles/hifi-add-asset.css
@@ -365,10 +365,14 @@
     background 100ms,
     color 100ms;
 }
-.hf-dropzone:hover {
+.hf-dropzone:not(:disabled):hover {
   border-color: var(--hf-brand);
   color: var(--hf-brand);
   background: var(--hf-brand-bg);
+}
+.hf-dropzone:disabled {
+  cursor: not-allowed;
+  opacity: 0.68;
 }
 .hf-dropzone-icon {
   width: 38px;
@@ -401,6 +405,16 @@
   border-left: 3px solid var(--hf-brand);
   border-radius: var(--hf-r);
   background: var(--hf-brand-bg);
+}
+
+.hf-aa-error {
+  padding: 10px 12px;
+  border: 1px solid oklch(78% 0.1 25);
+  border-radius: var(--hf-r);
+  background: oklch(97% 0.025 25);
+  color: oklch(42% 0.11 25);
+  font-size: 13px;
+  line-height: 1.4;
 }
 .hf-aa-next-icon {
   width: 34px;

--- a/apps/web/src/design/styles/hifi.css
+++ b/apps/web/src/design/styles/hifi.css
@@ -505,6 +505,10 @@
 .hf-btn:hover {
   background: var(--hf-surface-2);
 }
+.hf-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.58;
+}
 .hf-btn-primary {
   background: var(--hf-ink);
   color: var(--hf-surface);

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -15,3 +15,27 @@ body,
 #root {
   height: 100%;
 }
+
+.route-message {
+  box-sizing: border-box;
+  min-height: 100%;
+  display: grid;
+  align-content: center;
+  justify-items: start;
+  gap: 12px;
+  max-width: 680px;
+  margin: 0 auto;
+  padding: 32px;
+  color: #24211d;
+  font-family: Inter, system-ui, sans-serif;
+}
+
+.route-message h1,
+.route-message p {
+  margin: 0;
+}
+
+.route-message a {
+  color: #176b45;
+  font-weight: 600;
+}

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1,18 +1,40 @@
-import { createBrowserRouter } from "react-router";
+import { createBrowserRouter, redirect, type LoaderFunctionArgs } from "react-router";
+import { getSession } from "./api/client";
 import { AuthFlow } from "./auth/AuthFlow";
+import { loginPath, safeAppPath } from "./auth/redirects";
 import { AppAddAsset } from "./app/AppAddAsset";
 import { AppAssets } from "./app/AppAssets";
 import { AppHome } from "./app/AppHome";
 import { MarketingHome } from "./marketing/MarketingHome";
+import { NotFoundPage, ProtectedAppLayout, RouteErrorPage } from "./routing/RoutePages";
 import { routePaths } from "./routes";
 
+export async function requireSession({ request }: LoaderFunctionArgs) {
+  const session = await getSession();
+  if (session) return session;
+
+  const url = new URL(request.url);
+  return redirect(loginPath({ next: safeAppPath(`${url.pathname}${url.search}${url.hash}`) }));
+}
+
 export const router = createBrowserRouter([
-  { path: routePaths.home, element: <MarketingHome /> },
-  { path: routePaths.login, element: <AuthFlow /> },
-  { path: routePaths.appHome, element: <AppHome /> },
-  { path: routePaths.assets, element: <AppAssets /> },
-  { path: routePaths.addAsset, element: <AppAddAsset /> },
-  // TODO: unknown routes currently fall back to the marketing home. Design a
-  // real not-found / 404 experience and route it here.
-  { path: "*", element: <MarketingHome /> },
+  {
+    path: routePaths.home,
+    errorElement: <RouteErrorPage />,
+    children: [
+      { index: true, element: <MarketingHome /> },
+      { path: routePaths.login, element: <AuthFlow /> },
+      {
+        path: routePaths.appHome,
+        loader: requireSession,
+        element: <ProtectedAppLayout />,
+        children: [
+          { index: true, element: <AppHome /> },
+          { path: "assets", element: <AppAssets /> },
+          { path: "assets/new", element: <AppAddAsset /> },
+        ],
+      },
+      { path: "*", element: <NotFoundPage /> },
+    ],
+  },
 ]);

--- a/apps/web/src/routing/RoutePages.tsx
+++ b/apps/web/src/routing/RoutePages.tsx
@@ -1,0 +1,26 @@
+import { Link, Outlet } from "react-router";
+import { paths } from "../routes";
+
+export function ProtectedAppLayout() {
+  return <Outlet />;
+}
+
+export function RouteErrorPage() {
+  return (
+    <main className="route-message">
+      <h1>Page unavailable</h1>
+      <p>FieldOps could not load this page. Try again in a moment.</p>
+      <a href={window.location.href}>Try again</a>
+    </main>
+  );
+}
+
+export function NotFoundPage() {
+  return (
+    <main className="route-message">
+      <h1>Page not found</h1>
+      <p>The page you requested does not exist.</p>
+      <Link to={paths.home}>Return home</Link>
+    </main>
+  );
+}

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,10 +1,16 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 import { cloudflare } from "@cloudflare/vite-plugin";
 
 // Vite + React, bundled and served by a Cloudflare Worker via
 // @cloudflare/vite-plugin. The Worker (worker/index.ts) handles any /api/*
 // routes; everything else falls back to the SPA (see wrangler.jsonc).
-export default defineConfig({
-  plugins: [react(), cloudflare()],
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, ".", "");
+  if (mode === "production" && env["VITE_API_URL"]) {
+    throw new Error(
+      "VITE_API_URL must be empty for production builds. Production web and API requests are same-origin.",
+    );
+  }
+  return { plugins: [react(), cloudflare()] };
 });

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -36,15 +36,31 @@ BETTER_AUTH_SECRET=dev-only-change-me
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 
+# Local Better Auth URL and cross-port web origin.
+BETTER_AUTH_URL=http://localhost:8787
+DEV_WEB_ORIGIN=http://localhost:5173
+
 # Dev bypass: treat every request as this user, skipping the login flow.
-# Remove it to exercise the real Google session flow. NEVER set in production.
+# Both values are required. Remove them to exercise the real Google session
+# flow. They only work with a loopback BETTER_AUTH_URL. NEVER set in production.
+DEV_AUTH_BYPASS_ENABLED=true
 DEV_AUTH_EMAIL=you@example.com
 ```
+
+For the web app, copy the development-only API URL:
+
+```bash
+cp apps/web/.env.example apps/web/.env.development.local
+```
+
+Production web builds reject `VITE_API_URL`; deployed web and API requests are
+same-origin.
 
 ## 4. Run
 
 ```bash
 pnpm dev        # from repo root → http://localhost:8787
+pnpm --filter @snaveevans/pineapple-web dev  # web → http://localhost:5173
 ```
 
 Try it:
@@ -52,7 +68,7 @@ Try it:
 ```bash
 curl http://localhost:8787/health                 # {"status":"ok"}
 open http://localhost:8787/reference              # interactive API docs
-curl http://localhost:8787/api/assets             # works via DEV_AUTH_EMAIL bypass
+curl http://localhost:8787/api/assets             # works via the local bypass
 ```
 
 ## 5. Google OAuth (for the real login flow)

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -34,9 +34,10 @@ Auth is **Better Auth + Google OAuth**, handled inside the Worker under
 The API maps the session to a domain user by email, creating the user on first
 sign-in. There is no separate "register" step.
 
-> **Local development:** set `DEV_AUTH_EMAIL` in `apps/api/.dev.vars` to bypass
-> the session check entirely — every request is treated as that user. Never set
-> it in production. See [getting-started](../guides/getting-started.md).
+> **Local development:** set `DEV_AUTH_BYPASS_ENABLED=true` and `DEV_AUTH_EMAIL`
+> in `apps/api/.dev.vars` to bypass the session check entirely. The bypass only
+> works with a loopback `BETTER_AUTH_URL`. Never set it in production. See
+> [getting-started](../guides/getting-started.md).
 
 ## Endpoints
 
@@ -80,14 +81,15 @@ All errors share one JSON shape:
 
 `field` is present only for validation errors. Status codes:
 
-| Status | Meaning                                     |
-| ------ | ------------------------------------------- |
-| 401    | Not authenticated (no/expired session)      |
-| 403    | Authenticated, but the resource isn't yours |
-| 404    | Resource not found                          |
-| 409    | Conflict (e.g. uniqueness violation)        |
-| 422    | Request body/params failed validation       |
-| 500    | Unexpected server error                     |
+| Status | Meaning                                 |
+| ------ | --------------------------------------- |
+| 401    | Not authenticated (no/expired session)  |
+| 404    | Resource not found                      |
+| 409    | Conflict (e.g. uniqueness violation)    |
+| 413    | Request body exceeds the endpoint limit |
+| 429    | Request rate limit exceeded             |
+| 422    | Request body/params failed validation   |
+| 500    | Unexpected server error                 |
 
 These map directly to the domain error types (see
 [ADR-0004](../decisions/0004-error-handling-strategy.md)). Structural validation
@@ -100,4 +102,6 @@ in the domain (see [ADR-0007](../decisions/0007-api-validation-boundary.md)).
 - IDs are UUID strings.
 - Timestamps are ISO-8601 UTC strings (e.g. `2026-05-29T03:25:24.887Z`).
 - `GET /api/assets` returns only **active** assets (archived ones are excluded).
-- You can only read assets you own; requesting another user's asset returns 403.
+- You can only read assets you own; missing and non-owned asset IDs both return
+  `404`.
+- `POST /api/assets` accepts JSON request bodies up to `16 KiB`.

--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -89,11 +89,13 @@
           "make": {
             "type": "string",
             "minLength": 1,
+            "maxLength": 64,
             "example": "Ram"
           },
           "model": {
             "type": "string",
             "minLength": 1,
+            "maxLength": 64,
             "example": "2500"
           },
           "year": {
@@ -106,6 +108,7 @@
             "type": "string",
             "minLength": 17,
             "maxLength": 17,
+            "pattern": "^[A-HJ-NPR-Z0-9]{17}$",
             "example": "1C6RR7LT4GS123456"
           }
         },
@@ -121,23 +124,28 @@
         "properties": {
           "street": {
             "type": "string",
-            "minLength": 1
+            "minLength": 1,
+            "maxLength": 160
           },
           "city": {
             "type": "string",
-            "minLength": 1
+            "minLength": 1,
+            "maxLength": 80
           },
           "state": {
             "type": "string",
-            "minLength": 1
+            "minLength": 1,
+            "maxLength": 80
           },
           "postalCode": {
             "type": "string",
-            "minLength": 1
+            "minLength": 1,
+            "maxLength": 20
           },
           "country": {
             "type": "string",
-            "minLength": 1
+            "minLength": 1,
+            "maxLength": 80
           }
         },
         "required": [
@@ -159,6 +167,7 @@
           },
           "nickname": {
             "type": "string",
+            "maxLength": 80,
             "example": "Lake cabin"
           },
           "address": {
@@ -181,14 +190,17 @@
           },
           "manufacturer": {
             "type": "string",
+            "maxLength": 80,
             "example": "Honda"
           },
           "modelNumber": {
             "type": "string",
+            "maxLength": 80,
             "example": "EU2200i"
           },
           "serialNumber": {
             "type": "string",
+            "maxLength": 80,
             "example": "EAMT-1234567"
           }
         },
@@ -223,6 +235,7 @@
           "name": {
             "type": "string",
             "minLength": 1,
+            "maxLength": 120,
             "example": "My Truck"
           },
           "metadata": {
@@ -329,6 +342,7 @@
           "Assets"
         ],
         "summary": "Create an asset",
+        "description": "Creates an asset owned by the caller. The JSON request body must not exceed 16 KiB.",
         "security": [
           {
             "cookieAuth": []
@@ -365,8 +379,46 @@
               }
             }
           },
+          "409": {
+            "description": "Active asset quota reached",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "Request body exceeds 16 KiB",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "422": {
             "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Write rate limit exceeded",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the caller should retry",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -401,6 +453,24 @@
           },
           "401": {
             "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Read rate limit exceeded",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the caller should retry",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -455,8 +525,8 @@
               }
             }
           },
-          "403": {
-            "description": "The asset belongs to another user",
+          "404": {
+            "description": "No such asset",
             "content": {
               "application/json": {
                 "schema": {
@@ -465,8 +535,16 @@
               }
             }
           },
-          "404": {
-            "description": "No such asset",
+          "429": {
+            "description": "Read rate limit exceeded",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the caller should retry",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {


### PR DESCRIPTION
## Summary

Hardens the API and authenticated frontend flow after the React Router merge, then finishes the add-asset form against the secured API contract.

## What changed

- require an explicit loopback-only `DEV_AUTH_BYPASS_ENABLED=true` opt-in before honoring `DEV_AUTH_EMAIL`
- replace reflected credentialed CORS origins with an allowlist for production same-origin and configured loopback development origins
- add API security headers, generic invariant `500` responses, and ownership-safe `404` responses
- enforce asset schema limits, VIN-safe validation, a `16 KiB` request-body cap, a 500-active-asset quota, and Cloudflare read/write rate-limit bindings
- protect `/app` routes with a React Router session loader, sanitized internal return paths, a safe error boundary, and a not-found screen
- wire the add-asset form to `POST /api/assets`, disable the unfinished photo upload control, and preserve the local bypass workflow for protected screen development
- prevent production Vite builds from embedding a local `VITE_API_URL`, move local config to `.env.development.local`, and add deployed static security headers
- regenerate the committed OpenAPI document and update operator/reference docs
- correct the existing `wrangler.toml` table placement so production routes remain top-level rather than being parsed under observability

## Why

The prior implementation allowed a production auth-bypass configuration footgun, reflected arbitrary credentialed CORS origins on auth routes, exposed ownership and invariant details, lacked abuse controls and deployed security headers, and left authenticated frontend routes publicly renderable. The routing merge made a parent route loader the appropriate place to enforce the frontend session boundary.

## Validation

- `pnpm lint`
- `pnpm type-check`
- `pnpm test` (29 tests)
- `pnpm audit --json` (0 vulnerabilities)
- `pnpm --filter @snaveevans/pineapple-web build`
- production bundle scan for localhost API URL leakage
- negative production build guard check with `VITE_API_URL=http://localhost:8787`
- API and web `wrangler deploy --dry-run`
- HTTP smoke checks for allowed/rejected credentialed CORS and API security headers
- browser smoke test for protected-route redirect and successful local asset creation