### PR TITLE
[codex] Wire assets UX to real data

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,8 @@ instead.
 ## Commands
 
 ```bash
-pnpm dev                 # wrangler dev (http://localhost:8787)
+pnpm --filter @snaveevans/pineapple-api dev   # wrangler dev (http://localhost:8787)
+pnpm --filter @snaveevans/pineapple-web dev   # vite (http://localhost:5173), proxies /api/*
 pnpm lint                # eslint (includes layer-boundary + Workers constraints)
 pnpm type-check          # tsc --noEmit across workspace
 pnpm -r test             # vitest (domain tests live in apps/api/src/**)

--- a/README.md
+++ b/README.md
@@ -26,8 +26,12 @@ stack that stays cheap and fast at small scale and is disciplined enough to grow
 ```bash
 pnpm install
 
-# Run the API locally (http://localhost:8787)
-pnpm dev
+# Terminal 1: run the API locally (http://localhost:8787)
+pnpm --filter @snaveevans/pineapple-api dev
+
+# Terminal 2: run the web app (http://localhost:5173)
+# Vite proxies same-origin /api/* requests to the API Worker.
+pnpm --filter @snaveevans/pineapple-web dev
 
 # Apply the database schema to your local D1
 pnpm --filter @snaveevans/pineapple-api wrangler d1 migrations apply pineapple --local

--- a/apps/api/src/infrastructure/auth/auth.ts
+++ b/apps/api/src/infrastructure/auth/auth.ts
@@ -12,19 +12,13 @@ export type AuthEnv = {
   GOOGLE_CLIENT_ID: string;
   GOOGLE_CLIENT_SECRET: string;
   /**
-   * Local dev only — comma-separated extra origins to trust for sign-in /
-   * callbackURL checks. The web app runs on a different port (5173) than the
-   * API (8787) in dev, so its origin must be trusted explicitly. In production
-   * web + API share a hostname, so this is unset. Set in .dev.vars.
-   */
-  DEV_WEB_ORIGIN?: string;
-  /**
    * Explicit Better Auth base URL. REQUIRED in local dev: `wrangler dev` serves
    * the worker under the production `routes` hostname from wrangler.toml, so the
-   * request URL is NOT localhost — without this, OAuth `redirect_uri`s point at
-   * the production domain. Set to `http://localhost:8787` in .dev.vars. In
-   * production leave it unset; the worker falls back to the request origin
-   * (the real public hostname). Better Auth's conventional env var name.
+   * request URL is NOT localhost. Set this to the Vite origin
+   * (`http://localhost:5173`) so OAuth callbacks return through Vite's `/api`
+   * development proxy. In production leave it unset; the worker falls back to
+   * the request origin (the real public hostname). Better Auth's conventional
+   * env var name.
    */
   BETTER_AUTH_URL?: string;
 };
@@ -65,17 +59,9 @@ export function createAuth(env?: AuthEnv, baseURL?: string) {
     },
   );
 
