### PR TITLE
[codex] Implement maintenance record API

### DIFF
--- a/apps/api/src/api/middleware/technicalTelemetry.test.ts
+++ b/apps/api/src/api/middleware/technicalTelemetry.test.ts
@@ -71,4 +71,34 @@ describe("buildApiRequestTelemetryDataPoint", () => {
       doubles: [3, 1, 422, 0],
     });
   });
+
+  it.each([
+    ["POST", "CreateMaintenanceRecord"],
+    ["GET", "ListMaintenanceRecords"],
+  ])("maps %s maintenance routes to %s", (method, operation) => {
+    expect(
+      buildApiRequestTelemetryDataPoint({
+        method,
+        pathname: "/api/assets/195d0ef0-47f5-439f-abfd-29f892c9a040/maintenance-records",
+        status: 200,
+        durationMs: 1,
+        requestSizeBytes: 0,
+        authenticated: true,
+        error: null,
+      }),
+    ).toMatchObject({
+      indexes: [operation],
+      blobs: [
+        operation,
+        "/api/assets/{assetId}/maintenance-records",
+        method,
+        "2xx",
+        "200",
+        "success",
+        "none",
+        "true",
+        "v1",
+      ],
+    });
+  });
 });

--- a/apps/api/src/api/middleware/technicalTelemetry.ts
+++ b/apps/api/src/api/middleware/technicalTelemetry.ts
@@ -118,6 +118,18 @@ function routeTelemetry(method: string, pathname: string): RouteTelemetry {
   if (/^\/api\/assets\/[^/]+$/.test(pathname) && method === "GET") {
     return { operation: "GetAsset", routePattern: "/api/assets/{id}" };
   }
+  if (/^\/api\/assets\/[^/]+\/maintenance-records$/.test(pathname) && method === "POST") {
+    return {
+      operation: "CreateMaintenanceRecord",
+      routePattern: "/api/assets/{assetId}/maintenance-records",
+    };
+  }
+  if (/^\/api\/assets\/[^/]+\/maintenance-records$/.test(pathname) && method === "GET") {
+    return {
+      operation: "ListMaintenanceRecords",
+      routePattern: "/api/assets/{assetId}/maintenance-records",
+    };
+  }
   if (pathname === "/health" && method === "GET") {
     return { operation: "Health", routePattern: "/health" };
   }

--- a/apps/api/src/api/openapi.ts
+++ b/apps/api/src/api/openapi.ts
@@ -8,6 +8,12 @@ import {
   ErrorResponseSchema,
   HealthResponseSchema,
 } from "./schemas/assetSchemas.ts";
+import {
+  CreateMaintenanceRecordBodySchema,
+  MaintenanceAssetIdParamSchema,
+  MaintenanceRecordListResponseSchema,
+  MaintenanceRecordResponseSchema,
+} from "./schemas/maintenanceRecordSchemas.ts";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // OpenAPI route specs (metadata only — no handlers, no infrastructure).
@@ -41,6 +47,10 @@ export const openApiConfig = {
   tags: [
     { name: "System", description: "Health and meta endpoints" },
     { name: "Assets", description: "Create and read assets owned by the caller" },
+    {
+      name: "Maintenance",
+      description: "Create and read asset maintenance records owned by the caller",
+    },
   ],
 };
 
@@ -134,6 +144,76 @@ export const getAssetRoute = createRoute({
   },
 });
 
