### PR TITLE
Harden local auth bypass with an explicit development gate

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -109,7 +109,13 @@ jobs:
       - name: Reject production development auth bypass
         working-directory: apps/api
         run: |
-          secrets="$(CI=true pnpm wrangler secret list --format json)"
+          secrets="$(pnpm wrangler secret list --format json)"
+          if ! jq -e \
+            'type == "array" and all(.[]; type == "object" and ((.name | type) == "string"))' \
+            <<<"$secrets" >/dev/null; then
+            echo "::error::Unable to validate the production Worker secret list"
+            exit 1
+          fi
           if jq -e 'any(.[]; .name == "DEV_AUTH_EMAIL")' <<<"$secrets" >/dev/null; then
             echo "::error::DEV_AUTH_EMAIL is configured on the production Worker"
             exit 1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -106,6 +106,15 @@ jobs:
           test -n "$CLOUDFLARE_ACCOUNT_ID"
           test -n "$CLOUDFLARE_API_TOKEN"
 
+      - name: Reject production development auth bypass
+        working-directory: apps/api
+        run: |
+          secrets="$(CI=true pnpm wrangler secret list --format json)"
+          if jq -e 'any(.[]; .name == "DEV_AUTH_EMAIL")' <<<"$secrets" >/dev/null; then
+            echo "::error::DEV_AUTH_EMAIL is configured on the production Worker"
+            exit 1
+          fi
+
       # Apply any pending D1 migrations to production first, so the schema is
       # ready before the new code goes live. CI=true makes wrangler
       # non-interactive; it reads the CLOUDFLARE_* env vars for auth.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ pnpm -r test
 ```
 
 Local secrets live in `apps/api/.dev.vars` (gitignored). Set `DEV_AUTH_EMAIL`
-there to bypass the login flow during development. See
+there to bypass the login flow during development. The API dev script supplies
+the required `ENVIRONMENT=development` runtime marker; production defaults to
+`ENVIRONMENT=production` and rejects the bypass. See
 [`docs/guides/getting-started.md`](docs/guides/getting-started.md) for the full
 setup, including Google OAuth.
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "wrangler dev",
+    "dev": "wrangler dev --var ENVIRONMENT:development",
     "deploy": "wrangler deploy",
     "type-check": "tsc --noEmit",
     "test": "vitest run",

--- a/apps/api/src/infrastructure/auth/BetterAuthResolver.test.ts
+++ b/apps/api/src/infrastructure/auth/BetterAuthResolver.test.ts
@@ -1,4 +1,4 @@
-import { Email, InvariantError } from "@snaveevans/pineapple-shared";
+import { Email, InvariantError, UnauthorizedError } from "@snaveevans/pineapple-shared";
 import { describe, expect, it, vi } from "vitest";
 import type { UserRepository } from "../../domain/identity/UserRepository.ts";
 import { User } from "../../domain/identity/User.ts";
@@ -79,4 +79,18 @@ describe("BetterAuthResolver", () => {
       expect(save).not.toHaveBeenCalled();
     },
   );
+
+  it("rejects a request without DEV_AUTH_EMAIL or an active session", async () => {
+    const { resolver, getSession, findByEmail, save } = createHarness({
+      environment: "production",
+    });
+
+    await expect(
+      resolver.resolve(new Request("https://pineapple.example/api/assets")),
+    ).rejects.toBeInstanceOf(UnauthorizedError);
+
+    expect(getSession).toHaveBeenCalledOnce();
+    expect(findByEmail).not.toHaveBeenCalled();
+    expect(save).not.toHaveBeenCalled();
+  });
 });

--- a/apps/api/src/infrastructure/auth/BetterAuthResolver.test.ts
+++ b/apps/api/src/infrastructure/auth/BetterAuthResolver.test.ts
@@ -1,0 +1,82 @@
+import { Email, InvariantError } from "@snaveevans/pineapple-shared";
+import { describe, expect, it, vi } from "vitest";
+import type { UserRepository } from "../../domain/identity/UserRepository.ts";
+import { User } from "../../domain/identity/User.ts";
+import type { Auth } from "./auth.ts";
+import { BetterAuthResolver } from "./BetterAuthResolver.ts";
+
+function createHarness(options: {
+  environment?: string | undefined;
+  devEmail?: string;
+  sessionEmail?: string;
+  existingUser?: User;
+}) {
+  const getSession = vi
+    .fn()
+    .mockResolvedValue(options.sessionEmail ? { user: { email: options.sessionEmail } } : null);
+  const findByEmail = vi.fn().mockResolvedValue(options.existingUser ?? null);
+  const save = vi.fn().mockResolvedValue(undefined);
+  const auth = { api: { getSession } } as unknown as Auth;
+  const users = {
+    findById: vi.fn().mockResolvedValue(null),
+    findByEmail,
+    save,
+  } satisfies UserRepository;
+  const resolver = new BetterAuthResolver(auth, users, options.environment, options.devEmail);
+
+  return { resolver, getSession, findByEmail, save };
+}
+
+describe("BetterAuthResolver", () => {
+  it("uses DEV_AUTH_EMAIL and provisions the user in development", async () => {
+    const { resolver, getSession, findByEmail, save } = createHarness({
+      environment: "development",
+      devEmail: "Dev@example.com",
+    });
+
+    const user = await resolver.resolve(new Request("http://localhost/api/assets"));
+
+    expect(user.email).toBe(Email.from("dev@example.com"));
+    expect(getSession).not.toHaveBeenCalled();
+    expect(findByEmail).toHaveBeenCalledWith(Email.from("dev@example.com"));
+    expect(save).toHaveBeenCalledWith(user);
+  });
+
+  it.each([undefined, "production", "staging"])(
+    "rejects DEV_AUTH_EMAIL when ENVIRONMENT is %s",
+    async (environment) => {
+      const { resolver, getSession, findByEmail, save } = createHarness({
+        environment,
+        devEmail: "dev@example.com",
+      });
+
+      await expect(
+        resolver.resolve(new Request("https://pineapple.example/api/assets")),
+      ).rejects.toBeInstanceOf(InvariantError);
+
+      expect(getSession).not.toHaveBeenCalled();
+      expect(findByEmail).not.toHaveBeenCalled();
+      expect(save).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["production", "development"])(
+    "uses the verified session without DEV_AUTH_EMAIL in %s",
+    async (environment) => {
+      const existingUser = User.create(Email.from("session@example.com"));
+      const { resolver, getSession, findByEmail, save } = createHarness({
+        environment,
+        sessionEmail: "session@example.com",
+        existingUser,
+      });
+
+      await expect(
+        resolver.resolve(new Request("https://pineapple.example/api/assets")),
+      ).resolves.toBe(existingUser);
+
+      expect(getSession).toHaveBeenCalledOnce();
+      expect(findByEmail).toHaveBeenCalledWith(Email.from("session@example.com"));
+      expect(save).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/apps/api/src/infrastructure/auth/BetterAuthResolver.ts
+++ b/apps/api/src/infrastructure/auth/BetterAuthResolver.ts
@@ -17,21 +17,20 @@ import type { Auth } from "./auth.ts";
  * `users` table is what the rest of the app references.
  *
  * LOCAL DEV: pass `devEmail` (from DEV_AUTH_EMAIL in .dev.vars) to skip the
- * session check entirely. Lets local development proceed before Google OAuth
- * credentials are configured. Never set DEV_AUTH_EMAIL in production.
+ * session check entirely. The bypass is honored only when `environment` is
+ * exactly "development"; any other configuration fails closed.
  */
 export class BetterAuthResolver implements AuthenticatedUserResolver {
   constructor(
     private readonly auth: Auth,
     private readonly users: UserRepository,
+    private readonly environment: string | undefined,
     private readonly devEmail?: string,
     private readonly eventBus?: EventBus,
   ) {}
 
   async resolve(request: Request): Promise<User> {
-    const email = this.devEmail
-      ? Email.from(this.devEmail)
-      : await this.#resolveFromSession(request);
+    const email = await this.#resolveEmail(request);
 
     let user = await this.users.findByEmail(email);
     if (!user) {
@@ -40,6 +39,18 @@ export class BetterAuthResolver implements AuthenticatedUserResolver {
       await this.eventBus?.publish(UserProvisioned({ userId: user.id }));
     }
     return user;
+  }
+
+  async #resolveEmail(request: Request): Promise<Email> {
+    if (!this.devEmail) return this.#resolveFromSession(request);
+
+    if (this.environment !== "development") {
+      throw new InvariantError(
+        "DEV_AUTH_EMAIL may only be used when ENVIRONMENT is set to development",
+      );
+    }
+
+    return Email.from(this.devEmail);
   }
 
   /** Production: read the verified Better Auth session and extract the email. */

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -44,11 +44,12 @@ import type { MaintenanceRecordResponseSchema } from "./api/schemas/maintenanceR
 import type { z } from "@hono/zod-openapi";
 
 type Bindings = AuthEnv & {
+  ENVIRONMENT: string;
   ASSET_DOMAIN_TELEMETRY: AnalyticsEngineDataset;
   MAINTENANCE_DOMAIN_TELEMETRY: AnalyticsEngineDataset;
   USER_DOMAIN_TELEMETRY: AnalyticsEngineDataset;
   API_REQUEST_TELEMETRY: AnalyticsEngineDataset;
-  /** Local dev only — set in .dev.vars, never in wrangler.toml. Bypasses the Better Auth session check. */
+  /** Local dev only; honored only when ENVIRONMENT is exactly "development". */
   DEV_AUTH_EMAIL?: string;
 };
 type Variables = { user: User; auth: Auth; eventBus: EventBus };
@@ -155,6 +156,7 @@ app.use("/api/*", async (c, next) => {
   const resolver = new BetterAuthResolver(
     c.get("auth"),
     new D1UserRepository(c.env.DB),
+    c.env.ENVIRONMENT,
     c.env.DEV_AUTH_EMAIL,
     c.get("eventBus"),
   );

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -17,6 +17,9 @@ routes = [
   { pattern = "pineapple.tylerevans.co/health", zone_name = "tylerevans.co" },
 ]
 
+[vars]
+ENVIRONMENT = "production"
+
 [observability]
 enabled = true
 head_sampling_rate = 1

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -37,7 +37,7 @@ GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 
 # Dev bypass: treat every request as this user, skipping the login flow.
-# Remove it to exercise the real Google session flow. NEVER set in production.
+# The API dev script supplies ENVIRONMENT=development; other environments reject it.
 DEV_AUTH_EMAIL=you@example.com
 
 # OAuth callbacks should return through Vite's same-origin /api proxy.
@@ -52,6 +52,10 @@ Run the API Worker and web app in separate terminals:
 pnpm --filter @snaveevans/pineapple-api dev   # http://localhost:8787
 pnpm --filter @snaveevans/pineapple-web dev   # http://localhost:5173
 ```
