### PR TITLE
Fix vehicle year validation and OpenAPI spec showing maximum: 1971 in production

### DIFF
--- a/apps/api/src/api/schemas/assetSchemas.ts
+++ b/apps/api/src/api/schemas/assetSchemas.ts
@@ -15,8 +15,12 @@ const VehicleMetadataSchema = z
       .number()
       .int()
       .min(1900, "Year must be 1900 or later")
-      .max(new Date().getFullYear() + 1, "Year is too far in the future")
-      .openapi({ example: 2016 }),
+      // .refine() (not .max()) so the year ceiling is evaluated per-request, not
+      // at module init where Cloudflare Workers freezes Date to the Unix epoch.
+      .refine((val: number) => val <= new Date().getFullYear() + 1, {
+        message: "Year is too far in the future",
+      })
+      .openapi({ maximum: new Date().getFullYear() + 1, example: 2016 }),
     vin: z
       .string()
       .length(17, "VIN must be exactly 17 characters")

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -30,9 +30,9 @@ import {
   getAssetRoute,
   healthRoute,
   listAssetsRoute,
-  openApiConfig,
   registerOpenApiComponents,
 } from "./api/openapi.ts";
+import openApiSpec from "../../../docs/reference/openapi.json";
 import type { AssetResponseSchema } from "./api/schemas/assetSchemas.ts";
 import type { z } from "@hono/zod-openapi";
 
@@ -103,8 +103,8 @@ function createEventBus(c: Context<AppEnv>): EventBus {
 
 app.openapi(healthRoute, (c) => c.json({ status: "ok" } as const, 200));
 
-// Machine-readable spec + interactive docs.
-app.doc("/openapi.json", openApiConfig);
+// Serve committed spec (app.doc() bakes in epoch date at module init in Workers).
+app.get("/openapi.json", (c) => c.json(openApiSpec));
 app.get("/reference", Scalar({ url: "/openapi.json" }));
 
 // ── Better Auth ───────────────────────────────────────────────────────────

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
     "types": ["@cloudflare/workers-types", "vitest/globals"],
     "lib": ["ESNext"]
   },


### PR DESCRIPTION
## Summary

- Replaces `.max(new Date().getFullYear() + 1)` with `.refine()` in `VehicleMetadataSchema` — fixing a critical bug where all vehicles with model year > 1971 were rejected at the HTTP boundary in production
- Switches the `/openapi.json` endpoint from `app.doc()` (dynamic, broken) to serving the committed spec directly (bundled at deploy time)
- Adds `resolveJsonModule: true` to `apps/api/tsconfig.json` to support the JSON import

**Root cause**: Cloudflare Workers freezes `Date` to the Unix epoch during module initialization. Any `new Date()` at module level returns timestamp 0, so `getFullYear() + 1 = 1971`. The `.max()` Zod constraint was baked in at that point, making all POST /api/assets requests with `year > 1971` fail with a 422. The dynamically-generated spec at `/openapi.json` had the same frozen value, showing `maximum: 1971` instead of `2027`.

## Test plan

- [ ] `pnpm -r test` passes (all 13 tests)
- [ ] `pnpm type-check` passes for `apps/api`
- [ ] After deploy, `GET /openapi.json` shows `maximum: 2027` for `VehicleMetadata.year`
- [ ] POST /api/assets with a 2024 vehicle no longer returns 422

🤖 Generated with [Claude Code](https://claude.com/claude-code)