### PR TITLE
Make spec skills context-aware instead of taking commands

### DIFF
--- a/.claude/skills/spec-author/SKILL.md
+++ b/.claude/skills/spec-author/SKILL.md
@@ -1,22 +1,43 @@
 ---
 name: spec-author
-description: Draft or update a feature spec. Use /spec-author new for greenfield, /spec-author sync to document existing code, or /spec-author revise to complete a draft spec and make it implementation-ready. Walks through persona brainstorming, scenarios, user stories, and all six cross-cutting concerns.
+description: Draft, document, or revise a feature spec. Walks through persona brainstorming, scenarios, user stories, and all six cross-cutting concerns, and keeps specs organized by package.
 ---
 
 Work conversationally. Ask questions and confirm assumptions before writing. Do not generate a full draft until the steps below are complete.
 
 ## Existing specs
 
-!`find docs/specs/features -name "*.md" | sort`
+!`find apps/api/specs apps/web/specs -name "*.md" 2>/dev/null | sort`
 
-## Mode
+## Specs are organized by package
 
-Arguments: `$ARGUMENTS`
+Specs live with the package they describe (see `docs/specs/SPECS.md`):
 
-- `new [name]` → **Greenfield**: spec a feature that does not yet exist in code
-- `sync [name|path]` → **Brownfield**: document a spec from existing code
-- `revise [name]` → **Revise**: complete a draft spec and make it implementation-ready; the spec drives the code, not the other way around
-- No arguments or ambiguous → ask the user which mode and what the feature is
+- **API capability** (endpoint + validation/ownership/telemetry) → `apps/api/specs/features/`
+- **UX** (a screen/flow) → `apps/web/specs/features/`
+- A full-stack feature is **two specs**, one per package, that link to each other.
+- Cross-cutting concerns are per-package (`apps/<pkg>/specs/cross-cutting/`); the
+  genuine API↔web wire contracts live in `docs/specs/universal/`.
+
+**Before drafting, decide which package(s) the feature touches.** If both, plan to
+write an API capability spec and a web UX spec and cross-link them.
+
+## Figure out what you're doing
+
+Do NOT expect a command argument. Infer the mode from the conversation and the repo,
+confirm it in one line, and only ask when genuinely ambiguous:
+
+- The feature/code doesn't exist yet, or the user describes something to build →
+  **Greenfield** (author a new spec)
+- The user points at existing code, or a spec is missing for code that already
+  exists → **Brownfield** (document current behavior)
+- A spec already exists and the user wants to complete/sharpen it → **Revise**
+  (complete a draft and make it implementation-ready; the spec drives the code, not
+  the other way around)
+
+If the user's message already makes the mode and feature obvious, state your reading
+and proceed. If not, ask which of the three they want and what the feature is. The
+`Existing specs` list above is your reference for what already exists.
 
 ---
 
@@ -24,23 +45,25 @@ Arguments: `$ARGUMENTS`
 
 **1. Intent** — Ask for the user problem this feature solves in one sentence. Do not proceed until you have it.
 
-**2. Personas** — Identify all actors. Start with the primary persona (authenticated owner-operator for app features; unauthenticated visitor for public pages) then expand:
+**2. Name** — From the intent and the capability/screen described, propose a kebab-case spec name (e.g. `archive-asset`, `service-queue`). Present it as a suggestion and ask the user to confirm or replace it. **Always take the user's chosen name** — your suggestion is only a starting point. Use the agreed name for the spec file(s).
+
+**3. Personas** — Identify all actors. Start with the primary persona (authenticated owner-operator for app features; unauthenticated visitor for public pages) then expand:
 
 - Different states of the primary user (new user with no data, established user, user mid-flow)
 - Secondary personas (future team members, delegates)
 - System actors (background jobs, webhooks, scheduled tasks)
 
