### PR TITLE
Sign-in: error state, auto-redirect, and telemetry improvements

### DIFF
--- a/apps/api/src/api/middleware/technicalTelemetry.test.ts
+++ b/apps/api/src/api/middleware/technicalTelemetry.test.ts
@@ -21,6 +21,29 @@ describe("buildApiRequestTelemetryDataPoint", () => {
     });
   });
 
+  it("maps auth sub-routes to their specific operation names", () => {
+    const cases: [string, string, string][] = [
+      ["POST", "/api/auth/sign-in/social", "SignIn"],
+      ["GET", "/api/auth/callback/google", "OAuthCallback"],
+      ["GET", "/api/auth/get-session", "SessionCheck"],
+      ["POST", "/api/auth/sign-out", "SignOut"],
+      ["GET", "/api/auth/csrf", "Auth"],
+    ];
+    for (const [method, pathname, operation] of cases) {
+      expect(
+        buildApiRequestTelemetryDataPoint({
+          method,
+          pathname,
+          status: 200,
+          durationMs: 1,
+          requestSizeBytes: 0,
+          authenticated: false,
+          error: null,
+        }).indexes[0],
+      ).toBe(operation);
+    }
+  });
+
   it("normalizes asset ids and records validation failures", () => {
     expect(
       buildApiRequestTelemetryDataPoint({

--- a/apps/api/src/api/middleware/technicalTelemetry.ts
+++ b/apps/api/src/api/middleware/technicalTelemetry.ts
@@ -94,6 +94,18 @@ export function buildApiRequestTelemetryDataPoint(
 }
 
 function routeTelemetry(method: string, pathname: string): RouteTelemetry {
+  if (pathname === "/api/auth/sign-in/social" && method === "POST") {
+    return { operation: "SignIn", routePattern: "/api/auth/sign-in/social" };
+  }
+  if (pathname === "/api/auth/callback/google" && method === "GET") {
+    return { operation: "OAuthCallback", routePattern: "/api/auth/callback/google" };
+  }
+  if (pathname === "/api/auth/get-session" && method === "GET") {
+    return { operation: "SessionCheck", routePattern: "/api/auth/get-session" };
+  }
+  if (pathname === "/api/auth/sign-out" && method === "POST") {
+    return { operation: "SignOut", routePattern: "/api/auth/sign-out" };
+  }
   if (pathname.startsWith("/api/auth/")) {
     return { operation: "Auth", routePattern: "/api/auth/*" };
   }

--- a/apps/api/src/domain/identity/events/UserProvisioned.ts
+++ b/apps/api/src/domain/identity/events/UserProvisioned.ts
@@ -1,0 +1,13 @@
+import type { UserId } from "@snaveevans/pineapple-shared";
+import type { DomainEvent } from "../../events/DomainEvent.ts";
+
+export type UserProvisioned = DomainEvent & {
+  type: "UserProvisioned";
+  userId: UserId;
+};
+
+export const UserProvisioned = (props: { userId: UserId }): UserProvisioned => ({
+  type: "UserProvisioned",
+  userId: props.userId,
+  occurredAt: new Date(),
+});

--- a/apps/api/src/infrastructure/auth/BetterAuthResolver.ts
+++ b/apps/api/src/infrastructure/auth/BetterAuthResolver.ts
@@ -1,7 +1,9 @@
 import { Email, InvariantError, UnauthorizedError } from "@snaveevans/pineapple-shared";
 import { User } from "../../domain/identity/User.ts";
+import { UserProvisioned } from "../../domain/identity/events/UserProvisioned.ts";
 import type { UserRepository } from "../../domain/identity/UserRepository.ts";
 import type { AuthenticatedUserResolver } from "../../application/ports/AuthenticatedUserResolver.ts";
+import type { EventBus } from "../../application/ports/EventBus.ts";
 import type { Auth } from "./auth.ts";
 
 /**
@@ -23,6 +25,7 @@ export class BetterAuthResolver implements AuthenticatedUserResolver {
     private readonly auth: Auth,
     private readonly users: UserRepository,
     private readonly devEmail?: string,
+    private readonly eventBus?: EventBus,
   ) {}
 
   async resolve(request: Request): Promise<User> {
@@ -34,6 +37,7 @@ export class BetterAuthResolver implements AuthenticatedUserResolver {
     if (!user) {
       user = User.create(email);
       await this.users.save(user);
+      await this.eventBus?.publish(UserProvisioned({ userId: user.id }));
     }
     return user;
   }

--- a/apps/api/src/infrastructure/telemetry/registerDomainTelemetry.ts
+++ b/apps/api/src/infrastructure/telemetry/registerDomainTelemetry.ts
@@ -1,11 +1,16 @@
 import type { EventBus } from "../../application/ports/EventBus.ts";
 import { AnalyticsEngineTelemetrySink } from "./AnalyticsEngineTelemetrySink.ts";
 import { AssetCreatedTelemetryHandler } from "./asset/AssetCreatedTelemetryHandler.ts";
+import { UserProvisionedTelemetryHandler } from "./user/UserProvisionedTelemetryHandler.ts";
 
 export function registerDomainTelemetry(deps: {
   eventBus: EventBus;
   assetDomainDataset: AnalyticsEngineDataset;
+  userDomainDataset: AnalyticsEngineDataset;
 }): void {
   const assetDomainSink = new AnalyticsEngineTelemetrySink(deps.assetDomainDataset);
   deps.eventBus.subscribe(new AssetCreatedTelemetryHandler(assetDomainSink));
+
+  const userDomainSink = new AnalyticsEngineTelemetrySink(deps.userDomainDataset);
+  deps.eventBus.subscribe(new UserProvisionedTelemetryHandler(userDomainSink));
 }

--- a/apps/api/src/infrastructure/telemetry/user/UserProvisionedTelemetryHandler.ts
+++ b/apps/api/src/infrastructure/telemetry/user/UserProvisionedTelemetryHandler.ts
@@ -1,0 +1,21 @@
+import type { DomainEventHandler } from "../../../application/ports/EventBus.ts";
+import type { UserProvisioned } from "../../../domain/identity/events/UserProvisioned.ts";
+import type { TelemetryDataPoint, TelemetrySink } from "../AnalyticsEngineTelemetrySink.ts";
+
+export function mapUserProvisionedTelemetry(event: UserProvisioned): TelemetryDataPoint {
+  return {
+    indexes: [event.userId],
+    blobs: [event.type, "User", event.userId, "v1", "success", "ProvisionUser"],
+    doubles: [1, event.occurredAt.getTime()],
+  };
+}
+
+export class UserProvisionedTelemetryHandler implements DomainEventHandler<UserProvisioned> {
+  readonly eventType = "UserProvisioned" as const;
+
+  constructor(private readonly sink: TelemetrySink) {}
+
+  handle(event: UserProvisioned): void {
+    this.sink.write(mapUserProvisionedTelemetry(event));
+  }
+}

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -37,11 +37,12 @@ import type { z } from "@hono/zod-openapi";
 
 type Bindings = AuthEnv & {
   ASSET_DOMAIN_TELEMETRY: AnalyticsEngineDataset;
+  USER_DOMAIN_TELEMETRY: AnalyticsEngineDataset;
   API_REQUEST_TELEMETRY: AnalyticsEngineDataset;
   /** Local dev only — set in .dev.vars, never in wrangler.toml. Bypasses the Better Auth session check. */
   DEV_AUTH_EMAIL?: string;
 };
-type Variables = { user: User; auth: Auth };
+type Variables = { user: User; auth: Auth; eventBus: EventBus };
 type AppEnv = { Bindings: Bindings; Variables: Variables };
 
 const app = new OpenAPIHono<AppEnv>({
@@ -89,15 +90,6 @@ function serializeAsset(asset: Asset): z.infer<typeof AssetResponseSchema> {
   };
 }
 
-function createEventBus(c: Context<AppEnv>): EventBus {
-  const eventBus = new InMemoryEventBus();
-  registerDomainTelemetry({
-    eventBus,
-    assetDomainDataset: c.env.ASSET_DOMAIN_TELEMETRY,
-  });
-  return eventBus;
-}
-
 // ── Public routes (no auth) ──────────────────────────────────────────────────
 
 app.openapi(healthRoute, (c) => c.json({ status: "ok" } as const, 200));
@@ -117,6 +109,15 @@ app.use("/api/*", async (c, next) => {
   const baseURL = c.env.BETTER_AUTH_URL ?? new URL(c.req.url).origin;
   const auth = createAuth(c.env, baseURL);
   c.set("auth", auth);
+
+  const eventBus = new InMemoryEventBus();
+  registerDomainTelemetry({
+    eventBus,
+    assetDomainDataset: c.env.ASSET_DOMAIN_TELEMETRY,
+    userDomainDataset: c.env.USER_DOMAIN_TELEMETRY,
+  });
+  c.set("eventBus", eventBus);
+
   await next();
 });
 
@@ -132,6 +133,7 @@ app.use("/api/*", async (c, next) => {
     c.get("auth"),
     new D1UserRepository(c.env.DB),
     c.env.DEV_AUTH_EMAIL,
+    c.get("eventBus"),
   );
   const user = await resolver.resolve(c.req.raw);
   c.set("user", user);
@@ -143,7 +145,7 @@ app.use("/api/*", async (c, next) => {
 app.openapi(createAssetRoute, async (c) => {
   const user = c.get("user");
   const { name, metadata } = c.req.valid("json");
-  const result = await new CreateAsset(new D1AssetRepository(c.env.DB), createEventBus(c)).execute({
+  const result = await new CreateAsset(new D1AssetRepository(c.env.DB), c.get("eventBus")).execute({
     ownerId: user.id,
     name,
     // Cast: Zod's `.optional()` yields `T | undefined` but the domain type uses

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -40,5 +40,9 @@ binding = "ASSET_DOMAIN_TELEMETRY"
 dataset = "pineapple_asset_domain_events"
 
 [[analytics_engine_datasets]]
+binding = "USER_DOMAIN_TELEMETRY"
+dataset = "pineapple_user_domain_events"
+
+[[analytics_engine_datasets]]
 binding = "API_REQUEST_TELEMETRY"
 dataset = "pineapple_api_request_events"

--- a/apps/web/src/auth/AuthFlow.tsx
+++ b/apps/web/src/auth/AuthFlow.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Link, useSearchParams } from "react-router";
+import { Link, useNavigate, useSearchParams } from "react-router";
 import { Icon } from "../design/Icon";
 import { Brandmark } from "../design/Brandmark";
 import { HFAssetIcon, HFAssetThumb } from "../design/hf";
@@ -243,66 +243,38 @@ function AuthFailure({ onRetry, onBack }: { onRetry: () => void; onBack: () => v
   );
 }
 
-/* ============ signed-in confirmation (post-OAuth return) ============ */
-function AuthSignedIn({
-  user,
-  onSignOut,
-}: {
-  user: { email: string; name?: string | null };
-  onSignOut: () => void;
-}) {
-  return (
-    <div className="au-redirect">
-      <div className="au-redirect-badge">
-        <Icon name="check" size={30} color="var(--hf-brand)" stroke={2.4} />
-      </div>
-      <h1>You're signed in</h1>
-      <p>
-        Signed in as <strong>{user.name ?? user.email}</strong>
-        {user.name ? ` (${user.email})` : ""}.
-      </p>
-      <div className="au-hero-cta" style={{ display: "flex", gap: 12, marginTop: 24 }}>
-        <Link className="au-google" style={{ width: "auto", padding: "0 20px" }} to={paths.appHome}>
-          Go to FieldOps
-        </Link>
-      </div>
-      <button className="au-redirect-cancel" onClick={onSignOut}>
-        Sign out
-      </button>
-    </div>
-  );
-}
-
 /* ============ page ============ */
 export function AuthFlow() {
-  // mode: "login" | "signup" ; phase: "form" | "redirect"
+  // mode: "login" | "signup" ; phase: "form" | "redirect" | "error"
   // initial mode comes from ?mode= so marketing CTAs can deep-link the right screen
   const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
   const initialMode: Mode = searchParams.get("mode") === "signup" ? "signup" : "login";
   const [mode, setMode] = useState<Mode>(initialMode);
   const [phase, setPhase] = useState<Phase>(searchParams.has("error") ? "error" : "form");
-  // undefined = still checking; null = logged out; object = logged in
-  const [session, setSession] = useState<SessionUser | undefined>(undefined);
 
   useEffect(() => {
     document.title = "FieldOps — Sign in";
   }, []);
 
   // On load (and after returning from Google) check whether a session exists.
+  // If a session is found, navigate directly to the app dashboard.
   useEffect(() => {
     let cancelled = false;
     fetch("/api/auth/get-session", { credentials: "include" })
       .then((r) => (r.ok ? r.json() : null))
       .then((data: { user?: SessionUser } | null) => {
-        if (!cancelled) setSession(data?.user ?? null);
+        if (!cancelled && data?.user) {
+          void navigate(paths.appHome, { replace: true });
+        }
       })
       .catch(() => {
-        if (!cancelled) setSession(null);
+        // session check failed — stay on login form
       });
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [navigate]);
 
   const onGoogle = () => {
     setPhase("redirect");
@@ -312,30 +284,12 @@ export function AuthFlow() {
     });
   };
 
-  const onSignOut = () => {
-    // Better Auth's /sign-out requires a JSON content-type AND a (non-empty)
-    // JSON body — without the header it 415s, with the header but an empty body
-    // it 500s on JSON.parse. Send "{}". The response clears the session cookies.
-    fetch("/api/auth/sign-out", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: "{}",
-      credentials: "include",
-    }).finally(() => {
-      // Logged out → full-page reload to the marketing home so any in-memory
-      // session state is wiped, not just unmounted.
-      window.location.href = paths.home;
-    });
-  };
-
   return (
     <div className="au">
       <div className="au-split">
         <AuthBrand />
         <div className="au-form-side">
-          {session ? (
-            <AuthSignedIn user={session} onSignOut={onSignOut} />
-          ) : phase === "redirect" ? (
+          {phase === "redirect" ? (
             <AuthRedirect mode={mode} onCancel={() => setPhase("form")} />
           ) : phase === "error" ? (
             <AuthFailure onRetry={onGoogle} onBack={() => setPhase("form")} />

--- a/apps/web/src/auth/AuthFlow.tsx
+++ b/apps/web/src/auth/AuthFlow.tsx
@@ -13,7 +13,7 @@ import "../design/styles/hifi-assets.css";
 import "./styles/auth.css";
 
 type Mode = "login" | "signup";
-type Phase = "form" | "redirect";
+type Phase = "form" | "redirect" | "error";
 
 type SessionUser = { email: string; name?: string | null } | null;
 
@@ -220,6 +220,29 @@ function AuthRedirect({ mode, onCancel }: { mode: Mode; onCancel: () => void }) 
   );
 }
 
+/* ============ off-flow error state (OAuth came back broken) ============ */
+function AuthFailure({ onRetry, onBack }: { onRetry: () => void; onBack: () => void }) {
+  return (
+    <div className="au-fail">
+      <div className="au-fail-badge">
+        <Icon name="alert" size={30} stroke={1.9} />
+      </div>
+      <h1>Something went wrong</h1>
+      <p>We're sorry — we ran into an unexpected error while signing you in. Please try again in a moment.</p>
+      <div className="au-fail-ref">Error · sign-in could not be completed</div>
+      <div className="au-fail-actions">
+        <button className="au-btn-primary" onClick={onRetry}>
+          <Icon name="repeat" size={17} stroke={2} />
+          Try again
+        </button>
+        <button className="au-fail-back" onClick={onBack}>
+          Back to sign in
+        </button>
+      </div>
+    </div>
+  );
+}
+
 /* ============ signed-in confirmation (post-OAuth return) ============ */
 function AuthSignedIn({
   user,
@@ -257,7 +280,7 @@ export function AuthFlow() {
   const [searchParams] = useSearchParams();
   const initialMode: Mode = searchParams.get("mode") === "signup" ? "signup" : "login";
   const [mode, setMode] = useState<Mode>(initialMode);
-  const [phase, setPhase] = useState<Phase>("form");
+  const [phase, setPhase] = useState<Phase>(searchParams.has("error") ? "error" : "form");
   // undefined = still checking; null = logged out; object = logged in
   const [session, setSession] = useState<SessionUser | undefined>(undefined);
 
@@ -314,6 +337,8 @@ export function AuthFlow() {
             <AuthSignedIn user={session} onSignOut={onSignOut} />
           ) : phase === "redirect" ? (
             <AuthRedirect mode={mode} onCancel={() => setPhase("form")} />
+          ) : phase === "error" ? (
+            <AuthFailure onRetry={onGoogle} onBack={() => setPhase("form")} />
           ) : (
             <AuthCard mode={mode} onGoogle={onGoogle} onSwitch={(m) => setMode(m)} />
           )}

--- a/apps/web/src/auth/styles/auth.css
+++ b/apps/web/src/auth/styles/auth.css
@@ -401,6 +401,96 @@
   text-decoration: underline;
 }
 
+/* ============ off-flow error state (OAuth came back broken) ============ */
+.au-fail {
+  width: 100%;
+  max-width: 380px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+.au-fail-badge {
+  width: 72px;
+  height: 72px;
+  border-radius: 20px;
+  background: var(--hf-bad-bg);
+  border: 1px solid oklch(88% 0.045 28);
+  color: var(--hf-bad);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 24px;
+}
+.au-fail h1 {
+  margin: 0 0 8px;
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+.au-fail p {
+  margin: 0;
+  font-size: 14.5px;
+  color: var(--hf-ink-soft);
+  line-height: 1.55;
+  max-width: 320px;
+}
+.au-fail-ref {
+  margin-top: 14px;
+  font-family: var(--hf-mono);
+  font-size: 11px;
+  color: var(--hf-ink-faint);
+  letter-spacing: 0.02em;
+}
+.au-fail-actions {
+  margin-top: 28px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.au-btn-primary {
+  width: 100%;
+  height: 50px;
+  border-radius: 11px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 9px;
+  background: var(--hf-brand);
+  border: 1px solid var(--hf-brand-2);
+  color: #fff;
+  font-family: inherit;
+  font-size: 15.5px;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: var(--hf-shadow-1);
+  transition:
+    background 120ms,
+    box-shadow 120ms,
+    transform 80ms;
+}
+.au-btn-primary:hover {
+  background: var(--hf-brand-2);
+  box-shadow: var(--hf-shadow-2);
+}
+.au-btn-primary:active {
+  transform: translateY(1px);
+}
+.au-fail-back {
+  font-size: 13.5px;
+  color: var(--hf-ink-soft);
+  background: none;
+  border: 0;
+  cursor: pointer;
+  font: inherit;
+  padding: 6px;
+}
+.au-fail-back:hover {
+  color: var(--hf-ink);
+  text-decoration: underline;
+}
+
 /* ============ floating collage in brand panel ============ */
 .au-collage {
   position: relative;

--- a/docs/specs/SPECS.md
+++ b/docs/specs/SPECS.md
@@ -30,7 +30,7 @@ relevant cross-cutting specs rather than re-describing the behavior.
 
 | Spec                                              | Area      | Status |
 | ------------------------------------------------- | --------- | ------ |
-| [sign-in.md](./features/sign-in.md)               | Auth      | draft  |
+| [sign-in.md](./features/sign-in.md)               | Auth      | review |
 | [create-asset.md](./features/create-asset.md)     | Assets    | draft  |
 | [asset-library.md](./features/asset-library.md)   | Assets    | draft  |
 | [dashboard.md](./features/dashboard.md)           | Home      | wip    |

--- a/docs/specs/cross-cutting/telemetry.md
+++ b/docs/specs/cross-cutting/telemetry.md
@@ -97,22 +97,27 @@ These limits apply to every data point written and must be respected when design
 | ------------------------------------- | ------------------------------ | ------------------------------------ |
 | `pineapple_asset_domain_events`       | `ASSET_DOMAIN_TELEMETRY`       | Asset lifecycle events — implemented |
 | `pineapple_api_request_events`        | `API_REQUEST_TELEMETRY`        | HTTP request telemetry — implemented |
+| `pineapple_user_domain_events`        | `USER_DOMAIN_TELEMETRY`        | User lifecycle events — planned      |
 | `pineapple_maintenance_domain_events` | `MAINTENANCE_DOMAIN_TELEMETRY` | Maintenance record events — planned  |
 
 ### Operation Name Mapping
 
 Every API route maps to a named operation used as the `indexes[0]` value in request telemetry. The current mapping:
 
-| Route                  | Operation         |
-| ---------------------- | ----------------- |
-| `/api/auth/*`          | `Auth`            |
-| `POST /api/assets`     | `CreateAsset`     |
-| `GET /api/assets`      | `ListAssets`      |
-| `GET /api/assets/{id}` | `GetAsset`        |
-| `GET /health`          | `Health`          |
-| `GET /openapi.json`    | `OpenApiDocument` |
-| `GET /reference`       | `ApiReference`    |
-| (anything else)        | `Unknown`         |
+| Route                           | Operation         |
+| ------------------------------- | ----------------- |
+| `POST /api/auth/sign-in/social` | `SignIn`          |
+| `GET /api/auth/callback/google` | `OAuthCallback`   |
+| `GET /api/auth/get-session`     | `SessionCheck`    |
+| `POST /api/auth/sign-out`       | `SignOut`         |
+| `/api/auth/*` (other)           | `Auth`            |
+| `POST /api/assets`              | `CreateAsset`     |
+| `GET /api/assets`               | `ListAssets`      |
+| `GET /api/assets/{id}`          | `GetAsset`        |
+| `GET /health`                   | `Health`          |
+| `GET /openapi.json`             | `OpenApiDocument` |
+| `GET /reference`                | `ApiReference`    |
+| (anything else)                 | `Unknown`         |
 
 ### Failure Policy
 

--- a/docs/specs/features/sign-in.md
+++ b/docs/specs/features/sign-in.md
@@ -7,22 +7,21 @@ metadata:
 
 # Sign In
 
-**Status:** draft
+**Status:** review
 **Owner:** [unknown — assign on review]
-**Last Updated:** 2026-06-03
+**Last Updated:** 2026-06-04
 **Related Specs:** [authentication.md](../cross-cutting/authentication.md), [error-handling.md](../cross-cutting/error-handling.md), [loading-states.md](../cross-cutting/loading-states.md), [telemetry.md](../cross-cutting/telemetry.md)
 
 ---
 
 ## Summary
 
-The Sign In feature lets users authenticate with FieldOps via Google OAuth. It lives at `/login` and covers the entire auth lifecycle on that page: arriving in login or signup mode, initiating the Google OAuth redirect, the in-progress state while waiting for Google, the post-OAuth signed-in confirmation, and signing out.
+The Sign In feature lets users authenticate with FieldOps via Google OAuth. It lives at `/login` and covers the entire auth lifecycle on that page: arriving in login or signup mode, initiating the Google OAuth redirect, the in-progress state while waiting for Google, automatic navigation to the dashboard on success, and an error message when Google's callback returns a failure.
 
 ## User Stories
 
 - As a **new visitor**, I can **create an account with Google** so that **I can start tracking assets without creating a separate password**
 - As a **returning user**, I can **log back in with Google** so that **I can access my fleet**
-- As a **signed-in user visiting `/login`**, I can **see that I am already signed in** and **navigate to the app or sign out**
 - As a **marketing CTA visitor**, I can **arrive directly in signup vs. login mode** so that **the page matches my intent**
 
 ## Acceptance Criteria
@@ -32,46 +31,60 @@ The Sign In feature lets users authenticate with FieldOps via Google OAuth. It l
 - [ ] The login and signup forms share the same "Continue with Google" button; clicking switches to the redirect phase
 - [ ] The redirect phase shows a spinner, Google G mark, and "Connecting to Google…" message with a Cancel button
 - [ ] Clicking Cancel in the redirect phase returns to the form
-- [ ] After a successful OAuth callback, `/login` detects the session and shows the signed-in confirmation with user name/email and a "Go to FieldOps" link
-- [ ] The "Go to FieldOps" link navigates to `/app`
-- [ ] Clicking "Sign out" on the confirmation screen clears the session and performs a full-page reload to `/`
+- [ ] After a successful OAuth callback, the app automatically navigates to `/app` (the dashboard)
+- [ ] Visiting `/login` with `?error=google` in the query string shows a generic error message on the form [REVIEW NEEDED: exact error message text and visual treatment pending design]
 - [ ] The login screen includes a mode-switch link: login → "New to FieldOps? Create an account" (switches to signup mode); signup → "Already have an account? Log in" (switches to login mode)
 - [ ] The brand panel displays three value propositions and a product preview collage
 - [ ] An informational notice states that email & password sign-in is "coming soon" and Google is the current method
 
 ## Edge Cases & Error States
 
-| Scenario                                                                    | Expected Behavior                                                                                                                                           |
-| --------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `POST /api/auth/sign-in/social` returns a non-OK status                     | Error is caught; phase returns to `form`                                                                                                                    |
-| `POST /api/auth/sign-in/social` returns OK but no `url` field               | Error is caught; phase returns to `form`                                                                                                                    |
-| `GET /api/auth/get-session` fails on load                                   | Session treated as `null` (logged out); login form shown                                                                                                    |
-| User already has a valid session when visiting `/login`                     | Signed-in confirmation shown immediately                                                                                                                    |
-| OAuth callback includes `?error=google`                                     | [REVIEW NEEDED: `errorCallbackURL` is set to `/login?error=google` but no code renders an error state for this query param — the error is silently ignored] |
-| Google OAuth fails during the window redirect (network error before return) | User is stuck at Google's error page; they must navigate back manually                                                                                      |
-| Sign-out request fails                                                      | Sign-out fetch uses `.finally()` — the page reloads to `/` regardless of whether the sign-out succeeded                                                     |
+| Scenario                                                                    | Expected Behavior                                                      |
+| --------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `POST /api/auth/sign-in/social` returns a non-OK status                     | Error is caught; phase returns to `form`                               |
+| `POST /api/auth/sign-in/social` returns OK but no `url` field               | Error is caught; phase returns to `form`                               |
+| `GET /api/auth/get-session` fails on load                                   | Session treated as `null` (logged out); login form shown               |
+| User already has a valid session when visiting `/login`                     | Navigates to `/app` after session check resolves                       |
+| OAuth callback includes `?error=google`                                     | Generic error message shown on the form; phase set to `form`           |
+| Google OAuth fails during the window redirect (network error before return) | User is stuck at Google's error page; they must navigate back manually |
 
 ## Telemetry
 
-**Request telemetry:** All `/api/auth/*` requests map to the `Auth` operation via `createTechnicalTelemetryMiddleware`. See [telemetry.md](../cross-cutting/telemetry.md) for the full data point shape.
+**Request telemetry:** Auth routes map to specific operation names. The previous catch-all `Auth` operation is replaced with the following:
 
-**Domain events:** None. The sign-in flow does not produce domain events.
+| Route                           | Operation       |
+| ------------------------------- | --------------- |
+| `POST /api/auth/sign-in/social` | `SignIn`        |
+| `GET /api/auth/callback/google` | `OAuthCallback` |
+| `GET /api/auth/get-session`     | `SessionCheck`  |
+| `POST /api/auth/sign-out`       | `SignOut`       |
+| (other `/api/auth/*`)           | `Auth`          |
+
+These entries must be added to the operation name mapping in `createTechnicalTelemetryMiddleware`. See [telemetry.md](../cross-cutting/telemetry.md) for the full request data point shape and Feature Integration Contract.
+
+**Domain events:** The `UserProvisioned` event is published when `BetterAuthResolver.resolve()` creates a new domain `User` for the first time. Dataset: `pineapple_user_domain_events`. Binding: `USER_DOMAIN_TELEMETRY`.
+
+**`UserProvisioned` data point** (index: `user_id`):
+
+| Field        | Name              | Value                                          |
+| ------------ | ----------------- | ---------------------------------------------- |
+| `indexes[0]` | —                 | `user_id` (partition key for per-user queries) |
+| `blobs[0]`   | `event_type`      | `"UserProvisioned"`                            |
+| `blobs[1]`   | `aggregate_type`  | `"User"`                                       |
+| `blobs[2]`   | `user_id`         | User UUID                                      |
+| `blobs[3]`   | `schema_version`  | `"v1"`                                         |
+| `blobs[4]`   | `result`          | `"success"`                                    |
+| `blobs[5]`   | `source_use_case` | `"ProvisionUser"`                              |
+| `doubles[0]` | `count`           | Always `1`                                     |
+| `doubles[1]` | `event_time_ms`   | Event timestamp (ms since epoch)               |
 
 ## Flags
 
 **REVIEW NEEDED — silent OAuth initiation error:** When `startGoogleSignIn()` throws (e.g. bad network, non-OK status), the phase resets to `form` but the error is only logged to the browser console. No in-page error message is shown to the user.
 
-**REVIEW NEEDED — `?error=google` unhandled:** Google can redirect back to `/login?error=google` on failure, but the page does not display an error for this state.
-
-**AMBIGUOUS — session check flicker:** During the initial session check, the form is shown. If a session already exists, the page switches from the form to the signed-in confirmation after the check resolves. There is no explicit loading state for the session check phase.
+**AMBIGUOUS — session check flicker:** During the initial session check, the login form is shown. If the user has an active session, the page navigates to `/app` after the check resolves — the form is briefly visible before the redirect fires. No explicit loading state exists for the session check phase.
 
 **NOT SPECIFIED — Terms of Service / Privacy Policy:** The auth card links to Terms of Service and Privacy Policy via `href="#"`. No actual documents exist at those URLs.
-
-**REVIEW NEEDED — Sign-out failure behavior is intentionally unresolved:** Sign-out uses `.finally()` to reload to `/` regardless of whether the server-side sign-out succeeded. If the sign-out request fails, the session may still be active while the user is redirected to the marketing page. The spec describes what the code does but does not confirm whether this is a deliberate trade-off or an oversight.
-
-**NOT SPECIFIED — No `UserProvisioned` event:** `BetterAuthResolver.resolve()` silently creates a new domain `User` when one does not exist, but no domain event is published. From telemetry, a first-time sign-up is indistinguishable from a returning login — both appear as an `Auth` request. New user count is not currently observable.
-
-**NOT SPECIFIED — `Auth` operation too coarse to distinguish sub-flows:** All `/api/auth/*` routes collapse into a single `Auth` operation in request telemetry. Sign-in initiation, OAuth callback, session check, and sign-out are indistinguishable by operation name. Sign-in rate, sign-out rate, and session-check frequency cannot be measured independently.
 
 ## Out of Scope
 
@@ -80,3 +93,6 @@ The Sign In feature lets users authenticate with FieldOps via Google OAuth. It l
 - Password reset flow
 - Session expiry handling within the app (handled by API middleware redirecting 401s to login, not this page)
 - Account deletion or deactivation
+- Signed-in confirmation screen (replaced by auto-redirect to `/app`)
+- User initialization / onboarding page for new users (future update)
+- Sign-out from `/login` (confirmation screen removed; sign-out is handled within the app)


### PR DESCRIPTION
## Summary

- **Error state**: `/login?error=google` (the OAuth `errorCallbackURL`) now renders a dedicated full-screen error screen instead of silently ignoring the param — alert badge, generic copy, primary \"Try again\" button (restarts Google flow), and a \"Back to sign in\" ghost link.
- **Auto-redirect on success**: the signed-in confirmation screen is removed. When the session check resolves with a user, the page navigates directly to `/app`. Visiting `/login` while already signed in also redirects immediately.
- **Granular auth telemetry**: the `/api/auth/*` catch-all `Auth` operation is replaced with four specific operations — `SignIn`, `OAuthCallback`, `SessionCheck`, `SignOut` — making sign-in rate, callback errors, and session-check frequency independently measurable.
- **`UserProvisioned` domain event**: `BetterAuthResolver` now publishes a `UserProvisioned` event the first time it creates a domain user. A new `UserProvisionedTelemetryHandler` writes it to `pineapple_user_domain_events` (`USER_DOMAIN_TELEMETRY` binding). First-time sign-ups are now distinguishable from returning logins in Analytics Engine.

## What changed

**Frontend** (`apps/web/src/auth/`)
- `AuthFlow.tsx` — added `AuthFailure` (error phase), `?error=` URL param initialises to `"error"` phase; removed `AuthSignedIn` confirmation screen and `onSignOut`; session check now calls `navigate("/app", { replace: true })` on success; `Phase` extended to `"form" | "redirect" | "error"`
- `auth.css` — added `.au-fail*`, `.au-btn-primary`, `.au-fail-back` styles

**Backend** (`apps/api/src/`)
- `domain/identity/events/UserProvisioned.ts` — new domain event
- `infrastructure/telemetry/user/UserProvisionedTelemetryHandler.ts` — new handler; writes to `pineapple_user_domain_events` per the spec's blobs/doubles contract
- `infrastructure/auth/BetterAuthResolver.ts` — accepts optional `EventBus`; publishes `UserProvisioned` on new user creation
- `infrastructure/telemetry/registerDomainTelemetry.ts` — registers both asset and user domain handlers; takes `userDomainDataset`
- `api/middleware/technicalTelemetry.ts` — specific operation mappings for the four auth routes; `Auth` fallback for remaining `/api/auth/*`
- `worker.ts` — single per-request event bus created in the first `/api/*` middleware, stored in context (`Variables.eventBus`), threaded into `BetterAuthResolver` and `CreateAsset`; `USER_DOMAIN_TELEMETRY` added to `Bindings`
- `wrangler.toml` — `USER_DOMAIN_TELEMETRY` → `pineapple_user_domain_events`

## Reviewer notes

- The `UserProvisioned` event fires on the **first authenticated API request** after a new user signs in (not during the OAuth callback itself), because `BetterAuthResolver` only runs in the auth gate middleware for application routes — not for `/api/auth/*` routes handled by Better Auth. This is consistent with the spec intent and the existing JIT-provisioning behaviour.
- Three spec flags remain open and are unchanged: `REVIEW NEEDED — silent OAuth initiation error` (no in-page error when `startGoogleSignIn()` throws), `AMBIGUOUS — session check flicker`, and `NOT SPECIFIED — Terms of Service / Privacy Policy`.
- No API schema changes — `openapi:generate` not required.

## Test plan

- [x] `pnpm lint && pnpm type-check` — clean
- [x] `pnpm -r test` — 25 tests passing (1 new: auth operation name mapping)
- [x] `/login` renders login form with no session (browser verified)
- [x] `/login?error=google` renders `AuthFailure` screen (browser verified, desktop + mobile)
- [x] \"Back to sign in\" returns to form (browser verified via snapshot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)