### PR TITLE
Add spec-driven development system and cross-cutting specs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,7 @@ secrets, never committed.
 ## Where to look
 
 - **Why** anything is built a certain way → [`docs/decisions/`](docs/decisions/) (ADRs, MADR format)
+- **What a feature is supposed to do** → [`docs/specs/`](docs/specs/) (intent ledger; index at `docs/specs/SPECS.md`)
 - **API contract** → [`docs/reference/api.md`](docs/reference/api.md), `docs/reference/openapi.json`
 - **Data shapes** → [`docs/reference/data-model.md`](docs/reference/data-model.md)
 - **Product features** → [`docs/product/features.md`](docs/product/features.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ this repo.
 | --------------- | ---------------------------------------- | ------------------------------- | -------------------------- |
 | Front door      | `README.md`, `CLAUDE.md`                 | hand-written                    | newcomers · AI agents      |
 | Decisions (ADR) | `docs/decisions/`                        | hand-written                    | engineers (the _why_)      |
+| Specs           | `docs/specs/`                            | hand-written                    | everyone (the _what_)      |
 | API reference   | `docs/reference/api.md` + `openapi.json` | **generated from Zod**          | UI/integration devs · LLMs |
 | Data model      | `docs/reference/data-model.md`           | hand-written, mirrors `domain/` | designers · devs           |
 | Product         | `docs/product/`                          | hand-written                    | PM · marketing             |
@@ -26,8 +27,8 @@ this repo.
   (`/openapi.json`, `/reference`); `reference/data-model.md` for field details.
 - **Designer** → `reference/data-model.md` (what data and which enums exist) and
   `product/features.md` (what flows are possible).
-- **Product manager** → `product/features.md` (what we have) and
-  `product/roadmap.md` (gaps & opportunities).
+- **Product manager** → `specs/SPECS.md` (intent ledger) and `product/features.md`
+  (what we have) and `product/roadmap.md` (gaps & opportunities).
 - **Marketing** → `product/features.md` (benefit-framed capability list).
 - **AI agent** → `CLAUDE.md` is the hub; everything is linked and, where
   possible, machine-readable.

--- a/docs/specs/SPECS.md
+++ b/docs/specs/SPECS.md
@@ -1,0 +1,62 @@
+> **Audience:** everyone · **Purpose:** authoritative map of all feature and cross-cutting specs · **Source of truth:** this file · **Last reviewed:** 2026-06-01
+
+# Spec Index
+
+The spec system captures _intent_ — what a feature is supposed to do and why —
+so the objective record survives as code changes over time. Specs are not API
+contracts (those live in `openapi.json`) and not decisions about _how_ we built
+something (those live in `docs/decisions/`). They answer: **what should this
+do, for whom, and under what conditions?**
+
+See `templates/` for blank starting points and `prompts/` for AI prompts that
+generate or sync specs from code and PRs.
+
+## Cross-Cutting Specs
+
+Concerns that apply to every feature. When writing a feature spec, reference the
+relevant cross-cutting specs rather than re-describing the behavior.
+
+| Spec                                                   | Concern                         | Status |
+| ------------------------------------------------------ | ------------------------------- | ------ |
+| [authentication.md](./cross-cutting/authentication.md) | Auth, sessions, identity        | draft  |
+| [error-handling.md](./cross-cutting/error-handling.md) | Error states and user messaging | draft  |
+| [permissions.md](./cross-cutting/permissions.md)       | Role-based access control       | draft  |
+| [validation.md](./cross-cutting/validation.md)         | Input validation patterns       | draft  |
+| [loading-states.md](./cross-cutting/loading-states.md) | Async UI states                 | draft  |
+
+## Feature Specs
+
+| Spec | Area | Status |
+| ---- | ---- | ------ |
+
+## Directory Structure
+
+```
+docs/specs/
+  SPECS.md                        ← this file
+  templates/
+    feature-spec.template.md      ← blank feature spec
+    cross-cutting.template.md     ← blank cross-cutting spec
+  prompts/
+    retro-feature.md              ← AI prompt: generate spec from existing code
+    retro-cross-cutting.md        ← AI prompt: identify cross-cutting concerns
+    pr-sync.md                    ← AI prompt: sync spec after a PR merges
+  cross-cutting/
+    authentication.md
+    error-handling.md
+    permissions.md
+    validation.md
+  features/
+    [feature-name].md
+```
+
+## Workflow
+
+**Starting a new feature:** copy `templates/feature-spec.template.md` into
+`features/`, fill it out before writing code, then link it here.
+
+**Retroactively documenting existing code:** use the prompt in
+`prompts/retro-feature.md`, review the output, and file it as a spec.
+
+**After a PR merges:** run `prompts/pr-sync.md` against the diff to classify
+changes and update the spec if behavior changed.

--- a/docs/specs/SPECS.md
+++ b/docs/specs/SPECS.md
@@ -18,11 +18,12 @@ relevant cross-cutting specs rather than re-describing the behavior.
 
 | Spec                                                   | Concern                         | Status |
 | ------------------------------------------------------ | ------------------------------- | ------ |
-| [authentication.md](./cross-cutting/authentication.md) | Auth, sessions, identity        | draft  |
-| [error-handling.md](./cross-cutting/error-handling.md) | Error states and user messaging | draft  |
-| [permissions.md](./cross-cutting/permissions.md)       | Role-based access control       | draft  |
-| [validation.md](./cross-cutting/validation.md)         | Input validation patterns       | draft  |
-| [loading-states.md](./cross-cutting/loading-states.md) | Async UI states                 | draft  |
+| [authentication.md](./cross-cutting/authentication.md) | Auth, sessions, identity        | active |
+| [error-handling.md](./cross-cutting/error-handling.md) | Error states and user messaging | active |
+| [permissions.md](./cross-cutting/permissions.md)       | Role-based access control       | active |
+| [validation.md](./cross-cutting/validation.md)         | Input validation patterns       | active |
+| [loading-states.md](./cross-cutting/loading-states.md) | Async UI states                 | active |
+| [telemetry.md](./cross-cutting/telemetry.md)           | Telemetry and observability     | active |
 
 ## Feature Specs
 

--- a/docs/specs/cross-cutting/authentication.md
+++ b/docs/specs/cross-cutting/authentication.md
@@ -1,0 +1,62 @@
+---
+audience: all contributors
+purpose: canonical auth behavior for feature specs
+source: this file
+date: 2026-06-02
+---
+
+# Authentication — Cross-Cutting Spec
+
+**Status:** `active`
+**Owner:** engineering
+**Applies To:** All features unless listed in Exceptions
+
+---
+
+## Summary
+
+All application features operate within an authenticated session. Better Auth handles the OAuth flow and session cookie lifecycle; the backend resolves a domain `User` from that session on every protected request. Features must never assume identity — they must receive it from the resolved session context.
+
+## Canonical Behavior
+
+**Backend:**
+
+- Better Auth is mounted at `/api/auth/*` and owns the `user`, `session`, `account`, and `verification` tables.
+- All `/api/*` routes outside `/api/auth/*` are protected by the `BetterAuthResolver` middleware registered in `worker.ts`.
+- The middleware calls `resolver.resolve()`, which reads the session cookie, validates it, and provisions a domain `User` JIT from the Better Auth record (keyed on email).
+- If no valid session exists, the middleware throws `UnauthorizedError` → 401.
+- In local development, `DEV_AUTH_EMAIL` in `.dev.vars` bypasses session validation and injects a synthetic user. This must never reach production.
+
+**Frontend:**
+
+- All `fetch` calls include `credentials: "include"` so the session cookie is sent automatically.
+- App routes (`/app/*`) are client-rendered and accessible at the page-load level without a session. There is no route guard that prevents a page from rendering before auth is confirmed. Auth is enforced by API responses, not by route access: a protected page renders, makes its first API call, and redirects to login on a 401.
+- 401 responses from any API call are treated as a signal to redirect to the login screen. This check belongs in the API client layer, not in individual feature components.
+
+## Feature Integration Contract
+
+Every feature spec must document:
+
+- Whether the feature is accessible unauthenticated (only the routes listed in Exceptions qualify).
+- Whether the feature uses the resolved `User.id` as a domain input (e.g., as `requesterId` or `ownerId`).
+
+## Exceptions
+
+| Feature                           | Deviation                     | Reason                                                          |
+| --------------------------------- | ----------------------------- | --------------------------------------------------------------- |
+| Google OAuth flow (`/api/auth/*`) | Unauthenticated by definition | Initiates the session; cannot require one                       |
+| Marketing / landing page          | Unauthenticated               | Public content, no domain data                                  |
+| `GET /health`                     | Unauthenticated               | Operational liveness check; must be reachable without a session |
+| `GET /openapi.json`               | Unauthenticated               | Public API spec                                                 |
+| `GET /reference`                  | Unauthenticated               | Public API documentation UI                                     |
+
+## Anti-Patterns
+
+- **Checking the session inside a route handler:** Route handlers receive the resolved `User` from middleware context — they must not re-read the session cookie or call Better Auth directly.
+- **Hardcoding `DEV_AUTH_EMAIL` values in tests:** Use the test harness auth injection instead. `DEV_AUTH_EMAIL` is a local-dev escape hatch only.
+- **Handling 401 inside individual React components:** 401s must be caught at the API client layer and trigger a single centralized redirect. Duplicating this in each feature creates silent divergence.
+
+## Known Issues
+
+- Frontend 401 handling is currently duplicated: `AppAssets.tsx` catches 401 from React Query and navigates to `/login` directly, rather than delegating to a centralized interceptor in the API client. Every new feature that fetches data will need the same fix until this is consolidated.
+- Session state in `AuthFlow.tsx` uses a bespoke three-value convention (`undefined` = checking, `null` = logged out, `Session` object = logged in) that is not shared with the rest of the app. See the Loading States spec for the exception rationale.

--- a/docs/specs/cross-cutting/error-handling.md
+++ b/docs/specs/cross-cutting/error-handling.md
@@ -1,0 +1,72 @@
+---
+audience: all contributors
+purpose: canonical error flow for feature specs
+source: this file
+date: 2026-06-02
+---
+
+# Error Handling — Cross-Cutting Spec
+
+**Status:** `active`
+**Owner:** engineering
+**Applies To:** All features unless listed in Exceptions
+
+---
+
+## Summary
+
+Errors flow from the domain outward through a typed hierarchy. Use cases express failure as `Result<T, DomainError>`; HTTP handlers throw the error to a central handler that maps it to the correct status code and response shape. The frontend deserializes this shape into an `ApiError` class for uniform handling.
+
+## Canonical Behavior
+
+**Domain error types (`packages/shared/src/errors.ts`):**
+
+| Subclass            | HTTP status | Meaning                                                      |
+| ------------------- | ----------- | ------------------------------------------------------------ |
+| `NotFoundError`     | 404         | Entity does not exist or is not visible to the requester     |
+| `UnauthorizedError` | 401         | No valid session                                             |
+| `ForbiddenError`    | 403         | Session is valid but requester lacks access to this resource |
+| `ValidationError`   | 422         | Input failed a domain rule; carries an optional `field` name |
+| `ConflictError`     | 409         | Operation would violate a uniqueness or state constraint     |
+| `InvariantError`    | 500         | Internal invariant violated; a bug, not a user error         |
+
+**Backend flow:**
+
+1. Use cases return `ok(value)` or `err(domainError)` — they never throw domain errors.
+2. Route handlers check `.ok`; if false, they `throw result.error`.
+3. The global `app.onError` in `worker.ts` catches everything: domain errors are mapped via `toHttpError()`; non-domain errors are logged and returned as a generic 500.
+4. Zod validation failures are caught by Hono's `defaultHook` before the handler runs, returning 422 with `{ error: string; field?: string }`.
+
+**Response envelope:** All app error responses follow `{ error: string; field?: string }`. Routes under `/api/auth/*` are delegated to Better Auth and are not processed by `app.onError`, so their error shapes are not guaranteed to conform to this envelope.
+
+**Frontend:**
+
+- `apiRequest()` in `apps/web/src/api/client.ts` constructs `ApiError(status, body)` for any non-2xx response.
+- Callers access `.status`, `.message`, and `.field` to branch on error type.
+- Field errors are mapped back to form field keys via `toAssetFormError()`.
+
+## Feature Integration Contract
+
+Every feature spec must document:
+
+- Which domain errors the feature can produce and under what conditions.
+- For each user-visible error, the message or UI treatment shown to the user.
+- Any field-level validation errors and which form field they map to.
+
+## Exceptions
+
+| Feature       | Deviation                     | Reason                                                                                                         |
+| ------------- | ----------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `/api/auth/*` | Error envelope not guaranteed | Routes are delegated directly to Better Auth and bypasses `app.onError`; Better Auth owns its own error shapes |
+
+## Anti-Patterns
+
+- **Throwing domain errors from use cases:** Use cases must return `err(...)`, never `throw`. Only route handlers throw, so the global handler cleanly owns the HTTP mapping boundary.
+- **Catching errors in route handlers:** Handlers call `throw result.error` and trust `app.onError`. Adding a local try-catch in a handler bypasses central mapping.
+- **Using non-domain error classes:** Throwing a plain `Error` or a class that does not extend `DomainError` will always produce a 500. Either it is a domain error (use the right subclass) or it is a bug (let it 500).
+- **Different error envelopes in individual routes:** Every error must follow `{ error: string; field?: string }`. The frontend `ApiError` parser depends on this contract.
+
+## Known Issues
+
+- **`InvariantError` responses expose `error.message` to the caller.** `toHttpError()` currently includes the domain error message in the response body for all error types, including `InvariantError`. For a 500, this may leak internal implementation details to API callers. **Planned:** decide whether `InvariantError` responses should include the message or return a generic `"Internal server error"` string, and enforce that policy in `toHttpError()`.
+- **Unhandled errors are not wrapped before re-throwing.** When a use case encounters an unexpected exception (e.g., a database failure), it re-throws the raw error rather than wrapping it in `InvariantError`. The error surfaces as a generic 500 with no domain context. **Planned:** use cases should catch unexpected errors and return `err(new InvariantError(...))` so the `Result` pattern stays consistent all the way to the handler and the error carries structured context.

--- a/docs/specs/cross-cutting/loading-states.md
+++ b/docs/specs/cross-cutting/loading-states.md
@@ -1,0 +1,70 @@
+---
+audience: all contributors
+purpose: canonical async UI state pattern for feature specs
+source: this file
+date: 2026-06-02
+---
+
+# Loading States — Cross-Cutting Spec
+
+**Status:** `active`
+**Owner:** engineering
+**Applies To:** All features with async data (fetching or mutating)
+
+---
+
+## Summary
+
+All async data operations in the frontend use React Query. Features must handle three observable states for reads (loading, error, data) and two for writes (pending, error). The UI must never show a blank or broken state — every async path requires an explicit treatment.
+
+## Canonical Behavior
+
+**Reads (queries):**
+
+Use `useQuery()`. Map states as follows:
+
+| State                     | UI treatment                                            |
+| ------------------------- | ------------------------------------------------------- |
+| `isPending`               | Loading indicator with a title and descriptive message  |
+| `isError`                 | Error state with a retry action                         |
+| `data` (populated)        | Render content                                          |
+| `data` (empty collection) | Empty state with a call-to-action; this is not an error |
+
+**Writes (mutations):**
+
+Use `useMutation()`:
+
+- `isPending` → disable the submit control and update its label (e.g., "Saving...")
+- `isError` → show an inline error banner; map field errors to individual inputs via the feature's error-mapping function
+- On success → invalidate the relevant query cache, then navigate or close
+- When the user modifies input after a failed submit → call `mutation.reset()` to clear the error state
+
+**Empty state:** An empty collection is not an error. It must render an explicit empty state with a call-to-action pointing to the creation flow.
+
+## Feature Integration Contract
+
+Every feature spec must document:
+
+- The loading state treatment for each async read (what appears during `isPending`).
+- The error state treatment for each async read (what appears, whether retry is offered).
+- The empty state treatment for any collection view.
+- Whether the feature disables or relabels controls during mutation `isPending`.
+- How mutation errors are cleared when the user resumes editing.
+
+## Exceptions
+
+| Feature   | Deviation                                                                                | Reason                                                                                        |
+| --------- | ---------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| Auth flow | Uses three-value session state (`undefined` / `null` / `Session`) instead of React Query | Auth lifecycle drives routing before React Query context is available; it is not a data query |
+
+## Anti-Patterns
+
+- **Rendering nothing during `isPending`:** Every async branch must produce visible UI. A blank area while data loads is a bug.
+- **Using the three-value session pattern for feature data:** That pattern is confined to `AuthFlow.tsx`. Feature data must use React Query.
+- **Ignoring the empty-collection case:** `data.items ?? []` being empty is a distinct UI state — rendering an empty list without an empty state is a poor experience.
+- **Leaving mutation errors visible after the user corrects input:** Call `mutation.reset()` when the user modifies input after a failed submit.
+
+## Known Issues
+
+- `HFAssetsState` (the loading/error/empty state component) is defined inside the assets feature and not yet part of the design system. A second list feature would need to either import from the wrong layer or duplicate the component. Future work: lift into `design/` or a shared component layer.
+- Two distinct async state paradigms coexist in the codebase: React Query (canonical) and the three-value session state in `AuthFlow.tsx` (exception). The exception is documented above, but developers new to the codebase may reach for the wrong pattern without knowing which applies where.

--- a/docs/specs/cross-cutting/permissions.md
+++ b/docs/specs/cross-cutting/permissions.md
@@ -1,0 +1,59 @@
+---
+audience: all contributors
+purpose: canonical ownership and access model for feature specs
+source: this file
+date: 2026-06-02
+---
+
+# Permissions & Ownership — Cross-Cutting Spec
+
+**Status:** `active`
+**Owner:** engineering
+**Applies To:** All features unless listed in Exceptions
+
+---
+
+## Summary
+
+The access model is single-tenant by user: every domain entity is owned by the `User` who created it. No roles, groups, or ACL exist. Ownership is enforced in two layers — at the repository query for collections, and at the use case for single-resource access.
+
+## Canonical Behavior
+
+**Ownership assignment:** On creation, the authenticated `User.id` is stored as `ownerId` on the entity. This is set by the use case using the `requesterId` passed from the route handler; it is never accepted from the API caller.
+
+**Collection access:** Repository queries always filter by `ownerId = requesterId`. An entity belonging to another user is invisible — it does not appear in lists and its existence is not revealed.
+
+**Single-resource access:** Use cases fetch by ID, then explicitly check `entity.ownerId !== requesterId`. Current behavior:
+
+- Entity exists, belongs to requester → proceed
+- Entity exists, belongs to another user → `err(new ForbiddenError(...))` → 403
+- Entity does not exist → `err(new NotFoundError(...))` → 404
+
+Note: the 403 vs 404 response for wrong-owner access has not been explicitly decided. See Known Issues.
+
+## Feature Integration Contract
+
+Every feature spec must document:
+
+- Whether the feature creates an owned entity, and confirm that `ownerId` is derived from the session `requesterId`, not the request body.
+- Whether the feature reads a single owned entity, and confirm that the post-fetch ownership check is present.
+- Whether the feature lists entities, and confirm that the repository query filters by `ownerId`.
+- If the feature involves sharing, delegation, or multi-user access, it must explicitly note that the current model does not support this and describe the required extension.
+
+## Exceptions
+
+| Feature | Deviation | Reason |
+| ------- | --------- | ------ |
+
+## Anti-Patterns
+
+- **Accepting `ownerId` from the request body:** Callers must never supply their own owner. The use case always derives it from the authenticated session.
+- **Listing without an ownership filter:** Querying all entities without filtering by `ownerId` leaks cross-user data.
+- **Returning 404 for forbidden single-resource access:** The canonical behavior is 403 for existence-but-forbidden. Returning 404 instead loses information and must be documented as an explicit exception if ever justified.
+
+## Known Issues
+
+- **403 vs 404 on wrong-owner single-resource access has not been decided.** The current code returns 403, which reveals that the entity exists but the requester cannot access it. An alternative is to return 404 unconditionally to avoid leaking existence. **Planned:** make a deliberate call, document the rationale here, and update the Canonical Behavior section accordingly.
+- **Different enforcement mechanisms for collections vs single resources.** Collections filter at the repo-query level; single resources check post-fetch at the use-case level. Both enforce the same invariant but in different places — a new repository method could accidentally skip the ownership filter without a compile-time signal. **Planned:** consider making `ownerId` a non-optional parameter on all repo read methods so the constraint is impossible to omit.
+- **Mutation ownership pattern not established.** Update and delete are not yet implemented. When added, they should follow the single-resource pattern (fetch → ownership check → mutate). This spec should be updated when the first mutation is added.
+- **Archived resource visibility is inconsistent.** Collection queries filter out archived assets, but single-resource access by ID does not exclude archived entities. Whether an archived but owned asset should be readable via direct ID lookup has not been decided. **Planned:** define the access policy for archived resources and apply it consistently across both collection and single-resource access.

--- a/docs/specs/cross-cutting/telemetry.md
+++ b/docs/specs/cross-cutting/telemetry.md
@@ -1,0 +1,163 @@
+---
+audience: all contributors
+purpose: canonical telemetry architecture and data contract for feature specs
+source: this file
+date: 2026-06-02
+---
+
+# Telemetry — Cross-Cutting Spec
+
+**Status:** `active`
+**Owner:** engineering
+**Applies To:** All features that add API endpoints or domain events
+
+---
+
+## Summary
+
+Telemetry is split into two independent systems: request-level telemetry (every HTTP request, captured in middleware) and domain-event telemetry (business events, captured in event handlers). Both write to Cloudflare Analytics Engine. Telemetry failures are never blocking — they are logged and swallowed so an Analytics Engine outage cannot break the API.
+
+## Canonical Behavior
+
+### Two Systems
+
+| System       | Dataset                         | Trigger                             | Capture point                        |
+| ------------ | ------------------------------- | ----------------------------------- | ------------------------------------ |
+| API Request  | `pineapple_api_request_events`  | Every HTTP request                  | `createTechnicalTelemetryMiddleware` |
+| Domain Event | `pineapple_asset_domain_events` | Domain event published to event bus | Per-event telemetry handler          |
+
+The two systems are complementary, not interchangeable. API request telemetry answers operational questions (latency, error rates, traffic). Domain event telemetry answers business questions (what entities were created, by whom, with what attributes).
+
+### Data Shape
+
+Both systems write to Cloudflare Analytics Engine using the same envelope:
+
+```ts
+{
+  indexes: string[]   // partition/lookup key — one value
+  blobs:   string[]   // categorical dimensions
+  doubles: number[]   // numeric measurements
+}
+```
+
+**API Request data point** (index: `operation`):
+
+| Field        | Name                 | Value                                                                                          |
+| ------------ | -------------------- | ---------------------------------------------------------------------------------------------- |
+| `indexes[0]` | —                    | Operation name (e.g. `"CreateAsset"`)                                                          |
+| `blobs[0]`   | `operation`          | Operation name                                                                                 |
+| `blobs[1]`   | `route_pattern`      | Route pattern (e.g. `"/api/assets/{id}"`)                                                      |
+| `blobs[2]`   | `method`             | HTTP method (`"GET"`, `"POST"`, …)                                                             |
+| `blobs[3]`   | `status_class`       | `"2xx"`, `"4xx"`, `"5xx"`                                                                      |
+| `blobs[4]`   | `status_code`        | HTTP status code as string                                                                     |
+| `blobs[5]`   | `outcome`            | `"success"`, `"failure"`, `"error"`                                                            |
+| `blobs[6]`   | `error_name`         | Error constructor name, `"unknown"` for non-`Error` values, or `"none"` when no error occurred |
+| `blobs[7]`   | `authenticated`      | `"true"` or `"false"`                                                                          |
+| `blobs[8]`   | `schema_version`     | `"v1"`                                                                                         |
+| `doubles[0]` | `duration_ms`        | Duration (ms)                                                                                  |
+| `doubles[1]` | `count`              | Always `1`                                                                                     |
+| `doubles[2]` | `status_code_number` | HTTP status code (numeric)                                                                     |
+| `doubles[3]` | `request_size_bytes` | Request size (bytes)                                                                           |
+
+> Analytics Engine SQL references blobs and doubles as 1-indexed (`blob1` = `blobs[0]`, `double1` = `doubles[0]`).
+
+**Domain event data point — `AssetCreated`** (dataset: `pineapple_asset_domain_events`, index: `owner_id`):
+
+| Field        | Name               | Value                                                                          |
+| ------------ | ------------------ | ------------------------------------------------------------------------------ |
+| `indexes[0]` | —                  | `owner_id` (partition key for per-owner queries)                               |
+| `blobs[0]`   | `event_type`       | `"AssetCreated"`                                                               |
+| `blobs[1]`   | `aggregate_type`   | `"Asset"`                                                                      |
+| `blobs[2]`   | `asset_id`         | Asset UUID                                                                     |
+| `blobs[3]`   | `owner_id`         | Owner UUID                                                                     |
+| `blobs[4]`   | `asset_type`       | `"vehicle"`, `"property"`, `"equipment"`                                       |
+| `blobs[5]`   | `actor_id`         | UUID of the user who performed the action — currently always equals `owner_id` |
+| `blobs[6]`   | `source_use_case`  | `"CreateAsset"`                                                                |
+| `blobs[7]`   | `schema_version`   | `"v1"`                                                                         |
+| `blobs[8]`   | `result`           | `"success"`                                                                    |
+| `doubles[0]` | `count`            | Always `1`                                                                     |
+| `doubles[1]` | `event_time_ms`    | Event timestamp (ms since epoch)                                               |
+| `doubles[2]` | `asset_model_year` | Model year for vehicles; `0` for other asset types                             |
+
+### Analytics Engine Constraints
+
+These limits apply to every data point written and must be respected when designing new event schemas:
+
+- Max 20 blobs, 20 doubles, and 1 index per `writeDataPoint` call
+- Total blob payload per data point must be under 16 KB
+- Index field must be 96 bytes or less
+- A single Worker invocation may write at most 250 data points
+- Data retention is 3 months — Analytics Engine is not an audit log, replay log, or long-term event store
+- SQL queries must account for `_sample_interval` when aggregating (e.g. `SUM(_sample_interval * double1)`)
+- SQL blob/double references are 1-indexed (`blob1` = `blobs[0]`, `double1` = `doubles[0]`)
+
+### Planned Datasets
+
+| Dataset                               | Binding                        | Purpose                              |
+| ------------------------------------- | ------------------------------ | ------------------------------------ |
+| `pineapple_asset_domain_events`       | `ASSET_DOMAIN_TELEMETRY`       | Asset lifecycle events — implemented |
+| `pineapple_api_request_events`        | `API_REQUEST_TELEMETRY`        | HTTP request telemetry — implemented |
+| `pineapple_maintenance_domain_events` | `MAINTENANCE_DOMAIN_TELEMETRY` | Maintenance record events — planned  |
+
+### Operation Name Mapping
+
+Every API route maps to a named operation used as the `indexes[0]` value in request telemetry. The current mapping:
+
+| Route                  | Operation         |
+| ---------------------- | ----------------- |
+| `/api/auth/*`          | `Auth`            |
+| `POST /api/assets`     | `CreateAsset`     |
+| `GET /api/assets`      | `ListAssets`      |
+| `GET /api/assets/{id}` | `GetAsset`        |
+| `GET /health`          | `Health`          |
+| `GET /openapi.json`    | `OpenApiDocument` |
+| `GET /reference`       | `ApiReference`    |
+| (anything else)        | `Unknown`         |
+
+### Failure Policy
+
+Telemetry failures are non-blocking at every layer:
+
+1. `AnalyticsEngineTelemetrySink.write()` wraps `dataset.writeDataPoint()` in try-catch — errors are logged with `console.error` and swallowed.
+2. The request telemetry middleware wraps the sink call in a second try-catch for the same reason.
+3. The `InMemoryEventBus` catches handler errors (including domain telemetry handlers) per-handler and logs them without re-throwing.
+
+A complete Analytics Engine outage will produce `console.error` log entries but will not affect API responses.
+
+## Feature Integration Contract
+
+**Adding a new API endpoint:**
+
+- Add an entry to the operation name mapping in the request telemetry middleware.
+- For use-case-backed routes, the operation name must match the use case name (e.g. `UpdateAsset`, `ArchiveAsset`). For system routes with no use case (health checks, API docs), use a descriptive label as shown in the Operation Name Mapping table.
+- The spec for the feature must name the operation it maps to.
+
+**Adding a new domain event:**
+
+- Create a telemetry handler for the event (following `AssetCreatedTelemetryHandler` as the pattern).
+- Register the handler in `registerDomainTelemetry()`.
+- The spec for the feature must define the full ordered `blobs` and `doubles` contract for the event — every position, its name, and its value. Use the `AssetCreated` table above as the model. Future events (e.g. `MaintenanceRecorded`) may use multiple domain-specific doubles; document each one explicitly.
+
+## Exceptions
+
+| Feature                                | Deviation                 | Reason                                                                           |
+| -------------------------------------- | ------------------------- | -------------------------------------------------------------------------------- |
+| Frontend                               | No telemetry              | Client-side instrumentation not yet implemented                                  |
+| Read operations (GetAsset, ListAssets) | No domain event telemetry | Reads do not produce domain events; request telemetry provides sufficient signal |
+
+## Anti-Patterns
+
+- **Throwing on telemetry failure:** Telemetry must never break a request. All sink calls must be wrapped so errors are swallowed after logging.
+- **Adding an endpoint without an operation name:** Routes that fall through to `"Unknown"` are invisible in telemetry. Every new route needs an entry in the mapping before it ships.
+- **Storing PII in blobs:** Blobs are retained and queryable. Never store user-supplied strings (names, addresses, emails, VINs, serial numbers, raw request bodies) in telemetry fields. For user and entity identifiers use stable non-PII IDs (UUIDs); categorical enum values (operation names, asset types, status codes, schema versions) are fine.
+- **Telemetry in the domain or application layer:** Telemetry handlers live in `infrastructure/telemetry/`. The domain publishes events; infrastructure decides what to record. Never import Analytics Engine bindings, sinks, or Hono from `domain/` or `application/`.
+- **Re-querying D1 inside a telemetry handler:** If a field is needed in telemetry, it must be part of the domain event payload. Handlers must not make additional database calls.
+- **Using Analytics Engine as an audit log or event store:** Retention is 3 months, writes are sampled, and exact replay is not supported. Use D1, R2, or Logpush for exact records.
+- **Using asset IDs or random UUIDs as the index:** The index is the query partition key. Use `owner_id` for domain events and `operation` for request telemetry, not high-cardinality random IDs.
+
+## Known Issues
+
+- **`actor_id` (`blobs[5]`) always equals `owner_id` (`blobs[3]`) today.** `actor_id` records who performed the action, which is semantically distinct from who owns the entity. In a system where only the owner can act, the two are the same. When delegation or assignment is introduced — where one user acts on another's behalf — `actor_id` will diverge from `owner_id`. The field is intentionally reserved for this future case.
+- **No request correlation across the two systems.** A domain event data point cannot be linked to the API request that produced it — there is no trace ID or correlation ID shared between them. **Planned:** generate a request-scoped correlation ID in the telemetry middleware, thread it through to domain events via the use case, and include it in both data points.
+- **No frontend telemetry.** User-facing errors and interactions are invisible unless they produce an API call that fails. **Planned:** define what frontend events are worth capturing before implementing, to avoid instrumenting noise.
+- **Telemetry is always active in all environments.** There is no reduced or disabled telemetry mode for local development — `wrangler dev` writes to Miniflare's Analytics Engine emulation at the same 100% sample rate as production. This is acceptable now but should be revisited if local test runs begin polluting a shared dev dataset.

--- a/docs/specs/cross-cutting/validation.md
+++ b/docs/specs/cross-cutting/validation.md
@@ -1,0 +1,67 @@
+---
+audience: all contributors
+purpose: canonical validation pattern for feature specs
+source: this file
+date: 2026-06-02
+---
+
+# Validation — Cross-Cutting Spec
+
+**Status:** `active`
+**Owner:** engineering
+**Applies To:** All features with user input
+
+---
+
+## Summary
+
+Input is validated at two distinct boundaries: the HTTP edge (Zod) and the domain (entity constructors and value objects). The frontend performs pre-submit validation as a UX convenience only — it is not authoritative. All validation ultimately runs on the backend.
+
+## Canonical Behavior
+
+**HTTP boundary (authoritative):**
+
+- Zod schemas in `apps/api/src/api/schemas/` use `@hono/zod-openapi` — they are the single source of truth for field types, required vs optional, and string constraints.
+- `c.req.valid("json")` / `c.req.valid("param")` enforce the schema before the handler runs. Failures are caught by Hono's `defaultHook` and returned as 422 with `{ error: string; field?: string }`.
+- Schemas carry `.openapi()` metadata and drive the generated OpenAPI spec. Never duplicate field definitions in docs.
+- Use `.refine()` instead of `.max()` for dynamic upper bounds (e.g., current year) because the Workers runtime can freeze the clock at deploy time.
+
+**Domain boundary:**
+
+- Entity constructors and value objects (`Asset.create()`, `Email.from()`, `validateMetadata()`) validate business rules that Zod cannot express (e.g., internal consistency across fields, format rules beyond simple string constraints).
+- Domain validation throws `ValidationError(message, field)` where `field` uses dot-notation for nested paths (e.g., `"metadata.vin"`).
+- Domain validation catches invalid states that would corrupt the data model. It is not a substitute for Zod — both layers run.
+
+**Frontend (UX convenience only):**
+
+- `validateAssetForm()` catches obvious errors before a network round-trip to reduce friction.
+- It must not be the only line of defense — the backend always re-validates.
+- `toAssetFormError()` maps API error `field` paths (dot-notation) back to form field keys for inline display.
+
+## Feature Integration Contract
+
+Every feature spec must document:
+
+- The Zod schema file that validates the feature's inputs.
+- Which fields are required vs optional and their constraints.
+- Any domain validation rules that apply beyond Zod.
+- How validation errors are surfaced to the user (field-level inline, banner, or both).
+
+## Exceptions
+
+| Feature | Deviation | Reason |
+| ------- | --------- | ------ |
+
+## Anti-Patterns
+
+- **Validating in the route handler body:** Validation runs automatically via `c.req.valid()`. Adding manual checks in the handler duplicates logic and breaks the Zod → OpenAPI chain.
+- **Using `.max(new Date().getFullYear())` on year fields:** Workers can freeze the clock; use `.refine(val => val <= new Date().getFullYear(), ...)` instead.
+- **Trusting frontend validation as authoritative:** Frontend validation can be bypassed. All constraints must be enforced on the backend.
+- **Inventing field names in `toAssetFormError()`:** The mapping must match the exact dot-notation paths produced by domain validation. Any mismatch silently drops a field error.
+
+## Known Issues
+
+- **Path IDs are not validated as UUIDs at the HTTP boundary.** `AssetIdParamSchema` accepts any non-empty string, and `AssetId.from()` is a type cast rather than a validated parse. A malformed ID passes the Zod layer and reaches the repository. **Planned:** add UUID format validation to path ID schemas so malformed IDs are rejected with a 422 at the HTTP boundary before reaching the domain.
+- Validation rules are expressed in three places: Zod schemas (backend HTTP boundary), domain methods (backend domain layer), and `validateAssetForm()` (frontend). The frontend rules are hand-maintained duplicates — they can drift from the backend without any compile-time signal. No mechanism currently exists to keep them in sync.
+- Vehicle year validation uses `.refine()` correctly on the backend, but the frontend validates year as a plain number comparison. If the upper bound logic changes, the frontend will not follow automatically.
+- Domain validation error `field` paths use dot-notation nesting, but `toAssetFormError()` maps only the known paths from the current schema. New nested fields require a manual update to the mapping function or the error silently goes unrendered.

--- a/docs/specs/prompts/pr-sync.md
+++ b/docs/specs/prompts/pr-sync.md
@@ -1,0 +1,41 @@
+# Prompt: Pre-Merge Spec Check
+
+Use this prompt before merging a PR to verify the proposed changes are
+consistent with the feature spec. If violations are found, either fix the code
+or explicitly update the spec as part of the PR.
+
+Paste the prompt below, then append the existing feature spec and the PR diff
+or description.
+
+---
+
+You are checking a PR against a feature spec before it merges.
+
+## Inputs
+
+- Feature spec (provided, with line numbers)
+- PR diff or description (provided)
+
+## Task
+
+For each meaningful change in the PR, classify it:
+
+- **VIOLATION** — PR behavior contradicts a specific spec line; flag it
+- **GAP FILLED** — PR adds behavior the spec doesn't cover; spec needs a new entry
+- **IMPLEMENTATION DETAIL** — no observable behavior change; spec unaffected
+
+## Output
+
+Return exactly two sections:
+
+### Violations & Gaps
+
+For each VIOLATION: cite the spec line number(s), quote the relevant spec text,
+and describe how the PR contradicts it.
+For each GAP FILLED: describe the new behavior that should be added to the spec.
+If none, write "None."
+
+### Implementation Details
+
+List changes classified as IMPLEMENTATION DETAIL.
+If none, write "None."

--- a/docs/specs/prompts/retro-cross-cutting.md
+++ b/docs/specs/prompts/retro-cross-cutting.md
@@ -1,0 +1,69 @@
+# Prompt: Retroactive Cross-Cutting Concern Discovery
+
+Use this prompt when scanning a codebase to identify shared concerns that
+should become standalone specs. Feed it source code from multiple features.
+
+Each concern in the output maps to one file under `docs/specs/cross-cutting/`.
+Copy the spec content for each concern into its own file and add it to SPECS.md.
+
+---
+
+You are analyzing a codebase to identify cross-cutting concerns that should become standalone specs.
+
+## Your Role
+
+Find behaviors that repeat across multiple features and define a canonical spec for each.
+
+## Task
+
+1. Scan the provided code for repeated patterns: authentication, permissions, error handling,
+   loading/async states, input validation, logging, etc.
+2. For each concern:
+   a. Identify whether the implementation is consistent or inconsistent across the codebase
+   b. Define the canonical (or most correct) pattern
+   c. List any inconsistencies — these are likely bugs or undocumented divergences
+3. Output one section per concern in the format below
+
+## Priority Heuristic
+
+- High: concerns that touch every feature (auth, errors, permissions)
+- Medium: concerns that touch most features (validation, loading states)
+- Low: concerns that appear in multiple but not most features
+
+## Output Format
+
+One section per concern, separated by `---`. No preamble or explanation.
+
+```
+## [Concern Name]
+**File:** `cross-cutting/kebab-case-name.md`
+**Priority:** high | medium | low
+
+**Inconsistencies found:**
+- [describe any inconsistent patterns — or "None" if consistent]
+
+**Spec:**
+
+# [Concern Name] — Cross-Cutting Spec
+**Status:** draft
+**Applies To:** All features unless listed in Exceptions
+
+## Summary
+[What this concern covers and why it applies globally]
+
+## Canonical Behavior
+[The authoritative description of how this works]
+
+## Feature Integration Contract
+[What every feature spec must document about this concern]
+
+## Exceptions
+| Feature | Deviation | Reason |
+|---------|-----------|--------|
+
+## Anti-Patterns
+- [Wrong approach and why]
+
+## References
+[Code paths where canonical implementation lives]
+```

--- a/docs/specs/prompts/retro-feature.md
+++ b/docs/specs/prompts/retro-feature.md
@@ -1,0 +1,78 @@
+# Prompt: Retroactive Feature Spec
+
+Use this prompt when generating a feature spec from existing code artifacts
+(source files, tests, PR descriptions, git history, existing docs).
+
+Paste the prompt below into a new Claude conversation, then append the code
+artifacts you want analyzed.
+
+---
+
+You are generating a feature spec from existing code artifacts.
+
+## Your Role
+
+Accurately describe what the code DOES. Do not speculate on intent beyond what is clearly observable.
+
+## Inputs You Will Receive
+
+Some combination of: source code, test files, PR descriptions, git history, existing docs.
+
+## Rules
+
+1. Describe observed behavior only — never invent intent
+2. If behavior is ambiguous, describe both paths and mark [AMBIGUOUS: description]
+3. If behavior looks unintentional or inconsistent, mark [REVIEW NEEDED: reason]
+4. For each cross-cutting concern below, state how this feature handles it or mark [NOT SPECIFIED]:
+   - Authentication / authorization
+   - Error states and user messaging
+   - Loading / async states
+   - Input validation
+   - Permissions / access control
+5. Acceptance criteria must be testable behaviors, not implementation details
+6. In Out of Scope, include obvious gaps you observe — these may be bugs or intentional omissions
+
+## Output
+
+Return ONLY the completed spec using the template below. No preamble or explanation.
+
+---
+
+# [Feature Name]
+
+**Status:** draft
+**Owner:** [unknown — assign on review]
+**Last Updated:** [today's date]
+**Related Specs:** [cross-cutting specs this feature touches]
+
+---
+
+## Summary
+
+[What this feature does and the user problem it solves]
+
+## User Stories
+
+- As a **[role]**, I can **[action]** so that **[outcome]**
+
+## Acceptance Criteria
+
+- [ ] [testable behavior]
+
+## Edge Cases & Error States
+
+| Scenario   | Expected Behavior |
+| ---------- | ----------------- |
+| [scenario] | [behavior]        |
+
+## Flags
+
+[All AMBIGUOUS, REVIEW NEEDED, NOT SPECIFIED items with detail]
+
+## Out of Scope
+
+[What this feature does not handle, including observed gaps]
+
+## References
+
+- Code: [files analyzed]

--- a/docs/specs/templates/cross-cutting.template.md
+++ b/docs/specs/templates/cross-cutting.template.md
@@ -1,0 +1,36 @@
+# [Concern Name] — Cross-Cutting Spec
+
+**Status:** `draft` | `review` | `active` | `deprecated`
+**Owner:** [team]
+**Applies To:** All features unless listed in Exceptions
+
+---
+
+## Summary
+
+What this concern covers and why it applies globally.
+
+## Canonical Behavior
+
+The authoritative description of how this works across the product.
+
+## Feature Integration Contract
+
+What every feature spec MUST document when this concern applies:
+
+- [required field 1]
+- [required field 2]
+
+## Exceptions
+
+| Feature | Deviation | Reason |
+| ------- | --------- | ------ |
+
+## Anti-Patterns
+
+- **[Wrong approach]:** Why it's wrong and what to do instead
+
+## References
+
+- Code: [path/to/canonical/implementation]
+- Design: [link]

--- a/docs/specs/templates/cross-cutting.template.md
+++ b/docs/specs/templates/cross-cutting.template.md
@@ -1,3 +1,10 @@
+---
+audience: all contributors
+purpose: [what this concern covers — one line]
+source: this file
+date: YYYY-MM-DD
+---
+
 # [Concern Name] — Cross-Cutting Spec
 
 **Status:** `draft` | `review` | `active` | `deprecated`
@@ -29,8 +36,3 @@ What every feature spec MUST document when this concern applies:
 ## Anti-Patterns
 
 - **[Wrong approach]:** Why it's wrong and what to do instead
-
-## References
-
-- Code: [path/to/canonical/implementation]
-- Design: [link]

--- a/docs/specs/templates/feature-spec.template.md
+++ b/docs/specs/templates/feature-spec.template.md
@@ -1,0 +1,41 @@
+# [Feature Name]
+
+**Status:** `draft` | `review` | `active` | `deprecated`
+**Owner:** [PM or team name]
+**Last Updated:** [YYYY-MM-DD]
+**Related Specs:** [cross-cutting specs this feature references]
+
+---
+
+## Summary
+
+One paragraph. What this feature does and the user problem it solves. No implementation details.
+
+## User Stories
+
+- As a **[role]**, I can **[action]** so that **[outcome]**
+
+## Acceptance Criteria
+
+- [ ] [Specific, testable behavior]
+- [ ] [Another testable criterion]
+
+## Edge Cases & Error States
+
+| Scenario   | Expected Behavior   |
+| ---------- | ------------------- |
+| [scenario] | [expected behavior] |
+
+## Out of Scope
+
+- [Explicitly what this feature does NOT handle]
+
+## Open Questions
+
+- [ ] [Question — owner — target resolution date]
+
+## References
+
+- Figma: [link]
+- Issues: [link]
+- Code: [path/to/relevant/files]

--- a/docs/specs/templates/feature-spec.template.md
+++ b/docs/specs/templates/feature-spec.template.md
@@ -1,8 +1,14 @@
+---
+audience: [who reads this spec]
+purpose: [what this feature does — one line]
+source: this file
+date: YYYY-MM-DD
+---
+
 # [Feature Name]
 
 **Status:** `draft` | `review` | `active` | `deprecated`
 **Owner:** [PM or team name]
-**Last Updated:** [YYYY-MM-DD]
 **Related Specs:** [cross-cutting specs this feature references]
 
 ---
@@ -33,9 +39,3 @@ One paragraph. What this feature does and the user problem it solves. No impleme
 ## Open Questions
 
 - [ ] [Question — owner — target resolution date]
-
-## References
-
-- Figma: [link]
-- Issues: [link]
-- Code: [path/to/relevant/files]


### PR DESCRIPTION
## Summary

- Introduces `docs/specs/` as an intent ledger for spec-driven development — templates, AI prompts, and a master index at `docs/specs/SPECS.md`
- Adds six active cross-cutting specs covering the concerns every feature must reference: authentication, error handling, permissions & ownership, validation, loading states, and telemetry
- Updates `CLAUDE.md` and `docs/README.md` to point agents and contributors to the new directory

## What's in each spec

Each cross-cutting spec documents canonical behavior, a feature integration contract (what every feature spec must declare), exceptions, anti-patterns, and known issues / planned work. The telemetry spec includes the full Analytics Engine data contracts derived from the telemetry plan — field-level ordering, naming, constraints, and planned datasets.

## Test plan

- [ ] Verify `docs/specs/` directory structure matches the layout in `SPECS.md`
- [ ] Spot-check that frontmatter is present and `status: active` on all six cross-cutting specs
- [ ] Confirm `CLAUDE.md` and `docs/README.md` link to `docs/specs/`
- [ ] CI passes (no code changes — docs only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)