-**3. Scenarios** — For each persona, generate scenarios across three categories:
+**4. Scenarios** — For each persona, generate scenarios across three categories:
 
 - **Happy path** — the intended flow from entry to success
 - **Error and edge cases** — empty state, validation failure, API error, 401, slow network, concurrent actions
 - **Lifecycle transitions** — before/during/after states; navigation on success and failure
 
-**4. User stories** — Derive from scenarios using: "As a **[persona]**, I can **[action]** so that **[outcome]**." Every significant scenario should map to at least one story.
+**5. User stories** — Derive from scenarios using: "As a **[persona]**, I can **[action]** so that **[outcome]**." Every significant scenario should map to at least one story.
 
-**5. Cross-cutting analysis** — Read and work through [cross-cutting-checklist.md](cross-cutting-checklist.md). Ask the user about unknowns rather than guessing.
+**6. Cross-cutting analysis** — Read and work through [cross-cutting-checklist.md](cross-cutting-checklist.md). Ask the user about unknowns rather than guessing.
 
-**6. Draft** — Read the template at `docs/specs/templates/feature-spec.template.md`, fill it in, and write the spec to `docs/specs/features/[feature-name].md`. Add an entry to `docs/specs/SPECS.md`.
+**7. Draft** — Read the template at `docs/specs/templates/feature-spec.template.md`, fill it in, and write the spec to the right package: `apps/api/specs/features/[name].md` for an API capability, `apps/web/specs/features/[name].md` for UX. If the feature spans both, write both and cross-link them via the **Counterpart** line. Add an entry to the package's index (`apps/api/specs/SPECS.md` and/or `apps/web/specs/SPECS.md`).
 
 ---
 
@@ -48,7 +71,7 @@ Arguments: `$ARGUMENTS`
 
 **1. Locate the code** — Find relevant files: route handler in `apps/api/src/api/` or `worker.ts`, use case in `apps/api/src/application/usecases/`, UI component in `apps/web/src/`. Ask if unclear.
 
-**2. Check for an existing spec** — If one exists in `docs/specs/features/`, read it and note any gaps between spec and code.
+**2. Check for an existing spec** — Look in `apps/api/specs/features/` and `apps/web/specs/features/`. If it's unclear which package the feature lives in, ask, then use the `Existing specs` list (scoped to that package) to locate or rule out an existing spec. If one exists, read it and note any gaps between spec and code. Remember a full-stack feature may have one spec per package.
 
 **3. Describe current behavior** — Summarize what the code actually does: inputs → validation → domain logic → outputs → side effects. Confirm with the user before proceeding.
 
@@ -56,10 +79,10 @@ Arguments: `$ARGUMENTS`
 
 **5. Draft or update**
 
-- No spec: draft from `docs/specs/templates/feature-spec.template.md` and write to `docs/specs/features/[feature-name].md`
+- No spec: draft from `docs/specs/templates/feature-spec.template.md` and write to the right package's `features/` directory (API capability → `apps/api/specs/`, UX → `apps/web/specs/`)
 - Existing spec: update to match current behavior. Flag spec-vs-code divergences as `REVIEW NEEDED` flags rather than silently resolving them.
 
-Add or update the entry in `docs/specs/SPECS.md`.
+Add or update the entry in the relevant package index (`apps/api/specs/SPECS.md` and/or `apps/web/specs/SPECS.md`).
 
 ---
 
@@ -67,7 +90,14 @@ Add or update the entry in `docs/specs/SPECS.md`.
 
 Use this mode when a spec already exists but has open flags, gaps, or NOT SPECIFIED sections that need design decisions before implementation can begin. The spec is the source of truth — the goal is to produce something complete enough to hand to an implementer.
 