+
+The API dev script passes `ENVIRONMENT=development` directly to Wrangler.
+Production uses the committed `ENVIRONMENT=production` binding. Do not add the
+environment marker to `.dev.vars`.
 
 The browser should use `http://localhost:5173`. Vite proxies same-origin
 `/api/*` requests to the API Worker. Try it:
@@ -93,6 +97,9 @@ Deployment is automatic: **merging to `main`** runs CI, applies pending D1
 migrations to production, then `wrangler deploy`s the Worker (see
 [ADR-0006](../decisions/0006-deployment-platform.md) and the workflows in
 `.github/workflows/`).
+
+Before applying migrations, the deploy job lists the production Worker's
+secrets and fails if `DEV_AUTH_EMAIL` is present.
 
 **One-time setup:**
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -37,8 +37,9 @@ The API maps the session to a domain user by email, creating the user on first
 sign-in. There is no separate "register" step.
 
 > **Local development:** set `DEV_AUTH_EMAIL` in `apps/api/.dev.vars` to bypass
-> the session check entirely — every request is treated as that user. Never set
-> it in production. See [getting-started](../guides/getting-started.md).
+> the session check entirely — every request is treated as that user. The bypass
+> is honored only when `ENVIRONMENT` is exactly `development`; other
+> environments fail closed. See [getting-started](../guides/getting-started.md).
 
 ## Endpoints
 