-  // Dev-only: trust the web app's separate dev origin (e.g. localhost:5173).
-  // Better Auth always trusts baseURL; this adds the cross-port frontend.
-  const devOrigins =
-    env?.DEV_WEB_ORIGIN?.split(",")
-      .map((o) => o.trim())
-      .filter(Boolean) ?? [];
-
   const options: BetterAuthOptions = {
     ...(baseURL ? { baseURL } : {}),
     ...(env?.BETTER_AUTH_SECRET ? { secret: env.BETTER_AUTH_SECRET } : {}),
-    ...(devOrigins.length ? { trustedOrigins: devOrigins } : {}),
     // Cast: better-auth-cloudflare@0.3.0's plugin endpoint types drift from
     // better-auth@1.6's stricter `Endpoint` index signature (optional R2
     // endpoints we don't use). Runtime is unaffected; this only reconciles

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -1,6 +1,5 @@
 import { OpenAPIHono } from "@hono/zod-openapi";
 import { Scalar } from "@scalar/hono-api-reference";
-import { cors } from "hono/cors";
 import type { Context } from "hono";
 import { AssetId, DomainError } from "@snaveevans/pineapple-shared";
 import type { User } from "./domain/identity/User.ts";
@@ -108,17 +107,6 @@ app.get("/openapi.json", (c) => c.json(openApiSpec));
 app.get("/reference", Scalar({ url: "/openapi.json" }));
 
 // ── Better Auth ───────────────────────────────────────────────────────────
-
-// CORS for the Better Auth endpoints (browser hits these with credentials).
-app.use(
-  "/api/auth/**",
-  cors({
-    origin: (origin) => origin,
-    allowHeaders: ["Content-Type", "Authorization"],
-    allowMethods: ["GET", "POST", "OPTIONS"],
-    credentials: true,
-  }),
-);
 
 // Build a per-request Better Auth instance and stash it on the context. The
 // baseURL drives OAuth callbacks/cookies, so it must match the public origin.

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -4,10 +4,6 @@ compatibility_date = "2026-05-21"
 # Better Auth relies on Node APIs (crypto, etc.) on the Workers runtime.
 compatibility_flags = ["nodejs_compat"]
 
-[observability]
-enabled = true
-head_sampling_rate = 1
-
 # Production routes on the shared hostname. The API owns /api/* plus its
 # (non-/api) docs + health endpoints; the web Worker (pineapple-web) owns the
 # catch-all /* for the SPA. Cloudflare matches the most specific route, so
@@ -20,6 +16,10 @@ routes = [
   { pattern = "pineapple.tylerevans.co/reference", zone_name = "tylerevans.co" },
   { pattern = "pineapple.tylerevans.co/health", zone_name = "tylerevans.co" },
 ]
+
+[observability]
+enabled = true
+head_sampling_rate = 1
 
 # Auth config is provided as SECRETS (not committed here):
 #   wrangler secret put BETTER_AUTH_SECRET

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -65,6 +65,12 @@ pnpm --filter @snaveevans/pineapple-web preview      # preview the built worker 
 pnpm --filter @snaveevans/pineapple-web deploy       # build + wrangler deploy
 ```
 
+During local development, Vite proxies same-origin `/api/*` browser requests
+to the API Worker at `http://localhost:8787`. Run the API separately with
+`pnpm --filter @snaveevans/pineapple-api dev`. Set
+`BETTER_AUTH_URL=http://localhost:5173` in `apps/api/.dev.vars` so OAuth
+callbacks return through the proxy.
+
 > Unlike `apps/api`, this app **has a build step** (Vite). It uses Web/DOM
 > standard APIs in the Worker entry, so no `@cloudflare/workers-types` global
 > is pulled in (which would conflict with `lib.dom`).

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,9 +9,11 @@
     "preview": "vite preview",
     "deploy": "vite build && wrangler deploy",
     "type-check": "tsc --noEmit",
+    "test": "vitest run",
     "cf-typegen": "wrangler types"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.100.14",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.16.0"
@@ -22,6 +24,7 @@
     "@types/react-dom": "^19.1.0",
     "@vitejs/plugin-react": "^4.4.0",
     "vite": "^6.3.0",
+    "vitest": "^3.2.4",
     "wrangler": "^4.95.0"
   }
 }

--- a/apps/web/src/api/assets.ts
+++ b/apps/web/src/api/assets.ts
@@ -1,0 +1,69 @@
+import { apiRequest } from "./client";
+
+export type AssetType = "vehicle" | "property" | "equipment";
+
+export type VehicleMetadata = {
+  kind: "vehicle";
+  make: string;
+  model: string;
+  year: number;
+  vin?: string;
+};
+
+export type PropertyMetadata = {
+  kind: "property";
+  nickname?: string;
+  address: {
+    street: string;
+    city: string;
+    state: string;
+    postalCode: string;
+    country: string;
+  };
+};
+
+export type EquipmentMetadata = {
+  kind: "equipment";
+  manufacturer?: string;
+  modelNumber?: string;
+  serialNumber?: string;
+};
+
+export type AssetMetadata = VehicleMetadata | PropertyMetadata | EquipmentMetadata;
+
+export type AssetResponse = {
+  id: string;
+  name: string;
+  type: AssetType;
+  metadata: AssetMetadata;
+  archivedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type AssetListResponse = {
+  assets: AssetResponse[];
+};
+
+export type CreateAssetBody = {
+  name: string;
+  metadata: AssetMetadata;
+};
+
+export type CreatedAssetResponse = {
+  id: string;
+};
+
+export const assetsQueryKey = ["assets"] as const;
+
+export function listAssets(): Promise<AssetListResponse> {
+  return apiRequest<AssetListResponse>("/api/assets");
+}
+
+export function createAsset(body: CreateAssetBody): Promise<CreatedAssetResponse> {
+  return apiRequest<CreatedAssetResponse>("/api/assets", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}

--- a/apps/web/src/api/client.test.ts
+++ b/apps/web/src/api/client.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ApiError, apiRequest } from "./client";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("apiRequest", () => {
+  it("includes credentials and parses a successful JSON response", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ assets: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(apiRequest<{ assets: unknown[] }>("/api/assets")).resolves.toEqual({ assets: [] });
+    expect(fetchMock).toHaveBeenCalledWith("/api/assets", { credentials: "include" });
+  });
+
+  it("throws the standard API error shape", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({ error: "Year is too far in the future", field: "metadata.year" }),
+          {
+            status: 422,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      ),
+    );
+
+    const request = apiRequest("/api/assets");
+    await expect(request).rejects.toMatchObject({
+      status: 422,
+      field: "metadata.year",
+      message: "Year is too far in the future",
+    });
+    await expect(request).rejects.toBeInstanceOf(ApiError);
+  });
+});

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -1,0 +1,45 @@
+export type ApiErrorBody = {
+  error: string;
+  field?: string;
+};
+
+export class ApiError extends Error {
+  readonly status: number;
+  readonly field?: string;
+
+  constructor(status: number, body: ApiErrorBody) {
+    super(body.error);
+    this.name = "ApiError";
+    this.status = status;
+    if (body.field !== undefined) this.field = body.field;
+  }
+}
+
+function isApiErrorBody(value: unknown): value is ApiErrorBody {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "error" in value &&
+    typeof value.error === "string" &&
+    (!("field" in value) || value.field === undefined || typeof value.field === "string")
+  );
+}
+
+export async function apiRequest<T>(path: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(path, { ...init, credentials: "include" });
+
+  if (!response.ok) {
+    let body: unknown;
+    try {
+      body = await response.json();
+    } catch {
+      body = null;
+    }
+    throw new ApiError(
+      response.status,
+      isApiErrorBody(body) ? body : { error: `Request failed with status ${response.status}` },
+    );
+  }
+
+  return (await response.json()) as T;
+}

--- a/apps/web/src/app/AppAddAsset.tsx
+++ b/apps/web/src/app/AppAddAsset.tsx
@@ -1,103 +1,36 @@
 import { useEffect, useRef, useState, type ReactNode } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Link, useNavigate } from "react-router";
+import { assetsQueryKey, createAsset, type AssetType } from "../api/assets";
+import { ApiError } from "../api/client";
 import { Icon, type IconName } from "../design/Icon";
-import { HFTopBar } from "./AppChrome";
 import { paths } from "../routes";
+import { HFTopBar } from "./AppChrome";
+import {
+  EMPTY_ASSET_FORM,
+  type AssetForm,
+  type AssetFormErrors,
+  toAssetFormError,
+  toCreateAssetBody,
+  validateAssetForm,
+} from "./assetForm";
 
 import "../design/styles/hifi.css";
 import "../design/styles/hifi-assets.css";
 import "../design/styles/hifi-add-asset.css";
 
-type AssetType = "vehicle" | "property" | "other";
-type Subtype = "lawn" | "power-tool" | "appliance" | "hvac" | "generator" | "other";
+type SetField = (
+  key: keyof AssetForm,
+) => (ev: { target: HTMLInputElement | HTMLSelectElement }) => void;
 
-/* ============ form model ============ */
-const EMPTY_FORM = {
-  name: "",
-  make: "", model: "", year: "", vin: "",
-  nickname: "", street: "", city: "", state: "OR", postal: "", country: "United States",
-  manufacturer: "", modelNumber: "", serialNumber: "", engineHours: "",
-};
-
-type Form = typeof EMPTY_FORM;
-type Errors = Partial<Record<keyof Form, string>>;
-
-/* Validates against the Pineapple API CreateAssetBody schema */
-function validateAsset(type: AssetType, form: Form): Errors {
-  const e: Errors = {};
-  const has = (v: string) => v.trim().length > 0;
-
-  if (!has(form.name)) e.name = "Required — give this asset a name.";
-
-  if (type === "vehicle") {
-    if (!has(form.make)) e.make = "Required.";
-    if (!has(form.model)) e.model = "Required.";
-    if (!has(form.year)) {
-      e.year = "Required.";
-    } else if (!/^\d+$/.test(form.year.trim())) {
-      e.year = "Must be a whole number.";
-    } else if (parseInt(form.year, 10) < 1900) {
-      e.year = "Must be 1900 or later.";
-    }
-    const vin = form.vin.trim();
-    if (vin && vin.length !== 17) {
-      e.vin = `VIN must be exactly 17 characters (${vin.length} entered).`;
-    }
-  } else if (type === "property") {
-    if (!has(form.street)) e.street = "Required.";
-    if (!has(form.city)) e.city = "Required.";
-    if (!has(form.state)) e.state = "Required.";
-    if (!has(form.postal)) e.postal = "Required.";
-    if (!has(form.country)) e.country = "Required.";
-  }
-
-  return e;
+function focusFirstInvalid(scrollEl?: HTMLElement | null) {
+  setTimeout(() => {
+    const el = (scrollEl || document).querySelector<HTMLElement>(
+      ".hf-input.is-invalid, .hf-select.is-invalid",
+    );
+    el?.focus();
+  }, 0);
 }
-
-function useAddAssetForm(type: AssetType) {
-  const [form, setForm] = useState<Form>(EMPTY_FORM);
-  const [errors, setErrors] = useState<Errors>({});
-  const [status, setStatus] = useState<null | "error" | "ok">(null);
-
-  const setField =
-    (key: keyof Form) => (ev: { target: HTMLInputElement | HTMLSelectElement }) => {
-      const v = ev.target.value;
-      setForm((f: Form) => ({ ...f, [key]: v }));
-      setErrors((er: Errors) => {
-        if (!er[key]) return er;
-        const next = { ...er };
-        delete next[key];
-        return next;
-      });
-    };
-
-  const clearValidation = () => {
-    setErrors({});
-    setStatus(null);
-  };
-
-  const save = (scrollEl?: HTMLElement | null) => {
-    const errs = validateAsset(type, form);
-    setErrors(errs);
-    const count = Object.keys(errs).length;
-    setStatus(count ? "error" : "ok");
-    setTimeout(() => {
-      if (count) {
-        const el = (scrollEl || document).querySelector<HTMLElement>(
-          ".hf-input.is-invalid, .hf-select.is-invalid",
-        );
-        el?.focus();
-      } else if (scrollEl) {
-        scrollEl.scrollTop = 0;
-      }
-    }, 0);
-  };
-
-  return { form, errors, status, errorCount: Object.keys(errors).length, setField, save, clearValidation };
-}
-
-/* ============ field primitives ============ */
-type SetField = (key: keyof Form) => (ev: { target: HTMLInputElement | HTMLSelectElement }) => void;
 
 function HFField({
   label,
@@ -155,7 +88,16 @@ function HFTextField({
   value: string;
   onChange: (ev: { target: HTMLInputElement }) => void;
   error?: string | undefined;
-  inputMode?: "none" | "text" | "tel" | "url" | "email" | "numeric" | "decimal" | "search" | undefined;
+  inputMode?:
+    | "none"
+    | "text"
+    | "tel"
+    | "url"
+    | "email"
+    | "numeric"
+    | "decimal"
+    | "search"
+    | undefined;
   maxLength?: number | undefined;
 }) {
   return (
@@ -176,8 +118,6 @@ function HFTextField({
 function HFSelectField({
   label,
   required,
-  optional,
-  hint,
   options,
   value,
   onChange,
@@ -185,24 +125,22 @@ function HFSelectField({
 }: {
   label: string;
   required?: boolean | undefined;
-  optional?: boolean | undefined;
-  hint?: string | undefined;
   options: string[];
   value: string;
   onChange: (ev: { target: HTMLSelectElement }) => void;
   error?: string | undefined;
 }) {
   return (
-    <HFField label={label} required={required} optional={optional} hint={hint} error={error}>
+    <HFField label={label} required={required} error={error}>
       <select
         className={`hf-select${error ? " is-invalid" : ""}`}
         value={value}
         onChange={onChange}
         aria-invalid={error ? true : undefined}
       >
-        {options.map((o) => (
-          <option key={o} value={o}>
-            {o}
+        {options.map((option) => (
+          <option key={option} value={option}>
+            {option}
           </option>
         ))}
       </select>
@@ -210,71 +148,45 @@ function HFSelectField({
   );
 }
 
-/* ============ validation summary banner ============ */
-function HFValidationBanner({ status, count }: { status: null | "error" | "ok"; count: number }) {
-  if (status === "error") {
-    return (
-      <div className="hf-aa-banner is-error" role="alert">
-        <span className="hf-aa-banner-icon">
-          <Icon name="alert" size={15} stroke={2} />
-        </span>
-        <div className="hf-aa-banner-text">
-          <div className="hf-aa-banner-title">
-            {count === 1 ? "1 field needs attention" : `${count} fields need attention`}
-          </div>
-          <div className="hf-aa-banner-sub">Fix the highlighted fields below, then save again.</div>
-        </div>
+function HFValidationBanner({ title, description }: { title: string; description: string }) {
+  return (
+    <div className="hf-aa-banner is-error" role="alert">
+      <span className="hf-aa-banner-icon">
+        <Icon name="alert" size={15} stroke={2} />
+      </span>
+      <div className="hf-aa-banner-text">
+        <div className="hf-aa-banner-title">{title}</div>
+        <div className="hf-aa-banner-sub">{description}</div>
       </div>
-    );
-  }
-  if (status === "ok") {
-    return (
-      <div className="hf-aa-banner is-ok" role="status">
-        <span className="hf-aa-banner-icon">
-          <Icon name="check" size={15} stroke={2.4} />
-        </span>
-        <div className="hf-aa-banner-text">
-          <div className="hf-aa-banner-title">Looks good</div>
-          <div className="hf-aa-banner-sub">Everything checks out — this asset is ready to save.</div>
-        </div>
-      </div>
-    );
-  }
-  return null;
+    </div>
+  );
 }
 
-/* ============ type picker ============ */
 const HF_TYPES: { id: AssetType; icon: IconName; name: string; desc: string }[] = [
   { id: "vehicle", icon: "car", name: "Vehicle", desc: "Cars, trucks, vans, trailers" },
-  { id: "property", icon: "home", name: "Property", desc: "Homes, land, rentals & what's on them" },
-  { id: "other", icon: "wrench", name: "Other", desc: "Tools, HVAC, generators, appliances" },
+  { id: "property", icon: "home", name: "Property", desc: "Homes, land, and rentals" },
+  { id: "equipment", icon: "wrench", name: "Equipment", desc: "Tools, HVAC, and generators" },
 ];
 
-function HFTypePicker({
-  value,
-  onChange,
-}: {
-  value: AssetType;
-  onChange: (v: AssetType) => void;
-}) {
+function HFTypePicker({ value, onChange }: { value: AssetType; onChange: (v: AssetType) => void }) {
   return (
     <div className="hf-aa-types" role="radiogroup" aria-label="Asset type">
-      {HF_TYPES.map((t) => (
+      {HF_TYPES.map((type) => (
         <button
-          key={t.id}
+          key={type.id}
           type="button"
           role="radio"
-          aria-checked={value === t.id}
-          className={`hf-type-card${value === t.id ? " selected" : ""}`}
-          onClick={() => onChange(t.id)}
+          aria-checked={value === type.id}
+          className={`hf-type-card${value === type.id ? " selected" : ""}`}
+          onClick={() => onChange(type.id)}
         >
           <span className="hf-type-radio" />
-          <span className="hf-type-icon" data-cat={t.id}>
-            <Icon name={t.icon} size={19} stroke={1.7} />
+          <span className="hf-type-icon" data-cat={type.id}>
+            <Icon name={type.icon} size={19} stroke={1.7} />
           </span>
           <span className="hf-type-text">
-            <span className="hf-type-name">{t.name}</span>
-            <span className="hf-type-desc">{t.desc}</span>
+            <span className="hf-type-name">{type.name}</span>
+            <span className="hf-type-desc">{type.desc}</span>
           </span>
         </button>
       ))}
@@ -282,70 +194,19 @@ function HFTypePicker({
   );
 }
 
-/* ============ subtype chips (within "Other") ============ */
-const HF_SUBTYPES: { id: Subtype; glyph: IconName; label: string }[] = [
-  { id: "lawn", glyph: "leaf", label: "Lawn equipment" },
-  { id: "power-tool", glyph: "wrench", label: "Power tool" },
-  { id: "appliance", glyph: "grid", label: "Appliance" },
-  { id: "hvac", glyph: "home", label: "HVAC" },
-  { id: "generator", glyph: "bolt", label: "Generator" },
-  { id: "other", glyph: "dot", label: "Something else" },
-];
-
-function HFSubtypeChips({
-  value,
-  onChange,
-}: {
-  value: Subtype;
-  onChange: (v: Subtype) => void;
-}) {
-  return (
-    <div className="hf-aa-chips">
-      {HF_SUBTYPES.map((s) => (
-        <button
-          key={s.id}
-          type="button"
-          className={`hf-subchip${value === s.id ? " selected" : ""}`}
-          onClick={() => onChange(s.id)}
-        >
-          <span className="hf-subchip-glyph">
-            <Icon name={s.glyph} size={13} stroke={1.8} />
-          </span>
-          {s.label}
-        </button>
-      ))}
-    </div>
-  );
-}
-
-/* ============ photo dropzone ============ */
-function HFDropzone() {
-  return (
-    <div className="hf-dropzone">
-      <div className="hf-dropzone-icon">
-        <Icon name="camera" size={18} color="var(--hf-ink-soft)" />
-      </div>
-      <div className="hf-dropzone-label">Add photo</div>
-      <div className="hf-dropzone-sub">drag or click</div>
-    </div>
-  );
-}
-
-/* ============ contextual detail sections ============ */
 function HFVehicleFields({
   form,
   errors,
   setField,
 }: {
-  form: Form;
-  errors: Errors;
+  form: AssetForm;
+  errors: AssetFormErrors;
   setField: SetField;
 }) {
   return (
     <div className="hf-aa-section">
       <div className="hf-aa-section-head">
         <span className="hf-aa-section-title">Vehicle details</span>
-        <span className="hf-aa-section-hint">helps with service reminders</span>
       </div>
       <div className="hf-field-row">
         <HFTextField
@@ -367,7 +228,7 @@ function HFVehicleFields({
         <HFTextField
           label="Year"
           required
-          hint="1900 or later"
+          hint={`1900-${new Date().getFullYear() + 1}`}
           placeholder="2022"
           mono
           inputMode="numeric"
@@ -397,8 +258,8 @@ function HFPropertyFields({
   errors,
   setField,
 }: {
-  form: Form;
-  errors: Errors;
+  form: AssetForm;
+  errors: AssetFormErrors;
   setField: SetField;
 }) {
   return (
@@ -410,8 +271,7 @@ function HFPropertyFields({
       <HFTextField
         label="Nickname"
         optional
-        hint="handy when you own multiples"
-        placeholder="Main house, Cabin…"
+        placeholder="Main house, cabin..."
         value={form.nickname}
         onChange={setField("nickname")}
       />
@@ -445,7 +305,6 @@ function HFPropertyFields({
           required
           placeholder="97204"
           mono
-          inputMode="numeric"
           value={form.postal}
           onChange={setField("postal")}
           error={errors.postal}
@@ -463,44 +322,25 @@ function HFPropertyFields({
   );
 }
 
-function HFOtherFields({
-  subtype,
-  onSubtype,
-  form,
-  setField,
-}: {
-  subtype: Subtype;
-  onSubtype: (v: Subtype) => void;
-  form: Form;
-  setField: SetField;
-}) {
+function HFEquipmentFields({ form, setField }: { form: AssetForm; setField: SetField }) {
   return (
     <div className="hf-aa-section">
       <div className="hf-aa-section-head">
-        <span className="hf-aa-section-title">Details</span>
-        <span className="hf-aa-section-hint">all optional — fill what you know</span>
+        <span className="hf-aa-section-title">Equipment details</span>
+        <span className="hf-aa-section-hint">fill in what you know</span>
       </div>
-      <HFField label="What is it?" hint="picks the right service reminders">
-        <HFSubtypeChips value={subtype} onChange={onSubtype} />
-      </HFField>
       <div className="hf-field-row">
         <HFTextField
           label="Manufacturer"
-          placeholder={
-            subtype === "lawn"
-              ? "Toro"
-              : subtype === "hvac"
-                ? "Carrier"
-                : subtype === "generator"
-                  ? "Generac"
-                  : "Brand"
-          }
+          optional
+          placeholder="Honda"
           value={form.manufacturer}
           onChange={setField("manufacturer")}
         />
         <HFTextField
           label="Model number"
-          placeholder="MX5060"
+          optional
+          placeholder="EU2200i"
           mono
           value={form.modelNumber}
           onChange={setField("modelNumber")}
@@ -509,128 +349,106 @@ function HFOtherFields({
       <HFTextField
         label="Serial number"
         optional
-        hint="useful for warranty"
         placeholder="EAMT-1234567"
         mono
         value={form.serialNumber}
         onChange={setField("serialNumber")}
       />
-      {subtype === "lawn" && (
-        <div className="hf-field-row">
-          <HFTextField
-            label="Engine hours"
-            optional
-            hint="schedules oil changes"
-            placeholder="124"
-            mono
-            inputMode="numeric"
-            value={form.engineHours}
-            onChange={setField("engineHours")}
-          />
-        </div>
-      )}
     </div>
   );
 }
 
-/* maps current type → name placeholder + follow-up label */
-function namePlaceholder(type: AssetType, subtype: Subtype): string {
-  if (type === "vehicle") return "Ford F-150 · #4";
-  if (type === "property") return "12 Oak St";
-  if (subtype === "lawn") return "Toro ZTR Mower";
-  if (subtype === "hvac") return "Rooftop AC unit";
-  if (subtype === "generator") return "Generac 22kW";
-  return "Pressure washer";
+function namePlaceholder(type: AssetType): string {
+  switch (type) {
+    case "vehicle":
+      return "Ford F-150";
+    case "property":
+      return "12 Oak St";
+    case "equipment":
+      return "Pressure washer";
+  }
 }
 
-function followLabel(type: AssetType, subtype: Subtype): string {
-  if (type === "vehicle") return "vehicle";
-  if (type === "property") return "property";
-  if (subtype === "lawn") return "equipment";
-  if (subtype === "hvac") return "unit";
-  return "asset";
-}
-
-/* ============ shared field-stack ============ */
-function HFAddAssetFields({
-  type,
-  setType,
-  subtype,
-  setSubtype,
-  form,
-  errors,
-  setField,
-  showHeaderHint,
-}: {
-  type: AssetType;
-  setType: (v: AssetType) => void;
-  subtype: Subtype;
-  setSubtype: (v: Subtype) => void;
-  form: Form;
-  errors: Errors;
-  setField: SetField;
-  showHeaderHint?: boolean | undefined;
-}) {
-  return (
-    <>
-      {/* TYPE */}
-      <div className="hf-aa-section">
-        <HFField
-          label="Asset type"
-          required
-          hint={showHeaderHint ? "three buckets — pick what fits" : undefined}
-        >
-          <HFTypePicker value={type} onChange={setType} />
-        </HFField>
-      </div>
-
-      {/* NAME */}
-      <HFTextField
-        label="Asset name"
-        required
-        hint="how you'll recognize it"
-        placeholder={namePlaceholder(type, subtype)}
-        value={form.name}
-        onChange={setField("name")}
-        error={errors.name}
-      />
-
-      <div className="hf-aa-rule" />
-
-      {/* CONTEXTUAL FIELDS */}
-      {type === "vehicle" && <HFVehicleFields form={form} errors={errors} setField={setField} />}
-      {type === "property" && <HFPropertyFields form={form} errors={errors} setField={setField} />}
-      {type === "other" && (
-        <HFOtherFields subtype={subtype} onSubtype={setSubtype} form={form} setField={setField} />
-      )}
-    </>
-  );
-}
-
-/* ============ main: full-page add-asset form ============ */
 export function AppAddAsset({ initialType = "vehicle" }: { initialType?: AssetType }) {
-  const [type, setTypeRaw] = useState<AssetType>(initialType);
-  const [subtype, setSubtype] = useState<Subtype>("lawn");
-  const { form, errors, status, errorCount, setField, save, clearValidation } =
-    useAddAssetForm(type);
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const bodyRef = useRef<HTMLDivElement>(null);
+  const [type, setType] = useState<AssetType>(initialType);
+  const [form, setForm] = useState<AssetForm>(EMPTY_ASSET_FORM);
+  const [errors, setErrors] = useState<AssetFormErrors>({});
+  const [banner, setBanner] = useState<{ title: string; description: string } | null>(null);
 
-  const setType = (t: AssetType) => {
-    setTypeRaw(t);
+  const mutation = useMutation({
+    mutationFn: createAsset,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: assetsQueryKey });
+      navigate(paths.assets);
+    },
+    onError: (error) => {
+      if (error instanceof ApiError && error.status === 401) {
+        navigate(paths.login(), { replace: true });
+        return;
+      }
+      const fieldErrors =
+        error instanceof ApiError ? toAssetFormError(error.field, error.message) : {};
+      setErrors(fieldErrors);
+      setBanner({
+        title: "Asset could not be saved",
+        description: error instanceof Error ? error.message : "Please try again.",
+      });
+      focusFirstInvalid(bodyRef.current);
+    },
+  });
+
+  const clearValidation = () => {
+    setErrors({});
+    setBanner(null);
+    mutation.reset();
+  };
+
+  const setField: SetField = (key) => (ev) => {
+    const value = ev.target.value;
+    setForm((current) => ({ ...current, [key]: value }));
+    setErrors((current) => {
+      if (!current[key]) return current;
+      const next = { ...current };
+      delete next[key];
+      return next;
+    });
+    setBanner(null);
+    mutation.reset();
+  };
+
+  const selectType = (nextType: AssetType) => {
+    setType(nextType);
     clearValidation();
   };
 
+  const save = () => {
+    const nextErrors = validateAssetForm(type, form);
+    setErrors(nextErrors);
+    const errorCount = Object.keys(nextErrors).length;
+    if (errorCount > 0) {
+      setBanner({
+        title: errorCount === 1 ? "1 field needs attention" : `${errorCount} fields need attention`,
+        description: "Fix the highlighted fields below, then save again.",
+      });
+      focusFirstInvalid(bodyRef.current);
+      return;
+    }
+    mutation.mutate(toCreateAssetBody(type, form));
+  };
+
   useEffect(() => {
-    document.title = "FieldOps — Add Asset";
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") navigate(paths.assets);
+    document.title = "FieldOps - Add Asset";
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") navigate(paths.assets);
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
   }, [navigate]);
 
-  const cancel = () => navigate(paths.assets);
+  const errorCount = Object.keys(errors).length;
 
   return (
     <div className="hf hf-app hf-aa-page">
@@ -651,65 +469,49 @@ export function AppAddAsset({ initialType = "vehicle" }: { initialType?: AssetTy
         <div className="hf-aa-col">
           <div className="hf-aa-head">
             <h1>Add an asset</h1>
-            <p>
-              Track anything that needs regular service — pick a type and we'll ask the right
-              details.
-            </p>
+            <p>Track a vehicle, property, or piece of equipment.</p>
           </div>
 
-          <HFValidationBanner status={status} count={errorCount} />
+          {banner && <HFValidationBanner title={banner.title} description={banner.description} />}
 
-          <HFAddAssetFields
-            type={type}
-            setType={setType}
-            subtype={subtype}
-            setSubtype={setSubtype}
-            form={form}
-            errors={errors}
-            setField={setField}
-            showHeaderHint
+          <div className="hf-aa-section">
+            <HFField label="Asset type" required>
+              <HFTypePicker value={type} onChange={selectType} />
+            </HFField>
+          </div>
+
+          <HFTextField
+            label="Asset name"
+            required
+            hint="how you'll recognize it"
+            placeholder={namePlaceholder(type)}
+            value={form.name}
+            onChange={setField("name")}
+            error={errors.name}
           />
 
           <div className="hf-aa-rule" />
 
-          {/* PHOTO */}
-          <div className="hf-photo-row">
-            <div className="hf-photo-text">
-              <label className="hf-field-label">
-                Photo <span className="hf-field-opt">optional</span>
-              </label>
-              <div className="hf-photo-sub">
-                Helps you spot it in the grid. If you skip it, we'll use a category icon — you can
-                add or change this anytime.
-              </div>
-            </div>
-            <HFDropzone />
-          </div>
-
-          {/* NEXT STEP */}
-          <div className="hf-aa-next">
-            <div className="hf-aa-next-icon">
-              <Icon name="calendar" size={17} stroke={1.8} />
-            </div>
-            <div className="hf-aa-next-text">
-              <div className="hf-aa-next-title">Next: set up a service schedule</div>
-              <div className="hf-aa-next-sub">
-                After saving, we'll ask when this {followLabel(type, subtype)} needs its next
-                service.
-              </div>
-            </div>
-            <Icon name="arrow-right" size={18} color="var(--hf-brand-2)" />
-          </div>
+          {type === "vehicle" && (
+            <HFVehicleFields form={form} errors={errors} setField={setField} />
+          )}
+          {type === "property" && (
+            <HFPropertyFields form={form} errors={errors} setField={setField} />
+          )}
+          {type === "equipment" && <HFEquipmentFields form={form} setField={setField} />}
         </div>
       </div>
 
-      {/* STICKY SAVE BAR */}
       <div className="hf-aa-footer">
         <div className="hf-aa-footer-note">
-          {status === "error" ? (
+          {banner ? (
             <span className="hf-aa-footer-err">
               <Icon name="alert" size={13} stroke={2} />
-              {errorCount === 1 ? "1 field needs attention" : `${errorCount} fields need attention`}
+              {errorCount > 0
+                ? errorCount === 1
+                  ? "1 field needs attention"
+                  : `${errorCount} fields need attention`
+                : "Asset could not be saved"}
             </span>
           ) : (
             <>
@@ -718,15 +520,19 @@ export function AppAddAsset({ initialType = "vehicle" }: { initialType?: AssetTy
           )}
         </div>
         <div className="hf-aa-footer-actions">
-          <button className="hf-btn hf-btn-secondary hf-btn-lg" onClick={cancel}>
+          <button
+            className="hf-btn hf-btn-secondary hf-btn-lg"
+            onClick={() => navigate(paths.assets)}
+          >
             Cancel
           </button>
           <button
             className="hf-btn hf-btn-primary hf-btn-lg"
-            onClick={() => save(bodyRef.current)}
+            onClick={save}
+            disabled={mutation.isPending}
           >
             <Icon name="check" size={15} stroke={2.2} />
-            Save asset
+            {mutation.isPending ? "Saving..." : "Save asset"}
           </button>
         </div>
       </div>

--- a/apps/web/src/app/AppAssets.tsx
+++ b/apps/web/src/app/AppAssets.tsx
@@ -1,44 +1,16 @@
 import { useEffect } from "react";
-import { Link } from "react-router";
+import { useQuery } from "@tanstack/react-query";
+import { Link, useNavigate } from "react-router";
+import { assetsQueryKey, listAssets } from "../api/assets";
+import { ApiError } from "../api/client";
 import { Icon, type IconName } from "../design/Icon";
-import { HFAssetThumb, HFStatusPill, type AssetCategory, type AssetStatus } from "../design/hf";
-import { HFTopBar, HFBottomNav } from "./AppChrome";
+import { HFAssetThumb, type AssetCategory } from "../design/hf";
 import { paths } from "../routes";
+import { HFTopBar, HFBottomNav } from "./AppChrome";
+import { type AssetPresentation, toAssetPresentation } from "./assetPresentation";
 
-// FieldOps — Assets (card grid). The authenticated asset library: a header with
-// fleet count + add button, a toolbar (search, category filter chips, grid/list
-// view toggle), and a responsive grid of asset cards that collapses to stacked
-// rows on mobile. Ported from the FieldOps design prototype (Assets.html /
-// hifi-assets.jsx); styling comes from the shared .hf tokens in styles/hifi.css
-// plus the .hf-asset-* scopes in styles/hifi-assets.css.
 import "../design/styles/hifi.css";
 import "../design/styles/hifi-assets.css";
-
-/* ============ data ============ */
-interface Asset {
-  id: string;
-  name: string;
-  cat: AssetCategory;
-  icon: IconName;
-  status: AssetStatus;
-  next: string;
-  due: string;
-  loc: string;
-  meter: string;
-}
-
-const HF_ASSETS_ALL: Asset[] = [
-  { id: "TRK-04", name: "Ford F-150 · #4", cat: "vehicle", icon: "truck", status: "soon", next: "Oil change + tire rotation", due: "2 days", loc: "Lot · Main", meter: "48,210 mi" },
-  { id: "VAN-02", name: "Sprinter Van · #2", cat: "vehicle", icon: "van", status: "ok", next: "Annual state inspection", due: "14 days", loc: "Lot · Main", meter: "82,400 mi" },
-  { id: "TRL-01", name: "16ft Equipment Trailer", cat: "vehicle", icon: "truck", status: "ok", next: "Wheel bearing repack", due: "30 days", loc: "Lot · Back", meter: "—" },
-  { id: "MOWER-A", name: "Toro ZTR Mower", cat: "equipment", icon: "mower", status: "overdue", next: "Blade sharpen + belt check", due: "3 days late", loc: "Shed B", meter: "312 hrs" },
-  { id: "GEN-1", name: "Generac 22kW Generator", cat: "equipment", icon: "bolt", status: "ok", next: "Annual load test + oil", due: "21 days", loc: "12 Oak St", meter: "118 hrs" },
-  { id: "PW-2", name: "Pressure Washer", cat: "equipment", icon: "wrench", status: "ok", next: "Pump oil change", due: "45 days", loc: "Shed A", meter: "84 hrs" },
-  { id: "PROP-12", name: "12 Oak St", cat: "property", icon: "home", status: "soon", next: "Quarterly HVAC inspection", due: "5 days", loc: "Oak St", meter: "—" },
-  { id: "PROP-48", name: "48 Elm Ave", cat: "property", icon: "home", status: "ok", next: "Gutter clean & inspect", due: "60 days", loc: "Elm Ave", meter: "—" },
-  { id: "LAWN-A", name: "Riverside Lawn", cat: "lawn", icon: "leaf", status: "soon", next: "Spring fertilizer treatment", due: "9 days", loc: "Riverside", meter: "—" },
-  { id: "LAWN-B", name: "Park Hedge Row", cat: "lawn", icon: "leaf", status: "ok", next: "Hedge trim & cleanup", due: "25 days", loc: "Park West", meter: "—" },
-];
 
 const HF_CAT_LABELS: Record<AssetCategory, string> = {
   vehicle: "Vehicle",
@@ -47,61 +19,44 @@ const HF_CAT_LABELS: Record<AssetCategory, string> = {
   lawn: "Grounds",
 };
 
-/* ============ grid card ============ */
-function HFAssetGridCard({ asset }: { asset: Asset }) {
+function HFAssetGridCard({ asset }: { asset: AssetPresentation }) {
   return (
-    <article className="hf-asset-card" data-status={asset.status} tabIndex={0}>
+    <article className="hf-asset-card hf-asset-card-static">
       <HFAssetThumb asset={asset} height={132} />
       <div className="hf-asset-body">
         <h3 className="hf-asset-card-name">{asset.name}</h3>
         <div className="hf-asset-card-meta">
-          <span className="hf-mono">{asset.id}</span>
-          {asset.meter !== "—" && (
-            <>
-              <span className="hf-dot-sep" />
-              <span>{asset.meter}</span>
-            </>
-          )}
+          <span className="hf-mono" title={asset.id}>
+            {asset.displayId}
+          </span>
         </div>
       </div>
-      <div className="hf-asset-footer">
-        <div className="hf-asset-footer-text">
-          <div className="hf-label-sm">Next</div>
-          <div className="hf-asset-next">{asset.next}</div>
-        </div>
-        <HFStatusPill status={asset.status} due={asset.due} />
-      </div>
+      <div className="hf-asset-summary">{asset.summary}</div>
     </article>
   );
 }
 
-/* horizontal row card — used on mobile */
-function HFAssetRowCard({ asset }: { asset: Asset }) {
+function HFAssetRowCard({ asset }: { asset: AssetPresentation }) {
   return (
-    <article className="hf-asset-row" data-status={asset.status} tabIndex={0}>
+    <article className="hf-asset-row hf-asset-row-static">
       <HFAssetThumb asset={asset} height={84} />
       <div className="hf-asset-row-body">
         <div className="hf-asset-row-top">
           <h3 className="hf-asset-card-name">{asset.name}</h3>
           <div className="hf-asset-card-meta">
-            <span className="hf-mono">{asset.id}</span>
+            <span className="hf-mono" title={asset.id}>
+              {asset.displayId}
+            </span>
             <span className="hf-dot-sep" />
             <span>{HF_CAT_LABELS[asset.cat]}</span>
           </div>
         </div>
-        <div className="hf-asset-row-bot">
-          <div className="hf-asset-next-mobile">
-            <span className="hf-label-sm">Next</span>
-            <span className="hf-asset-next-text">{asset.next}</span>
-          </div>
-          <HFStatusPill status={asset.status} due={asset.due} />
-        </div>
+        <div className="hf-asset-row-summary">{asset.summary}</div>
       </div>
     </article>
   );
 }
 
-/* ============ add-asset ghost card (slots into the grid) ============ */
 function HFAddCard() {
   return (
     <Link to={paths.addAsset} className="hf-asset-card hf-add-card">
@@ -110,51 +65,56 @@ function HFAddCard() {
           <Icon name="plus" size={20} stroke={2} />
         </div>
         <div className="hf-add-card-label">Add an asset</div>
-        <div className="hf-add-card-sub">Vehicle, equipment, property, grounds…</div>
+        <div className="hf-add-card-sub">Vehicle, equipment, or property</div>
       </div>
     </Link>
   );
 }
 
-/* ============ toolbar: search + filter chips + view toggle ============ */
-function HFAssetsToolbar({
-  activeCat = "all",
-  activeView = "grid",
-}: {
-  activeCat?: string;
-  activeView?: "grid" | "list";
-}) {
+function HFAssetsToolbar({ assets }: { assets: AssetPresentation[] }) {
   const cats = [
-    { id: "all", label: "All", count: HF_ASSETS_ALL.length },
-    { id: "vehicle", label: "Vehicles", count: HF_ASSETS_ALL.filter((a) => a.cat === "vehicle").length },
-    { id: "equipment", label: "Equipment", count: HF_ASSETS_ALL.filter((a) => a.cat === "equipment").length },
-    { id: "property", label: "Properties", count: HF_ASSETS_ALL.filter((a) => a.cat === "property").length },
-    { id: "lawn", label: "Grounds", count: HF_ASSETS_ALL.filter((a) => a.cat === "lawn").length },
+    { id: "all", label: "All", count: assets.length },
+    { id: "vehicle", label: "Vehicles", count: assets.filter((a) => a.cat === "vehicle").length },
+    {
+      id: "equipment",
+      label: "Equipment",
+      count: assets.filter((a) => a.cat === "equipment").length,
+    },
+    {
+      id: "property",
+      label: "Properties",
+      count: assets.filter((a) => a.cat === "property").length,
+    },
   ];
   const views: { id: "grid" | "list"; icon: IconName }[] = [
     { id: "grid", icon: "grid" },
     { id: "list", icon: "menu" },
   ];
+
   return (
-    <div className="hf-assets-toolbar">
+    <div className="hf-assets-toolbar hf-assets-toolbar-disabled" aria-label="Asset controls">
       <div className="hf-search">
         <Icon name="search" size={15} color="var(--hf-ink-faint)" />
-        <input className="hf-search-input" placeholder="Search assets, IDs, locations…" />
-        <kbd className="hf-kbd">⌘ K</kbd>
+        <input className="hf-search-input" placeholder="Search assets" disabled />
       </div>
       <div className="hf-filter-chips">
-        {cats.map((c) => (
-          <button key={c.id} className={`hf-chip ${activeCat === c.id ? "active" : ""}`}>
-            {c.label}
-            <span className="hf-chip-count">{c.count}</span>
+        {cats.map((cat) => (
+          <button key={cat.id} className={`hf-chip ${cat.id === "all" ? "active" : ""}`} disabled>
+            {cat.label}
+            <span className="hf-chip-count">{cat.count}</span>
           </button>
         ))}
       </div>
       <div className="hf-assets-toolbar-end">
         <div className="hf-view-toggle">
-          {views.map((v) => (
-            <button key={v.id} className={`hf-view-btn ${activeView === v.id ? "active" : ""}`} title={v.id}>
-              <Icon name={v.icon} size={15} />
+          {views.map((view) => (
+            <button
+              key={view.id}
+              className={`hf-view-btn ${view.id === "grid" ? "active" : ""}`}
+              title={`${view.id} view`}
+              disabled
+            >
+              <Icon name={view.icon} size={15} />
             </button>
           ))}
         </div>
@@ -163,13 +123,12 @@ function HFAssetsToolbar({
   );
 }
 
-/* ============ header ============ */
-function HFAssetsHeader() {
+function HFAssetsHeader({ count }: { count: number }) {
   return (
     <div className="hf-greeting">
       <div className="hf-greeting-text">
         <h1 className="hf-h1">Assets</h1>
-        <div className="hf-greeting-sub">{HF_ASSETS_ALL.length} things you take care of</div>
+        <div className="hf-greeting-sub">{count} things you take care of</div>
       </div>
       <div className="hf-stats hf-stats-tight">
         <Link className="hf-btn hf-btn-primary" to={paths.addAsset}>
@@ -181,37 +140,98 @@ function HFAssetsHeader() {
   );
 }
 
-/* ============ main: assets card grid (responsive) ============ */
+function HFAssetsState({
+  title,
+  description,
+  action,
+}: {
+  title: string;
+  description: string;
+  action?: React.ReactNode;
+}) {
+  return (
+    <div className="hf-assets-state">
+      <div className="hf-assets-state-title">{title}</div>
+      <div className="hf-assets-state-sub">{description}</div>
+      {action}
+    </div>
+  );
+}
+
 export function AppAssets() {
+  const navigate = useNavigate();
+  const assetsQuery = useQuery({
+    queryKey: assetsQueryKey,
+    queryFn: listAssets,
+    retry: (failureCount, error) =>
+      !(error instanceof ApiError && error.status === 401) && failureCount < 2,
+  });
+
   useEffect(() => {
-    document.title = "FieldOps — Assets";
+    document.title = "FieldOps - Assets";
   }, []);
 
-  // The add-card slots in at the END of the grid so the "+" stays discoverable
-  // inline; the stacked rows (mobile) get their own add button at the bottom.
+  useEffect(() => {
+    if (assetsQuery.error instanceof ApiError && assetsQuery.error.status === 401) {
+      navigate(paths.login(), { replace: true });
+    }
+  }, [assetsQuery.error, navigate]);
+
+  const assets = (assetsQuery.data?.assets ?? []).map(toAssetPresentation);
+
   return (
     <div className="hf hf-app hf-assets-page">
       <HFTopBar />
       <main className="hf-main hf-shell">
-        <HFAssetsHeader />
-        <HFAssetsToolbar activeCat="all" activeView="grid" />
+        <HFAssetsHeader count={assets.length} />
+        <HFAssetsToolbar assets={assets} />
 
-        <div className="hf-asset-grid">
-          {HF_ASSETS_ALL.map((a) => (
-            <HFAssetGridCard key={a.id} asset={a} />
-          ))}
-          <HFAddCard />
-        </div>
+        {assetsQuery.isPending ? (
+          <HFAssetsState title="Loading assets" description="Fetching your asset library..." />
+        ) : assetsQuery.isError ? (
+          <HFAssetsState
+            title="Assets could not be loaded"
+            description={assetsQuery.error.message}
+            action={
+              <button
+                className="hf-btn hf-btn-secondary"
+                onClick={() => void assetsQuery.refetch()}
+              >
+                Try again
+              </button>
+            }
+          />
+        ) : assets.length === 0 ? (
+          <HFAssetsState
+            title="No assets yet"
+            description="Add your first vehicle, property, or piece of equipment."
+            action={
+              <Link className="hf-btn hf-btn-primary" to={paths.addAsset}>
+                <Icon name="plus" size={14} stroke={2.2} />
+                Add asset
+              </Link>
+            }
+          />
+        ) : (
+          <>
+            <div className="hf-asset-grid">
+              {assets.map((asset) => (
+                <HFAssetGridCard key={asset.id} asset={asset} />
+              ))}
+              <HFAddCard />
+            </div>
 
-        <div className="hf-asset-rows">
-          {HF_ASSETS_ALL.map((a) => (
-            <HFAssetRowCard key={a.id} asset={a} />
-          ))}
-          <Link className="hf-row-add" to={paths.addAsset}>
-            <Icon name="plus" size={16} stroke={2} />
-            Add an asset
-          </Link>
-        </div>
+            <div className="hf-asset-rows">
+              {assets.map((asset) => (
+                <HFAssetRowCard key={asset.id} asset={asset} />
+              ))}
+              <Link className="hf-row-add" to={paths.addAsset}>
+                <Icon name="plus" size={16} stroke={2} />
+                Add an asset
+              </Link>
+            </div>
+          </>
+        )}
       </main>
       <HFBottomNav />
     </div>

--- a/apps/web/src/app/assetForm.test.ts
+++ b/apps/web/src/app/assetForm.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import {
+  EMPTY_ASSET_FORM,
+  toAssetFormError,
+  toCreateAssetBody,
+  validateAssetForm,
+} from "./assetForm";
+
+describe("toCreateAssetBody", () => {
+  it("maps a trimmed vehicle and omits a blank VIN", () => {
+    expect(
+      toCreateAssetBody("vehicle", {
+        ...EMPTY_ASSET_FORM,
+        name: "  Truck  ",
+        make: "  Ram ",
+        model: " 2500 ",
+        year: "2016",
+        vin: " ",
+      }),
+    ).toEqual({
+      name: "Truck",
+      metadata: { kind: "vehicle", make: "Ram", model: "2500", year: 2016 },
+    });
+  });
+
+  it("maps a property address and omits a blank nickname", () => {
+    expect(
+      toCreateAssetBody("property", {
+        ...EMPTY_ASSET_FORM,
+        name: " Main house ",
+        nickname: " ",
+        street: " 12 Oak St ",
+        city: " Portland ",
+        postal: " 97204 ",
+      }),
+    ).toEqual({
+      name: "Main house",
+      metadata: {
+        kind: "property",
+        address: {
+          street: "12 Oak St",
+          city: "Portland",
+          state: "OR",
+          postalCode: "97204",
+          country: "United States",
+        },
+      },
+    });
+  });
+
+  it("maps equipment and omits blank optional fields", () => {
+    expect(
+      toCreateAssetBody("equipment", {
+        ...EMPTY_ASSET_FORM,
+        name: " Generator ",
+        manufacturer: " Honda ",
+        modelNumber: " ",
+        serialNumber: " EAMT-123 ",
+      }),
+    ).toEqual({
+      name: "Generator",
+      metadata: { kind: "equipment", manufacturer: "Honda", serialNumber: "EAMT-123" },
+    });
+  });
+});
+
+describe("validateAssetForm", () => {
+  it("rejects a vehicle year beyond the API limit", () => {
+    const errors = validateAssetForm("vehicle", {
+      ...EMPTY_ASSET_FORM,
+      name: "Truck",
+      make: "Ram",
+      model: "2500",
+      year: String(new Date().getFullYear() + 2),
+    });
+
+    expect(errors.year).toContain("Must be between");
+  });
+});
+
+describe("toAssetFormError", () => {
+  it("maps an API metadata path back to its form field", () => {
+    expect(toAssetFormError("metadata.address.postalCode", "Postal code is required")).toEqual({
+      postal: "Postal code is required",
+    });
+  });
+});

--- a/apps/web/src/app/assetForm.ts
+++ b/apps/web/src/app/assetForm.ts
@@ -1,0 +1,146 @@
+import type { AssetType, CreateAssetBody } from "../api/assets";
+
+export type AssetForm = {
+  name: string;
+  make: string;
+  model: string;
+  year: string;
+  vin: string;
+  nickname: string;
+  street: string;
+  city: string;
+  state: string;
+  postal: string;
+  country: string;
+  manufacturer: string;
+  modelNumber: string;
+  serialNumber: string;
+};
+
+export type AssetFormErrors = Partial<Record<keyof AssetForm, string>>;
+
+export const EMPTY_ASSET_FORM: AssetForm = {
+  name: "",
+  make: "",
+  model: "",
+  year: "",
+  vin: "",
+  nickname: "",
+  street: "",
+  city: "",
+  state: "OR",
+  postal: "",
+  country: "United States",
+  manufacturer: "",
+  modelNumber: "",
+  serialNumber: "",
+};
+
+const trimmedOrUndefined = (value: string) => value.trim() || undefined;
+
+export function validateAssetForm(type: AssetType, form: AssetForm): AssetFormErrors {
+  const errors: AssetFormErrors = {};
+  const has = (value: string) => value.trim().length > 0;
+
+  if (!has(form.name)) errors.name = "Required - give this asset a name.";
+
+  if (type === "vehicle") {
+    if (!has(form.make)) errors.make = "Required.";
+    if (!has(form.model)) errors.model = "Required.";
+    if (!has(form.year)) {
+      errors.year = "Required.";
+    } else if (!/^\d+$/.test(form.year.trim())) {
+      errors.year = "Must be a whole number.";
+    } else if (
+      Number.parseInt(form.year, 10) < 1900 ||
+      Number.parseInt(form.year, 10) > new Date().getFullYear() + 1
+    ) {
+      errors.year = `Must be between 1900 and ${new Date().getFullYear() + 1}.`;
+    }
+    const vin = form.vin.trim();
+    if (vin && vin.length !== 17) {
+      errors.vin = `VIN must be exactly 17 characters (${vin.length} entered).`;
+    }
+  } else if (type === "property") {
+    if (!has(form.street)) errors.street = "Required.";
+    if (!has(form.city)) errors.city = "Required.";
+    if (!has(form.state)) errors.state = "Required.";
+    if (!has(form.postal)) errors.postal = "Required.";
+    if (!has(form.country)) errors.country = "Required.";
+  }
+
+  return errors;
+}
+
+export function toCreateAssetBody(type: AssetType, form: AssetForm): CreateAssetBody {
+  const name = form.name.trim();
+
+  switch (type) {
+    case "vehicle": {
+      const vin = trimmedOrUndefined(form.vin);
+      return {
+        name,
+        metadata: {
+          kind: "vehicle",
+          make: form.make.trim(),
+          model: form.model.trim(),
+          year: Number.parseInt(form.year, 10),
+          ...(vin ? { vin } : {}),
+        },
+      };
+    }
+    case "property": {
+      const nickname = trimmedOrUndefined(form.nickname);
+      return {
+        name,
+        metadata: {
+          kind: "property",
+          ...(nickname ? { nickname } : {}),
+          address: {
+            street: form.street.trim(),
+            city: form.city.trim(),
+            state: form.state.trim(),
+            postalCode: form.postal.trim(),
+            country: form.country.trim(),
+          },
+        },
+      };
+    }
+    case "equipment": {
+      const manufacturer = trimmedOrUndefined(form.manufacturer);
+      const modelNumber = trimmedOrUndefined(form.modelNumber);
+      const serialNumber = trimmedOrUndefined(form.serialNumber);
+      return {
+        name,
+        metadata: {
+          kind: "equipment",
+          ...(manufacturer ? { manufacturer } : {}),
+          ...(modelNumber ? { modelNumber } : {}),
+          ...(serialNumber ? { serialNumber } : {}),
+        },
+      };
+    }
+  }
+}
+
+const API_FIELD_TO_FORM_FIELD: Record<string, keyof AssetForm> = {
+  name: "name",
+  "metadata.make": "make",
+  "metadata.model": "model",
+  "metadata.year": "year",
+  "metadata.vin": "vin",
+  "metadata.nickname": "nickname",
+  "metadata.address.street": "street",
+  "metadata.address.city": "city",
+  "metadata.address.state": "state",
+  "metadata.address.postalCode": "postal",
+  "metadata.address.country": "country",
+  "metadata.manufacturer": "manufacturer",
+  "metadata.modelNumber": "modelNumber",
+  "metadata.serialNumber": "serialNumber",
+};
+
+export function toAssetFormError(field: string | undefined, message: string): AssetFormErrors {
+  const formField = field ? API_FIELD_TO_FORM_FIELD[field] : undefined;
+  return formField ? { [formField]: message } : {};
+}

--- a/apps/web/src/app/assetPresentation.test.ts
+++ b/apps/web/src/app/assetPresentation.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import type { AssetResponse } from "../api/assets";
+import { shortenAssetId, toAssetPresentation } from "./assetPresentation";
+
+const BASE_ASSET = {
+  id: "195d0ef0-47f5-439f-abfd-29f892c9a040",
+  archivedAt: null,
+  createdAt: "2026-05-29T03:25:24.887Z",
+  updatedAt: "2026-05-29T03:25:24.887Z",
+} as const;
+
+describe("shortenAssetId", () => {
+  it("uses the first eight UUID characters for display", () => {
+    expect(shortenAssetId(BASE_ASSET.id)).toBe("195D0EF0");
+  });
+});
+
+describe("toAssetPresentation", () => {
+  it("builds a vehicle summary", () => {
+    const asset: AssetResponse = {
+      ...BASE_ASSET,
+      name: "Truck",
+      type: "vehicle",
+      metadata: { kind: "vehicle", make: "Ram", model: "2500", year: 2016 },
+    };
+
+    expect(toAssetPresentation(asset)).toMatchObject({
+      cat: "vehicle",
+      icon: "truck",
+      summary: "2016 Ram 2500",
+    });
+  });
+
+  it("builds a property summary", () => {
+    const asset: AssetResponse = {
+      ...BASE_ASSET,
+      name: "Main house",
+      type: "property",
+      metadata: {
+        kind: "property",
+        address: {
+          street: "12 Oak St",
+          city: "Portland",
+          state: "OR",
+          postalCode: "97204",
+          country: "United States",
+        },
+      },
+    };
+
+    expect(toAssetPresentation(asset)).toMatchObject({
+      cat: "property",
+      icon: "home",
+      summary: "12 Oak St, Portland, OR",
+    });
+  });
+
+  it("falls back gracefully when equipment details are blank", () => {
+    const asset: AssetResponse = {
+      ...BASE_ASSET,
+      name: "Pressure washer",
+      type: "equipment",
+      metadata: { kind: "equipment" },
+    };
+
+    expect(toAssetPresentation(asset)).toMatchObject({
+      cat: "equipment",
+      icon: "wrench",
+      summary: "Equipment details not added",
+    });
+  });
+});

--- a/apps/web/src/app/assetPresentation.ts
+++ b/apps/web/src/app/assetPresentation.ts
@@ -1,0 +1,67 @@
+import type { AssetResponse, AssetType } from "../api/assets";
+import type { IconName } from "../design/Icon";
+import type { AssetCategory } from "../design/hf";
+
+export type AssetPresentation = {
+  id: string;
+  displayId: string;
+  name: string;
+  cat: AssetCategory;
+  icon: IconName;
+  summary: string;
+};
+
+export function shortenAssetId(id: string): string {
+  return id.slice(0, 8).toUpperCase();
+}
+
+export function assetTypeLabel(type: AssetType): string {
+  switch (type) {
+    case "vehicle":
+      return "Vehicle";
+    case "property":
+      return "Property";
+    case "equipment":
+      return "Equipment";
+  }
+}
+
+export function toAssetPresentation(asset: AssetResponse): AssetPresentation {
+  const base = {
+    id: asset.id,
+    displayId: shortenAssetId(asset.id),
+    name: asset.name,
+  };
+
+  switch (asset.metadata.kind) {
+    case "vehicle":
+      return {
+        ...base,
+        cat: "vehicle",
+        icon: "truck",
+        summary: `${asset.metadata.year} ${asset.metadata.make} ${asset.metadata.model}`,
+      };
+    case "property":
+      return {
+        ...base,
+        cat: "property",
+        icon: "home",
+        summary: [
+          asset.metadata.address.street,
+          asset.metadata.address.city,
+          asset.metadata.address.state,
+        ].join(", "),
+      };
+    case "equipment": {
+      const summary = [asset.metadata.manufacturer, asset.metadata.modelNumber]
+        .filter(Boolean)
+        .join(" ");
+      return {
+        ...base,
+        cat: "equipment",
+        icon: "wrench",
+        summary: summary || asset.metadata.serialNumber || "Equipment details not added",
+      };
+    }
+  }
+}

--- a/apps/web/src/auth/AuthFlow.tsx
+++ b/apps/web/src/auth/AuthFlow.tsx
@@ -15,16 +15,11 @@ import "./styles/auth.css";
 type Mode = "login" | "signup";
 type Phase = "form" | "redirect";
 
-// Where the Better Auth endpoints live. In dev the API runs on its own port
-// (set VITE_API_URL=http://localhost:8787); in production web + API share a
-// hostname so the default empty base = same-origin /api/auth/*.
-const API_BASE = import.meta.env.VITE_API_URL ?? "";
-
 type SessionUser = { email: string; name?: string | null } | null;
 
 /** Kick off Better Auth's Google OAuth. Resolves the consent URL then navigates. */
 async function startGoogleSignIn() {
-  const res = await fetch(`${API_BASE}/api/auth/sign-in/social`, {
+  const res = await fetch("/api/auth/sign-in/social", {
     method: "POST",
     headers: { "content-type": "application/json" },
     credentials: "include",
@@ -273,7 +268,7 @@ export function AuthFlow() {
   // On load (and after returning from Google) check whether a session exists.
   useEffect(() => {
     let cancelled = false;
-    fetch(`${API_BASE}/api/auth/get-session`, { credentials: "include" })
+    fetch("/api/auth/get-session", { credentials: "include" })
       .then((r) => (r.ok ? r.json() : null))
       .then((data: { user?: SessionUser } | null) => {
         if (!cancelled) setSession(data?.user ?? null);
@@ -298,7 +293,7 @@ export function AuthFlow() {
     // Better Auth's /sign-out requires a JSON content-type AND a (non-empty)
     // JSON body — without the header it 415s, with the header but an empty body
     // it 500s on JSON.parse. Send "{}". The response clears the session cookies.
-    fetch(`${API_BASE}/api/auth/sign-out`, {
+    fetch("/api/auth/sign-out", {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: "{}",

--- a/apps/web/src/design/hf.tsx
+++ b/apps/web/src/design/hf.tsx
@@ -57,7 +57,7 @@ export function HFAssetThumb({
   asset,
   height = 132,
 }: {
-  asset: { cat: AssetCategory; icon: IconName; status: AssetStatus };
+  asset: { cat: AssetCategory; icon: IconName; status?: AssetStatus };
   height?: number;
 }) {
   return (
@@ -66,7 +66,7 @@ export function HFAssetThumb({
         <Icon name={asset.icon} size={Math.round(height * 0.36)} stroke={1.4} />
       </div>
       <span className="hf-asset-cat-badge">{CAT_LABELS[asset.cat]}</span>
-      <span className="hf-asset-status-dot" data-status={asset.status} />
+      {asset.status && <span className="hf-asset-status-dot" data-status={asset.status} />}
     </div>
   );
 }

--- a/apps/web/src/design/styles/hifi-assets.css
+++ b/apps/web/src/design/styles/hifi-assets.css
@@ -105,6 +105,10 @@
   background: var(--hf-ink);
   color: var(--hf-surface);
 }
+.hf-assets-toolbar-disabled :disabled {
+  cursor: not-allowed;
+  opacity: 0.62;
+}
 
 /* ============ The grid ============ */
 .hf-asset-grid {
@@ -139,6 +143,14 @@
 .hf-asset-card:focus-visible {
   outline: 2px solid var(--hf-ink);
   outline-offset: 2px;
+}
+.hf-asset-card-static {
+  cursor: default;
+}
+.hf-asset-card-static:hover {
+  border-color: var(--hf-line);
+  box-shadow: var(--hf-shadow-1);
+  transform: none;
 }
 
 /* overdue accent: left edge stripe + tinted thumb fade */
@@ -269,6 +281,14 @@
   border-top: 1px dashed var(--hf-line);
   padding-top: 10px;
 }
+.hf-asset-summary {
+  padding: 8px 14px 14px;
+  margin-top: auto;
+  border-top: 1px dashed var(--hf-line);
+  color: var(--hf-ink-soft);
+  font-size: 12.5px;
+  line-height: 1.35;
+}
 .hf-asset-footer-text {
   display: flex;
   flex-direction: column;
@@ -358,6 +378,12 @@
 .hf-asset-row:hover {
   border-color: oklch(80% 0.012 80);
 }
+.hf-asset-row-static {
+  cursor: default;
+}
+.hf-asset-row-static:hover {
+  border-color: var(--hf-line);
+}
 .hf-asset-row[data-status="overdue"] {
   border-color: oklch(85% 0.05 28);
 }
@@ -413,6 +439,11 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
+.hf-asset-row-summary {
+  color: var(--hf-ink-soft);
+  font-size: 12.5px;
+  line-height: 1.35;
+}
 
 .hf-row-add {
   display: flex;
@@ -432,6 +463,32 @@
   color: var(--hf-brand);
   border-color: var(--hf-brand);
   background: var(--hf-brand-bg);
+}
+
+/* ============ Loading, error, and empty states ============ */
+.hf-assets-state {
+  min-height: 240px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 32px;
+  border: 1px dashed var(--hf-line);
+  border-radius: var(--hf-r-lg);
+  background: var(--hf-surface);
+  text-align: center;
+}
+.hf-assets-state-title {
+  color: var(--hf-ink);
+  font-size: 16px;
+  font-weight: 600;
+}
+.hf-assets-state-sub {
+  max-width: 420px;
+  margin-bottom: 4px;
+  color: var(--hf-ink-soft);
+  font-size: 13px;
 }
 
 /* ===================================================================

--- a/apps/web/src/design/styles/hifi.css
+++ b/apps/web/src/design/styles/hifi.css
@@ -505,6 +505,10 @@
 .hf-btn:hover {
   background: var(--hf-surface-2);
 }
+.hf-btn:disabled {
+  cursor: wait;
+  opacity: 0.65;
+}
 .hf-btn-primary {
   background: var(--hf-ink);
   color: var(--hf-surface);

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,14 +1,19 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { RouterProvider } from "react-router";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import "./index.css";
 import { router } from "./router";
 
 const root = document.getElementById("root");
 if (!root) throw new Error("Root element #root not found");
 
+const queryClient = new QueryClient();
+
 createRoot(root).render(
   <StrictMode>
-    <RouterProvider router={router} />
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>
   </StrictMode>,
 );

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -7,4 +7,9 @@ import { cloudflare } from "@cloudflare/vite-plugin";
 // routes; everything else falls back to the SPA (see wrangler.jsonc).
 export default defineConfig({
   plugins: [react(), cloudflare()],
+  server: {
+    proxy: {
+      "/api": "http://localhost:8787",
+    },
+  },
 });

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -39,20 +39,28 @@ GOOGLE_CLIENT_SECRET=
 # Dev bypass: treat every request as this user, skipping the login flow.
 # Remove it to exercise the real Google session flow. NEVER set in production.
 DEV_AUTH_EMAIL=you@example.com
+
+# OAuth callbacks should return through Vite's same-origin /api proxy.
+BETTER_AUTH_URL=http://localhost:5173
 ```
 
 ## 4. Run
 
+Run the API Worker and web app in separate terminals:
+
 ```bash
-pnpm dev        # from repo root → http://localhost:8787
+pnpm --filter @snaveevans/pineapple-api dev   # http://localhost:8787
+pnpm --filter @snaveevans/pineapple-web dev   # http://localhost:5173
 ```
 
-Try it:
+The browser should use `http://localhost:5173`. Vite proxies same-origin
+`/api/*` requests to the API Worker. Try it:
 
 ```bash
 curl http://localhost:8787/health                 # {"status":"ok"}
 open http://localhost:8787/reference              # interactive API docs
 curl http://localhost:8787/api/assets             # works via DEV_AUTH_EMAIL bypass
+open http://localhost:5173/app/assets             # web app through the Vite proxy
 ```
 
 ## 5. Google OAuth (for the real login flow)
@@ -60,11 +68,11 @@ curl http://localhost:8787/api/assets             # works via DEV_AUTH_EMAIL byp
 1. Google Cloud Console → **APIs & Services → Credentials → Create OAuth client
    ID** → type **Web application**.
 2. **Authorized redirect URIs:**
-   - `http://localhost:8787/api/auth/callback/google`
+   - `http://localhost:5173/api/auth/callback/google`
    - `https://<your-prod-domain>/api/auth/callback/google`
 3. Put the client ID/secret in `.dev.vars` (local) and as Worker secrets (prod,
    step 7). Then sign in via
-   `http://localhost:8787/api/auth/sign-in/social?provider=google`.
+   `http://localhost:5173/api/auth/sign-in/social?provider=google`.
 
 ## 6. Quality gates
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -10,7 +10,9 @@ This page is the narrative guide. For the precise, machine-readable contract
 - **Static spec (in repo):** [`docs/reference/openapi.json`](openapi.json)
 - **Live spec:** `GET /openapi.json`
 - **Interactive docs (Scalar):** open `/reference` in a browser
-- Local base URL: `http://localhost:8787` · Production: `https://pineapple-api.tylerjevans.workers.dev`
+- Local API base URL: `http://localhost:8787` · Local browser requests:
+  same-origin `/api/*` through Vite at `http://localhost:5173` · Production:
+  same-origin `/api/*`
 
 The spec is generated from the Zod schemas, so it never drifts from the running
 code. If this prose and the spec disagree, the spec wins.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@tanstack/react-query':
+        specifier: ^5.100.14
+        version: 5.100.14(react@19.2.6)
       react:
         specifier: ^19.1.0
         version: 19.2.6
@@ -106,6 +109,9 @@ importers:
       vite:
         specifier: ^6.3.0
         version: 6.4.2(@types/node@25.9.1)(tsx@4.22.3)(yaml@2.9.0)
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@25.9.1)(tsx@4.22.3)(yaml@2.9.0)
       wrangler:
         specifier: ^4.95.0
         version: 4.95.0(@cloudflare/workers-types@4.20260525.1)
@@ -1408,6 +1414,14 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tanstack/query-core@5.100.14':
+    resolution: {integrity: sha512-5X41dGpxgeaHISCRW2oYwcSycZeULZzAunaudXT9ov1KOTj9xwt0CH6hbwqP1/z74ZWF7rYFnDpyYH07XFcZew==}
+
+  '@tanstack/react-query@5.100.14':
+    resolution: {integrity: sha512-oOr6aRdSFEwWhzxEkD/9ZcItM3+LjBSkeVmadWKwUssAHTsqd/7bOjWrX4AbvEkoEhgAxzN0Xk6H/aYzXiYBAw==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -3699,6 +3713,13 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@tanstack/query-core@5.100.14': {}
+
+  '@tanstack/react-query@5.100.14(react@19.2.6)':
+    dependencies:
+      '@tanstack/query-core': 5.100.14
+      react: 19.2.6
+
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.29.7
@@ -3868,6 +3889,14 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 7.3.3(@types/node@22.19.19)(tsx@4.22.3)(yaml@2.9.0)
+
+  '@vitest/mocker@3.2.4(vite@7.3.3(@types/node@25.9.1)(tsx@4.22.3)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.3(@types/node@25.9.1)(tsx@4.22.3)(yaml@2.9.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -5069,7 +5098,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.3(@types/node@22.19.19)(tsx@4.22.3)(yaml@2.9.0))
+      '@vitest/mocker': 3.2.4(vite@7.3.3(@types/node@25.9.1)(tsx@4.22.3)(yaml@2.9.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4


### PR DESCRIPTION
## Summary
- add a typed same-origin API client and TanStack Query provider for authenticated asset requests
- replace `/app/assets` fixtures with real list data and loading, empty, retry, and expired-session states
- wire `/app/assets/new` to create assets, map validation failures, invalidate the list cache, and navigate back after success
- remove unsupported prototype-only asset fields and disable list controls that are not wired yet
- proxy `/api/*` through Vite in development and fix API Worker route placement in `wrangler.toml`

## Developer impact
- local browser traffic stays same-origin on `http://localhost:5173`
- Vite forwards `/api/*` to the API Worker on `http://localhost:8787`
- Better Auth local callbacks should use `BETTER_AUTH_URL=http://localhost:5173`

## Validation
- `pnpm lint`
- `pnpm type-check`
- `pnpm -r test`
- `pnpm --filter @snaveevans/pineapple-web build`
- `wrangler deploy --dry-run`
- live Vite proxy check for `/api/assets`
- browser verification for unauthenticated redirect and add-asset validation