-**1. Read the spec** — Read `docs/specs/features/[feature-name].md` in full. Catalogue every open item:
+**0. Locate the spec** — If the user hasn't pinpointed a file:
+
+1. Ask which project the spec lives in — `apps/api` (capabilities) or `apps/web` (UX). A full-stack feature may have one in each.
+2. List the specs in that project from the `Existing specs` output above and have the user pick. Confirm the exact file path(s) before reading.
+
+If the user already named the feature, locate matching files across both packages and confirm which to revise.
+
+**1. Read the spec** — Read the spec in its package (`apps/api/specs/features/[name].md` or `apps/web/specs/features/[name].md`) in full; if the feature spans both packages, read both counterparts. Catalogue every open item:
 
 - `NOT SPECIFIED` flags — behavior that has never been decided
 - `REVIEW NEEDED` flags — behavior that exists but needs a decision
@@ -88,7 +118,7 @@ Work through decisions conversationally. Do not resolve a flag by guessing — i
 
 **5. Cross-cutting analysis** — Read and work through [cross-cutting-checklist.md](cross-cutting-checklist.md) against the **intended** behavior (decisions made in step 3), not the current code. Flag anything still unresolved.
 
-**6. Update the spec** — Rewrite or update `docs/specs/features/[feature-name].md`:
+**6. Update the spec** — Rewrite or update the spec in its package (and its counterpart if the change crosses the API↔web seam):
 
 - Replace resolved flags with acceptance criteria or edge case table rows
 - Remove flags that are explicitly out of scope (add to Out of Scope section instead)
@@ -101,7 +131,9 @@ Work through decisions conversationally. Do not resolve a flag by guessing — i
 
 Before writing the file, verify:
 
+- The spec is in the correct package directory for what it covers (API capability vs UX)
 - Every user story maps to at least one acceptance criterion
-- Every cross-cutting concern has been addressed or explicitly flagged
-- The Telemetry section names the operation(s) and states whether domain events apply
+- Every cross-cutting concern for that package has been addressed or explicitly flagged
+- **API specs only:** the Telemetry section names the operation(s) and states whether domain events apply
+- If the feature spans both packages, the API and web specs reference each other via the Counterpart line and neither duplicates the other's half
 - Anything unresolved is a named flag, not a missing section

--- a/.claude/skills/spec-implement/SKILL.md
+++ b/.claude/skills/spec-implement/SKILL.md
@@ -1,25 +1,41 @@
 ---
 name: spec-implement
-description: Implement a feature from a spec. Use /spec-implement new to build a complete spec from scratch across all layers, or /spec-implement diff to implement only what changed in an updated spec.
+description: Implement a feature from its spec(s). Detects the target spec from recent spec changes, builds a complete spec across all layers, or implements only what changed in an updated spec.
 ---
 
-## Mode
+## Find the target spec
 
-Arguments: `$ARGUMENTS`
+Do NOT expect a command argument. Work out which spec to implement from git state:
 
-- `new [name]` → **New**: implement a complete spec from scratch, layer by layer
-- `diff [name]` → **Diff**: implement only what changed in a recently updated spec
-- No arguments or ambiguous → ask the user which mode and which feature
+```!
+echo "── Uncommitted spec changes ──"
+git status --porcelain -- 'apps/*/specs/**/*.md'
+echo "── Spec files changed vs main ──"
+git diff --name-only main -- 'apps/*/specs/**/*.md' 2>/dev/null
+echo "── Recently committed specs ──"
+git log --oneline -10 --name-only -- 'apps/*/specs/**/*.md' 2>/dev/null
+```
+
+Use the output to pick the target and the mode:
+
+- A **new, untracked** spec file (or a spec with no implementing code yet) → **New** (full build across all layers).
+- An **existing** spec with uncommitted edits or recent commits that changed it → **Diff** (implement only the delta).
+
+Propose the spec file(s) and the mode you inferred in one line and confirm with the user. If nothing relevant shows up, or several candidates are equally likely, ask the user which feature to implement. A full-stack feature may have a spec in each package — implement the API spec's layers and the web spec's layers together.
 
 ---
 
 ## Pre-flight (both modes)
 