--- a/docs/specs/cross-cutting/authentication.md
+++ b/docs/specs/cross-cutting/authentication.md
@@ -25,7 +25,8 @@ All application features operate within an authenticated session. Better Auth ha
 - All `/api/*` routes outside `/api/auth/*` are protected by the `BetterAuthResolver` middleware registered in `worker.ts`.
 - The middleware calls `resolver.resolve()`, which reads the session cookie, validates it, and provisions a domain `User` JIT from the Better Auth record (keyed on email).
 - If no valid session exists, the middleware throws `UnauthorizedError` → 401.
-- In local development, `DEV_AUTH_EMAIL` in `.dev.vars` bypasses session validation and injects a synthetic user. This must never reach production.
+- In local development, `DEV_AUTH_EMAIL` in `.dev.vars` bypasses session validation and injects a synthetic user only when `ENVIRONMENT` is exactly `development`.
+- If `DEV_AUTH_EMAIL` is present in any other or unspecified environment, authentication fails closed before session resolution or user provisioning. The production deploy also rejects a persisted `DEV_AUTH_EMAIL` Worker secret.
 
 **Frontend:**
 


### PR DESCRIPTION
## Summary
- Require `ENVIRONMENT=development` before `DEV_AUTH_EMAIL` can bypass Better Auth.
- Default production to `ENVIRONMENT=production` and wire the dev script to set the development marker explicitly.
- Reject a persisted `DEV_AUTH_EMAIL` secret during production deploys.
- Update auth and setup docs to reflect the enforced safeguard.

## Testing
- Added unit coverage for development bypass, production rejection, missing environment rejection, and normal session resolution.
- Ran repository checks: lint, type-check, and the full test suite passed.
- Verified the API Worker with a Wrangler dry run to confirm the production binding layout.