+export const createMaintenanceRecordRoute = createRoute({
+  method: "post",
+  path: "/api/assets/{assetId}/maintenance-records",
+  tags: ["Maintenance"],
+  summary: "Create a maintenance record",
+  security: [cookieAuth],
+  request: {
+    params: MaintenanceAssetIdParamSchema,
+    body: {
+      required: true,
+      content: { "application/json": { schema: CreateMaintenanceRecordBodySchema } },
+    },
+  },
+  responses: {
+    201: {
+      description: "Maintenance record created",
+      content: { "application/json": { schema: MaintenanceRecordResponseSchema } },
+    },
+    401: {
+      description: "Not authenticated",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    403: {
+      description: "The asset belongs to another user",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    404: {
+      description: "No such asset",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    409: {
+      description: "The asset is archived",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    422: {
+      description: "Validation failed",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
+export const listMaintenanceRecordsRoute = createRoute({
+  method: "get",
+  path: "/api/assets/{assetId}/maintenance-records",
+  tags: ["Maintenance"],
+  summary: "List maintenance records for an asset",
+  description:
+    "Returns records newest first by performed date, then creation time. Archived asset history remains readable.",
+  security: [cookieAuth],
+  request: { params: MaintenanceAssetIdParamSchema },
+  responses: {
+    200: {
+      description: "The asset's maintenance records",
+      content: { "application/json": { schema: MaintenanceRecordListResponseSchema } },
+    },
+    401: {
+      description: "Not authenticated",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    403: {
+      description: "The asset belongs to another user",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    404: {
+      description: "No such asset",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
 /**
  * Register shared OpenAPI components (security schemes) on a registry.
  * Keyed off the registry type (not the app's Env) so it works for both the
@@ -164,6 +244,8 @@ export function getApiDocument() {
   doc.openapi(createAssetRoute, stub);
   doc.openapi(listAssetsRoute, stub);
   doc.openapi(getAssetRoute, stub);
+  doc.openapi(createMaintenanceRecordRoute, stub);
+  doc.openapi(listMaintenanceRecordsRoute, stub);
   registerOpenApiComponents(doc.openAPIRegistry);
   return doc.getOpenAPIDocument(openApiConfig);
 }

--- a/apps/api/src/api/schemas/maintenanceRecordSchemas.test.ts
+++ b/apps/api/src/api/schemas/maintenanceRecordSchemas.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+  CreateMaintenanceRecordBodySchema,
+  MaintenanceAssetIdParamSchema,
+  MaintenanceRecordResponseSchema,
+} from "./maintenanceRecordSchemas.ts";
+
+describe("maintenance record schemas", () => {
+  it("trims valid input and accepts omitted notes", () => {
+    expect(
+      CreateMaintenanceRecordBodySchema.parse({
+        title: "  Changed oil  ",
+        performedAt: "2026-06-09",
+      }),
+    ).toEqual({ title: "Changed oil", performedAt: "2026-06-09" });
+  });
+
+  it("accepts whitespace-only notes and trims them to an empty string", () => {
+    expect(
+      CreateMaintenanceRecordBodySchema.parse({
+        title: "Changed oil",
+        performedAt: "2026-06-09",
+        notes: "   ",
+      }),
+    ).toEqual({ title: "Changed oil", performedAt: "2026-06-09", notes: "" });
+  });
+
+  it.each([
+    { title: "", performedAt: "2026-06-09" },
+    { title: "t".repeat(101), performedAt: "2026-06-09" },
+    { title: "Maintenance", performedAt: "2026-02-29" },
+    { title: "Maintenance", performedAt: "06/09/2026" },
+    { title: "Maintenance", performedAt: "2026-06-09", notes: "n".repeat(1001) },
+  ])("rejects invalid body %#", (body) => {
+    expect(CreateMaintenanceRecordBodySchema.safeParse(body).success).toBe(false);
+  });
+
+  it("rejects malformed asset ids", () => {
+    expect(MaintenanceAssetIdParamSchema.safeParse({ assetId: "not-a-uuid" }).success).toBe(false);
+  });
+
+  it("accepts the documented response shape with nullable notes", () => {
+    expect(
+      MaintenanceRecordResponseSchema.safeParse({
+        id: "e914b960-772f-46a7-b6fb-f333dcfc7fc9",
+        assetId: "195d0ef0-47f5-439f-abfd-29f892c9a040",
+        title: "Changed oil",
+        performedAt: "2026-06-09",
+        notes: null,
+        createdAt: "2026-06-09T18:25:24.887Z",
+      }).success,
+    ).toBe(true);
+  });
+});

--- a/apps/api/src/api/schemas/maintenanceRecordSchemas.ts
+++ b/apps/api/src/api/schemas/maintenanceRecordSchemas.ts
@@ -1,0 +1,51 @@
+import { z } from "@hono/zod-openapi";
+import { isValidDateOnly } from "../../domain/maintenance/DateOnly.ts";
+
+const DateOnlySchema = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, "Date must use YYYY-MM-DD format")
+  .refine(isValidDateOnly, "Date must be a valid calendar date")
+  .openapi({ format: "date", example: "2026-06-09" });
+
+export const MaintenanceAssetIdParamSchema = z.object({
+  assetId: z
+    .string()
+    .uuid("Asset id must be a UUID")
+    .openapi({
+      param: { name: "assetId", in: "path" },
+      example: "195d0ef0-47f5-439f-abfd-29f892c9a040",
+    }),
+});
+
+export const CreateMaintenanceRecordBodySchema = z
+  .object({
+    title: z
+      .string()
+      .trim()
+      .min(1, "Title is required")
+      .max(100, "Title must be 100 characters or fewer")
+      .openapi({ example: "Changed oil" }),
+    performedAt: DateOnlySchema,
+    notes: z
+      .string()
+      .trim()
+      .max(1000, "Notes must be 1000 characters or fewer")
+      .optional()
+      .openapi({ example: "Used 7 quarts of 5W-20 synthetic oil." }),
+  })
+  .openapi("CreateMaintenanceRecordBody");
+
+export const MaintenanceRecordResponseSchema = z
+  .object({
+    id: z.string().uuid().openapi({ example: "e914b960-772f-46a7-b6fb-f333dcfc7fc9" }),
+    assetId: z.string().uuid().openapi({ example: "195d0ef0-47f5-439f-abfd-29f892c9a040" }),
+    title: z.string().openapi({ example: "Changed oil" }),
+    performedAt: DateOnlySchema,
+    notes: z.string().nullable().openapi({ example: "Used 7 quarts of synthetic oil." }),
+    createdAt: z.string().datetime().openapi({ example: "2026-06-09T18:25:24.887Z" }),
+  })
+  .openapi("MaintenanceRecord");
+
+export const MaintenanceRecordListResponseSchema = z
+  .object({ maintenanceRecords: z.array(MaintenanceRecordResponseSchema) })
+  .openapi("MaintenanceRecordListResponse");

--- a/apps/api/src/application/ports/UtcDateProvider.ts
+++ b/apps/api/src/application/ports/UtcDateProvider.ts
@@ -1,0 +1,3 @@
+export interface UtcDateProvider {
+  today(): string;
+}

--- a/apps/api/src/application/usecases/CreateMaintenanceRecord.test.ts
+++ b/apps/api/src/application/usecases/CreateMaintenanceRecord.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from "vitest";
+import {
+  AssetId,
+  ConflictError,
+  ForbiddenError,
+  NotFoundError,
+  UserId,
+  ValidationError,
+} from "@snaveevans/pineapple-shared";
+import { Asset } from "../../domain/asset/Asset.ts";
+import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
+import type { DomainEvent } from "../../domain/events/DomainEvent.ts";
+import type { MaintenanceRecord } from "../../domain/maintenance/MaintenanceRecord.ts";
+import type { MaintenanceRecordRepository } from "../../domain/maintenance/MaintenanceRecordRepository.ts";
+import type { EventBus } from "../ports/EventBus.ts";
+import type { UtcDateProvider } from "../ports/UtcDateProvider.ts";
+import { CreateMaintenanceRecord } from "./CreateMaintenanceRecord.ts";
+
+class AssetRepositoryFake implements AssetRepository {
+  constructor(private readonly asset: Asset | null) {}
+
+  findById(): Promise<Asset | null> {
+    return Promise.resolve(this.asset);
+  }
+
+  findByOwner(): Promise<Asset[]> {
+    return Promise.resolve([]);
+  }
+
+  save(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+class MaintenanceRecordRepositoryFake implements MaintenanceRecordRepository {
+  saved: MaintenanceRecord | null = null;
+
+  findByAsset(): Promise<MaintenanceRecord[]> {
+    return Promise.resolve([]);
+  }
+
+  save(record: MaintenanceRecord): Promise<void> {
+    this.saved = record;
+    return Promise.resolve();
+  }
+}
+
+class EventBusFake implements EventBus {
+  readonly events: DomainEvent[] = [];
+
+  publish(event: DomainEvent): Promise<void> {
+    this.events.push(event);
+    return Promise.resolve();
+  }
+
+  publishAll(events: readonly DomainEvent[]): Promise<void> {
+    this.events.push(...events);
+    return Promise.resolve();
+  }
+
+  subscribe(): void {}
+}
+
+const dates: UtcDateProvider = { today: () => "2026-06-09" };
+
+describe("CreateMaintenanceRecord", () => {
+  const ownerId = UserId.generate();
+
+  function assetFor(owner = ownerId): Asset {
+    return Asset.create({
+      ownerId: owner,
+      name: "Truck",
+      metadata: { kind: "vehicle", make: "Ram", model: "2500", year: 2016 },
+    });
+  }
+
+  it("saves a record and publishes MaintenanceRecordCreated", async () => {
+    const asset = assetFor();
+    const records = new MaintenanceRecordRepositoryFake();
+    const events = new EventBusFake();
+
+    const result = await new CreateMaintenanceRecord(
+      new AssetRepositoryFake(asset),
+      records,
+      events,
+      dates,
+    ).execute({
+      assetId: asset.id,
+      requesterId: ownerId,
+      title: "Changed oil",
+      performedAt: "2026-06-09",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(records.saved).toBe(result.ok ? result.value : null);
+    expect(events.events).toEqual([
+      expect.objectContaining({
+        type: "MaintenanceRecordCreated",
+        assetId: asset.id,
+        ownerId,
+        actorId: ownerId,
+      }),
+    ]);
+    expect(records.saved?.pullEvents()).toEqual([]);
+  });
+
+  it("returns not found when the asset does not exist", async () => {
+    const result = await executeWithAsset(null, ownerId);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBeInstanceOf(NotFoundError);
+  });
+
+  it("returns forbidden for another owner's asset", async () => {
+    const result = await executeWithAsset(assetFor(UserId.generate()), ownerId);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBeInstanceOf(ForbiddenError);
+  });
+
+  it("returns conflict for an archived asset", async () => {
+    const asset = assetFor();
+    asset.archivedAt = new Date("2026-06-08T00:00:00.000Z");
+
+    const result = await executeWithAsset(asset, ownerId);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBeInstanceOf(ConflictError);
+  });
+
+  it("returns validation error for a future performed date", async () => {
+    const asset = assetFor();
+    const result = await new CreateMaintenanceRecord(
+      new AssetRepositoryFake(asset),
+      new MaintenanceRecordRepositoryFake(),
+      new EventBusFake(),
+      dates,
+    ).execute({
+      assetId: asset.id,
+      requesterId: ownerId,
+      title: "Changed oil",
+      performedAt: "2026-06-10",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(ValidationError);
+      expect((result.error as ValidationError).field).toBe("performedAt");
+    }
+  });
+
+  it("normalizes blank notes to null before persistence and response", async () => {
+    const asset = assetFor();
+    const records = new MaintenanceRecordRepositoryFake();
+    const result = await new CreateMaintenanceRecord(
+      new AssetRepositoryFake(asset),
+      records,
+      new EventBusFake(),
+      dates,
+    ).execute({
+      assetId: asset.id,
+      requesterId: ownerId,
+      title: "Changed oil",
+      performedAt: "2026-06-09",
+      notes: "   ",
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.notes).toBeNull();
+    expect(records.saved?.notes).toBeNull();
+  });
+
+  it("returns an invariant error for a malformed UTC date provider value", async () => {
+    const asset = assetFor();
+    const result = await new CreateMaintenanceRecord(
+      new AssetRepositoryFake(asset),
+      new MaintenanceRecordRepositoryFake(),
+      new EventBusFake(),
+      { today: () => "not-a-date" },
+    ).execute({
+      assetId: asset.id,
+      requesterId: ownerId,
+      title: "Changed oil",
+      performedAt: "2026-06-09",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.name).toBe("InvariantError");
+      expect("field" in result.error).toBe(false);
+    }
+  });
+
+  function executeWithAsset(asset: Asset | null, requesterId: UserId) {
+    return new CreateMaintenanceRecord(
+      new AssetRepositoryFake(asset),
+      new MaintenanceRecordRepositoryFake(),
+      new EventBusFake(),
+      dates,
+    ).execute({
+      assetId: asset?.id ?? AssetId.generate(),
+      requesterId,
+      title: "Changed oil",
+      performedAt: "2026-06-09",
+    });
+  }
+});

--- a/apps/api/src/application/usecases/CreateMaintenanceRecord.ts
+++ b/apps/api/src/application/usecases/CreateMaintenanceRecord.ts
@@ -1,0 +1,65 @@
+import {
+  type AssetId,
+  ConflictError,
+  type DomainError,
+  DomainError as DomainErrorClass,
+  ForbiddenError,
+  NotFoundError,
+  type Result,
+  type UserId,
+  err,
+  ok,
+} from "@snaveevans/pineapple-shared";
+import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
+import { MaintenanceRecord } from "../../domain/maintenance/MaintenanceRecord.ts";
+import type { MaintenanceRecordRepository } from "../../domain/maintenance/MaintenanceRecordRepository.ts";
+import type { EventBus } from "../ports/EventBus.ts";
+import type { UtcDateProvider } from "../ports/UtcDateProvider.ts";
+
+export type CreateMaintenanceRecordCommand = {
+  assetId: AssetId;
+  requesterId: UserId;
+  title: string;
+  performedAt: string;
+  notes?: string;
+};
+
+export class CreateMaintenanceRecord {
+  constructor(
+    private readonly assets: AssetRepository,
+    private readonly records: MaintenanceRecordRepository,
+    private readonly eventBus: EventBus,
+    private readonly dates: UtcDateProvider,
+  ) {}
+
+  async execute(
+    command: CreateMaintenanceRecordCommand,
+  ): Promise<Result<MaintenanceRecord, DomainError>> {
+    try {
+      const asset = await this.assets.findById(command.assetId);
+      if (!asset) return err(new NotFoundError("Asset not found"));
+      if (asset.ownerId !== command.requesterId) {
+        return err(new ForbiddenError("Access denied"));
+      }
+      if (asset.archivedAt !== null) {
+        return err(new ConflictError("Cannot add maintenance to an archived asset"));
+      }
+
+      const record = MaintenanceRecord.create({
+        assetId: asset.id,
+        ownerId: asset.ownerId,
+        actorId: command.requesterId,
+        title: command.title,
+        performedAt: command.performedAt,
+        ...(command.notes !== undefined ? { notes: command.notes } : {}),
+        todayUtc: this.dates.today(),
+      });
+      await this.records.save(record);
+      await this.eventBus.publishAll(record.pullEvents());
+      return ok(record);
+    } catch (error) {
+      if (error instanceof DomainErrorClass) return err(error);
+      throw error;
+    }
+  }
+}

--- a/apps/api/src/application/usecases/ListMaintenanceRecords.test.ts
+++ b/apps/api/src/application/usecases/ListMaintenanceRecords.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { ForbiddenError, NotFoundError, UserId } from "@snaveevans/pineapple-shared";
+import { Asset } from "../../domain/asset/Asset.ts";
+import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
+import { MaintenanceRecord } from "../../domain/maintenance/MaintenanceRecord.ts";
+import type { MaintenanceRecordRepository } from "../../domain/maintenance/MaintenanceRecordRepository.ts";
+import { ListMaintenanceRecords } from "./ListMaintenanceRecords.ts";
+
+class AssetRepositoryFake implements AssetRepository {
+  constructor(private readonly asset: Asset | null) {}
+
+  findById(): Promise<Asset | null> {
+    return Promise.resolve(this.asset);
+  }
+
+  findByOwner(): Promise<Asset[]> {
+    return Promise.resolve([]);
+  }
+
+  save(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+class MaintenanceRecordRepositoryFake implements MaintenanceRecordRepository {
+  requestedOwnerId: string | null = null;
+
+  constructor(private readonly records: MaintenanceRecord[]) {}
+
+  findByAsset(_assetId: string, ownerId: string): Promise<MaintenanceRecord[]> {
+    this.requestedOwnerId = ownerId;
+    return Promise.resolve(this.records);
+  }
+
+  save(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+describe("ListMaintenanceRecords", () => {
+  const ownerId = UserId.generate();
+
+  it("returns archived asset history newest first and filters by requester", async () => {
+    const asset = assetFor();
+    asset.archivedAt = new Date("2026-06-08T00:00:00.000Z");
+    const older = record(asset, "2026-05-01", "2026-06-01T00:00:00.000Z");
+    const sameDateOlder = record(asset, "2026-06-01", "2026-06-01T00:00:00.000Z");
+    const sameDateNewer = record(asset, "2026-06-01", "2026-06-02T00:00:00.000Z");
+    const repositoryOrder = [sameDateNewer, sameDateOlder, older];
+    const records = new MaintenanceRecordRepositoryFake(repositoryOrder);
+
+    const result = await new ListMaintenanceRecords(
+      new AssetRepositoryFake(asset),
+      records,
+    ).execute({ assetId: asset.id, requesterId: ownerId });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toEqual(repositoryOrder);
+    expect(records.requestedOwnerId).toBe(ownerId);
+  });
+
+  it("returns not found when the asset does not exist", async () => {
+    const assetId = assetFor().id;
+    const result = await new ListMaintenanceRecords(
+      new AssetRepositoryFake(null),
+      new MaintenanceRecordRepositoryFake([]),
+    ).execute({ assetId, requesterId: ownerId });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBeInstanceOf(NotFoundError);
+  });
+
+  it("returns forbidden for another owner's asset", async () => {
+    const asset = assetFor();
+    expect(asset.archivedAt).toBeNull();
+
+    const result = await new ListMaintenanceRecords(
+      new AssetRepositoryFake(asset),
+      new MaintenanceRecordRepositoryFake([]),
+    ).execute({ assetId: asset.id, requesterId: UserId.generate() });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBeInstanceOf(ForbiddenError);
+  });
+
+  function assetFor(): Asset {
+    return Asset.create({
+      ownerId,
+      name: "Truck",
+      metadata: { kind: "vehicle", make: "Ram", model: "2500", year: 2016 },
+    });
+  }
+
+  function record(asset: Asset, performedAt: string, createdAt: string): MaintenanceRecord {
+    const created = MaintenanceRecord.create({
+      assetId: asset.id,
+      ownerId,
+      actorId: ownerId,
+      title: "Maintenance",
+      performedAt,
+      todayUtc: "2026-06-09",
+    });
+    return MaintenanceRecord.reconstitute({
+      id: created.id,
+      assetId: created.assetId,
+      ownerId: created.ownerId,
+      title: created.title,
+      performedAt: created.performedAt,
+      notes: created.notes,
+      createdAt: new Date(createdAt),
+    });
+  }
+});

--- a/apps/api/src/application/usecases/ListMaintenanceRecords.ts
+++ b/apps/api/src/application/usecases/ListMaintenanceRecords.ts
@@ -1,0 +1,44 @@
+import {
+  type AssetId,
+  type DomainError,
+  DomainError as DomainErrorClass,
+  ForbiddenError,
+  NotFoundError,
+  type Result,
+  type UserId,
+  err,
+  ok,
+} from "@snaveevans/pineapple-shared";
+import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
+import type { MaintenanceRecord } from "../../domain/maintenance/MaintenanceRecord.ts";
+import type { MaintenanceRecordRepository } from "../../domain/maintenance/MaintenanceRecordRepository.ts";
+
+export type ListMaintenanceRecordsQuery = {
+  assetId: AssetId;
+  requesterId: UserId;
+};
+
+export class ListMaintenanceRecords {
+  constructor(
+    private readonly assets: AssetRepository,
+    private readonly records: MaintenanceRecordRepository,
+  ) {}
+
+  async execute(
+    query: ListMaintenanceRecordsQuery,
+  ): Promise<Result<MaintenanceRecord[], DomainError>> {
+    try {
+      const asset = await this.assets.findById(query.assetId);
+      if (!asset) return err(new NotFoundError("Asset not found"));
+      if (asset.ownerId !== query.requesterId) {
+        return err(new ForbiddenError("Access denied"));
+      }
+
+      const records = await this.records.findByAsset(asset.id, query.requesterId);
+      return ok(records);
+    } catch (error) {
+      if (error instanceof DomainErrorClass) return err(error);
+      throw error;
+    }
+  }
+}

--- a/apps/api/src/domain/maintenance/DateOnly.ts
+++ b/apps/api/src/domain/maintenance/DateOnly.ts
@@ -1,0 +1,32 @@
+import { ValidationError } from "@snaveevans/pineapple-shared";
+
+const DATE_ONLY_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+export function isValidDateOnly(value: string): boolean {
+  const match = DATE_ONLY_PATTERN.exec(value);
+  if (!match) return false;
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  return year >= 1 && month >= 1 && month <= 12 && day >= 1 && day <= daysInMonth(year, month);
+}
+
+export function validateDateOnly(value: string, field = "performedAt"): void {
+  if (!DATE_ONLY_PATTERN.test(value)) {
+    throw new ValidationError("Date must use YYYY-MM-DD format", field);
+  }
+  if (!isValidDateOnly(value)) {
+    throw new ValidationError("Date must be a valid calendar date", field);
+  }
+}
+
+function daysInMonth(year: number, month: number): number {
+  if (month === 2) return isLeapYear(year) ? 29 : 28;
+  if (month === 4 || month === 6 || month === 9 || month === 11) return 30;
+  return 31;
+}
+
+function isLeapYear(year: number): boolean {
+  return year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+}

--- a/apps/api/src/domain/maintenance/MaintenanceRecord.test.ts
+++ b/apps/api/src/domain/maintenance/MaintenanceRecord.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { AssetId, InvariantError, UserId, ValidationError } from "@snaveevans/pineapple-shared";
+import { MaintenanceRecord } from "./MaintenanceRecord.ts";
+
+describe("MaintenanceRecord", () => {
+  const assetId = AssetId.generate();
+  const ownerId = UserId.generate();
+
+  function create(
+    overrides: Partial<Parameters<typeof MaintenanceRecord.create>[0]> = {},
+  ): MaintenanceRecord {
+    return MaintenanceRecord.create({
+      assetId,
+      ownerId,
+      actorId: ownerId,
+      title: "Changed oil",
+      performedAt: "2026-06-09",
+      todayUtc: "2026-06-09",
+      ...overrides,
+    });
+  }
+
+  it("trims fields, converts blank notes to null, and emits the creation event", () => {
+    const record = create({ title: "  Changed oil  ", notes: "   " });
+
+    expect(record.title).toBe("Changed oil");
+    expect(record.notes).toBeNull();
+    expect(record.pullEvents()).toEqual([
+      expect.objectContaining({
+        type: "MaintenanceRecordCreated",
+        maintenanceRecordId: record.id,
+        assetId,
+        ownerId,
+        actorId: ownerId,
+        performedAt: "2026-06-09",
+      }),
+    ]);
+  });
+
+  it("accepts title and notes at their maximum lengths", () => {
+    const record = create({ title: "t".repeat(100), notes: "n".repeat(1000) });
+    expect(record.title).toHaveLength(100);
+    expect(record.notes).toHaveLength(1000);
+  });
+
+  it.each([
+    [{ title: "   " }, "title"],
+    [{ title: "t".repeat(101) }, "title"],
+    [{ notes: "n".repeat(1001) }, "notes"],
+    [{ performedAt: "2026-6-09" }, "performedAt"],
+    [{ performedAt: "0000-01-01" }, "performedAt"],
+    [{ performedAt: "2026-02-29" }, "performedAt"],
+    [{ performedAt: "2026-06-10" }, "performedAt"],
+  ])("rejects invalid input %o", (overrides, field) => {
+    try {
+      create(overrides);
+      expect.fail("Expected validation to fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ValidationError);
+      expect((error as ValidationError).field).toBe(field);
+    }
+  });
+
+  it("accepts a leap day in a leap year", () => {
+    expect(create({ performedAt: "2024-02-29" }).performedAt).toBe("2024-02-29");
+  });
+
+  it("rejects an invalid UTC date provider value as an invariant error", () => {
+    expect(() => create({ todayUtc: "not-a-date" })).toThrow(InvariantError);
+  });
+
+  it("reconstitutes without emitting an event", () => {
+    const original = create();
+    original.pullEvents();
+
+    const record = MaintenanceRecord.reconstitute({
+      id: original.id,
+      assetId: original.assetId,
+      ownerId: original.ownerId,
+      title: original.title,
+      performedAt: original.performedAt,
+      notes: original.notes,
+      createdAt: original.createdAt,
+    });
+
+    expect(record.pullEvents()).toEqual([]);
+  });
+});

--- a/apps/api/src/domain/maintenance/MaintenanceRecord.ts
+++ b/apps/api/src/domain/maintenance/MaintenanceRecord.ts
@@ -1,0 +1,101 @@
+import {
+  type AssetId,
+  InvariantError,
+  MaintenanceRecordId,
+  type UserId,
+  ValidationError,
+} from "@snaveevans/pineapple-shared";
+import type { DomainEvent } from "../events/DomainEvent.ts";
+import { validateDateOnly } from "./DateOnly.ts";
+import { MaintenanceRecordCreated } from "./events/MaintenanceRecordCreated.ts";
+
+export class MaintenanceRecord {
+  private _domainEvents: DomainEvent[] = [];
+
+  private constructor(
+    readonly id: MaintenanceRecordId,
+    readonly assetId: AssetId,
+    readonly ownerId: UserId,
+    readonly title: string,
+    readonly performedAt: string,
+    readonly notes: string | null,
+    readonly createdAt: Date,
+  ) {}
+
+  static create(props: {
+    assetId: AssetId;
+    ownerId: UserId;
+    actorId: UserId;
+    title: string;
+    performedAt: string;
+    notes?: string;
+    todayUtc: string;
+  }): MaintenanceRecord {
+    const title = props.title.trim();
+    if (!title) throw new ValidationError("Title is required", "title");
+    if (title.length > 100) {
+      throw new ValidationError("Title must be 100 characters or fewer", "title");
+    }
+
+    const notes = props.notes?.trim() || null;
+    if (notes !== null && notes.length > 1000) {
+      throw new ValidationError("Notes must be 1000 characters or fewer", "notes");
+    }
+
+    validateDateOnly(props.performedAt);
+    try {
+      validateDateOnly(props.todayUtc);
+    } catch {
+      throw new InvariantError("UTC date provider returned an invalid date");
+    }
+    if (props.performedAt > props.todayUtc) {
+      throw new ValidationError("Performed date must be today or earlier", "performedAt");
+    }
+
+    const record = new MaintenanceRecord(
+      MaintenanceRecordId.generate(),
+      props.assetId,
+      props.ownerId,
+      title,
+      props.performedAt,
+      notes,
+      new Date(),
+    );
+    record._domainEvents.push(
+      MaintenanceRecordCreated({
+        maintenanceRecordId: record.id,
+        assetId: record.assetId,
+        ownerId: record.ownerId,
+        actorId: props.actorId,
+        performedAt: record.performedAt,
+      }),
+    );
+    return record;
+  }
+
+  static reconstitute(props: {
+    id: MaintenanceRecordId;
+    assetId: AssetId;
+    ownerId: UserId;
+    title: string;
+    performedAt: string;
+    notes: string | null;
+    createdAt: Date;
+  }): MaintenanceRecord {
+    return new MaintenanceRecord(
+      props.id,
+      props.assetId,
+      props.ownerId,
+      props.title,
+      props.performedAt,
+      props.notes,
+      props.createdAt,
+    );
+  }
+
+  pullEvents(): DomainEvent[] {
+    const events = [...this._domainEvents];
+    this._domainEvents = [];
+    return events;
+  }
+}

--- a/apps/api/src/domain/maintenance/MaintenanceRecordRepository.ts
+++ b/apps/api/src/domain/maintenance/MaintenanceRecordRepository.ts
@@ -1,0 +1,8 @@
+import type { AssetId, UserId } from "@snaveevans/pineapple-shared";
+import type { MaintenanceRecord } from "./MaintenanceRecord.ts";
+
+export interface MaintenanceRecordRepository {
+  /** Returns records ordered by performedAt DESC, then createdAt DESC. */
+  findByAsset(assetId: AssetId, ownerId: UserId): Promise<MaintenanceRecord[]>;
+  save(record: MaintenanceRecord): Promise<void>;
+}

--- a/apps/api/src/domain/maintenance/events/MaintenanceRecordCreated.ts
+++ b/apps/api/src/domain/maintenance/events/MaintenanceRecordCreated.ts
@@ -1,0 +1,27 @@
+import type { AssetId, MaintenanceRecordId, UserId } from "@snaveevans/pineapple-shared";
+import type { DomainEvent } from "../../events/DomainEvent.ts";
+
+export type MaintenanceRecordCreated = DomainEvent & {
+  type: "MaintenanceRecordCreated";
+  maintenanceRecordId: MaintenanceRecordId;
+  assetId: AssetId;
+  ownerId: UserId;
+  actorId: UserId;
+  performedAt: string;
+};
+
+export const MaintenanceRecordCreated = (props: {
+  maintenanceRecordId: MaintenanceRecordId;
+  assetId: AssetId;
+  ownerId: UserId;
+  actorId: UserId;
+  performedAt: string;
+}): MaintenanceRecordCreated => ({
+  type: "MaintenanceRecordCreated",
+  maintenanceRecordId: props.maintenanceRecordId,
+  assetId: props.assetId,
+  ownerId: props.ownerId,
+  actorId: props.actorId,
+  performedAt: props.performedAt,
+  occurredAt: new Date(),
+});

--- a/apps/api/src/infrastructure/persistence/D1MaintenanceRecordRepository.ts
+++ b/apps/api/src/infrastructure/persistence/D1MaintenanceRecordRepository.ts
@@ -1,0 +1,63 @@
+import { AssetId, MaintenanceRecordId, UserId } from "@snaveevans/pineapple-shared";
+import { MaintenanceRecord } from "../../domain/maintenance/MaintenanceRecord.ts";
+import type { MaintenanceRecordRepository } from "../../domain/maintenance/MaintenanceRecordRepository.ts";
+
+type MaintenanceRecordRow = {
+  id: string;
+  asset_id: string;
+  owner_id: string;
+  title: string;
+  performed_at: string;
+  notes: string | null;
+  created_at: string;
+};
+
+const SELECT_COLUMNS = "id, asset_id, owner_id, title, performed_at, notes, created_at";
+
+export class D1MaintenanceRecordRepository implements MaintenanceRecordRepository {
+  constructor(private readonly db: D1Database) {}
+
+  async findByAsset(assetId: AssetId, ownerId: UserId): Promise<MaintenanceRecord[]> {
+    const result = await this.db
+      .prepare(
+        `SELECT ${SELECT_COLUMNS}
+         FROM maintenance_records
+         WHERE asset_id = ? AND owner_id = ?
+         ORDER BY performed_at DESC, created_at DESC`,
+      )
+      .bind(assetId, ownerId)
+      .all<MaintenanceRecordRow>();
+    return result.results.map((row) => this.#rowToRecord(row));
+  }
+
+  async save(record: MaintenanceRecord): Promise<void> {
+    await this.db
+      .prepare(
+        `INSERT INTO maintenance_records
+           (id, asset_id, owner_id, title, performed_at, notes, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(
+        record.id,
+        record.assetId,
+        record.ownerId,
+        record.title,
+        record.performedAt,
+        record.notes,
+        record.createdAt.toISOString(),
+      )
+      .run();
+  }
+
+  #rowToRecord(row: MaintenanceRecordRow): MaintenanceRecord {
+    return MaintenanceRecord.reconstitute({
+      id: MaintenanceRecordId.from(row.id),
+      assetId: AssetId.from(row.asset_id),
+      ownerId: UserId.from(row.owner_id),
+      title: row.title,
+      performedAt: row.performed_at,
+      notes: row.notes,
+      createdAt: new Date(row.created_at),
+    });
+  }
+}

--- a/apps/api/src/infrastructure/telemetry/maintenance/MaintenanceRecordCreatedTelemetryHandler.test.ts
+++ b/apps/api/src/infrastructure/telemetry/maintenance/MaintenanceRecordCreatedTelemetryHandler.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { AssetId, MaintenanceRecordId, UserId } from "@snaveevans/pineapple-shared";
+import type { MaintenanceRecordCreated } from "../../../domain/maintenance/events/MaintenanceRecordCreated.ts";
+import type { TelemetryDataPoint, TelemetrySink } from "../AnalyticsEngineTelemetrySink.ts";
+import {
+  MaintenanceRecordCreatedTelemetryHandler,
+  mapMaintenanceRecordCreatedTelemetry,
+} from "./MaintenanceRecordCreatedTelemetryHandler.ts";
+
+describe("MaintenanceRecordCreatedTelemetryHandler", () => {
+  const event: MaintenanceRecordCreated = {
+    type: "MaintenanceRecordCreated",
+    maintenanceRecordId: MaintenanceRecordId.from("e914b960-772f-46a7-b6fb-f333dcfc7fc9"),
+    assetId: AssetId.from("195d0ef0-47f5-439f-abfd-29f892c9a040"),
+    ownerId: UserId.from("7d914909-c903-41a4-a13a-82cbd0f61851"),
+    actorId: UserId.from("71afbc20-f2e0-4fc8-a989-278437cf792c"),
+    performedAt: "2026-06-09",
+    occurredAt: new Date("2026-06-09T12:00:00.000Z"),
+  };
+
+  it("maps the event to the documented Analytics Engine field order", () => {
+    expect(mapMaintenanceRecordCreatedTelemetry(event)).toEqual({
+      indexes: [event.ownerId],
+      blobs: [
+        "MaintenanceRecordCreated",
+        "MaintenanceRecord",
+        event.maintenanceRecordId,
+        event.assetId,
+        event.ownerId,
+        event.actorId,
+        "CreateMaintenanceRecord",
+        "v1",
+        "success",
+      ],
+      doubles: [1, event.occurredAt.getTime(), Date.UTC(2026, 5, 9)],
+    });
+  });
+
+  it("writes the mapped data point to the sink", () => {
+    const writes: TelemetryDataPoint[] = [];
+    const sink: TelemetrySink = {
+      write: (dataPoint) => {
+        writes.push(dataPoint);
+      },
+    };
+
+    new MaintenanceRecordCreatedTelemetryHandler(sink).handle(event);
+
+    expect(writes).toEqual([mapMaintenanceRecordCreatedTelemetry(event)]);
+  });
+});

--- a/apps/api/src/infrastructure/telemetry/maintenance/MaintenanceRecordCreatedTelemetryHandler.ts
+++ b/apps/api/src/infrastructure/telemetry/maintenance/MaintenanceRecordCreatedTelemetryHandler.ts
@@ -1,0 +1,38 @@
+import type { DomainEventHandler } from "../../../application/ports/EventBus.ts";
+import type { MaintenanceRecordCreated } from "../../../domain/maintenance/events/MaintenanceRecordCreated.ts";
+import type { TelemetryDataPoint, TelemetrySink } from "../AnalyticsEngineTelemetrySink.ts";
+
+export function mapMaintenanceRecordCreatedTelemetry(
+  event: MaintenanceRecordCreated,
+): TelemetryDataPoint {
+  return {
+    indexes: [event.ownerId],
+    blobs: [
+      event.type,
+      "MaintenanceRecord",
+      event.maintenanceRecordId,
+      event.assetId,
+      event.ownerId,
+      event.actorId,
+      "CreateMaintenanceRecord",
+      "v1",
+      "success",
+    ],
+    doubles: [1, event.occurredAt.getTime(), dateOnlyToUtcMidnight(event.performedAt)],
+  };
+}
+
+export class MaintenanceRecordCreatedTelemetryHandler implements DomainEventHandler<MaintenanceRecordCreated> {
+  readonly eventType = "MaintenanceRecordCreated" as const;
+
+  constructor(private readonly sink: TelemetrySink) {}
+
+  handle(event: MaintenanceRecordCreated): void {
+    this.sink.write(mapMaintenanceRecordCreatedTelemetry(event));
+  }
+}
+
+function dateOnlyToUtcMidnight(value: string): number {
+  const [year, month, day] = value.split("-").map(Number);
+  return Date.UTC(year ?? 0, (month ?? 1) - 1, day ?? 1);
+}

--- a/apps/api/src/infrastructure/telemetry/registerDomainTelemetry.ts
+++ b/apps/api/src/infrastructure/telemetry/registerDomainTelemetry.ts
@@ -1,11 +1,13 @@
 import type { EventBus } from "../../application/ports/EventBus.ts";
 import { AnalyticsEngineTelemetrySink } from "./AnalyticsEngineTelemetrySink.ts";
 import { AssetCreatedTelemetryHandler } from "./asset/AssetCreatedTelemetryHandler.ts";
+import { MaintenanceRecordCreatedTelemetryHandler } from "./maintenance/MaintenanceRecordCreatedTelemetryHandler.ts";
 import { UserProvisionedTelemetryHandler } from "./user/UserProvisionedTelemetryHandler.ts";
 
 export function registerDomainTelemetry(deps: {
   eventBus: EventBus;
   assetDomainDataset: AnalyticsEngineDataset;
+  maintenanceDomainDataset: AnalyticsEngineDataset;
   userDomainDataset: AnalyticsEngineDataset;
 }): void {
   const assetDomainSink = new AnalyticsEngineTelemetrySink(deps.assetDomainDataset);
@@ -13,4 +15,7 @@ export function registerDomainTelemetry(deps: {
 
   const userDomainSink = new AnalyticsEngineTelemetrySink(deps.userDomainDataset);
   deps.eventBus.subscribe(new UserProvisionedTelemetryHandler(userDomainSink));
+
+  const maintenanceDomainSink = new AnalyticsEngineTelemetrySink(deps.maintenanceDomainDataset);
+  deps.eventBus.subscribe(new MaintenanceRecordCreatedTelemetryHandler(maintenanceDomainSink));
 }

--- a/apps/api/src/infrastructure/time/SystemUtcDateProvider.ts
+++ b/apps/api/src/infrastructure/time/SystemUtcDateProvider.ts
@@ -1,0 +1,7 @@
+import type { UtcDateProvider } from "../../application/ports/UtcDateProvider.ts";
+
+export class SystemUtcDateProvider implements UtcDateProvider {
+  today(): string {
+    return new Date().toISOString().slice(0, 10);
+  }
+}

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -5,20 +5,25 @@ import { AssetId, DomainError } from "@snaveevans/pineapple-shared";
 import type { User } from "./domain/identity/User.ts";
 import type { Asset } from "./domain/asset/Asset.ts";
 import type { AssetMetadata } from "./domain/asset/AssetMetadata.ts";
+import type { MaintenanceRecord } from "./domain/maintenance/MaintenanceRecord.ts";
 
 // Infrastructure
 import { D1UserRepository } from "./infrastructure/persistence/D1UserRepository.ts";
 import { D1AssetRepository } from "./infrastructure/persistence/D1AssetRepository.ts";
+import { D1MaintenanceRecordRepository } from "./infrastructure/persistence/D1MaintenanceRecordRepository.ts";
 import { createAuth, type Auth, type AuthEnv } from "./infrastructure/auth/auth.ts";
 import { BetterAuthResolver } from "./infrastructure/auth/BetterAuthResolver.ts";
 import { InMemoryEventBus } from "./infrastructure/events/InMemoryEventBus.ts";
 import { AnalyticsEngineTelemetrySink } from "./infrastructure/telemetry/AnalyticsEngineTelemetrySink.ts";
 import { registerDomainTelemetry } from "./infrastructure/telemetry/registerDomainTelemetry.ts";
+import { SystemUtcDateProvider } from "./infrastructure/time/SystemUtcDateProvider.ts";
 
 // Application
 import { CreateAsset } from "./application/usecases/CreateAsset.ts";
 import { GetAsset } from "./application/usecases/GetAsset.ts";
 import { ListAssets } from "./application/usecases/ListAssets.ts";
+import { CreateMaintenanceRecord } from "./application/usecases/CreateMaintenanceRecord.ts";
+import { ListMaintenanceRecords } from "./application/usecases/ListMaintenanceRecords.ts";
 import type { EventBus } from "./application/ports/EventBus.ts";
 
 // API layer
@@ -26,17 +31,21 @@ import { toHttpError } from "./api/errors.ts";
 import { createTechnicalTelemetryMiddleware } from "./api/middleware/technicalTelemetry.ts";
 import {
   createAssetRoute,
+  createMaintenanceRecordRoute,
   getAssetRoute,
   healthRoute,
   listAssetsRoute,
+  listMaintenanceRecordsRoute,
   registerOpenApiComponents,
 } from "./api/openapi.ts";
 import openApiSpec from "../../../docs/reference/openapi.json";
 import type { AssetResponseSchema } from "./api/schemas/assetSchemas.ts";
+import type { MaintenanceRecordResponseSchema } from "./api/schemas/maintenanceRecordSchemas.ts";
 import type { z } from "@hono/zod-openapi";
 
 type Bindings = AuthEnv & {
   ASSET_DOMAIN_TELEMETRY: AnalyticsEngineDataset;
+  MAINTENANCE_DOMAIN_TELEMETRY: AnalyticsEngineDataset;
   USER_DOMAIN_TELEMETRY: AnalyticsEngineDataset;
   API_REQUEST_TELEMETRY: AnalyticsEngineDataset;
   /** Local dev only — set in .dev.vars, never in wrangler.toml. Bypasses the Better Auth session check. */
@@ -90,6 +99,19 @@ function serializeAsset(asset: Asset): z.infer<typeof AssetResponseSchema> {
   };
 }
 
+function serializeMaintenanceRecord(
+  record: MaintenanceRecord,
+): z.infer<typeof MaintenanceRecordResponseSchema> {
+  return {
+    id: record.id,
+    assetId: record.assetId,
+    title: record.title,
+    performedAt: record.performedAt,
+    notes: record.notes,
+    createdAt: record.createdAt.toISOString(),
+  };
+}
+
 // ── Public routes (no auth) ──────────────────────────────────────────────────
 
 app.openapi(healthRoute, (c) => c.json({ status: "ok" } as const, 200));
@@ -114,6 +136,7 @@ app.use("/api/*", async (c, next) => {
   registerDomainTelemetry({
     eventBus,
     assetDomainDataset: c.env.ASSET_DOMAIN_TELEMETRY,
+    maintenanceDomainDataset: c.env.MAINTENANCE_DOMAIN_TELEMETRY,
     userDomainDataset: c.env.USER_DOMAIN_TELEMETRY,
   });
   c.set("eventBus", eventBus);
@@ -174,6 +197,42 @@ app.openapi(getAssetRoute, async (c) => {
   });
   if (!result.ok) throw result.error;
   return c.json(serializeAsset(result.value), 200);
+});
+
+// ── Maintenance record endpoints ────────────────────────────────────────────
+
+app.openapi(createMaintenanceRecordRoute, async (c) => {
+  const user = c.get("user");
+  const { assetId } = c.req.valid("param");
+  const { title, performedAt, notes } = c.req.valid("json");
+  const result = await new CreateMaintenanceRecord(
+    new D1AssetRepository(c.env.DB),
+    new D1MaintenanceRecordRepository(c.env.DB),
+    c.get("eventBus"),
+    new SystemUtcDateProvider(),
+  ).execute({
+    assetId: AssetId.from(assetId),
+    requesterId: user.id,
+    title,
+    performedAt,
+    ...(notes !== undefined ? { notes } : {}),
+  });
+  if (!result.ok) throw result.error;
+  return c.json(serializeMaintenanceRecord(result.value), 201);
+});
+
+app.openapi(listMaintenanceRecordsRoute, async (c) => {
+  const user = c.get("user");
+  const { assetId } = c.req.valid("param");
+  const result = await new ListMaintenanceRecords(
+    new D1AssetRepository(c.env.DB),
+    new D1MaintenanceRecordRepository(c.env.DB),
+  ).execute({
+    assetId: AssetId.from(assetId),
+    requesterId: user.id,
+  });
+  if (!result.ok) throw result.error;
+  return c.json({ maintenanceRecords: result.value.map(serializeMaintenanceRecord) }, 200);
 });
 
 export default app;

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -44,5 +44,9 @@ binding = "USER_DOMAIN_TELEMETRY"
 dataset = "pineapple_user_domain_events"
 
 [[analytics_engine_datasets]]
+binding = "MAINTENANCE_DOMAIN_TELEMETRY"
+dataset = "pineapple_maintenance_domain_events"
+
+[[analytics_engine_datasets]]
 binding = "API_REQUEST_TELEMETRY"
 dataset = "pineapple_api_request_events"

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -42,15 +42,17 @@ sign-in. There is no separate "register" step.
 
 ## Endpoints
 
-| Method | Path               | Auth | Description                              |
-| ------ | ------------------ | ---- | ---------------------------------------- |
-| GET    | `/health`          | no   | Liveness check                           |
-| GET    | `/openapi.json`    | no   | The OpenAPI spec                         |
-| GET    | `/reference`       | no   | Interactive API docs (Scalar)            |
-| `*`    | `/api/auth/*`      | —    | Better Auth (sign-in, callback, session) |
-| POST   | `/api/assets`      | yes  | Create an asset                          |
-| GET    | `/api/assets`      | yes  | List the caller's active assets          |
-| GET    | `/api/assets/{id}` | yes  | Get one asset the caller owns            |
+| Method | Path                                        | Auth | Description                              |
+| ------ | ------------------------------------------- | ---- | ---------------------------------------- |
+| GET    | `/health`                                   | no   | Liveness check                           |
+| GET    | `/openapi.json`                             | no   | The OpenAPI spec                         |
+| GET    | `/reference`                                | no   | Interactive API docs (Scalar)            |
+| `*`    | `/api/auth/*`                               | —    | Better Auth (sign-in, callback, session) |
+| POST   | `/api/assets`                               | yes  | Create an asset                          |
+| GET    | `/api/assets`                               | yes  | List the caller's active assets          |
+| GET    | `/api/assets/{id}`                          | yes  | Get one asset the caller owns            |
+| POST   | `/api/assets/{assetId}/maintenance-records` | yes  | Create a maintenance record              |
+| GET    | `/api/assets/{assetId}/maintenance-records` | yes  | List an asset's maintenance history      |
 
 See [`data-model.md`](data-model.md) for the shape of an asset and its metadata
 variants.
@@ -101,5 +103,7 @@ in the domain (see [ADR-0007](../decisions/0007-api-validation-boundary.md)).
 - All request and response bodies are JSON.
 - IDs are UUID strings.
 - Timestamps are ISO-8601 UTC strings (e.g. `2026-05-29T03:25:24.887Z`).
+- Maintenance `performedAt` values are timezone-free calendar dates in
+  `YYYY-MM-DD` format.
 - `GET /api/assets` returns only **active** assets (archived ones are excluded).
 - You can only read assets you own; requesting another user's asset returns 403.

--- a/docs/reference/data-model.md
+++ b/docs/reference/data-model.md
@@ -5,11 +5,14 @@
 ## Entities at a glance
 
 ```
-User 1 ──< owns >── * Asset
+User 1 ──< owns >── * Asset 1 ──< has >── * MaintenanceRecord
 ```
 
 A **User** owns many **Assets**. An asset always belongs to exactly one user,
 and a user only ever sees their own assets.
+
+An **Asset** has zero or more **Maintenance Records**. Each record belongs to
+exactly one asset and inherits access through that asset's owner.
 
 ## User
 
@@ -43,31 +46,44 @@ These are **branded** types, not raw strings — constructed via `.from()` /
 `.generate()` and validated on creation (see
 [ADR-0002](../decisions/0002-use-tactical-ddd-patterns-for-the-domain-layer.md)).
 
-| Type      | Backed by   | Notes                        |
-| --------- | ----------- | ---------------------------- |
-| `UserId`  | UUID string | `.generate()` for new users  |
-| `AssetId` | UUID string | `.generate()` for new assets |
-| `Email`   | string      | validated email format       |
+| Type                  | Backed by   | Notes                         |
+| --------------------- | ----------- | ----------------------------- |
+| `UserId`              | UUID string | `.generate()` for new users   |
+| `AssetId`             | UUID string | `.generate()` for new assets  |
+| `MaintenanceRecordId` | UUID string | `.generate()` for new records |
+| `Email`               | string      | validated email format        |
+
+## Maintenance Record
+
+The public shape and validation rules live in the [OpenAPI spec](openapi.json)
+(`MaintenanceRecord`, `CreateMaintenanceRecordBody`). Domain-only details:
+
+- **`ownerId`** is copied from the target asset at creation and is not exposed
+  in API responses.
+- **`performedAt`** is stored as a timezone-free `YYYY-MM-DD` calendar date.
+  It is never converted to a timestamp for persistence or display.
+- Archived assets retain readable history but cannot receive new records.
 
 ## Domain events
 
 Aggregates raise events when something significant happens. Today:
 
-| Event          | Raised when         | Carries            |
-| -------------- | ------------------- | ------------------ |
-| `AssetCreated` | an asset is created | the new asset's id |
+| Event                      | Raised when                     | Carries                                  |
+| -------------------------- | ------------------------------- | ---------------------------------------- |
+| `AssetCreated`             | an asset is created             | asset, owner, type, and optional year    |
+| `MaintenanceRecordCreated` | a maintenance record is created | record, asset, owner, and performed date |
 
-There is no event bus yet — events are drained and dropped after persistence.
-This is the seam where future side effects (notifications, projections) will
-attach.
+Events are published after persistence through the in-memory event bus.
+Infrastructure telemetry handlers consume the implemented events.
 
 ## Storage mapping
 
-| Domain concept     | D1 table                                     | Notes                                                                  |
-| ------------------ | -------------------------------------------- | ---------------------------------------------------------------------- |
-| `User`             | `users`                                      |                                                                        |
-| `Asset`            | `assets`                                     | `metadata` is a JSON string column                                     |
-| Auth (Better Auth) | `user`, `session`, `account`, `verification` | **singular** names; auth infra, separate from the domain `users` table |
+| Domain concept      | D1 table                                     | Notes                                                                  |
+| ------------------- | -------------------------------------------- | ---------------------------------------------------------------------- |
+| `User`              | `users`                                      |                                                                        |
+| `Asset`             | `assets`                                     | `metadata` is a JSON string column                                     |
+| `MaintenanceRecord` | `maintenance_records`                        | `performed_at` is a date-only text column                              |
+| Auth (Better Auth)  | `user`, `session`, `account`, `verification` | **singular** names; auth infra, separate from the domain `users` table |
 
 Timestamps are stored as ISO-8601 strings. Schema lives in
 [`/migrations`](../../migrations) and is applied with

--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -23,6 +23,10 @@
     {
       "name": "Assets",
       "description": "Create and read assets owned by the caller"
+    },
+    {
+      "name": "Maintenance",
+      "description": "Create and read asset maintenance records owned by the caller"
     }
   ],
   "components": {
@@ -297,6 +301,89 @@
         "required": [
           "assets"
         ]
+      },
+      "MaintenanceRecord": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "e914b960-772f-46a7-b6fb-f333dcfc7fc9"
+          },
+          "assetId": {
+            "type": "string",
+            "format": "uuid",
+            "example": "195d0ef0-47f5-439f-abfd-29f892c9a040"
+          },
+          "title": {
+            "type": "string",
+            "example": "Changed oil"
+          },
+          "performedAt": {
+            "type": "string",
+            "format": "date",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+            "example": "2026-06-09"
+          },
+          "notes": {
+            "type": "string",
+            "nullable": true,
+            "example": "Used 7 quarts of synthetic oil."
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2026-06-09T18:25:24.887Z"
+          }
+        },
+        "required": [
+          "id",
+          "assetId",
+          "title",
+          "performedAt",
+          "notes",
+          "createdAt"
+        ]
+      },
+      "CreateMaintenanceRecordBody": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 100,
+            "example": "Changed oil"
+          },
+          "performedAt": {
+            "type": "string",
+            "format": "date",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+            "example": "2026-06-09"
+          },
+          "notes": {
+            "type": "string",
+            "maxLength": 1000,
+            "example": "Used 7 quarts of 5W-20 synthetic oil."
+          }
+        },
+        "required": [
+          "title",
+          "performedAt"
+        ]
+      },
+      "MaintenanceRecordListResponse": {
+        "type": "object",
+        "properties": {
+          "maintenanceRecords": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MaintenanceRecord"
+            }
+          }
+        },
+        "required": [
+          "maintenanceRecords"
+        ]
       }
     },
     "parameters": {}
@@ -441,6 +528,169 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Asset"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The asset belongs to another user",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No such asset",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/assets/{assetId}/maintenance-records": {
+      "post": {
+        "tags": [
+          "Maintenance"
+        ],
+        "summary": "Create a maintenance record",
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "195d0ef0-47f5-439f-abfd-29f892c9a040"
+            },
+            "required": true,
+            "name": "assetId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateMaintenanceRecordBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Maintenance record created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MaintenanceRecord"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The asset belongs to another user",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No such asset",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The asset is archived",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Maintenance"
+        ],
+        "summary": "List maintenance records for an asset",
+        "description": "Returns records newest first by performed date, then creation time. Archived asset history remains readable.",
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "195d0ef0-47f5-439f-abfd-29f892c9a040"
+            },
+            "required": true,
+            "name": "assetId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The asset's maintenance records",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MaintenanceRecordListResponse"
                 }
               }
             }

--- a/docs/specs/SPECS.md
+++ b/docs/specs/SPECS.md
@@ -28,13 +28,14 @@ relevant cross-cutting specs rather than re-describing the behavior.
 
 ## Feature Specs
 
-| Spec                                              | Area      | Status |
-| ------------------------------------------------- | --------- | ------ |
-| [sign-in.md](./features/sign-in.md)               | Auth      | review |
-| [create-asset.md](./features/create-asset.md)     | Assets    | draft  |
-| [asset-library.md](./features/asset-library.md)   | Assets    | draft  |
-| [dashboard.md](./features/dashboard.md)           | Home      | wip    |
-| [marketing-home.md](./features/marketing-home.md) | Marketing | active |
+| Spec                                                      | Area        | Status |
+| --------------------------------------------------------- | ----------- | ------ |
+| [sign-in.md](./features/sign-in.md)                       | Auth        | review |
+| [create-asset.md](./features/create-asset.md)             | Assets      | draft  |
+| [asset-library.md](./features/asset-library.md)           | Assets      | draft  |
+| [dashboard.md](./features/dashboard.md)                   | Home        | wip    |
+| [maintenance-record.md](./features/maintenance-record.md) | Maintenance | draft  |
+| [marketing-home.md](./features/marketing-home.md)         | Marketing   | active |
 
 ## Directory Structure
 

--- a/docs/specs/cross-cutting/telemetry.md
+++ b/docs/specs/cross-cutting/telemetry.md
@@ -79,6 +79,24 @@ Both systems write to Cloudflare Analytics Engine using the same envelope:
 | `doubles[1]` | `event_time_ms`    | Event timestamp (ms since epoch)                                               |
 | `doubles[2]` | `asset_model_year` | Model year for vehicles; `0` for other asset types                             |
 
+**Domain event data point — `MaintenanceRecordCreated`** (dataset: `pineapple_maintenance_domain_events`, index: `owner_id`):
+
+| Field        | Name                    | Value                                                   |
+| ------------ | ----------------------- | ------------------------------------------------------- |
+| `indexes[0]` | —                       | `owner_id` (partition key for per-owner queries)        |
+| `blobs[0]`   | `event_type`            | `"MaintenanceRecordCreated"`                            |
+| `blobs[1]`   | `aggregate_type`        | `"MaintenanceRecord"`                                   |
+| `blobs[2]`   | `maintenance_record_id` | Maintenance record UUID                                 |
+| `blobs[3]`   | `asset_id`              | Asset UUID                                              |
+| `blobs[4]`   | `owner_id`              | Owner UUID                                              |
+| `blobs[5]`   | `actor_id`              | UUID of the authenticated user who performed the action |
+| `blobs[6]`   | `source_use_case`       | `"CreateMaintenanceRecord"`                             |
+| `blobs[7]`   | `schema_version`        | `"v1"`                                                  |
+| `blobs[8]`   | `result`                | `"success"`                                             |
+| `doubles[0]` | `count`                 | Always `1`                                              |
+| `doubles[1]` | `event_time_ms`         | Event timestamp (ms since epoch)                        |
+| `doubles[2]` | `performed_date_ms`     | Performed date at UTC midnight (ms since epoch)         |
+
 ### Analytics Engine Constraints
 
 These limits apply to every data point written and must be respected when designing new event schemas:
@@ -93,31 +111,33 @@ These limits apply to every data point written and must be respected when design
 
 ### Planned Datasets
 
-| Dataset                               | Binding                        | Purpose                              |
-| ------------------------------------- | ------------------------------ | ------------------------------------ |
-| `pineapple_asset_domain_events`       | `ASSET_DOMAIN_TELEMETRY`       | Asset lifecycle events — implemented |
-| `pineapple_api_request_events`        | `API_REQUEST_TELEMETRY`        | HTTP request telemetry — implemented |
-| `pineapple_user_domain_events`        | `USER_DOMAIN_TELEMETRY`        | User lifecycle events — planned      |
-| `pineapple_maintenance_domain_events` | `MAINTENANCE_DOMAIN_TELEMETRY` | Maintenance record events — planned  |
+| Dataset                               | Binding                        | Purpose                                 |
+| ------------------------------------- | ------------------------------ | --------------------------------------- |
+| `pineapple_asset_domain_events`       | `ASSET_DOMAIN_TELEMETRY`       | Asset lifecycle events — implemented    |
+| `pineapple_api_request_events`        | `API_REQUEST_TELEMETRY`        | HTTP request telemetry — implemented    |
+| `pineapple_user_domain_events`        | `USER_DOMAIN_TELEMETRY`        | User lifecycle events — planned         |
+| `pineapple_maintenance_domain_events` | `MAINTENANCE_DOMAIN_TELEMETRY` | Maintenance record events — implemented |
 
 ### Operation Name Mapping
 
 Every API route maps to a named operation used as the `indexes[0]` value in request telemetry. The current mapping:
 
-| Route                           | Operation         |
-| ------------------------------- | ----------------- |
-| `POST /api/auth/sign-in/social` | `SignIn`          |
-| `GET /api/auth/callback/google` | `OAuthCallback`   |
-| `GET /api/auth/get-session`     | `SessionCheck`    |
-| `POST /api/auth/sign-out`       | `SignOut`         |
-| `/api/auth/*` (other)           | `Auth`            |
-| `POST /api/assets`              | `CreateAsset`     |
-| `GET /api/assets`               | `ListAssets`      |
-| `GET /api/assets/{id}`          | `GetAsset`        |
-| `GET /health`                   | `Health`          |
-| `GET /openapi.json`             | `OpenApiDocument` |
-| `GET /reference`                | `ApiReference`    |
-| (anything else)                 | `Unknown`         |
+| Route                                            | Operation                 |
+| ------------------------------------------------ | ------------------------- |
+| `POST /api/auth/sign-in/social`                  | `SignIn`                  |
+| `GET /api/auth/callback/google`                  | `OAuthCallback`           |
+| `GET /api/auth/get-session`                      | `SessionCheck`            |
+| `POST /api/auth/sign-out`                        | `SignOut`                 |
+| `/api/auth/*` (other)                            | `Auth`                    |
+| `POST /api/assets`                               | `CreateAsset`             |
+| `GET /api/assets`                                | `ListAssets`              |
+| `GET /api/assets/{id}`                           | `GetAsset`                |
+| `POST /api/assets/{assetId}/maintenance-records` | `CreateMaintenanceRecord` |
+| `GET /api/assets/{assetId}/maintenance-records`  | `ListMaintenanceRecords`  |
+| `GET /health`                                    | `Health`                  |
+| `GET /openapi.json`                              | `OpenApiDocument`         |
+| `GET /reference`                                 | `ApiReference`            |
+| (anything else)                                  | `Unknown`                 |
 
 ### Failure Policy
 

--- a/docs/specs/features/maintenance-record.md
+++ b/docs/specs/features/maintenance-record.md
@@ -34,6 +34,9 @@ The Maintenance Record feature lets an authenticated user create dated maintenan
 - [ ] The API never accepts `ownerId` in the request body; ownership is derived from the authenticated session
 - [ ] The create use case checks that the target asset exists and belongs to the authenticated user before creating the record
 - [ ] The list use case returns only records for an asset owned by the authenticated user
+- [ ] `POST /api/assets/{assetId}/maintenance-records` accepts `{ title, performedAt, notes? }` and returns the full created maintenance record with status 201
+- [ ] `GET /api/assets/{assetId}/maintenance-records` returns `{ maintenanceRecords: [...] }` with status 200
+- [ ] Maintenance record responses contain `id`, `assetId`, `title`, `performedAt`, nullable `notes`, and `createdAt`; `ownerId` is never exposed
 - [ ] The user can start maintenance record creation from an asset detail page
 - [ ] The maintenance record form requires a **Title** field describing the work performed
 - [ ] Title is limited to 100 characters
@@ -42,6 +45,8 @@ The Maintenance Record feature lets an authenticated user create dated maintenan
 - [ ] Notes are limited to 1000 characters
 - [ ] The performed date must be today or earlier; future dates are rejected with a field-level validation error
 - [ ] Performed date is treated as date-only data in `YYYY-MM-DD` format, not as a user-local timestamp
+- [ ] The API uses the current UTC calendar date as the authoritative definition of today
+- [ ] An archived asset's maintenance history remains readable, but creating a new record for it returns 409
 - [ ] Submitting with missing or invalid required fields shows an error banner and field-level errors
 - [ ] Editing a field that has an error clears that field's error immediately
 - [ ] Save button shows "Saving..." and is disabled while save is in flight
@@ -62,9 +67,9 @@ The Maintenance Record feature lets an authenticated user create dated maintenan
 
 **Permissions:** Maintenance records are owned through the asset they belong to. A user can create and list maintenance records only for assets they own. The client cannot supply `ownerId`.
 
-**HTTP validation:** Inputs are validated at the Zod HTTP edge in a planned schema file, `apps/api/src/api/schemas/maintenanceRecordSchemas.ts`, and drive the generated OpenAPI contract. The schema must require `title` and `performedAt`, allow optional `notes`, enforce title length <= 100 characters, enforce notes length <= 1000 characters, and reject future performed dates.
+**HTTP validation:** Inputs are validated at the Zod HTTP edge in `apps/api/src/api/schemas/maintenanceRecordSchemas.ts` and drive the generated OpenAPI contract. The schema requires `title` and `performedAt`, allows optional `notes`, enforces title length <= 100 characters, enforces notes length <= 1000 characters, validates `assetId` as a UUID, and rejects malformed calendar dates. The domain performs the authoritative current-UTC-date comparison.
 
-**Domain validation:** Domain construction must preserve the same invariants: a maintenance record has an asset ID, owner ID derived from the session context, non-empty title of 100 characters or fewer, date-only performed date of today or earlier, optional notes of 1000 characters or fewer, and creation timestamp.
+**Domain validation:** Domain construction trims title and notes, converts blank notes to `null`, and preserves these invariants: a maintenance record has an asset ID, owner ID derived from the session context, non-empty title of 100 characters or fewer, date-only performed date of today or earlier, nullable notes of 1000 characters or fewer, and a UTC creation timestamp.
 
 **Date-only mitigation:** Until a cross-cutting time spec exists, this feature treats `performedAt` as a timezone-free calendar date string in `YYYY-MM-DD` format across the UI, API, domain, and D1 persistence. The implementation should compare dates lexicographically against today's `YYYY-MM-DD` value and must not parse `performedAt` through `Date` for validation, storage, or display. The stored maintenance date is not "in UTC"; it is a date-only value with no time zone. Generated timestamps such as `createdAt`, domain event time, and request telemetry time are UTC instants. Event telemetry may convert `performedAt` to UTC midnight only at the telemetry boundary because Analytics Engine doubles require a number.
 
@@ -79,9 +84,11 @@ The Maintenance Record feature lets an authenticated user create dated maintenan
 | Title is over 100 characters                        | Save blocked; title field shows a max-length error                          |
 | Performed date is empty                             | Save blocked; performed date field shows a required-field error             |
 | Performed date is in the future                     | Save blocked; performed date field shows a "must be today or earlier" error |
-| Notes is empty                                      | Accepted                                                                    |
+| Notes is empty or whitespace-only                   | Accepted and normalized to `null`                                           |
 | Notes is over 1000 characters                       | Save blocked; notes field shows a max-length error                          |
 | Notes contains component details                    | Accepted as free text; no structured component/location fields are created  |
+| Asset is archived and history is requested          | Existing maintenance history is returned                                    |
+| Asset is archived and record creation is attempted  | Creation rejected with 409                                                  |
 | User submits and the API returns 422 with a field   | Banner shown and the server message is pinned to the matching form field    |
 | User submits and the API returns 422 without field  | Banner shown; no field highlighted                                          |
 | User submits and the API returns 401                | Redirect to `/login` (replace history entry)                                |
@@ -100,21 +107,21 @@ The Maintenance Record feature lets an authenticated user create dated maintenan
 
 **MaintenanceRecordCreated data point contract:**
 
-| Field        | Name                    | Value                                                                         |
-| ------------ | ----------------------- | ----------------------------------------------------------------------------- |
-| `indexes[0]` | -                       | `owner_id` (partition key for per-owner queries)                              |
-| `blobs[0]`   | `event_type`            | `"MaintenanceRecordCreated"`                                                  |
-| `blobs[1]`   | `aggregate_type`        | `"MaintenanceRecord"`                                                         |
-| `blobs[2]`   | `maintenance_record_id` | Maintenance record UUID                                                       |
-| `blobs[3]`   | `asset_id`              | Asset UUID                                                                    |
-| `blobs[4]`   | `owner_id`              | Owner UUID                                                                    |
-| `blobs[5]`   | `actor_id`              | UUID of the user who performed the action; currently always equals `owner_id` |
-| `blobs[6]`   | `source_use_case`       | `"CreateMaintenanceRecord"`                                                   |
-| `blobs[7]`   | `schema_version`        | `"v1"`                                                                        |
-| `blobs[8]`   | `result`                | `"success"`                                                                   |
-| `doubles[0]` | `count`                 | Always `1`                                                                    |
-| `doubles[1]` | `event_time_ms`         | Event timestamp (ms since epoch)                                              |
-| `doubles[2]` | `performed_date_ms`     | Performed date at UTC midnight (ms since epoch)                               |
+| Field        | Name                    | Value                                                   |
+| ------------ | ----------------------- | ------------------------------------------------------- |
+| `indexes[0]` | -                       | `owner_id` (partition key for per-owner queries)        |
+| `blobs[0]`   | `event_type`            | `"MaintenanceRecordCreated"`                            |
+| `blobs[1]`   | `aggregate_type`        | `"MaintenanceRecord"`                                   |
+| `blobs[2]`   | `maintenance_record_id` | Maintenance record UUID                                 |
+| `blobs[3]`   | `asset_id`              | Asset UUID                                              |
+| `blobs[4]`   | `owner_id`              | Owner UUID                                              |
+| `blobs[5]`   | `actor_id`              | UUID of the authenticated user who performed the action |
+| `blobs[6]`   | `source_use_case`       | `"CreateMaintenanceRecord"`                             |
+| `blobs[7]`   | `schema_version`        | `"v1"`                                                  |
+| `blobs[8]`   | `result`                | `"success"`                                             |
+| `doubles[0]` | `count`                 | Always `1`                                              |
+| `doubles[1]` | `event_time_ms`         | Event timestamp (ms since epoch)                        |
+| `doubles[2]` | `performed_date_ms`     | Performed date at UTC midnight (ms since epoch)         |
 
 ## Flags
 

--- a/docs/specs/features/maintenance-record.md
+++ b/docs/specs/features/maintenance-record.md
@@ -1,0 +1,136 @@
+---
+name: maintenance-record
+description: Historical maintenance log entries tied to assets, including creation, asset-level history, validation, ownership, and telemetry
+metadata:
+  type: feature
+---
+
+# Maintenance Record
+
+**Status:** draft
+**Owner:** [unknown - assign on review]
+**Last Updated:** 2026-06-04
+**Related Specs:** [authentication.md](../cross-cutting/authentication.md), [validation.md](../cross-cutting/validation.md), [error-handling.md](../cross-cutting/error-handling.md), [loading-states.md](../cross-cutting/loading-states.md), [permissions.md](../cross-cutting/permissions.md), [telemetry.md](../cross-cutting/telemetry.md), [dashboard.md](./dashboard.md)
+
+---
+
+## Summary
+
+The Maintenance Record feature lets an authenticated user create dated maintenance log entries for an asset and view that asset's maintenance history. Records capture what was done, when it was done, and optional notes so the user can later answer questions like "when did I last change this?" without introducing service schedules, reminders, structured maintenance tasks, or component analytics.
+
+## User Stories
+
+- As an **authenticated owner-operator**, I can **record completed maintenance on one of my assets** so that **I have a durable history of work I performed**
+- As **DIYer Dale**, I can **record a home air-filter change** so that **I can later see when I last changed it**
+- As **DIYer Dale**, I can **record a propane tank replacement on my toy hauler trailer** so that **I can later compare replacement history manually**
+- As **DIYer Dale**, I can **record a sprinkler replacement with location details in notes** so that **I can later spot repeated problems by reviewing the history**
+- As **DIYer Dale**, I can **record when I added water softener pellets** so that **I can later see my replenishment history**
+- As an **authenticated owner-operator**, I can **view maintenance records for an asset in reverse chronological order** so that **the most recent work is easiest to find**
+- As a **user entering a maintenance record**, I can **see clear validation errors** so that **I know exactly what must be corrected before saving**
+
+## Acceptance Criteria
+
+- [ ] A maintenance record is always tied to an existing asset owned by the authenticated user
+- [ ] The API never accepts `ownerId` in the request body; ownership is derived from the authenticated session
+- [ ] The create use case checks that the target asset exists and belongs to the authenticated user before creating the record
+- [ ] The list use case returns only records for an asset owned by the authenticated user
+- [ ] The user can start maintenance record creation from an asset detail page
+- [ ] The maintenance record form requires a **Title** field describing the work performed
+- [ ] Title is limited to 100 characters
+- [ ] The maintenance record form requires a **Performed date** field
+- [ ] The maintenance record form includes optional **Notes** for free-form details such as component location, observed condition, cost, vendor, quantity, or replacement context
+- [ ] Notes are limited to 1000 characters
+- [ ] The performed date must be today or earlier; future dates are rejected with a field-level validation error
+- [ ] Performed date is treated as date-only data in `YYYY-MM-DD` format, not as a user-local timestamp
+- [ ] Submitting with missing or invalid required fields shows an error banner and field-level errors
+- [ ] Editing a field that has an error clears that field's error immediately
+- [ ] Save button shows "Saving..." and is disabled while save is in flight
+- [ ] On successful save, the asset's maintenance history includes the newly created record
+- [ ] On successful save, the user remains in or returns to the asset context where the record can be seen
+- [ ] The asset maintenance history shows records newest first by performed date
+- [ ] If two records have the same performed date, the most recently created record appears first
+- [ ] An asset with no maintenance records shows an empty state with an action to add the first record
+- [ ] A 401 response from the API redirects to `/login` through the API client layer
+- [ ] A 403 response is shown as an access-denied error if the asset exists but belongs to another user
+- [ ] A 404 response is shown as a not-found error if the asset does not exist
+- [ ] A non-401 API error shows a banner with the server error message; if the API identifies a specific field, the error is mapped to that field
+- [ ] Creating a maintenance record publishes a `MaintenanceRecordCreated` domain event
+
+## Validation & Ownership
+
+**Authentication:** This feature is available only to authenticated users. API requests use the resolved `User.id` as `requesterId`.
+
+**Permissions:** Maintenance records are owned through the asset they belong to. A user can create and list maintenance records only for assets they own. The client cannot supply `ownerId`.
+
+**HTTP validation:** Inputs are validated at the Zod HTTP edge in a planned schema file, `apps/api/src/api/schemas/maintenanceRecordSchemas.ts`, and drive the generated OpenAPI contract. The schema must require `title` and `performedAt`, allow optional `notes`, enforce title length <= 100 characters, enforce notes length <= 1000 characters, and reject future performed dates.
+
+**Domain validation:** Domain construction must preserve the same invariants: a maintenance record has an asset ID, owner ID derived from the session context, non-empty title of 100 characters or fewer, date-only performed date of today or earlier, optional notes of 1000 characters or fewer, and creation timestamp.
+
+**Date-only mitigation:** Until a cross-cutting time spec exists, this feature treats `performedAt` as a timezone-free calendar date string in `YYYY-MM-DD` format across the UI, API, domain, and D1 persistence. The implementation should compare dates lexicographically against today's `YYYY-MM-DD` value and must not parse `performedAt` through `Date` for validation, storage, or display. The stored maintenance date is not "in UTC"; it is a date-only value with no time zone. Generated timestamps such as `createdAt`, domain event time, and request telemetry time are UTC instants. Event telemetry may convert `performedAt` to UTC midnight only at the telemetry boundary because Analytics Engine doubles require a number.
+
+**Field errors:** Validation errors map back to `title`, `performedAt`, and `notes` when the backend includes a known `field` value.
+
+## Edge Cases & Error States
+
+| Scenario                                            | Expected Behavior                                                           |
+| --------------------------------------------------- | --------------------------------------------------------------------------- |
+| Asset has no maintenance records                    | Empty state shown with an add action                                        |
+| Title is empty                                      | Save blocked; title field shows a required-field error                      |
+| Title is over 100 characters                        | Save blocked; title field shows a max-length error                          |
+| Performed date is empty                             | Save blocked; performed date field shows a required-field error             |
+| Performed date is in the future                     | Save blocked; performed date field shows a "must be today or earlier" error |
+| Notes is empty                                      | Accepted                                                                    |
+| Notes is over 1000 characters                       | Save blocked; notes field shows a max-length error                          |
+| Notes contains component details                    | Accepted as free text; no structured component/location fields are created  |
+| User submits and the API returns 422 with a field   | Banner shown and the server message is pinned to the matching form field    |
+| User submits and the API returns 422 without field  | Banner shown; no field highlighted                                          |
+| User submits and the API returns 401                | Redirect to `/login` (replace history entry)                                |
+| User submits or views another user's asset          | 403 access-denied treatment                                                 |
+| User submits or views a missing asset               | 404 not-found treatment                                                     |
+| Maintenance history request fails                   | Error state shown with retry action                                         |
+| Maintenance history request is pending              | Loading state shown; history area is not blank                              |
+| User edits a field after a failed submit            | Field error clears and mutation error state resets                          |
+| User records two entries on the same performed date | Both records are shown; newest created entry sorts first within that date   |
+
+## Telemetry
+
+**Request telemetry:** `POST /api/assets/{assetId}/maintenance-records` maps to the `CreateMaintenanceRecord` operation via `createTechnicalTelemetryMiddleware`. `GET /api/assets/{assetId}/maintenance-records` maps to the `ListMaintenanceRecords` operation. Both route patterns must be added to the operation name mapping in `technicalTelemetry.ts`; see [telemetry.md](../cross-cutting/telemetry.md) for the full request data point shape.
+
+**Domain event:** On successful maintenance record creation, a `MaintenanceRecordCreated` event is published to the event bus and captured by a maintenance-record telemetry handler (planned dataset: `pineapple_maintenance_domain_events`, binding: `MAINTENANCE_DOMAIN_TELEMETRY`). The event must not include user-entered title or notes in telemetry blobs.
+
+**MaintenanceRecordCreated data point contract:**
+
+| Field        | Name                    | Value                                                                         |
+| ------------ | ----------------------- | ----------------------------------------------------------------------------- |
+| `indexes[0]` | -                       | `owner_id` (partition key for per-owner queries)                              |
+| `blobs[0]`   | `event_type`            | `"MaintenanceRecordCreated"`                                                  |
+| `blobs[1]`   | `aggregate_type`        | `"MaintenanceRecord"`                                                         |
+| `blobs[2]`   | `maintenance_record_id` | Maintenance record UUID                                                       |
+| `blobs[3]`   | `asset_id`              | Asset UUID                                                                    |
+| `blobs[4]`   | `owner_id`              | Owner UUID                                                                    |
+| `blobs[5]`   | `actor_id`              | UUID of the user who performed the action; currently always equals `owner_id` |
+| `blobs[6]`   | `source_use_case`       | `"CreateMaintenanceRecord"`                                                   |
+| `blobs[7]`   | `schema_version`        | `"v1"`                                                                        |
+| `blobs[8]`   | `result`                | `"success"`                                                                   |
+| `doubles[0]` | `count`                 | Always `1`                                                                    |
+| `doubles[1]` | `event_time_ms`         | Event timestamp (ms since epoch)                                              |
+| `doubles[2]` | `performed_date_ms`     | Performed date at UTC midnight (ms since epoch)                               |
+
+## Flags
+
+**REVIEW NEEDED - Dashboard entry path belongs with dashboard design:** Creation must be available from the asset detail page. A dashboard entry path is desired, but the exact interaction and placement should be resolved in the dashboard spec after design review.
+
+**NOT SPECIFIED - Navigation after successful creation:** The user should remain in or return to the asset context, but the exact presentation is not specified: inline form, modal, drawer, or separate route.
+
+**FOLLOW-UP NEEDED - Cross-cutting time spec:** This feature uses a local mitigation for date-only maintenance records. A future cross-cutting time spec should define project-wide rules for date-only fields, timestamps, user time zones, server clock comparisons, and telemetry conversions.
+
+## Out of Scope
+
+- Editing maintenance records
+- Deleting maintenance records
+- Service schedules, reminders, recurrence rules, next-due dates, and maintenance-task definitions
+- Structured maintenance task/category management
+- Structured component or location tracking for repeated failures
+- Structured quantity, cost, vendor, mileage, odometer, or attachment fields
+- Automatic lifetime, consumption, replacement-interval, or failure-frequency analytics
+- Cross-asset maintenance history views

--- a/migrations/0003_maintenance_records.sql
+++ b/migrations/0003_maintenance_records.sql
@@ -1,0 +1,35 @@
+CREATE TABLE IF NOT EXISTS maintenance_records (
+  id           TEXT NOT NULL PRIMARY KEY,
+  asset_id     TEXT NOT NULL REFERENCES assets(id),
+  owner_id     TEXT NOT NULL REFERENCES users(id),
+  title        TEXT NOT NULL CHECK (length(title) BETWEEN 1 AND 100),
+  performed_at TEXT NOT NULL CHECK (
+    length(performed_at) = 10
+    AND performed_at GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'
+    AND CAST(substr(performed_at, 1, 4) AS INTEGER) BETWEEN 1 AND 9999
+    AND CAST(substr(performed_at, 6, 2) AS INTEGER) BETWEEN 1 AND 12
+    AND CAST(substr(performed_at, 9, 2) AS INTEGER) BETWEEN 1 AND CASE
+      WHEN CAST(substr(performed_at, 6, 2) AS INTEGER) IN (1, 3, 5, 7, 8, 10, 12)
+        THEN 31
+      WHEN CAST(substr(performed_at, 6, 2) AS INTEGER) IN (4, 6, 9, 11)
+        THEN 30
+      WHEN CAST(substr(performed_at, 6, 2) AS INTEGER) = 2
+        AND (
+          CAST(substr(performed_at, 1, 4) AS INTEGER) % 400 = 0
+          OR (
+            CAST(substr(performed_at, 1, 4) AS INTEGER) % 4 = 0
+            AND CAST(substr(performed_at, 1, 4) AS INTEGER) % 100 != 0
+          )
+        )
+        THEN 29
+      WHEN CAST(substr(performed_at, 6, 2) AS INTEGER) = 2
+        THEN 28
+      ELSE 0
+    END
+  ),
+  notes        TEXT CHECK (notes IS NULL OR length(notes) <= 1000),
+  created_at   TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_maintenance_records_owner_asset_history
+  ON maintenance_records(owner_id, asset_id, performed_at DESC, created_at DESC);

--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -1,4 +1,5 @@
 export { AssetId } from "./types/AssetId.ts";
+export { MaintenanceRecordId } from "./types/MaintenanceRecordId.ts";
 export { UserId } from "./types/UserId.ts";
 export { Email } from "./types/Email.ts";
 export { type Result, ok, err } from "./result.ts";

--- a/packages/shared/types/MaintenanceRecordId.ts
+++ b/packages/shared/types/MaintenanceRecordId.ts
@@ -1,0 +1,6 @@
+export type MaintenanceRecordId = string & { readonly _brand: "MaintenanceRecordId" };
+
+export const MaintenanceRecordId = {
+  generate: (): MaintenanceRecordId => crypto.randomUUID() as MaintenanceRecordId,
+  from: (raw: string): MaintenanceRecordId => raw as MaintenanceRecordId,
+};


### PR DESCRIPTION
## Summary

- add create and asset-history APIs for maintenance records across domain, application, D1, OpenAPI, and Worker composition
- enforce ownership, archived-asset behavior, date-only validation, title/note limits, and repository-owned history ordering
- add request telemetry and `MaintenanceRecordCreated` domain telemetry with explicit actor identity
- update the feature spec and API/data-model/telemetry reference documentation

## Database

Adds `0003_maintenance_records.sql` with ownership foreign keys, length constraints, a calendar-valid `performed_at` check, and an index for asset history ordering.

The revised migration was tested against a fresh local D1 store. Valid dates and leap day were accepted; malformed dates, invalid months/days, non-leap February 29, and year 0000 were rejected.

## Review fixes

- isolate mutable assets in list-use-case tests
- document and test whitespace-only notes normalizing to `null`
- remove redundant application sorting and make the repository contract authoritative
- return an invariant failure for malformed internal UTC date-provider values
- carry `actorId` on the creation event instead of deriving it in telemetry

## Validation

- `pnpm lint`
- `pnpm type-check`
- `pnpm -r test` (60 tests passed)
- changed-file Prettier check
- `git diff --check`
- Wrangler deployment dry-run
- fresh local D1 migration and constraint verification