-Before writing any code, read the spec at `docs/specs/features/[feature-name].md` and verify:
+Specs are organized by package (see `docs/specs/SPECS.md`). A feature may have an
+API capability spec (`apps/api/specs/features/[name].md`), a web UX spec
+(`apps/web/specs/features/[name].md`), or both. Read **every** spec that exists for
+the feature — the API spec drives the backend layers, the web spec drives the
+frontend. Then verify each:
 
-1. **Status is not `wip`** — WIP specs are not ready to implement. Stop and tell the user to run `/spec-author revise [name]` first.
+1. **Status is not `wip`** — WIP specs are not ready to implement. Stop and tell the user to run `/spec-author` first to complete the spec.
 2. **No blocking `NOT SPECIFIED` flags** — any flag whose resolution would change what code to write is a blocker. Surface them and ask the user to resolve before continuing.
-3. **Telemetry section exists** — if missing, the operation name and domain event contract are unknown. Stop and flag it.
+3. **Telemetry section exists (API spec)** — if the feature has an API capability spec and its Telemetry section is missing, the operation name and domain event contract are unknown. Stop and flag it. (Pure web specs have no telemetry.)
 4. **Acceptance criteria exist** — if the AC section is empty or has only placeholders, the spec is not implementable. Stop.
 
 If pre-flight passes, summarize what will be built and confirm with the user before proceeding.
@@ -57,9 +73,13 @@ Implement only the delta between the spec's last committed state and its current
 
 **1. Get the spec diff**
 
-```!
-git diff main -- docs/specs/features/$ARGUMENTS.md 2>/dev/null || git diff HEAD~1 -- docs/specs/features/$ARGUMENTS.md 2>/dev/null || echo "No diff found — spec may not have changed since main"
+Run a diff against the spec file(s) you identified in **Find the target spec** (substitute the detected path; a full-stack feature has one per package, so run it for each):
+
 ```
+git diff main -- "<detected-spec-path>" 2>/dev/null || git diff HEAD~1 -- "<detected-spec-path>" 2>/dev/null || echo "No diff found — spec may not have changed since main"
+```
+
+A full-stack feature may show a diff in both the API and web specs. Interpret each.
 
 If no diff is found, ask the user to confirm which version of the spec changed and how.
 
@@ -87,4 +107,4 @@ When implementation is done:
 
 - Confirm all acceptance criteria in the spec are satisfied — walk through them one by one
 - Note any criteria that could not be met and why (flag candidates for the spec)
-- Remind the user to run `/spec-author sync [name]` if behavior diverged from the spec during implementation
+- Remind the user to run `/spec-author` (document existing code) if behavior diverged from the spec during implementation


### PR DESCRIPTION
## Summary

- Drops CLI-style positional commands (`$ARGUMENTS`: new/sync/revise/diff) from `spec-author` and `spec-implement` skills
- Both skills now infer intent and target from the conversation and repo state, asking the user only for genuine decisions
- Updates spec paths from flat `docs/specs/features/` to per-package `apps/api/specs/features/` and `apps/web/specs/features/`

## What changed

**`spec-author`**
- New `## Figure out what you're doing` section replaces the `$ARGUMENTS`-based mode selector — infers greenfield/brownfield/revise from context
- Greenfield adds a **Name** step (step 2) that proposes a kebab-case name before personas, then defers to the user's chosen name
- Revise adds **step 0** to locate the spec by asking which package, then listing from the `Existing specs` output
- Brownfield and quality check sections updated for per-package paths and cross-package consistency checks

**`spec-implement`**
- New `## Find the target spec` section replaces the mode argument — runs git commands to detect uncommitted/recent spec changes and infers new-vs-diff automatically
- Pre-flight updated for per-package spec paths; WIP message now points to `/spec-author` (no subcommand)
- Diff section uses `<detected-spec-path>` placeholder instead of `$ARGUMENTS` in the git diff command

## Notes

This is a cherry-pick of the context-aware changes from another branch. The per-package spec directory structure (`apps/*/specs/`) is a dependency that will be wired up in a follow-on migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)