### PR TITLE
Add maintenance records UI (focus layout, all states)

### DIFF
--- a/apps/web/src/api/assets.ts
+++ b/apps/web/src/api/assets.ts
@@ -55,6 +55,11 @@ export type CreatedAssetResponse = {
 };
 
 export const assetsQueryKey = ["assets"] as const;
+export const assetQueryKey = (id: string) => ["asset", id] as const;
+
+export function getAsset(id: string): Promise<AssetResponse> {
+  return apiRequest<AssetResponse>(`/api/assets/${id}`);
+}
 
 export function listAssets(): Promise<AssetListResponse> {
   return apiRequest<AssetListResponse>("/api/assets");

--- a/apps/web/src/api/maintenanceRecords.ts
+++ b/apps/web/src/api/maintenanceRecords.ts
@@ -1,0 +1,38 @@
+import { apiRequest } from "./client.ts";
+
+export type MaintenanceRecord = {
+  id: string;
+  assetId: string;
+  title: string;
+  performedAt: string;
+  notes: string | null;
+  createdAt: string;
+};
+
+export type MaintenanceRecordListResponse = {
+  maintenanceRecords: MaintenanceRecord[];
+};
+
+export type CreateMaintenanceRecordBody = {
+  title: string;
+  performedAt: string;
+  notes?: string;
+};
+
+export const maintenanceRecordsQueryKey = (assetId: string) =>
+  ["maintenanceRecords", assetId] as const;
+
+export function listMaintenanceRecords(assetId: string): Promise<MaintenanceRecordListResponse> {
+  return apiRequest<MaintenanceRecordListResponse>(`/api/assets/${assetId}/maintenance-records`);
+}
+
+export function createMaintenanceRecord(
+  assetId: string,
+  body: CreateMaintenanceRecordBody,
+): Promise<MaintenanceRecord> {
+  return apiRequest<MaintenanceRecord>(`/api/assets/${assetId}/maintenance-records`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}

--- a/apps/web/src/app/AppAssets.tsx
+++ b/apps/web/src/app/AppAssets.tsx
@@ -21,7 +21,7 @@ const HF_CAT_LABELS: Record<AssetCategory, string> = {
 
 function HFAssetGridCard({ asset }: { asset: AssetPresentation }) {
   return (
-    <article className="hf-asset-card hf-asset-card-static">
+    <Link to={paths.assetMaintenance(asset.id)} className="hf-asset-card">
       <HFAssetThumb asset={asset} height={132} />
       <div className="hf-asset-body">
         <h3 className="hf-asset-card-name">{asset.name}</h3>
@@ -32,13 +32,13 @@ function HFAssetGridCard({ asset }: { asset: AssetPresentation }) {
         </div>
       </div>
       <div className="hf-asset-summary">{asset.summary}</div>
-    </article>
+    </Link>
   );
 }
 
 function HFAssetRowCard({ asset }: { asset: AssetPresentation }) {
   return (
-    <article className="hf-asset-row hf-asset-row-static">
+    <Link to={paths.assetMaintenance(asset.id)} className="hf-asset-row">
       <HFAssetThumb asset={asset} height={84} />
       <div className="hf-asset-row-body">
         <div className="hf-asset-row-top">
@@ -53,7 +53,7 @@ function HFAssetRowCard({ asset }: { asset: AssetPresentation }) {
         </div>
         <div className="hf-asset-row-summary">{asset.summary}</div>
       </div>
-    </article>
+    </Link>
   );
 }
 

--- a/apps/web/src/app/AppMaintenanceRecords.tsx
+++ b/apps/web/src/app/AppMaintenanceRecords.tsx
@@ -1,0 +1,721 @@
+import { useEffect, useRef, useState, useMemo } from "react";
+import { Link, useNavigate, useParams } from "react-router";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { ApiError } from "../api/client.ts";
+import { getAsset, assetQueryKey } from "../api/assets.ts";
+import {
+  listMaintenanceRecords,
+  createMaintenanceRecord,
+  maintenanceRecordsQueryKey,
+  type MaintenanceRecord,
+  type MaintenanceRecordListResponse,
+} from "../api/maintenanceRecords.ts";
+import { Icon } from "../design/Icon.tsx";
+import { HFAssetIcon } from "../design/hf.tsx";
+import { HFTopBar, HFBottomNav } from "./AppChrome.tsx";
+import { toAssetPresentation, type AssetPresentation } from "./assetPresentation.ts";
+import { paths } from "../routes.ts";
+
+import "../design/styles/hifi.css";
+import "../design/styles/hifi-assets.css";
+import "../design/styles/mr.css";
+
+// ─── date helpers ────────────────────────────────────────────────────────────
+
+const MONTHS_SHORT = [
+  "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+];
+
+function todayDateOnly(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function ymdToUTC(s: string): number {
+  const parts = s.split("-").map(Number);
+  return Date.UTC(parts[0]!, parts[1]! - 1, parts[2]!);
+}
+
+function fmtDate(s: string): string {
+  const parts = s.split("-").map(Number);
+  return `${MONTHS_SHORT[parts[1]! - 1]} ${parts[2]}, ${s.slice(0, 4)}`;
+}
+
+function relAgo(s: string): string {
+  const n = Math.round((ymdToUTC(todayDateOnly()) - ymdToUTC(s)) / 86400000);
+  if (n <= 0) return "today";
+  if (n === 1) return "yesterday";
+  if (n < 7) return `${n} days ago`;
+  if (n < 14) return "1 week ago";
+  if (n < 31) return `${Math.round(n / 7)} weeks ago`;
+  const mo = Math.round(n / 30.4);
+  if (mo <= 1) return "1 month ago";
+  if (mo < 12) return `${mo} months ago`;
+  const yr = Math.floor(mo / 12);
+  return `${yr} ${yr > 1 ? "years" : "year"} ago`;
+}
+
+type GroupedRecord = MaintenanceRecord & { sameDay: boolean };
+type YearGroup = { year: string; items: GroupedRecord[] };
+
+function sortRecords(records: MaintenanceRecord[]): MaintenanceRecord[] {
+  return [...records].sort((a, b) => {
+    if (a.performedAt !== b.performedAt) return a.performedAt < b.performedAt ? 1 : -1;
+    return a.createdAt < b.createdAt ? 1 : -1;
+  });
+}
+
+function groupByYear(sorted: MaintenanceRecord[]): YearGroup[] {
+  const groups: YearGroup[] = [];
+  let cur: YearGroup | null = null;
+  sorted.forEach((r, i) => {
+    const yr = r.performedAt.slice(0, 4);
+    if (!cur || cur.year !== yr) {
+      cur = { year: yr, items: [] };
+      groups.push(cur);
+    }
+    const prev = sorted[i - 1];
+    const next = sorted[i + 1];
+    const sameDay =
+      (prev?.performedAt === r.performedAt) || (next?.performedAt === r.performedAt);
+    cur.items.push({ ...r, sameDay });
+  });
+  return groups;
+}
+
+// ─── sub-components ──────────────────────────────────────────────────────────
+
+function MRTimeline({ groups }: { groups: YearGroup[] }) {
+  return (
+    <div className="mr-tl">
+      {groups.map((g) => (
+        <div className="mr-tl-group" key={g.year}>
+          <div className="mr-tl-year">
+            <span>{g.year}</span>
+            <span className="mr-tl-year-line" />
+          </div>
+          {g.items.map((r) => (
+            <div className="mr-tl-item" key={r.id}>
+              <div className="mr-tl-aside">
+                <div className="mr-tl-date">{fmtDate(r.performedAt)}</div>
+                <div className="mr-tl-ago">{relAgo(r.performedAt)}</div>
+              </div>
+              <div className="mr-tl-rail">
+                <span className="mr-tl-dot" />
+                <span className="mr-tl-line" />
+              </div>
+              <div className="mr-tl-body">
+                <div className="mr-tl-date-inline">
+                  {fmtDate(r.performedAt)}
+                  <span className="mr-tl-ago-inline">· {relAgo(r.performedAt)}</span>
+                  {r.sameDay && <span className="mr-tl-sameday">same day</span>}
+                </div>
+                <div className="mr-tl-title">
+                  {r.title}
+                  {r.sameDay && <span className="mr-tl-sameday mr-tl-sameday-wide">same day</span>}
+                </div>
+                {r.notes && <p className="mr-tl-notes">{r.notes}</p>}
+              </div>
+            </div>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function MRTable({ groups }: { groups: YearGroup[] }) {
+  return (
+    <div className="mr-table" role="table">
+      <div className="mr-thead" role="row">
+        <span className="mr-th mr-th-date" role="columnheader">Performed</span>
+        <span className="mr-th mr-th-work" role="columnheader">Work performed</span>
+        <span className="mr-th mr-th-notes" role="columnheader">Notes</span>
+        <span className="mr-th mr-th-logged" role="columnheader">Logged</span>
+      </div>
+      {groups.map((g) => (
+        <div className="mr-tbody" key={g.year} role="rowgroup">
+          <div className="mr-trow-year" role="row"><span>{g.year}</span></div>
+          {g.items.map((r) => (
+            <div className="mr-trow" role="row" key={r.id}>
+              <span className="mr-td mr-td-date" role="cell">
+                <span className="mr-td-date-main">{fmtDate(r.performedAt)}</span>
+                <span className="mr-td-date-ago">{relAgo(r.performedAt)}</span>
+              </span>
+              <span className="mr-td mr-td-work" role="cell">
+                {r.title}
+                {r.sameDay && <span className="mr-tl-sameday">same day</span>}
+              </span>
+              <span className="mr-td mr-td-notes" role="cell">
+                {r.notes || <span className="mr-td-dim">—</span>}
+              </span>
+              <span className="mr-td mr-td-logged" role="cell">
+                {relAgo(r.createdAt.slice(0, 10))}
+              </span>
+            </div>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function MRLoading({ density }: { density: "timeline" | "table" }) {
+  const rows = [0, 1, 2, 3, 4];
+  if (density === "table") {
+    return (
+      <div className="mr-skel-table" aria-busy="true" aria-label="Loading maintenance history">
+        {rows.map((i) => (
+          <div className="mr-skel-trow" key={i}>
+            <span className="mr-skel mr-skel-w90" />
+            <span className="mr-skel mr-skel-w70" />
+            <span className="mr-skel mr-skel-w80" />
+            <span className="mr-skel mr-skel-w50" />
+          </div>
+        ))}
+      </div>
+    );
+  }
+  return (
+    <div className="mr-skel-tl" aria-busy="true" aria-label="Loading maintenance history">
+      {rows.map((i) => (
+        <div className="mr-skel-item" key={i}>
+          <span className="mr-skel-dot" />
+          <div className="mr-skel-lines">
+            <span className="mr-skel mr-skel-w40" />
+            <span className="mr-skel mr-skel-w75" />
+            <span className="mr-skel mr-skel-block" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function MREmpty({ assetName, onAdd }: { assetName: string; onAdd: () => void }) {
+  return (
+    <div className="mr-empty">
+      <div className="mr-empty-art">
+        <Icon name="wrench" size={30} color="var(--hf-brand-2)" stroke={1.7} />
+      </div>
+      <div className="mr-empty-title">No maintenance logged yet</div>
+      <div className="mr-empty-sub">
+        Record work you've done on {assetName} so you can answer "when did I last…?" later.
+      </div>
+      <button className="mr-btn mr-btn-primary" onClick={onAdd}>
+        <Icon name="plus" size={16} stroke={2.2} />Add the first record
+      </button>
+    </div>
+  );
+}
+
+const ERROR_CONFIG = {
+  error: {
+    icon: "alert" as const,
+    title: "Couldn't load history",
+    sub: "Something went wrong fetching maintenance records.",
+    retry: true,
+  },
+  forbidden: {
+    icon: "alert" as const,
+    title: "Access denied",
+    sub: "This asset belongs to another account. You don't have permission to view its maintenance history.",
+    retry: false,
+  },
+  notfound: {
+    icon: "search" as const,
+    title: "Asset not found",
+    sub: "We couldn't find this asset. It may have been removed.",
+    retry: false,
+  },
+};
+
+function MRErrorState({
+  kind,
+  onRetry,
+}: {
+  kind: "error" | "forbidden" | "notfound";
+  onRetry?: () => void;
+}) {
+  const cfg = ERROR_CONFIG[kind];
+  return (
+    <div className={`mr-error mr-error-${kind}`}>
+      <div className="mr-error-art">
+        <Icon name={cfg.icon} size={26} stroke={1.9} />
+      </div>
+      <div className="mr-error-title">{cfg.title}</div>
+      <div className="mr-error-sub">{cfg.sub}</div>
+      {cfg.retry && onRetry && (
+        <button className="mr-btn mr-btn-secondary" onClick={onRetry}>
+          <Icon name="repeat" size={14} stroke={2} />Try again
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ─── form ────────────────────────────────────────────────────────────────────
+
+const TITLE_MAX = 100;
+const NOTES_MAX = 1000;
+
+function validateForm(
+  title: string,
+  performedAt: string,
+  notes: string,
+): Record<string, string> {
+  const errors: Record<string, string> = {};
+  const t = title.trim();
+  if (!t) errors.title = "Title is required.";
+  else if (t.length > TITLE_MAX) errors.title = `Title must be ${TITLE_MAX} characters or fewer.`;
+  if (!performedAt) errors.performedAt = "Performed date is required.";
+  else if (performedAt > todayDateOnly())
+    errors.performedAt = "Performed date must be today or earlier.";
+  if (notes.length > NOTES_MAX) errors.notes = `Notes must be ${NOTES_MAX} characters or fewer.`;
+  return errors;
+}
+
+interface MRFormProps {
+  asset: AssetPresentation;
+  assetId: string;
+  variant: "drawer" | "sheet";
+  onClose: () => void;
+  onSaved: (record: MaintenanceRecord) => void;
+}
+
+function MRForm({ asset, assetId, variant, onClose, onSaved }: MRFormProps) {
+  const [title, setTitle] = useState("");
+  const [performedAt, setPerformedAt] = useState(todayDateOnly());
+  const [notes, setNotes] = useState("");
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  const [banner, setBanner] = useState<string | null>(null);
+  const titleRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    titleRef.current?.focus();
+  }, []);
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      createMaintenanceRecord(assetId, {
+        title: title.trim(),
+        performedAt,
+        ...(notes.trim() ? { notes: notes.trim() } : {}),
+      }),
+    onSuccess: (record) => onSaved(record),
+    onError: (err) =>
+      setBanner(err instanceof Error ? err.message : "Failed to save. Please try again."),
+  });
+
+  const clearErr = (field: string) =>
+    setFieldErrors((prev) => {
+      if (!prev[field]) return prev;
+      const next = { ...prev };
+      delete next[field];
+      return next;
+    });
+
+  const handleSubmit = () => {
+    if (mutation.isPending) return;
+    const errs = validateForm(title, performedAt, notes);
+    setFieldErrors(errs);
+    if (Object.keys(errs).length) {
+      setBanner("Please fix the highlighted fields before saving.");
+      return;
+    }
+    setBanner(null);
+    mutation.mutate();
+  };
+
+  return (
+    <div className={`mr-form mr-form-${variant}`}>
+      {variant === "sheet" && <div className="mr-sheet-grab" />}
+      <div className="mr-form-head">
+        <div className="mr-form-head-txt">
+          <div className="mr-form-title">Log maintenance</div>
+          <div className="mr-form-sub">{asset.name}</div>
+        </div>
+        <button className="mr-form-close" onClick={onClose} aria-label="Close">
+          <Icon name="x" size={15} stroke={2.2} />
+        </button>
+      </div>
+
+      <div className="mr-form-body">
+        {banner && (
+          <div className="mr-banner" role="alert">
+            <Icon name="alert" size={15} stroke={2} />
+            <span>{banner}</span>
+          </div>
+        )}
+
+        <div className="mr-field">
+          <div className="mr-field-top">
+            <label className="mr-field-label" htmlFor="mr-title">
+              Title <span className="mr-req">*</span>
+            </label>
+            <span className={`mr-field-count ${title.length > TITLE_MAX ? "over" : ""}`}>
+              {title.length}/{TITLE_MAX}
+            </span>
+          </div>
+          <input
+            id="mr-title"
+            ref={titleRef}
+            type="text"
+            className={`mr-input ${fieldErrors.title ? "err" : ""}`}
+            placeholder='What did you do? e.g. "Oil change"'
+            maxLength={TITLE_MAX + 20}
+            value={title}
+            onChange={(e) => {
+              setTitle(e.target.value);
+              clearErr("title");
+              if (banner) setBanner(null);
+            }}
+          />
+          {fieldErrors.title && (
+            <div className="mr-field-err">
+              <Icon name="alert" size={13} stroke={2} />{fieldErrors.title}
+            </div>
+          )}
+        </div>
+
+        <div className="mr-field">
+          <div className="mr-field-top">
+            <label className="mr-field-label" htmlFor="mr-date">
+              Performed date <span className="mr-req">*</span>
+            </label>
+          </div>
+          <input
+            id="mr-date"
+            type="date"
+            className={`mr-input mr-input-date ${fieldErrors.performedAt ? "err" : ""}`}
+            max={todayDateOnly()}
+            value={performedAt}
+            onChange={(e) => {
+              setPerformedAt(e.target.value);
+              clearErr("performedAt");
+              if (banner) setBanner(null);
+            }}
+          />
+          {fieldErrors.performedAt ? (
+            <div className="mr-field-err">
+              <Icon name="alert" size={13} stroke={2} />{fieldErrors.performedAt}
+            </div>
+          ) : (
+            <div className="mr-field-hint">When the work was done. Today or earlier.</div>
+          )}
+        </div>
+
+        <div className="mr-field">
+          <div className="mr-field-top">
+            <label className="mr-field-label" htmlFor="mr-notes">Notes</label>
+            <span className={`mr-field-count ${notes.length > NOTES_MAX ? "over" : ""}`}>
+              {notes.length}/{NOTES_MAX}
+            </span>
+          </div>
+          <textarea
+            id="mr-notes"
+            className={`mr-input mr-textarea ${fieldErrors.notes ? "err" : ""}`}
+            placeholder="Optional — location, condition, cost, vendor, quantity…"
+            value={notes}
+            onChange={(e) => {
+              setNotes(e.target.value);
+              clearErr("notes");
+              if (banner) setBanner(null);
+            }}
+          />
+          {fieldErrors.notes ? (
+            <div className="mr-field-err">
+              <Icon name="alert" size={13} stroke={2} />{fieldErrors.notes}
+            </div>
+          ) : (
+            <div className="mr-field-hint">
+              Free-form details. No structured fields — just write what's useful.
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="mr-form-actions">
+        <button className="mr-btn mr-btn-ghost" onClick={onClose} disabled={mutation.isPending}>
+          Cancel
+        </button>
+        <button
+          className="mr-btn mr-btn-primary mr-btn-save"
+          onClick={handleSubmit}
+          disabled={mutation.isPending}
+        >
+          {mutation.isPending ? (
+            <><span className="mr-spinner" />Saving…</>
+          ) : (
+            <><Icon name="check" size={15} stroke={2.4} />Save record</>
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ─── page ────────────────────────────────────────────────────────────────────
+
+export function AppMaintenanceRecords() {
+  const { assetId = "" } = useParams<{ assetId: string }>();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [containerWidth, setContainerWidth] = useState(window.innerWidth);
+  const isMobile = containerWidth <= 600;
+
+  useEffect(() => {
+    const el = rootRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver((entries) => {
+      for (const e of entries) setContainerWidth(e.contentRect.width);
+    });
+    ro.observe(el);
+    setContainerWidth(el.offsetWidth);
+    return () => ro.disconnect();
+  }, []);
+
+  const [formOpen, setFormOpen] = useState(false);
+  const [density, setDensity] = useState<"timeline" | "table">("timeline");
+
+  const assetQuery = useQuery({
+    queryKey: assetQueryKey(assetId),
+    queryFn: () => getAsset(assetId),
+    enabled: !!assetId,
+    retry: (count, err) =>
+      !(err instanceof ApiError && (err.status === 401 || err.status === 403 || err.status === 404)) &&
+      count < 2,
+  });
+
+  const recordsQuery = useQuery({
+    queryKey: maintenanceRecordsQueryKey(assetId),
+    queryFn: () => listMaintenanceRecords(assetId),
+    enabled: !!assetId && assetQuery.isSuccess,
+    retry: (count, err) =>
+      !(err instanceof ApiError && err.status === 401) && count < 2,
+  });
+
+  // Redirect on 401
+  useEffect(() => {
+    const isUnauth =
+      (assetQuery.error instanceof ApiError && assetQuery.error.status === 401) ||
+      (recordsQuery.error instanceof ApiError && recordsQuery.error.status === 401);
+    if (isUnauth) void navigate(paths.login(), { replace: true });
+  }, [assetQuery.error, recordsQuery.error, navigate]);
+
+  const asset = assetQuery.data ? toAssetPresentation(assetQuery.data) : null;
+
+  const sorted = useMemo(
+    () => sortRecords(recordsQuery.data?.maintenanceRecords ?? []),
+    [recordsQuery.data],
+  );
+  const groups = useMemo(() => groupByYear(sorted), [sorted]);
+
+  const effectiveDensity = isMobile ? "timeline" : density;
+
+  const handleSaved = (record: MaintenanceRecord) => {
+    queryClient.setQueryData(
+      maintenanceRecordsQueryKey(assetId),
+      (old: MaintenanceRecordListResponse | undefined): MaintenanceRecordListResponse => ({
+        maintenanceRecords: [record, ...(old?.maintenanceRecords ?? [])],
+      }),
+    );
+    setFormOpen(false);
+  };
+
+  // ── derive page title
+  useEffect(() => {
+    document.title = asset ? `${asset.name} — Maintenance · FieldOps` : "Maintenance · FieldOps";
+  }, [asset]);
+
+  // ── error kinds
+  const assetErr = assetQuery.error instanceof ApiError ? assetQuery.error : null;
+  const assetStatus = assetErr?.status;
+  if (assetStatus === 403) {
+    return (
+      <div ref={rootRef} className="hf mr-root">
+        <HFTopBar />
+        <main className="mr-main mr-scroll" data-layout="focus">
+          <div className="mr-focus-wrap">
+            <MRErrorState kind="forbidden" />
+          </div>
+        </main>
+        <HFBottomNav />
+      </div>
+    );
+  }
+  if (assetStatus === 404) {
+    return (
+      <div ref={rootRef} className="hf mr-root">
+        <HFTopBar />
+        <main className="mr-main mr-scroll" data-layout="focus">
+          <div className="mr-focus-wrap">
+            <MRErrorState kind="notfound" />
+          </div>
+        </main>
+        <HFBottomNav />
+      </div>
+    );
+  }
+
+  // ── history area
+  const renderHistory = () => {
+    if (recordsQuery.isPending) return <MRLoading density={effectiveDensity} />;
+    if (recordsQuery.isError)
+      return (
+        <MRErrorState
+          kind="error"
+          onRetry={() => void recordsQuery.refetch()}
+        />
+      );
+    if (sorted.length === 0)
+      return <MREmpty assetName={asset?.name ?? "this asset"} onAdd={() => setFormOpen(true)} />;
+    return effectiveDensity === "table"
+      ? <MRTable groups={groups} />
+      : <MRTimeline groups={groups} />;
+  };
+
+  const histBlock = (
+    <div className="mr-hist-wrap">
+      {recordsQuery.isSuccess && sorted.length > 0 && (
+        <div className="mr-hist-head">
+          <div className="mr-hist-head-txt">
+            <span className="mr-hist-title">History</span>
+            <span className="mr-hist-meta">
+              newest first · {sorted.length} {sorted.length === 1 ? "record" : "records"}
+            </span>
+          </div>
+          {!isMobile && (
+            <div className="mr-density" role="group" aria-label="History density">
+              <button
+                className={density === "timeline" ? "active" : ""}
+                onClick={() => setDensity("timeline")}
+              >
+                <Icon name="menu" size={14} stroke={2} />Timeline
+              </button>
+              <button
+                className={density === "table" ? "active" : ""}
+                onClick={() => setDensity("table")}
+              >
+                <Icon name="grid" size={13} stroke={2} />Table
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+      {renderHistory()}
+    </div>
+  );
+
+  const overlayVariant: "drawer" | "sheet" = isMobile ? "sheet" : "drawer";
+  const showMobileAddBar =
+    isMobile &&
+    !assetQuery.isError &&
+    recordsQuery.isSuccess &&
+    sorted.length > 0;
+
+  return (
+    <div ref={rootRef} className="hf mr-root" data-density={effectiveDensity}>
+      <HFTopBar />
+
+      <main className="mr-main mr-scroll" data-layout="focus">
+        <div className="mr-focus-wrap">
+          {/* breadcrumb */}
+          <div className="mr-crumb">
+            <Link to={paths.assets} className="mr-crumb-link">Assets</Link>
+            <Icon name="chevron-right" size={14} color="var(--hf-ink-faint)" />
+            <span className="mr-crumb-cur">{asset?.name ?? "…"}</span>
+          </div>
+
+          {/* hero */}
+          {asset ? (
+            <div className="mr-hero">
+              <HFAssetIcon asset={{ category: asset.cat, icon: asset.icon }} size={56} />
+              <div className="mr-hero-id">
+                <h1 className="mr-hero-name">{asset.name}</h1>
+                <div className="mr-hero-meta">
+                  <span className="hf-mono">{asset.displayId}</span>
+                  <span className="mr-dot" />
+                  <span>{asset.summary}</span>
+                </div>
+              </div>
+              {!recordsQuery.isPending && (
+                <button
+                  className="mr-btn mr-btn-primary mr-hero-add"
+                  onClick={() => setFormOpen(true)}
+                >
+                  <Icon name="plus" size={16} stroke={2.2} />Log maintenance
+                </button>
+              )}
+            </div>
+          ) : assetQuery.isPending ? (
+            <div className="mr-hero">
+              <div className="mr-skel" style={{ width: 56, height: 56, borderRadius: 14 }} />
+              <div className="mr-hero-id" style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                <span className="mr-skel mr-skel-w80" style={{ height: 28, borderRadius: 8 }} />
+                <span className="mr-skel mr-skel-w50" />
+              </div>
+            </div>
+          ) : (
+            <div className="mr-hero">
+              <div className="mr-hero-id">
+                <h1 className="mr-hero-name">Asset</h1>
+              </div>
+            </div>
+          )}
+
+          {/* tabs */}
+          <div className="mr-tabs" role="tablist">
+            <button className="mr-tab" role="tab">Overview</button>
+            <button className="mr-tab active" role="tab" aria-selected="true">
+              Maintenance{" "}
+              <span className="mr-tab-count">
+                {recordsQuery.isSuccess ? sorted.length : "—"}
+              </span>
+            </button>
+          </div>
+
+          {/* history or full-page error */}
+          {assetQuery.isError ? (
+            <MRErrorState
+              kind="error"
+              onRetry={() => void assetQuery.refetch()}
+            />
+          ) : (
+            histBlock
+          )}
+        </div>
+      </main>
+
+      {showMobileAddBar && (
+        <div className="mr-addbar">
+          <button
+            className="mr-btn mr-btn-primary mr-addbar-btn"
+            onClick={() => setFormOpen(true)}
+          >
+            <Icon name="plus" size={17} stroke={2.2} />Add record
+          </button>
+        </div>
+      )}
+
+      <HFBottomNav />
+
+      {formOpen && asset && (
+        <div className={`mr-overlay mr-overlay-${overlayVariant}`}>
+          <div className="mr-scrim" onClick={() => setFormOpen(false)} />
+          <div className={`mr-overlay-panel-${overlayVariant}`}>
+            <MRForm
+              asset={asset}
+              assetId={assetId}
+              variant={overlayVariant}
+              onClose={() => setFormOpen(false)}
+              onSaved={handleSaved}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/AppMaintenanceRecords.tsx
+++ b/apps/web/src/app/AppMaintenanceRecords.tsx
@@ -108,11 +108,11 @@ function MRTimeline({ groups }: { groups: YearGroup[] }) {
                 <div className="mr-tl-date-inline">
                   {fmtDate(r.performedAt)}
                   <span className="mr-tl-ago-inline">· {relAgo(r.performedAt)}</span>
-                  {r.sameDay && <span className="mr-tl-sameday">same day</span>}
+                  {r.sameDay && <span className="mr-sameday">same day</span>}
                 </div>
                 <div className="mr-tl-title">
                   {r.title}
-                  {r.sameDay && <span className="mr-tl-sameday mr-tl-sameday-wide">same day</span>}
+                  {r.sameDay && <span className="mr-sameday mr-tl-sameday-wide">same day</span>}
                 </div>
                 {r.notes && <p className="mr-tl-notes">{r.notes}</p>}
               </div>
@@ -144,7 +144,7 @@ function MRTable({ groups }: { groups: YearGroup[] }) {
               </span>
               <span className="mr-td mr-td-work" role="cell">
                 {r.title}
-                {r.sameDay && <span className="mr-tl-sameday">same day</span>}
+                {r.sameDay && <span className="mr-sameday">same day</span>}
               </span>
               <span className="mr-td mr-td-notes" role="cell">
                 {r.notes || <span className="mr-td-dim">—</span>}
@@ -340,117 +340,119 @@ function MRForm({ asset, assetId, variant, onClose, onSaved }: MRFormProps) {
         </button>
       </div>
 
-      <div className="mr-form-body">
-        {banner && (
-          <div className="mr-banner" role="alert">
-            <Icon name="alert" size={15} stroke={2} />
-            <span>{banner}</span>
-          </div>
-        )}
-
-        <div className="mr-field">
-          <div className="mr-field-top">
-            <label className="mr-field-label" htmlFor="mr-title">
-              Title <span className="mr-req">*</span>
-            </label>
-            <span className={`mr-field-count ${title.length > TITLE_MAX ? "over" : ""}`}>
-              {title.length}/{TITLE_MAX}
-            </span>
-          </div>
-          <input
-            id="mr-title"
-            ref={titleRef}
-            type="text"
-            className={`mr-input ${fieldErrors.title ? "err" : ""}`}
-            placeholder='What did you do? e.g. "Oil change"'
-            maxLength={TITLE_MAX + 20}
-            value={title}
-            onChange={(e) => {
-              setTitle(e.target.value);
-              clearErr("title");
-              if (banner) setBanner(null);
-            }}
-          />
-          {fieldErrors.title && (
-            <div className="mr-field-err">
-              <Icon name="alert" size={13} stroke={2} />{fieldErrors.title}
+      <form onSubmit={(e) => { e.preventDefault(); handleSubmit(); }}>
+        <div className="mr-form-body">
+          {banner && (
+            <div className="mr-banner" role="alert">
+              <Icon name="alert" size={15} stroke={2} />
+              <span>{banner}</span>
             </div>
           )}
+
+          <div className="mr-field">
+            <div className="mr-field-top">
+              <label className="mr-field-label" htmlFor="mr-title">
+                Title <span className="mr-req">*</span>
+              </label>
+              <span className={`mr-field-count ${title.length > TITLE_MAX ? "over" : ""}`}>
+                {title.length}/{TITLE_MAX}
+              </span>
+            </div>
+            <input
+              id="mr-title"
+              ref={titleRef}
+              type="text"
+              className={`mr-input ${fieldErrors.title ? "err" : ""}`}
+              placeholder='What did you do? e.g. "Oil change"'
+              maxLength={TITLE_MAX + 20}
+              value={title}
+              onChange={(e) => {
+                setTitle(e.target.value);
+                clearErr("title");
+                if (banner) setBanner(null);
+              }}
+            />
+            {fieldErrors.title && (
+              <div className="mr-field-err">
+                <Icon name="alert" size={13} stroke={2} />{fieldErrors.title}
+              </div>
+            )}
+          </div>
+
+          <div className="mr-field">
+            <div className="mr-field-top">
+              <label className="mr-field-label" htmlFor="mr-date">
+                Performed date <span className="mr-req">*</span>
+              </label>
+            </div>
+            <input
+              id="mr-date"
+              type="date"
+              className={`mr-input mr-input-date ${fieldErrors.performedAt ? "err" : ""}`}
+              max={todayDateOnly()}
+              value={performedAt}
+              onChange={(e) => {
+                setPerformedAt(e.target.value);
+                clearErr("performedAt");
+                if (banner) setBanner(null);
+              }}
+            />
+            {fieldErrors.performedAt ? (
+              <div className="mr-field-err">
+                <Icon name="alert" size={13} stroke={2} />{fieldErrors.performedAt}
+              </div>
+            ) : (
+              <div className="mr-field-hint">When the work was done. Today or earlier.</div>
+            )}
+          </div>
+
+          <div className="mr-field">
+            <div className="mr-field-top">
+              <label className="mr-field-label" htmlFor="mr-notes">Notes</label>
+              <span className={`mr-field-count ${notes.length > NOTES_MAX ? "over" : ""}`}>
+                {notes.length}/{NOTES_MAX}
+              </span>
+            </div>
+            <textarea
+              id="mr-notes"
+              className={`mr-input mr-textarea ${fieldErrors.notes ? "err" : ""}`}
+              placeholder="Optional — location, condition, cost, vendor, quantity…"
+              value={notes}
+              onChange={(e) => {
+                setNotes(e.target.value);
+                clearErr("notes");
+                if (banner) setBanner(null);
+              }}
+            />
+            {fieldErrors.notes ? (
+              <div className="mr-field-err">
+                <Icon name="alert" size={13} stroke={2} />{fieldErrors.notes}
+              </div>
+            ) : (
+              <div className="mr-field-hint">
+                Free-form details. No structured fields — just write what's useful.
+              </div>
+            )}
+          </div>
         </div>
 
-        <div className="mr-field">
-          <div className="mr-field-top">
-            <label className="mr-field-label" htmlFor="mr-date">
-              Performed date <span className="mr-req">*</span>
-            </label>
-          </div>
-          <input
-            id="mr-date"
-            type="date"
-            className={`mr-input mr-input-date ${fieldErrors.performedAt ? "err" : ""}`}
-            max={todayDateOnly()}
-            value={performedAt}
-            onChange={(e) => {
-              setPerformedAt(e.target.value);
-              clearErr("performedAt");
-              if (banner) setBanner(null);
-            }}
-          />
-          {fieldErrors.performedAt ? (
-            <div className="mr-field-err">
-              <Icon name="alert" size={13} stroke={2} />{fieldErrors.performedAt}
-            </div>
-          ) : (
-            <div className="mr-field-hint">When the work was done. Today or earlier.</div>
-          )}
+        <div className="mr-form-actions">
+          <button type="button" className="mr-btn mr-btn-ghost" onClick={onClose} disabled={mutation.isPending}>
+            Cancel
+          </button>
+          <button
+            type="submit"
+            className="mr-btn mr-btn-primary mr-btn-save"
+            disabled={mutation.isPending}
+          >
+            {mutation.isPending ? (
+              <><span className="mr-spinner" />Saving…</>
+            ) : (
+              <><Icon name="check" size={15} stroke={2.4} />Save record</>
+            )}
+          </button>
         </div>
-
-        <div className="mr-field">
-          <div className="mr-field-top">
-            <label className="mr-field-label" htmlFor="mr-notes">Notes</label>
-            <span className={`mr-field-count ${notes.length > NOTES_MAX ? "over" : ""}`}>
-              {notes.length}/{NOTES_MAX}
-            </span>
-          </div>
-          <textarea
-            id="mr-notes"
-            className={`mr-input mr-textarea ${fieldErrors.notes ? "err" : ""}`}
-            placeholder="Optional — location, condition, cost, vendor, quantity…"
-            value={notes}
-            onChange={(e) => {
-              setNotes(e.target.value);
-              clearErr("notes");
-              if (banner) setBanner(null);
-            }}
-          />
-          {fieldErrors.notes ? (
-            <div className="mr-field-err">
-              <Icon name="alert" size={13} stroke={2} />{fieldErrors.notes}
-            </div>
-          ) : (
-            <div className="mr-field-hint">
-              Free-form details. No structured fields — just write what's useful.
-            </div>
-          )}
-        </div>
-      </div>
-
-      <div className="mr-form-actions">
-        <button className="mr-btn mr-btn-ghost" onClick={onClose} disabled={mutation.isPending}>
-          Cancel
-        </button>
-        <button
-          className="mr-btn mr-btn-primary mr-btn-save"
-          onClick={handleSubmit}
-          disabled={mutation.isPending}
-        >
-          {mutation.isPending ? (
-            <><span className="mr-spinner" />Saving…</>
-          ) : (
-            <><Icon name="check" size={15} stroke={2.4} />Save record</>
-          )}
-        </button>
-      </div>
+      </form>
     </div>
   );
 }
@@ -463,7 +465,9 @@ export function AppMaintenanceRecords() {
   const queryClient = useQueryClient();
 
   const rootRef = useRef<HTMLDivElement>(null);
-  const [containerWidth, setContainerWidth] = useState(window.innerWidth);
+  // Start at 0 so the first render defaults to mobile rather than using
+  // window.innerWidth, which can be wider than the actual container.
+  const [containerWidth, setContainerWidth] = useState(0);
   const isMobile = containerWidth <= 600;
 
   useEffect(() => {
@@ -528,6 +532,7 @@ export function AppMaintenanceRecords() {
   // ── derive page title
   useEffect(() => {
     document.title = asset ? `${asset.name} — Maintenance · FieldOps` : "Maintenance · FieldOps";
+    return () => { document.title = "FieldOps"; };
   }, [asset]);
 
   // ── error kinds
@@ -668,7 +673,8 @@ export function AppMaintenanceRecords() {
 
           {/* tabs */}
           <div className="mr-tabs" role="tablist">
-            <button className="mr-tab" role="tab">Overview</button>
+            {/* TODO: wire Overview tab when that panel is built */}
+            <button className="mr-tab" role="tab" aria-selected="false">Overview</button>
             <button className="mr-tab active" role="tab" aria-selected="true">
               Maintenance{" "}
               <span className="mr-tab-count">

--- a/apps/web/src/design/styles/mr.css
+++ b/apps/web/src/design/styles/mr.css
@@ -92,9 +92,9 @@
 .mr-tl-ago-inline { color: var(--hf-ink-faint); }
 .mr-tl-title { font-size: 16px; font-weight: 600; color: var(--hf-ink); letter-spacing: -0.014em; line-height: 1.25; display: flex; align-items: center; gap: 9px; flex-wrap: wrap; }
 .mr-tl-notes { margin: 8px 0 0; padding: 10px 13px; background: var(--hf-surface); border: 1px solid var(--hf-line-soft); border-left: 3px solid var(--hf-brand); border-radius: var(--hf-r-sm); font-size: 13.5px; color: var(--hf-ink-soft); line-height: 1.5; text-wrap: pretty; }
-.mr-tl-sameday { display: inline-flex; align-items: center; white-space: nowrap; padding: 1px 8px; border-radius: 999px; background: var(--hf-brand-bg); color: var(--hf-brand-2); font-family: var(--hf-sans); font-size: 10px; font-weight: 600; letter-spacing: 0.01em; }
+.mr-sameday { display: inline-flex; align-items: center; white-space: nowrap; padding: 1px 8px; border-radius: 999px; background: var(--hf-brand-bg); color: var(--hf-brand-2); font-family: var(--hf-sans); font-size: 10px; font-weight: 600; letter-spacing: 0.01em; }
 .mr-tl-sameday-wide { display: inline-flex; }
-.mr-tl-date-inline .mr-tl-sameday { text-transform: none; }
+.mr-tl-date-inline .mr-sameday { text-transform: none; }
 
 /* ============ TABLE ============ */
 .mr-table { border: 1px solid var(--hf-line); border-radius: var(--hf-r-lg); overflow: hidden; background: var(--hf-surface); }
@@ -146,6 +146,7 @@
 
 /* ============ FORM ============ */
 .mr-form { display: flex; flex-direction: column; min-height: 0; }
+.mr-form form { display: contents; }
 .mr-form-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; padding: 18px 20px 12px; flex-shrink: 0; }
 .mr-form-title { font-size: 18px; font-weight: 700; letter-spacing: -0.02em; color: var(--hf-ink); }
 .mr-form-sub { font-family: var(--hf-mono); font-size: 11.5px; color: var(--hf-ink-faint); margin-top: 3px; }

--- a/apps/web/src/design/styles/mr.css
+++ b/apps/web/src/design/styles/mr.css
@@ -1,0 +1,233 @@
+/* FieldOps — Maintenance Records (responsive). Loaded AFTER hifi.css so it can
+   rely on the --hf-* tokens. Scoped under .mr-root (which also carries .hf).
+   Breakpoints use the same container contract: @container hfapp.
+   Phones <=600 · tablet 601–1000 · desktop >1000. */
+
+.mr-root { position: relative; }
+.mr-scroll { overflow-y: auto; overflow-x: hidden; }
+.mr-scroll::-webkit-scrollbar { width: 10px; }
+.mr-scroll::-webkit-scrollbar-thumb { background: var(--hf-line); border-radius: 6px; border: 3px solid transparent; background-clip: content-box; }
+
+/* ============ buttons (local, FieldOps flavour) ============ */
+.mr-btn {
+  display: inline-flex; align-items: center; justify-content: center; gap: 7px;
+  padding: 9px 14px; border-radius: 9px;
+  font-size: 13.5px; font-weight: 600; letter-spacing: -0.01em;
+  border: 1px solid var(--hf-line); background: var(--hf-surface); color: var(--hf-ink);
+  transition: background 100ms, border-color 100ms, box-shadow 100ms; white-space: nowrap;
+}
+.mr-btn:hover { background: var(--hf-surface-2); }
+.mr-btn-primary { background: var(--hf-brand); color: #fff; border-color: var(--hf-brand); box-shadow: 0 1px 2px rgba(20,18,14,0.12); }
+.mr-btn-primary:hover { background: var(--hf-brand-2); border-color: var(--hf-brand-2); }
+.mr-btn-secondary { background: var(--hf-surface); }
+.mr-btn-ghost { background: transparent; border-color: transparent; color: var(--hf-ink-soft); }
+.mr-btn-ghost:hover { background: var(--hf-surface-2); color: var(--hf-ink); }
+.mr-btn:disabled { opacity: 0.6; cursor: default; }
+
+/* ============ layout scaffolds ============ */
+.mr-main { flex: 1; min-height: 0; }
+
+/* FOCUS — centered column */
+.mr-focus-wrap { max-width: 920px; margin: 0 auto; padding: 28px 32px 64px; display: flex; flex-direction: column; gap: 20px; }
+
+/* ============ breadcrumb ============ */
+.mr-crumb { display: flex; align-items: center; gap: 7px; font-size: 12.5px; }
+.mr-crumb-link { background: none; border: none; padding: 0; color: var(--hf-brand); font-weight: 600; font-size: 12.5px; text-decoration: none; }
+.mr-crumb-link:hover { text-decoration: underline; }
+.mr-crumb-cur { color: var(--hf-ink-soft); font-weight: 500; }
+
+/* ============ hero ============ */
+.mr-hero { display: flex; align-items: center; gap: 16px; }
+.mr-hero-id { min-width: 0; flex: 1; }
+.mr-hero-name { margin: 0; font-size: 26px; font-weight: 700; letter-spacing: -0.025em; color: var(--hf-ink); line-height: 1.1; }
+.mr-hero-meta { margin-top: 5px; display: flex; align-items: center; gap: 9px; flex-wrap: wrap; font-size: 13px; color: var(--hf-ink-soft); }
+.mr-hero-meta .hf-mono { font-family: var(--hf-mono); font-size: 12px; color: var(--hf-ink); }
+.mr-dot { width: 3px; height: 3px; border-radius: 50%; background: var(--hf-ink-faint); }
+.mr-hero-add { align-self: flex-start; flex-shrink: 0; }
+
+/* ============ tabs ============ */
+.mr-tabs { display: flex; gap: 4px; border-bottom: 1px solid var(--hf-line); margin-top: 2px; }
+.mr-tab {
+  position: relative; padding: 9px 4px 12px; margin-right: 18px; background: none; border: none;
+  font-size: 14px; font-weight: 500; color: var(--hf-ink-soft);
+  display: inline-flex; align-items: center; gap: 7px;
+}
+.mr-tab:hover { color: var(--hf-ink); }
+.mr-tab.active { color: var(--hf-ink); font-weight: 600; }
+.mr-tab.active::after { content: ""; position: absolute; left: 0; right: 0; bottom: -1px; height: 2px; background: var(--hf-brand); border-radius: 2px; }
+.mr-tab-count { font-family: var(--hf-mono); font-size: 11px; color: var(--hf-ink-faint); background: var(--hf-surface-2); border: 1px solid var(--hf-line); padding: 1px 6px; border-radius: 999px; }
+.mr-tab.active .mr-tab-count { color: var(--hf-brand-2); }
+
+/* ============ history head ============ */
+.mr-hist-wrap { display: flex; flex-direction: column; gap: 16px; }
+.mr-hist-head { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; }
+.mr-hist-head-txt { display: flex; align-items: baseline; gap: 10px; }
+.mr-hist-title { font-size: 14px; font-weight: 700; color: var(--hf-ink); letter-spacing: -0.01em; }
+.mr-hist-meta { font-family: var(--hf-mono); font-size: 11.5px; color: var(--hf-ink-faint); }
+.mr-density { display: flex; gap: 2px; background: var(--hf-surface-2); border: 1px solid var(--hf-line); border-radius: 9px; padding: 3px; }
+.mr-density button {
+  display: inline-flex; align-items: center; gap: 6px; padding: 5px 11px; border-radius: 6px;
+  border: none; background: none; font-size: 12.5px; font-weight: 500; color: var(--hf-ink-soft);
+}
+.mr-density button.active { background: var(--hf-surface); color: var(--hf-ink); font-weight: 600; box-shadow: var(--hf-shadow-1); }
+
+/* ============ TIMELINE ============ */
+.mr-tl { display: flex; flex-direction: column; }
+.mr-tl-year { display: flex; align-items: center; gap: 12px; margin: 4px 0 14px; }
+.mr-tl-group:first-child .mr-tl-year { margin-top: 0; }
+.mr-tl-year > span:first-child { font-family: var(--hf-mono); font-size: 12px; font-weight: 700; color: var(--hf-ink); letter-spacing: 0.04em; }
+.mr-tl-year-line { flex: 1; height: 1px; background: var(--hf-line); }
+
+.mr-tl-item { display: grid; grid-template-columns: 150px 18px 1fr; gap: 0 14px; }
+.mr-tl-aside { text-align: right; padding-top: 1px; }
+.mr-tl-date { font-family: var(--hf-mono); font-size: 12px; font-weight: 600; color: var(--hf-ink); white-space: nowrap; }
+.mr-tl-ago { font-size: 11px; color: var(--hf-ink-faint); margin-top: 2px; }
+.mr-tl-rail { display: flex; flex-direction: column; align-items: center; }
+.mr-tl-dot { width: 13px; height: 13px; border-radius: 50%; background: var(--hf-surface); border: 2.5px solid var(--hf-brand); margin-top: 3px; flex-shrink: 0; box-shadow: 0 0 0 3px var(--hf-bg); z-index: 1; }
+.mr-tl-group:first-child .mr-tl-item:first-child .mr-tl-dot { background: var(--hf-brand); }
+.mr-tl-line { width: 2px; flex: 1; background: var(--hf-line); margin-top: 2px; }
+.mr-tl-body { min-width: 0; padding-bottom: 22px; }
+.mr-tl-group:last-child .mr-tl-item:last-child .mr-tl-body { padding-bottom: 2px; }
+.mr-tl-date-inline { display: none; align-items: center; gap: 8px; white-space: nowrap; font-family: var(--hf-mono); font-size: 11px; text-transform: uppercase; letter-spacing: 0.03em; color: var(--hf-ink-faint); }
+.mr-tl-ago-inline { color: var(--hf-ink-faint); }
+.mr-tl-title { font-size: 16px; font-weight: 600; color: var(--hf-ink); letter-spacing: -0.014em; line-height: 1.25; display: flex; align-items: center; gap: 9px; flex-wrap: wrap; }
+.mr-tl-notes { margin: 8px 0 0; padding: 10px 13px; background: var(--hf-surface); border: 1px solid var(--hf-line-soft); border-left: 3px solid var(--hf-brand); border-radius: var(--hf-r-sm); font-size: 13.5px; color: var(--hf-ink-soft); line-height: 1.5; text-wrap: pretty; }
+.mr-tl-sameday { display: inline-flex; align-items: center; white-space: nowrap; padding: 1px 8px; border-radius: 999px; background: var(--hf-brand-bg); color: var(--hf-brand-2); font-family: var(--hf-sans); font-size: 10px; font-weight: 600; letter-spacing: 0.01em; }
+.mr-tl-sameday-wide { display: inline-flex; }
+.mr-tl-date-inline .mr-tl-sameday { text-transform: none; }
+
+/* ============ TABLE ============ */
+.mr-table { border: 1px solid var(--hf-line); border-radius: var(--hf-r-lg); overflow: hidden; background: var(--hf-surface); }
+.mr-thead, .mr-trow { display: grid; grid-template-columns: 168px minmax(0,1.4fr) minmax(0,2.1fr) 104px; gap: 18px; align-items: center; padding: 0 18px; }
+.mr-thead { height: 38px; background: var(--hf-surface-2); border-bottom: 1px solid var(--hf-line); }
+.mr-th { font-family: var(--hf-mono); font-size: 10.5px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; color: var(--hf-ink-faint); }
+.mr-th-logged, .mr-td-logged { text-align: right; }
+.mr-trow-year { padding: 9px 18px 7px; background: var(--hf-bg); border-bottom: 1px solid var(--hf-line-soft); }
+.mr-trow-year span { font-family: var(--hf-mono); font-size: 11px; font-weight: 700; color: var(--hf-ink-soft); letter-spacing: 0.04em; }
+.mr-trow { min-height: 52px; padding-top: 11px; padding-bottom: 11px; border-bottom: 1px solid var(--hf-line-soft); }
+.mr-tbody:last-child .mr-trow:last-child { border-bottom: none; }
+.mr-trow:hover { background: var(--hf-surface-2); }
+.mr-td { font-size: 13.5px; color: var(--hf-ink); min-width: 0; }
+.mr-td-date { display: flex; flex-direction: column; gap: 2px; }
+.mr-td-date-main { font-family: var(--hf-mono); font-size: 12.5px; font-weight: 600; color: var(--hf-ink); }
+.mr-td-date-ago { font-size: 11px; color: var(--hf-ink-faint); }
+.mr-td-work { font-weight: 600; letter-spacing: -0.01em; display: flex; align-items: center; gap: 9px; flex-wrap: wrap; }
+.mr-td-notes { font-size: 13px; color: var(--hf-ink-soft); line-height: 1.5; text-wrap: pretty; }
+.mr-td-dim { color: var(--hf-ink-faint); }
+.mr-td-logged { font-family: var(--hf-mono); font-size: 11.5px; color: var(--hf-ink-faint); }
+
+/* ============ EMPTY ============ */
+.mr-empty { display: flex; flex-direction: column; align-items: center; justify-content: center; text-align: center; gap: 13px; padding: 56px 24px; }
+.mr-empty-art { width: 72px; height: 72px; border-radius: 20px; background: var(--hf-brand-bg); display: flex; align-items: center; justify-content: center; }
+.mr-empty-title { font-size: 19px; font-weight: 700; color: var(--hf-ink); letter-spacing: -0.02em; }
+.mr-empty-sub { font-size: 14px; color: var(--hf-ink-soft); line-height: 1.55; max-width: 320px; }
+.mr-empty .mr-btn { margin-top: 4px; }
+
+/* ============ ERROR / 403 / 404 ============ */
+.mr-error { display: flex; flex-direction: column; align-items: center; justify-content: center; text-align: center; gap: 11px; padding: 52px 24px; }
+.mr-error-art { width: 60px; height: 60px; border-radius: 16px; display: flex; align-items: center; justify-content: center; background: var(--hf-surface-2); border: 1px solid var(--hf-line); color: var(--hf-ink-soft); }
+.mr-error-error .mr-error-art, .mr-error-forbidden .mr-error-art { background: var(--hf-bad-bg); border-color: oklch(88% 0.045 28); color: var(--hf-bad); }
+.mr-error-title { font-size: 18px; font-weight: 700; color: var(--hf-ink); letter-spacing: -0.02em; }
+.mr-error-sub { font-size: 13.5px; color: var(--hf-ink-soft); line-height: 1.55; max-width: 340px; }
+.mr-error .mr-btn { margin-top: 4px; }
+
+/* ============ LOADING SKELETON ============ */
+@keyframes mr-shimmer { 0% { background-position: -200px 0; } 100% { background-position: 320px 0; } }
+.mr-skel { display: block; height: 12px; border-radius: 6px; background: linear-gradient(90deg, var(--hf-line-soft) 0px, var(--hf-line) 40px, var(--hf-line-soft) 80px); background-size: 320px 100%; animation: mr-shimmer 1.1s linear infinite; }
+.mr-skel-w40 { width: 40%; } .mr-skel-w50 { width: 50%; } .mr-skel-w70 { width: 70%; } .mr-skel-w75 { width: 75%; } .mr-skel-w80 { width: 80%; } .mr-skel-w90 { width: 90%; }
+.mr-skel-block { width: 100%; height: 34px; border-radius: 8px; }
+.mr-skel-tl { display: flex; flex-direction: column; gap: 22px; }
+.mr-skel-item { display: grid; grid-template-columns: 18px 1fr; gap: 14px; }
+.mr-skel-dot { width: 13px; height: 13px; border-radius: 50%; background: var(--hf-line); margin-top: 3px; }
+.mr-skel-lines { display: flex; flex-direction: column; gap: 9px; }
+.mr-skel-table { border: 1px solid var(--hf-line); border-radius: var(--hf-r-lg); overflow: hidden; }
+.mr-skel-trow { display: grid; grid-template-columns: 168px 1.4fr 2.1fr 104px; gap: 18px; align-items: center; padding: 16px 18px; border-bottom: 1px solid var(--hf-line-soft); }
+.mr-skel-trow:last-child { border-bottom: none; }
+
+/* ============ FORM ============ */
+.mr-form { display: flex; flex-direction: column; min-height: 0; }
+.mr-form-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; padding: 18px 20px 12px; flex-shrink: 0; }
+.mr-form-title { font-size: 18px; font-weight: 700; letter-spacing: -0.02em; color: var(--hf-ink); }
+.mr-form-sub { font-family: var(--hf-mono); font-size: 11.5px; color: var(--hf-ink-faint); margin-top: 3px; }
+.mr-form-close { width: 30px; height: 30px; border-radius: 50%; background: var(--hf-surface-2); border: 1px solid var(--hf-line); display: flex; align-items: center; justify-content: center; color: var(--hf-ink-soft); flex-shrink: 0; }
+.mr-form-close:hover { background: var(--hf-line-soft); color: var(--hf-ink); }
+.mr-form-body { flex: 1; min-height: 0; overflow-y: auto; padding: 4px 20px 18px; display: flex; flex-direction: column; gap: 16px; }
+.mr-form-actions { display: flex; gap: 10px; justify-content: flex-end; padding: 14px 20px; border-top: 1px solid var(--hf-line); flex-shrink: 0; }
+.mr-form-actions .mr-btn-save { min-width: 130px; }
+
+.mr-banner { display: flex; align-items: center; gap: 9px; padding: 10px 12px; border-radius: var(--hf-r); background: var(--hf-bad-bg); border: 1px solid oklch(88% 0.045 28); color: var(--hf-bad); font-size: 13px; font-weight: 500; }
+
+.mr-field { display: flex; flex-direction: column; gap: 6px; }
+.mr-field-top { display: flex; align-items: baseline; justify-content: space-between; }
+.mr-field-label { font-size: 12.5px; font-weight: 600; color: var(--hf-ink); }
+.mr-req { color: var(--hf-bad); }
+.mr-field-count { font-family: var(--hf-mono); font-size: 10.5px; color: var(--hf-ink-faint); }
+.mr-field-count.over { color: var(--hf-bad); }
+.mr-input { width: 100%; background: var(--hf-surface); border: 1px solid var(--hf-line); border-radius: var(--hf-r); padding: 11px 13px; font-family: var(--hf-sans); font-size: 15px; color: var(--hf-ink); letter-spacing: -0.01em; outline: none; transition: border-color 100ms, box-shadow 100ms; }
+.mr-input:focus { border-color: var(--hf-brand); box-shadow: 0 0 0 3px var(--hf-brand-bg); }
+.mr-input::placeholder { color: var(--hf-ink-faint); }
+.mr-input.err { border-color: var(--hf-bad); }
+.mr-input.err:focus { box-shadow: 0 0 0 3px var(--hf-bad-bg); }
+.mr-input-date { font-family: var(--hf-mono); font-size: 14px; }
+.mr-textarea { min-height: 88px; line-height: 1.5; resize: vertical; }
+.mr-field-hint { font-size: 11.5px; color: var(--hf-ink-faint); line-height: 1.4; }
+.mr-field-err { display: flex; align-items: center; gap: 5px; font-size: 11.5px; color: var(--hf-bad); font-weight: 500; }
+
+.mr-spinner { width: 14px; height: 14px; border-radius: 50%; border: 2px solid rgba(255,255,255,0.4); border-top-color: #fff; animation: mr-spin 0.7s linear infinite; }
+@keyframes mr-spin { to { transform: rotate(360deg); } }
+
+/* ============ mobile sticky add bar ============ */
+.mr-addbar { display: none; flex-shrink: 0; padding: 10px 16px calc(10px + env(safe-area-inset-bottom, 0px)); background: var(--hf-surface); border-top: 1px solid var(--hf-line); }
+.mr-addbar-btn { width: 100%; padding: 13px; font-size: 15px; }
+
+/* ============ overlays ============ */
+.mr-overlay { position: absolute; inset: 0; z-index: 60; }
+.mr-scrim { position: absolute; inset: 0; background: rgba(20,18,14,0.34); animation: mr-fade 140ms ease; }
+@keyframes mr-fade { from { opacity: 0; } }
+
+/* drawer */
+.mr-overlay-panel-drawer { position: absolute; top: 0; right: 0; bottom: 0; width: min(440px, 100%); background: var(--hf-bg); box-shadow: -12px 0 50px rgba(20,18,14,0.2); display: flex; flex-direction: column; animation: mr-slide-r 200ms cubic-bezier(.3,.7,.4,1); overflow: hidden; }
+@keyframes mr-slide-r { from { transform: translateX(100%); } }
+
+/* sheet (mobile) */
+.mr-overlay-panel-sheet { position: absolute; left: 0; right: 0; bottom: 0; max-height: 92%; background: var(--hf-bg); border-radius: 22px 22px 0 0; box-shadow: 0 -8px 40px rgba(20,18,14,0.18); display: flex; flex-direction: column; animation: mr-slide-u 220ms cubic-bezier(.3,.7,.4,1); overflow: hidden; }
+@keyframes mr-slide-u { from { transform: translateY(100%); } }
+.mr-sheet-grab { width: 38px; height: 5px; border-radius: 999px; background: var(--hf-line); margin: 9px auto 0; flex-shrink: 0; }
+
+/* =====================================================================
+   RESPONSIVE
+   ===================================================================== */
+
+/* TABLET 601–1000 */
+@container hfapp (max-width: 1000px) {
+  .mr-focus-wrap { padding: 24px 24px 56px; }
+  .mr-hero-name { font-size: 23px; }
+  .mr-tl-item { grid-template-columns: 132px 18px 1fr; }
+}
+
+/* MOBILE <=600 */
+@container hfapp (max-width: 600px) {
+  .mr-focus-wrap { padding: 16px 16px 24px; gap: 16px; max-width: none; }
+
+  .mr-hero { gap: 13px; }
+  .mr-hero-name { font-size: 20px; }
+  .mr-hero-add { display: none; }
+
+  /* timeline: drop the date aside, show inline date above the title */
+  .mr-tl-item { grid-template-columns: 18px 1fr; }
+  .mr-tl-aside { display: none; }
+  .mr-tl-date-inline { display: flex; margin-bottom: 3px; }
+  .mr-tl-sameday-wide { display: none; }
+  .mr-tl-title { font-size: 15.5px; }
+
+  .mr-addbar { display: block; }
+
+  .mr-hist-head { gap: 8px; }
+  .mr-empty { padding: 40px 20px; }
+}
+
+/* honour reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .mr-scrim, .mr-overlay-panel-drawer, .mr-overlay-panel-sheet { animation: none; }
+  .mr-skel { animation: none; }
+}

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -3,6 +3,7 @@ import { AuthFlow } from "./auth/AuthFlow";
 import { AppAddAsset } from "./app/AppAddAsset";
 import { AppAssets } from "./app/AppAssets";
 import { AppHome } from "./app/AppHome";
+import { AppMaintenanceRecords } from "./app/AppMaintenanceRecords";
 import { MarketingHome } from "./marketing/MarketingHome";
 import { routePaths } from "./routes";
 
@@ -12,6 +13,7 @@ export const router = createBrowserRouter([
   { path: routePaths.appHome, element: <AppHome /> },
   { path: routePaths.assets, element: <AppAssets /> },
   { path: routePaths.addAsset, element: <AppAddAsset /> },
+  { path: routePaths.assetMaintenance, element: <AppMaintenanceRecords /> },
   // TODO: unknown routes currently fall back to the marketing home. Design a
   // real not-found / 404 experience and route it here.
   { path: "*", element: <MarketingHome /> },

--- a/apps/web/src/routes.ts
+++ b/apps/web/src/routes.ts
@@ -6,6 +6,7 @@ export const routePaths = {
   appHome: "/app",
   assets: "/app/assets",
   addAsset: "/app/assets/new",
+  assetMaintenance: "/app/assets/:assetId/maintenance",
 } as const;
 
 export const paths = {
@@ -14,4 +15,5 @@ export const paths = {
   appHome: routePaths.appHome,
   assets: routePaths.assets,
   addAsset: routePaths.addAsset,
+  assetMaintenance: (assetId: string) => `/app/assets/${assetId}/maintenance`,
 } as const;


### PR DESCRIPTION
## Summary

- **New page** at `/app/assets/:assetId/maintenance` — implements the Maintenance Records Responsive design in the focus layout direction
- **Timeline + Table density views** — timeline default, table toggle on desktop (hidden on mobile); records grouped by year with dated dots, relative timestamps, notes, and same-day badge
- **Log maintenance overlay** — right-side drawer on desktop, bottom sheet on mobile; full form with live character counters, field-level validation, error banner, saving spinner, and optimistic cache update via React Query on success
- **All spec states** — populated history, empty (with asset-name-interpolated copy), loading skeleton (shimmer), load-error + retry, 403 access denied, 404 not found
- **Asset card navigation** — grid and row cards on the Assets page are now `<Link>` elements pointing to the maintenance page

## New files

| File | Purpose |
|------|---------|
| `apps/web/src/api/maintenanceRecords.ts` | API client — `listMaintenanceRecords`, `createMaintenanceRecord`, types |
| `apps/web/src/app/AppMaintenanceRecords.tsx` | Page component with all sub-components (timeline, table, form, states) |
| `apps/web/src/design/styles/mr.css` | CSS ported from the Maintenance Records Responsive prototype |

## Changed files

| File | Change |
|------|--------|
| `apps/web/src/api/assets.ts` | Added `getAsset` + `assetQueryKey` |
| `apps/web/src/routes.ts` | Added `assetMaintenance` route path + helper |
| `apps/web/src/router.tsx` | Registered the new route |
| `apps/web/src/app/AppAssets.tsx` | Asset cards changed from static `<article>` to `<Link>` |

## Test plan

- [ ] Visit `/app/assets` → cards show hover lift and navigate to maintenance on click
- [ ] Populated history: timeline view shows year groups, dots, dates, notes; density toggle switches to table
- [ ] Log maintenance drawer (desktop): opens on button click, validates empty title, saves and prepends new record to list with updated count
- [ ] Log maintenance sheet (mobile, ≤600px): sticky add bar visible, sheet slides up from bottom
- [ ] Empty state: new asset with no records shows wrench illustration and "Add the first record" CTA
- [ ] 404: navigate to `/app/assets/00000000-.../maintenance` → "Asset not found" page
- [ ] 401: unauthenticated request redirects to login

🤖 Generated with [Claude Code](https://claude.com/claude-code)