### PR TITLE
Add HTTP security response headers (closes #17)

### DIFF
--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -1,6 +1,7 @@
 import { OpenAPIHono } from "@hono/zod-openapi";
 import { Scalar } from "@scalar/hono-api-reference";
 import type { Context } from "hono";
+import { secureHeaders } from "hono/secure-headers";
 import { AssetId, DomainError } from "@snaveevans/pineapple-shared";
 import type { User } from "./domain/identity/User.ts";
 import type { Asset } from "./domain/asset/Asset.ts";
@@ -83,6 +84,27 @@ app.use(
   createTechnicalTelemetryMiddleware<AppEnv>(
     (c) => new AnalyticsEngineTelemetrySink(c.env.API_REQUEST_TELEMETRY),
   ),
+);
+
+app.use(
+  "*",
+  secureHeaders({
+    xFrameOptions: "DENY",
+    xContentTypeOptions: true,
+    referrerPolicy: "strict-origin-when-cross-origin",
+    strictTransportSecurity: "max-age=31536000; includeSubDomains",
+    // Scalar's /reference UI loads from cdn.jsdelivr.net and emits an inline
+    // init script — unsafe-inline/CDN are unavoidable in the v0.10.x adapter.
+    // These directives are irrelevant for JSON API responses.
+    contentSecurityPolicy: {
+      defaultSrc: ["'none'"],
+      scriptSrc: ["'self'", "https://cdn.jsdelivr.net", "'unsafe-inline'"],
+      styleSrc: ["'self'", "'unsafe-inline'"],
+      imgSrc: ["'self'", "data:", "https:"],
+      connectSrc: ["'self'"],
+      frameAncestors: ["'none'"],
+    },
+  }),
 );
 
 // ── Serializers ────────────────────────────────────────────────────────────

--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -1,0 +1,6 @@
+/*
+  X-Frame-Options: DENY
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Strict-Transport-Security: max-age=31536000; includeSubDomains
+  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; form-action 'self'; base-uri 'self'


### PR DESCRIPTION
## Summary

- Adds Hono's built-in `secureHeaders` middleware globally to `apps/api/src/worker.ts`, covering all routes with `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, `Strict-Transport-Security`, and `Content-Security-Policy`
- Creates `apps/web/public/_headers` (new file) so Cloudflare Workers Assets injects the same set of headers on every SPA static response

No new dependencies — `secureHeaders` ships with Hono.

## What changed and why

Issue [#17](https://github.com/snaveevans/pineapple/issues/17) identified that neither worker set common HTTP security headers, leaving the app open to clickjacking and providing no second line of defense against future XSS regressions.

**API worker (`worker.ts`):** One `app.use("*", secureHeaders(...))` block added after the telemetry middleware. The CSP includes `cdn.jsdelivr.net` and `unsafe-inline` in `script-src` to accommodate Scalar's `/reference` UI (v0.10.x loads an external CDN script and emits an inline init script with no nonce plumbing). These relaxed `script-src` values are irrelevant for JSON API responses, where browsers don't evaluate CSP.

**Web SPA (`_headers`):** Cloudflare Workers Assets reads this file from the built asset bundle and injects the specified headers on static responses. CSP allows same-origin scripts (Vite production build, no inline scripts), `unsafe-inline` styles as a safe fallback, and Google Fonts (`fonts.googleapis.com` / `fonts.gstatic.com`).

## Reviewer notes

- `unsafe-inline` in `script-src` on the API worker is scoped to the developer-only `/reference` docs UI; the full rationale is in the inline comment
- The `_headers` file must live in `apps/web/public/` so Vite copies it to `dist/` on build; it is NOT processed by the Worker itself
- Verified all five headers present on `/health`, `/reference`, and `/openapi.json` via `curl -sI` against a local `wrangler dev` instance

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm type-check` — clean
- [x] `pnpm -r test` — 60/60 tests pass
- [x] `curl -sI http://localhost:878x/health` shows all five security headers
- [x] `curl -sI http://localhost:878x/reference` shows `cdn.jsdelivr.net` in `script-src`
- [ ] Deploy to staging and verify headers in browser DevTools (no CSP violations during Google OAuth + full app navigation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)