### PR TITLE
Add maintenance task domain with record-linking and auto-advance

### DIFF
--- a/apps/api/src/api/middleware/technicalTelemetry.ts
+++ b/apps/api/src/api/middleware/technicalTelemetry.ts
@@ -130,6 +130,24 @@ function routeTelemetry(method: string, pathname: string): RouteTelemetry {
       routePattern: "/api/assets/{assetId}/maintenance-records",
     };
   }
+  if (/^\/api\/assets\/[^/]+\/maintenance-tasks$/.test(pathname) && method === "POST") {
+    return {
+      operation: "CreateMaintenanceTask",
+      routePattern: "/api/assets/{assetId}/maintenance-tasks",
+    };
+  }
+  if (/^\/api\/assets\/[^/]+\/maintenance-tasks$/.test(pathname) && method === "GET") {
+    return {
+      operation: "ListMaintenanceTasks",
+      routePattern: "/api/assets/{assetId}/maintenance-tasks",
+    };
+  }
+  if (/^\/api\/assets\/[^/]+\/maintenance-tasks\/[^/]+$/.test(pathname) && method === "DELETE") {
+    return {
+      operation: "DeleteMaintenanceTask",
+      routePattern: "/api/assets/{assetId}/maintenance-tasks/{taskId}",
+    };
+  }
   if (pathname === "/health" && method === "GET") {
     return { operation: "Health", routePattern: "/health" };
   }

--- a/apps/api/src/api/openapi.ts
+++ b/apps/api/src/api/openapi.ts
@@ -14,6 +14,13 @@ import {
   MaintenanceRecordListResponseSchema,
   MaintenanceRecordResponseSchema,
 } from "./schemas/maintenanceRecordSchemas.ts";
+import {
+  CreateMaintenanceTaskBodySchema,
+  MaintenanceTaskAssetIdParamSchema,
+  MaintenanceTaskListResponseSchema,
+  MaintenanceTaskParamsSchema,
+  MaintenanceTaskResponseSchema,
+} from "./schemas/maintenanceTaskSchemas.ts";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // OpenAPI route specs (metadata only — no handlers, no infrastructure).
@@ -49,7 +56,7 @@ export const openApiConfig = {
     { name: "Assets", description: "Create and read assets owned by the caller" },
     {
       name: "Maintenance",
-      description: "Create and read asset maintenance records owned by the caller",
+      description: "Create and read maintenance records and tasks for assets owned by the caller",
     },
   ],
 };
@@ -214,6 +221,102 @@ export const listMaintenanceRecordsRoute = createRoute({
   },
 });
 
+export const createMaintenanceTaskRoute = createRoute({
+  method: "post",
+  path: "/api/assets/{assetId}/maintenance-tasks",
+  tags: ["Maintenance"],
+  summary: "Create a maintenance task",
+  security: [cookieAuth],
+  request: {
+    params: MaintenanceTaskAssetIdParamSchema,
+    body: {
+      required: true,
+      content: { "application/json": { schema: CreateMaintenanceTaskBodySchema } },
+    },
+  },
+  responses: {
+    201: {
+      description: "Maintenance task created",
+      content: { "application/json": { schema: MaintenanceTaskResponseSchema } },
+    },
+    401: {
+      description: "Not authenticated",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    403: {
+      description: "The asset belongs to another user",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    404: {
+      description: "No such asset",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    409: {
+      description: "The asset is archived",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    422: {
+      description: "Validation failed",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
+export const listMaintenanceTasksRoute = createRoute({
+  method: "get",
+  path: "/api/assets/{assetId}/maintenance-tasks",
+  tags: ["Maintenance"],
+  summary: "List maintenance tasks for an asset",
+  description:
+    "Returns tasks ordered by nextDue ascending (soonest due first). Archived asset tasks remain readable.",
+  security: [cookieAuth],
+  request: { params: MaintenanceTaskAssetIdParamSchema },
+  responses: {
+    200: {
+      description: "The asset's maintenance tasks",
+      content: { "application/json": { schema: MaintenanceTaskListResponseSchema } },
+    },
+    401: {
+      description: "Not authenticated",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    403: {
+      description: "The asset belongs to another user",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    404: {
+      description: "No such asset",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
+export const deleteMaintenanceTaskRoute = createRoute({
+  method: "delete",
+  path: "/api/assets/{assetId}/maintenance-tasks/{taskId}",
+  tags: ["Maintenance"],
+  summary: "Delete a maintenance task",
+  description:
+    "Permanently removes the task. Linked maintenance records are preserved with taskId set to null.",
+  security: [cookieAuth],
+  request: { params: MaintenanceTaskParamsSchema },
+  responses: {
+    204: { description: "Task deleted" },
+    401: {
+      description: "Not authenticated",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    403: {
+      description: "The task belongs to another user",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    404: {
+      description: "No such task",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
 /**
  * Register shared OpenAPI components (security schemes) on a registry.
  * Keyed off the registry type (not the app's Env) so it works for both the
@@ -246,6 +349,9 @@ export function getApiDocument() {
   doc.openapi(getAssetRoute, stub);
   doc.openapi(createMaintenanceRecordRoute, stub);
   doc.openapi(listMaintenanceRecordsRoute, stub);
+  doc.openapi(createMaintenanceTaskRoute, stub);
+  doc.openapi(listMaintenanceTasksRoute, stub);
+  doc.openapi(deleteMaintenanceTaskRoute, stub);
   registerOpenApiComponents(doc.openAPIRegistry);
   return doc.getOpenAPIDocument(openApiConfig);
 }

--- a/apps/api/src/api/schemas/maintenanceRecordSchemas.test.ts
+++ b/apps/api/src/api/schemas/maintenanceRecordSchemas.test.ts
@@ -47,6 +47,7 @@ describe("maintenance record schemas", () => {
         title: "Changed oil",
         performedAt: "2026-06-09",
         notes: null,
+        taskId: null,
         createdAt: "2026-06-09T18:25:24.887Z",
       }).success,
     ).toBe(true);

--- a/apps/api/src/api/schemas/maintenanceRecordSchemas.ts
+++ b/apps/api/src/api/schemas/maintenanceRecordSchemas.ts
@@ -32,6 +32,11 @@ export const CreateMaintenanceRecordBodySchema = z
       .max(1000, "Notes must be 1000 characters or fewer")
       .optional()
       .openapi({ example: "Used 7 quarts of 5W-20 synthetic oil." }),
+    taskId: z
+      .string()
+      .uuid("Task id must be a UUID")
+      .optional()
+      .openapi({ example: "a1b2c3d4-e5f6-7890-abcd-ef1234567890" }),
   })
   .openapi("CreateMaintenanceRecordBody");
 
@@ -42,6 +47,11 @@ export const MaintenanceRecordResponseSchema = z
     title: z.string().openapi({ example: "Changed oil" }),
     performedAt: DateOnlySchema,
     notes: z.string().nullable().openapi({ example: "Used 7 quarts of synthetic oil." }),
+    taskId: z
+      .string()
+      .uuid()
+      .nullable()
+      .openapi({ example: "a1b2c3d4-e5f6-7890-abcd-ef1234567890" }),
     createdAt: z.string().datetime().openapi({ example: "2026-06-09T18:25:24.887Z" }),
   })
   .openapi("MaintenanceRecord");

--- a/apps/api/src/api/schemas/maintenanceRecordSchemas.ts
+++ b/apps/api/src/api/schemas/maintenanceRecordSchemas.ts
@@ -1,11 +1,5 @@
 import { z } from "@hono/zod-openapi";
-import { isValidDateOnly } from "../../domain/maintenance/DateOnly.ts";
-
-const DateOnlySchema = z
-  .string()
-  .regex(/^\d{4}-\d{2}-\d{2}$/, "Date must use YYYY-MM-DD format")
-  .refine(isValidDateOnly, "Date must be a valid calendar date")
-  .openapi({ format: "date", example: "2026-06-09" });
+import { DateOnlySchema } from "./shared.ts";
 
 export const MaintenanceAssetIdParamSchema = z.object({
   assetId: z

--- a/apps/api/src/api/schemas/maintenanceTaskSchemas.ts
+++ b/apps/api/src/api/schemas/maintenanceTaskSchemas.ts
@@ -1,0 +1,72 @@
+import { z } from "@hono/zod-openapi";
+import { isValidDateOnly } from "../../domain/maintenance/DateOnly.ts";
+
+const DateOnlySchema = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, "Date must use YYYY-MM-DD format")
+  .refine(isValidDateOnly, "Date must be a valid calendar date")
+  .openapi({ format: "date", example: "2026-04-11" });
+
+const IntervalUnitSchema = z.enum(["day", "week", "month", "year"]).openapi({ example: "month" });
+
+export const MaintenanceTaskAssetIdParamSchema = z.object({
+  assetId: z
+    .string()
+    .uuid("Asset id must be a UUID")
+    .openapi({
+      param: { name: "assetId", in: "path" },
+      example: "195d0ef0-47f5-439f-abfd-29f892c9a040",
+    }),
+});
+
+export const MaintenanceTaskParamsSchema = z.object({
+  assetId: z
+    .string()
+    .uuid("Asset id must be a UUID")
+    .openapi({
+      param: { name: "assetId", in: "path" },
+      example: "195d0ef0-47f5-439f-abfd-29f892c9a040",
+    }),
+  taskId: z
+    .string()
+    .uuid("Task id must be a UUID")
+    .openapi({
+      param: { name: "taskId", in: "path" },
+      example: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    }),
+});
+
+export const CreateMaintenanceTaskBodySchema = z
+  .object({
+    title: z
+      .string()
+      .trim()
+      .min(1, "Title is required")
+      .max(100, "Title must be 100 characters or fewer")
+      .openapi({ example: "Replace furnace filter" }),
+    intervalValue: z
+      .number()
+      .int("Interval value must be an integer")
+      .min(1, "Interval value must be at least 1")
+      .openapi({ example: 2 }),
+    intervalUnit: IntervalUnitSchema,
+    lastCompletedDate: DateOnlySchema.optional().openapi({ example: "2026-04-11" }),
+  })
+  .openapi("CreateMaintenanceTaskBody");
+
+export const MaintenanceTaskResponseSchema = z
+  .object({
+    id: z.string().uuid().openapi({ example: "a1b2c3d4-e5f6-7890-abcd-ef1234567890" }),
+    assetId: z.string().uuid().openapi({ example: "195d0ef0-47f5-439f-abfd-29f892c9a040" }),
+    title: z.string().openapi({ example: "Replace furnace filter" }),
+    intervalValue: z.number().int().openapi({ example: 2 }),
+    intervalUnit: IntervalUnitSchema,
+    lastCompletedDate: z.string().nullable().openapi({ example: "2026-04-11" }),
+    nextDue: z.string().openapi({ example: "2026-06-11" }),
+    createdAt: z.string().datetime().openapi({ example: "2026-06-11T18:25:24.887Z" }),
+  })
+  .openapi("MaintenanceTask");
+
+export const MaintenanceTaskListResponseSchema = z
+  .object({ maintenanceTasks: z.array(MaintenanceTaskResponseSchema) })
+  .openapi("MaintenanceTaskListResponse");

--- a/apps/api/src/api/schemas/maintenanceTaskSchemas.ts
+++ b/apps/api/src/api/schemas/maintenanceTaskSchemas.ts
@@ -1,11 +1,5 @@
 import { z } from "@hono/zod-openapi";
-import { isValidDateOnly } from "../../domain/maintenance/DateOnly.ts";
-
-const DateOnlySchema = z
-  .string()
-  .regex(/^\d{4}-\d{2}-\d{2}$/, "Date must use YYYY-MM-DD format")
-  .refine(isValidDateOnly, "Date must be a valid calendar date")
-  .openapi({ format: "date", example: "2026-04-11" });
+import { DateOnlySchema } from "./shared.ts";
 
 const IntervalUnitSchema = z.enum(["day", "week", "month", "year"]).openapi({ example: "month" });
 
@@ -61,8 +55,8 @@ export const MaintenanceTaskResponseSchema = z
     title: z.string().openapi({ example: "Replace furnace filter" }),
     intervalValue: z.number().int().openapi({ example: 2 }),
     intervalUnit: IntervalUnitSchema,
-    lastCompletedDate: z.string().nullable().openapi({ example: "2026-04-11" }),
-    nextDue: z.string().openapi({ example: "2026-06-11" }),
+    lastCompletedDate: DateOnlySchema.nullable().openapi({ example: "2026-04-11" }),
+    nextDue: DateOnlySchema.openapi({ example: "2026-06-11" }),
     createdAt: z.string().datetime().openapi({ example: "2026-06-11T18:25:24.887Z" }),
   })
   .openapi("MaintenanceTask");

--- a/apps/api/src/api/schemas/shared.ts
+++ b/apps/api/src/api/schemas/shared.ts
@@ -1,0 +1,8 @@
+import { z } from "@hono/zod-openapi";
+import { isValidDateOnly } from "../../domain/maintenance/DateOnly.ts";
+
+export const DateOnlySchema = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, "Date must use YYYY-MM-DD format")
+  .refine(isValidDateOnly, "Date must be a valid calendar date")
+  .openapi({ format: "date", example: "2026-06-09" });

--- a/apps/api/src/application/ports/MaintenanceRecordWriter.ts
+++ b/apps/api/src/application/ports/MaintenanceRecordWriter.ts
@@ -1,0 +1,7 @@
+import type { MaintenanceRecord } from "../../domain/maintenance/MaintenanceRecord.ts";
+import type { MaintenanceTask } from "../../domain/maintenance/MaintenanceTask.ts";
+
+export interface MaintenanceRecordWriter {
+  /** Persists the record and an advanced task atomically when both are provided. */
+  save(record: MaintenanceRecord, advancedTask: MaintenanceTask | null): Promise<void>;
+}

--- a/apps/api/src/application/usecases/CreateMaintenanceRecord.test.ts
+++ b/apps/api/src/application/usecases/CreateMaintenanceRecord.test.ts
@@ -3,6 +3,7 @@ import {
   AssetId,
   ConflictError,
   ForbiddenError,
+  MaintenanceTaskId,
   NotFoundError,
   UserId,
   ValidationError,
@@ -12,6 +13,8 @@ import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
 import type { DomainEvent } from "../../domain/events/DomainEvent.ts";
 import type { MaintenanceRecord } from "../../domain/maintenance/MaintenanceRecord.ts";
 import type { MaintenanceRecordRepository } from "../../domain/maintenance/MaintenanceRecordRepository.ts";
+import { MaintenanceTask } from "../../domain/maintenance/MaintenanceTask.ts";
+import type { MaintenanceTaskRepository } from "../../domain/maintenance/MaintenanceTaskRepository.ts";
 import type { EventBus } from "../ports/EventBus.ts";
 import type { UtcDateProvider } from "../ports/UtcDateProvider.ts";
 import { CreateMaintenanceRecord } from "./CreateMaintenanceRecord.ts";
@@ -41,6 +44,24 @@ class MaintenanceRecordRepositoryFake implements MaintenanceRecordRepository {
 
   save(record: MaintenanceRecord): Promise<void> {
     this.saved = record;
+    return Promise.resolve();
+  }
+}
+
+class MaintenanceTaskRepositoryFake implements MaintenanceTaskRepository {
+  saved: MaintenanceTask | null = null;
+  constructor(private readonly task: MaintenanceTask | null = null) {}
+  findByAsset(): Promise<MaintenanceTask[]> {
+    return Promise.resolve([]);
+  }
+  findById(): Promise<MaintenanceTask | null> {
+    return Promise.resolve(this.task);
+  }
+  save(task: MaintenanceTask): Promise<void> {
+    this.saved = task;
+    return Promise.resolve();
+  }
+  delete(): Promise<void> {
     return Promise.resolve();
   }
 }
@@ -82,6 +103,7 @@ describe("CreateMaintenanceRecord", () => {
     const result = await new CreateMaintenanceRecord(
       new AssetRepositoryFake(asset),
       records,
+      new MaintenanceTaskRepositoryFake(),
       events,
       dates,
     ).execute({
@@ -130,6 +152,7 @@ describe("CreateMaintenanceRecord", () => {
     const result = await new CreateMaintenanceRecord(
       new AssetRepositoryFake(asset),
       new MaintenanceRecordRepositoryFake(),
+      new MaintenanceTaskRepositoryFake(),
       new EventBusFake(),
       dates,
     ).execute({
@@ -152,6 +175,7 @@ describe("CreateMaintenanceRecord", () => {
     const result = await new CreateMaintenanceRecord(
       new AssetRepositoryFake(asset),
       records,
+      new MaintenanceTaskRepositoryFake(),
       new EventBusFake(),
       dates,
     ).execute({
@@ -172,6 +196,7 @@ describe("CreateMaintenanceRecord", () => {
     const result = await new CreateMaintenanceRecord(
       new AssetRepositoryFake(asset),
       new MaintenanceRecordRepositoryFake(),
+      new MaintenanceTaskRepositoryFake(),
       new EventBusFake(),
       { today: () => "not-a-date" },
     ).execute({
@@ -192,6 +217,7 @@ describe("CreateMaintenanceRecord", () => {
     return new CreateMaintenanceRecord(
       new AssetRepositoryFake(asset),
       new MaintenanceRecordRepositoryFake(),
+      new MaintenanceTaskRepositoryFake(),
       new EventBusFake(),
       dates,
     ).execute({
@@ -201,4 +227,200 @@ describe("CreateMaintenanceRecord", () => {
       performedAt: "2026-06-09",
     });
   }
+
+  describe("with taskId", () => {
+    function makeTask(
+      overrides: {
+        assetId?: AssetId;
+        ownerId?: UserId;
+        lastCompletedDate?: string | null;
+      } = {},
+    ) {
+      const asset = assetFor();
+      return MaintenanceTask.reconstitute({
+        id: MaintenanceTaskId.generate(),
+        assetId: overrides.assetId ?? asset.id,
+        ownerId: overrides.ownerId ?? ownerId,
+        title: "Replace furnace filter",
+        intervalValue: 2,
+        intervalUnit: "month",
+        lastCompletedDate:
+          overrides.lastCompletedDate !== undefined ? overrides.lastCompletedDate : null,
+        nextDue: "2026-08-09",
+        createdAt: new Date(),
+      });
+    }
+
+    it("saves the record, advances the task, and publishes MaintenanceTaskAdvanced", async () => {
+      const asset = assetFor();
+      const task = MaintenanceTask.reconstitute({
+        id: MaintenanceTaskId.generate(),
+        assetId: asset.id,
+        ownerId,
+        title: "Replace furnace filter",
+        intervalValue: 2,
+        intervalUnit: "month",
+        lastCompletedDate: "2026-04-09",
+        nextDue: "2026-06-09",
+        createdAt: new Date(),
+      });
+      const tasks = new MaintenanceTaskRepositoryFake(task);
+      const events = new EventBusFake();
+
+      const result = await new CreateMaintenanceRecord(
+        new AssetRepositoryFake(asset),
+        new MaintenanceRecordRepositoryFake(),
+        tasks,
+        events,
+        dates,
+      ).execute({
+        assetId: asset.id,
+        requesterId: ownerId,
+        title: "Changed oil",
+        performedAt: "2026-06-09",
+        taskId: task.id,
+      });
+
+      expect(result.ok).toBe(true);
+      expect(tasks.saved).not.toBeNull();
+      expect(events.events).toContainEqual(
+        expect.objectContaining({ type: "MaintenanceTaskAdvanced", performedAt: "2026-06-09" }),
+      );
+    });
+
+    it("does not advance the task when performedAt equals lastCompletedDate", async () => {
+      const asset = assetFor();
+      const task = MaintenanceTask.reconstitute({
+        id: MaintenanceTaskId.generate(),
+        assetId: asset.id,
+        ownerId,
+        title: "Replace furnace filter",
+        intervalValue: 2,
+        intervalUnit: "month",
+        lastCompletedDate: "2026-06-09",
+        nextDue: "2026-08-09",
+        createdAt: new Date(),
+      });
+      const tasks = new MaintenanceTaskRepositoryFake(task);
+      const events = new EventBusFake();
+
+      const result = await new CreateMaintenanceRecord(
+        new AssetRepositoryFake(asset),
+        new MaintenanceRecordRepositoryFake(),
+        tasks,
+        events,
+        dates,
+      ).execute({
+        assetId: asset.id,
+        requesterId: ownerId,
+        title: "Changed oil",
+        performedAt: "2026-06-09",
+        taskId: task.id,
+      });
+
+      expect(result.ok).toBe(true);
+      expect(tasks.saved).toBeNull();
+      expect(events.events.some((e) => e.type === "MaintenanceTaskAdvanced")).toBe(false);
+    });
+
+    it("does not advance the task when performedAt is older than lastCompletedDate", async () => {
+      const asset = assetFor();
+      const task = MaintenanceTask.reconstitute({
+        id: MaintenanceTaskId.generate(),
+        assetId: asset.id,
+        ownerId,
+        title: "Replace furnace filter",
+        intervalValue: 2,
+        intervalUnit: "month",
+        lastCompletedDate: "2026-06-09",
+        nextDue: "2026-08-09",
+        createdAt: new Date(),
+      });
+      const tasks = new MaintenanceTaskRepositoryFake(task);
+      const events = new EventBusFake();
+
+      const result = await new CreateMaintenanceRecord(
+        new AssetRepositoryFake(asset),
+        new MaintenanceRecordRepositoryFake(),
+        tasks,
+        events,
+        dates,
+      ).execute({
+        assetId: asset.id,
+        requesterId: ownerId,
+        title: "Changed oil",
+        performedAt: "2026-04-01",
+        taskId: task.id,
+      });
+
+      expect(result.ok).toBe(true);
+      expect(tasks.saved).toBeNull();
+      expect(events.events.some((e) => e.type === "MaintenanceTaskAdvanced")).toBe(false);
+    });
+
+    it("returns not found when taskId references a non-existent task", async () => {
+      const asset = assetFor();
+      const result = await new CreateMaintenanceRecord(
+        new AssetRepositoryFake(asset),
+        new MaintenanceRecordRepositoryFake(),
+        new MaintenanceTaskRepositoryFake(null),
+        new EventBusFake(),
+        dates,
+      ).execute({
+        assetId: asset.id,
+        requesterId: ownerId,
+        title: "Changed oil",
+        performedAt: "2026-06-09",
+        taskId: MaintenanceTaskId.generate(),
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toBeInstanceOf(NotFoundError);
+    });
+
+    it("returns not found when taskId belongs to another user's task", async () => {
+      const asset = assetFor();
+      const task = makeTask({ assetId: asset.id, ownerId: UserId.generate() });
+      const result = await new CreateMaintenanceRecord(
+        new AssetRepositoryFake(asset),
+        new MaintenanceRecordRepositoryFake(),
+        new MaintenanceTaskRepositoryFake(task),
+        new EventBusFake(),
+        dates,
+      ).execute({
+        assetId: asset.id,
+        requesterId: ownerId,
+        title: "Changed oil",
+        performedAt: "2026-06-09",
+        taskId: task.id,
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toBeInstanceOf(NotFoundError);
+    });
+
+    it("returns validation error when taskId belongs to a different asset", async () => {
+      const asset = assetFor();
+      const task = makeTask({ assetId: AssetId.generate(), ownerId });
+      const result = await new CreateMaintenanceRecord(
+        new AssetRepositoryFake(asset),
+        new MaintenanceRecordRepositoryFake(),
+        new MaintenanceTaskRepositoryFake(task),
+        new EventBusFake(),
+        dates,
+      ).execute({
+        assetId: asset.id,
+        requesterId: ownerId,
+        title: "Changed oil",
+        performedAt: "2026-06-09",
+        taskId: task.id,
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toBeInstanceOf(ValidationError);
+        expect((result.error as ValidationError).field).toBe("taskId");
+      }
+    });
+  });
 });

--- a/apps/api/src/application/usecases/CreateMaintenanceRecord.test.ts
+++ b/apps/api/src/application/usecases/CreateMaintenanceRecord.test.ts
@@ -12,10 +12,10 @@ import { Asset } from "../../domain/asset/Asset.ts";
 import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
 import type { DomainEvent } from "../../domain/events/DomainEvent.ts";
 import type { MaintenanceRecord } from "../../domain/maintenance/MaintenanceRecord.ts";
-import type { MaintenanceRecordRepository } from "../../domain/maintenance/MaintenanceRecordRepository.ts";
 import { MaintenanceTask } from "../../domain/maintenance/MaintenanceTask.ts";
 import type { MaintenanceTaskRepository } from "../../domain/maintenance/MaintenanceTaskRepository.ts";
 import type { EventBus } from "../ports/EventBus.ts";
+import type { MaintenanceRecordWriter } from "../ports/MaintenanceRecordWriter.ts";
 import type { UtcDateProvider } from "../ports/UtcDateProvider.ts";
 import { CreateMaintenanceRecord } from "./CreateMaintenanceRecord.ts";
 
@@ -35,15 +35,13 @@ class AssetRepositoryFake implements AssetRepository {
   }
 }
 
-class MaintenanceRecordRepositoryFake implements MaintenanceRecordRepository {
-  saved: MaintenanceRecord | null = null;
+class MaintenanceRecordWriterFake implements MaintenanceRecordWriter {
+  savedRecord: MaintenanceRecord | null = null;
+  savedTask: MaintenanceTask | null = null;
 
-  findByAsset(): Promise<MaintenanceRecord[]> {
-    return Promise.resolve([]);
-  }
-
-  save(record: MaintenanceRecord): Promise<void> {
-    this.saved = record;
+  save(record: MaintenanceRecord, advancedTask: MaintenanceTask | null): Promise<void> {
+    this.savedRecord = record;
+    this.savedTask = advancedTask;
     return Promise.resolve();
   }
 }
@@ -97,7 +95,7 @@ describe("CreateMaintenanceRecord", () => {
 
   it("saves a record and publishes MaintenanceRecordCreated", async () => {
     const asset = assetFor();
-    const records = new MaintenanceRecordRepositoryFake();
+    const records = new MaintenanceRecordWriterFake();
     const events = new EventBusFake();
 
     const result = await new CreateMaintenanceRecord(
@@ -114,7 +112,8 @@ describe("CreateMaintenanceRecord", () => {
     });
 
     expect(result.ok).toBe(true);
-    expect(records.saved).toBe(result.ok ? result.value : null);
+    expect(records.savedRecord).toBe(result.ok ? result.value : null);
+    expect(records.savedTask).toBeNull();
     expect(events.events).toEqual([
       expect.objectContaining({
         type: "MaintenanceRecordCreated",
@@ -123,7 +122,7 @@ describe("CreateMaintenanceRecord", () => {
         actorId: ownerId,
       }),
     ]);
-    expect(records.saved?.pullEvents()).toEqual([]);
+    expect(records.savedRecord?.pullEvents()).toEqual([]);
   });
 
   it("returns not found when the asset does not exist", async () => {
@@ -151,7 +150,7 @@ describe("CreateMaintenanceRecord", () => {
     const asset = assetFor();
     const result = await new CreateMaintenanceRecord(
       new AssetRepositoryFake(asset),
-      new MaintenanceRecordRepositoryFake(),
+      new MaintenanceRecordWriterFake(),
       new MaintenanceTaskRepositoryFake(),
       new EventBusFake(),
       dates,
@@ -171,7 +170,7 @@ describe("CreateMaintenanceRecord", () => {
 
   it("normalizes blank notes to null before persistence and response", async () => {
     const asset = assetFor();
-    const records = new MaintenanceRecordRepositoryFake();
+    const records = new MaintenanceRecordWriterFake();
     const result = await new CreateMaintenanceRecord(
       new AssetRepositoryFake(asset),
       records,
@@ -188,14 +187,14 @@ describe("CreateMaintenanceRecord", () => {
 
     expect(result.ok).toBe(true);
     if (result.ok) expect(result.value.notes).toBeNull();
-    expect(records.saved?.notes).toBeNull();
+    expect(records.savedRecord?.notes).toBeNull();
   });
 
   it("returns an invariant error for a malformed UTC date provider value", async () => {
     const asset = assetFor();
     const result = await new CreateMaintenanceRecord(
       new AssetRepositoryFake(asset),
-      new MaintenanceRecordRepositoryFake(),
+      new MaintenanceRecordWriterFake(),
       new MaintenanceTaskRepositoryFake(),
       new EventBusFake(),
       { today: () => "not-a-date" },
@@ -216,7 +215,7 @@ describe("CreateMaintenanceRecord", () => {
   function executeWithAsset(asset: Asset | null, requesterId: UserId) {
     return new CreateMaintenanceRecord(
       new AssetRepositoryFake(asset),
-      new MaintenanceRecordRepositoryFake(),
+      new MaintenanceRecordWriterFake(),
       new MaintenanceTaskRepositoryFake(),
       new EventBusFake(),
       dates,
@@ -265,11 +264,12 @@ describe("CreateMaintenanceRecord", () => {
         createdAt: new Date(),
       });
       const tasks = new MaintenanceTaskRepositoryFake(task);
+      const records = new MaintenanceRecordWriterFake();
       const events = new EventBusFake();
 
       const result = await new CreateMaintenanceRecord(
         new AssetRepositoryFake(asset),
-        new MaintenanceRecordRepositoryFake(),
+        records,
         tasks,
         events,
         dates,
@@ -282,7 +282,37 @@ describe("CreateMaintenanceRecord", () => {
       });
 
       expect(result.ok).toBe(true);
-      expect(tasks.saved).not.toBeNull();
+      expect(records.savedTask).toBe(task);
+      expect(tasks.saved).toBeNull();
+      expect(events.events).toContainEqual(
+        expect.objectContaining({ type: "MaintenanceTaskAdvanced", performedAt: "2026-06-09" }),
+      );
+    });
+
+    it("advances a task with no previous completion", async () => {
+      const asset = assetFor();
+      const task = makeTask({ assetId: asset.id, lastCompletedDate: null });
+      const records = new MaintenanceRecordWriterFake();
+      const events = new EventBusFake();
+
+      const result = await new CreateMaintenanceRecord(
+        new AssetRepositoryFake(asset),
+        records,
+        new MaintenanceTaskRepositoryFake(task),
+        events,
+        dates,
+      ).execute({
+        assetId: asset.id,
+        requesterId: ownerId,
+        title: "Replaced furnace filter",
+        performedAt: "2026-06-09",
+        taskId: task.id,
+      });
+
+      expect(result.ok).toBe(true);
+      expect(records.savedTask).toBe(task);
+      expect(task.lastCompletedDate).toBe("2026-06-09");
+      expect(task.nextDue).toBe("2026-08-09");
       expect(events.events).toContainEqual(
         expect.objectContaining({ type: "MaintenanceTaskAdvanced", performedAt: "2026-06-09" }),
       );
@@ -302,11 +332,12 @@ describe("CreateMaintenanceRecord", () => {
         createdAt: new Date(),
       });
       const tasks = new MaintenanceTaskRepositoryFake(task);
+      const records = new MaintenanceRecordWriterFake();
       const events = new EventBusFake();
 
       const result = await new CreateMaintenanceRecord(
         new AssetRepositoryFake(asset),
-        new MaintenanceRecordRepositoryFake(),
+        records,
         tasks,
         events,
         dates,
@@ -319,7 +350,7 @@ describe("CreateMaintenanceRecord", () => {
       });
 
       expect(result.ok).toBe(true);
-      expect(tasks.saved).toBeNull();
+      expect(records.savedTask).toBeNull();
       expect(events.events.some((e) => e.type === "MaintenanceTaskAdvanced")).toBe(false);
     });
 
@@ -337,11 +368,12 @@ describe("CreateMaintenanceRecord", () => {
         createdAt: new Date(),
       });
       const tasks = new MaintenanceTaskRepositoryFake(task);
+      const records = new MaintenanceRecordWriterFake();
       const events = new EventBusFake();
 
       const result = await new CreateMaintenanceRecord(
         new AssetRepositoryFake(asset),
-        new MaintenanceRecordRepositoryFake(),
+        records,
         tasks,
         events,
         dates,
@@ -354,7 +386,7 @@ describe("CreateMaintenanceRecord", () => {
       });
 
       expect(result.ok).toBe(true);
-      expect(tasks.saved).toBeNull();
+      expect(records.savedTask).toBeNull();
       expect(events.events.some((e) => e.type === "MaintenanceTaskAdvanced")).toBe(false);
     });
 
@@ -362,7 +394,7 @@ describe("CreateMaintenanceRecord", () => {
       const asset = assetFor();
       const result = await new CreateMaintenanceRecord(
         new AssetRepositoryFake(asset),
-        new MaintenanceRecordRepositoryFake(),
+        new MaintenanceRecordWriterFake(),
         new MaintenanceTaskRepositoryFake(null),
         new EventBusFake(),
         dates,
@@ -383,7 +415,7 @@ describe("CreateMaintenanceRecord", () => {
       const task = makeTask({ assetId: asset.id, ownerId: UserId.generate() });
       const result = await new CreateMaintenanceRecord(
         new AssetRepositoryFake(asset),
-        new MaintenanceRecordRepositoryFake(),
+        new MaintenanceRecordWriterFake(),
         new MaintenanceTaskRepositoryFake(task),
         new EventBusFake(),
         dates,
@@ -404,7 +436,7 @@ describe("CreateMaintenanceRecord", () => {
       const task = makeTask({ assetId: AssetId.generate(), ownerId });
       const result = await new CreateMaintenanceRecord(
         new AssetRepositoryFake(asset),
-        new MaintenanceRecordRepositoryFake(),
+        new MaintenanceRecordWriterFake(),
         new MaintenanceTaskRepositoryFake(task),
         new EventBusFake(),
         dates,

--- a/apps/api/src/application/usecases/CreateMaintenanceRecord.ts
+++ b/apps/api/src/application/usecases/CreateMaintenanceRecord.ts
@@ -72,14 +72,20 @@ export class CreateMaintenanceRecord {
         todayUtc: this.dates.today(),
       });
       await this.records.save(record);
-      await this.eventBus.publishAll(record.pullEvents());
 
+      // Advance the task in the DB before publishing any events so both writes
+      // succeed before side effects fire.
+      let advanced = false;
       if (task !== null) {
-        const advanced = task.advance(record.performedAt, record.id, command.requesterId);
+        advanced = task.advance(record.performedAt, record.id, command.requesterId);
         if (advanced) {
           await this.tasks.save(task);
-          await this.eventBus.publishAll(task.pullEvents());
         }
+      }
+
+      await this.eventBus.publishAll(record.pullEvents());
+      if (task !== null && advanced) {
+        await this.eventBus.publishAll(task.pullEvents());
       }
 
       return ok(record);

--- a/apps/api/src/application/usecases/CreateMaintenanceRecord.ts
+++ b/apps/api/src/application/usecases/CreateMaintenanceRecord.ts
@@ -4,15 +4,18 @@ import {
   type DomainError,
   DomainError as DomainErrorClass,
   ForbiddenError,
+  type MaintenanceTaskId,
   NotFoundError,
   type Result,
   type UserId,
+  ValidationError,
   err,
   ok,
 } from "@snaveevans/pineapple-shared";
 import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
 import { MaintenanceRecord } from "../../domain/maintenance/MaintenanceRecord.ts";
 import type { MaintenanceRecordRepository } from "../../domain/maintenance/MaintenanceRecordRepository.ts";
+import type { MaintenanceTaskRepository } from "../../domain/maintenance/MaintenanceTaskRepository.ts";
 import type { EventBus } from "../ports/EventBus.ts";
 import type { UtcDateProvider } from "../ports/UtcDateProvider.ts";
 
@@ -22,12 +25,14 @@ export type CreateMaintenanceRecordCommand = {
   title: string;
   performedAt: string;
   notes?: string;
+  taskId?: MaintenanceTaskId;
 };
 
 export class CreateMaintenanceRecord {
   constructor(
     private readonly assets: AssetRepository,
     private readonly records: MaintenanceRecordRepository,
+    private readonly tasks: MaintenanceTaskRepository,
     private readonly eventBus: EventBus,
     private readonly dates: UtcDateProvider,
   ) {}
@@ -45,6 +50,17 @@ export class CreateMaintenanceRecord {
         return err(new ConflictError("Cannot add maintenance to an archived asset"));
       }
 
+      let task = null;
+      if (command.taskId !== undefined) {
+        task = await this.tasks.findById(command.taskId);
+        if (!task || task.ownerId !== command.requesterId) {
+          return err(new NotFoundError("Maintenance task not found"));
+        }
+        if (task.assetId !== command.assetId) {
+          return err(new ValidationError("Task does not belong to this asset", "taskId"));
+        }
+      }
+
       const record = MaintenanceRecord.create({
         assetId: asset.id,
         ownerId: asset.ownerId,
@@ -52,10 +68,20 @@ export class CreateMaintenanceRecord {
         title: command.title,
         performedAt: command.performedAt,
         ...(command.notes !== undefined ? { notes: command.notes } : {}),
+        ...(command.taskId !== undefined ? { taskId: command.taskId } : {}),
         todayUtc: this.dates.today(),
       });
       await this.records.save(record);
       await this.eventBus.publishAll(record.pullEvents());
+
+      if (task !== null) {
+        const advanced = task.advance(record.performedAt, record.id, command.requesterId);
+        if (advanced) {
+          await this.tasks.save(task);
+          await this.eventBus.publishAll(task.pullEvents());
+        }
+      }
+
       return ok(record);
     } catch (error) {
       if (error instanceof DomainErrorClass) return err(error);

--- a/apps/api/src/application/usecases/CreateMaintenanceRecord.ts
+++ b/apps/api/src/application/usecases/CreateMaintenanceRecord.ts
@@ -14,9 +14,9 @@ import {
 } from "@snaveevans/pineapple-shared";
 import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
 import { MaintenanceRecord } from "../../domain/maintenance/MaintenanceRecord.ts";
-import type { MaintenanceRecordRepository } from "../../domain/maintenance/MaintenanceRecordRepository.ts";
 import type { MaintenanceTaskRepository } from "../../domain/maintenance/MaintenanceTaskRepository.ts";
 import type { EventBus } from "../ports/EventBus.ts";
+import type { MaintenanceRecordWriter } from "../ports/MaintenanceRecordWriter.ts";
 import type { UtcDateProvider } from "../ports/UtcDateProvider.ts";
 
 export type CreateMaintenanceRecordCommand = {
@@ -31,7 +31,7 @@ export type CreateMaintenanceRecordCommand = {
 export class CreateMaintenanceRecord {
   constructor(
     private readonly assets: AssetRepository,
-    private readonly records: MaintenanceRecordRepository,
+    private readonly records: MaintenanceRecordWriter,
     private readonly tasks: MaintenanceTaskRepository,
     private readonly eventBus: EventBus,
     private readonly dates: UtcDateProvider,
@@ -71,21 +71,16 @@ export class CreateMaintenanceRecord {
         ...(command.taskId !== undefined ? { taskId: command.taskId } : {}),
         todayUtc: this.dates.today(),
       });
-      await this.records.save(record);
 
-      // Advance the task in the DB before publishing any events so both writes
-      // succeed before side effects fire.
-      let advanced = false;
-      if (task !== null) {
-        advanced = task.advance(record.performedAt, record.id, command.requesterId);
-        if (advanced) {
-          await this.tasks.save(task);
-        }
-      }
+      const advancedTask =
+        task !== null && task.advance(record.performedAt, record.id, command.requesterId)
+          ? task
+          : null;
+      await this.records.save(record, advancedTask);
 
       await this.eventBus.publishAll(record.pullEvents());
-      if (task !== null && advanced) {
-        await this.eventBus.publishAll(task.pullEvents());
+      if (advancedTask !== null) {
+        await this.eventBus.publishAll(advancedTask.pullEvents());
       }
 
       return ok(record);

--- a/apps/api/src/application/usecases/CreateMaintenanceTask.test.ts
+++ b/apps/api/src/application/usecases/CreateMaintenanceTask.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+import {
+  AssetId,
+  ConflictError,
+  ForbiddenError,
+  NotFoundError,
+  UserId,
+  ValidationError,
+} from "@snaveevans/pineapple-shared";
+import { Asset } from "../../domain/asset/Asset.ts";
+import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
+import type { DomainEvent } from "../../domain/events/DomainEvent.ts";
+import type { MaintenanceTask } from "../../domain/maintenance/MaintenanceTask.ts";
+import type { MaintenanceTaskRepository } from "../../domain/maintenance/MaintenanceTaskRepository.ts";
+import type { EventBus } from "../ports/EventBus.ts";
+import type { UtcDateProvider } from "../ports/UtcDateProvider.ts";
+import { CreateMaintenanceTask } from "./CreateMaintenanceTask.ts";
+
+class AssetRepositoryFake implements AssetRepository {
+  constructor(private readonly asset: Asset | null) {}
+  findById(): Promise<Asset | null> {
+    return Promise.resolve(this.asset);
+  }
+  findByOwner(): Promise<Asset[]> {
+    return Promise.resolve([]);
+  }
+  save(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+class MaintenanceTaskRepositoryFake implements MaintenanceTaskRepository {
+  saved: MaintenanceTask | null = null;
+  findByAsset(): Promise<MaintenanceTask[]> {
+    return Promise.resolve([]);
+  }
+  findById(): Promise<MaintenanceTask | null> {
+    return Promise.resolve(null);
+  }
+  save(task: MaintenanceTask): Promise<void> {
+    this.saved = task;
+    return Promise.resolve();
+  }
+  delete(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+class EventBusFake implements EventBus {
+  readonly events: DomainEvent[] = [];
+  publish(e: DomainEvent): Promise<void> {
+    this.events.push(e);
+    return Promise.resolve();
+  }
+  publishAll(events: readonly DomainEvent[]): Promise<void> {
+    this.events.push(...events);
+    return Promise.resolve();
+  }
+  subscribe(): void {}
+}
+
+const dates: UtcDateProvider = { today: () => "2026-06-11" };
+
+describe("CreateMaintenanceTask", () => {
+  const ownerId = UserId.generate();
+
+  function asset(owner = ownerId) {
+    return Asset.create({
+      ownerId: owner,
+      name: "House",
+      metadata: { kind: "equipment" },
+    });
+  }
+
+  async function execute(overrides: Partial<Parameters<CreateMaintenanceTask["execute"]>[0]> = {}) {
+    const a = asset();
+    const tasks = new MaintenanceTaskRepositoryFake();
+    const events = new EventBusFake();
+    const result = await new CreateMaintenanceTask(
+      new AssetRepositoryFake(a),
+      tasks,
+      events,
+      dates,
+    ).execute({
+      assetId: a.id,
+      requesterId: ownerId,
+      title: "Replace furnace filter",
+      intervalValue: 2,
+      intervalUnit: "month",
+      ...overrides,
+    });
+    return { result, tasks, events, a };
+  }
+
+  it("creates a task, saves it, and publishes MaintenanceTaskCreated", async () => {
+    const { result, tasks, events } = await execute();
+    expect(result.ok).toBe(true);
+    expect(tasks.saved).not.toBeNull();
+    expect(events.events).toEqual([expect.objectContaining({ type: "MaintenanceTaskCreated" })]);
+  });
+
+  it("seeds nextDue from today when no lastCompletedDate", async () => {
+    const { result } = await execute();
+    expect(result.ok && result.value.nextDue).toBe("2026-08-11");
+  });
+
+  it("seeds nextDue from lastCompletedDate when provided", async () => {
+    const { result } = await execute({ lastCompletedDate: "2026-04-11" });
+    expect(result.ok && result.value.nextDue).toBe("2026-06-11");
+  });
+
+  it("returns not found when asset does not exist", async () => {
+    const tasks = new MaintenanceTaskRepositoryFake();
+    const result = await new CreateMaintenanceTask(
+      new AssetRepositoryFake(null),
+      tasks,
+      new EventBusFake(),
+      dates,
+    ).execute({
+      assetId: AssetId.generate(),
+      requesterId: ownerId,
+      title: "T",
+      intervalValue: 1,
+      intervalUnit: "month",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBeInstanceOf(NotFoundError);
+  });
+
+  it("returns forbidden for another owner's asset", async () => {
+    const { result } = await execute({ requesterId: UserId.generate() });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBeInstanceOf(ForbiddenError);
+  });
+
+  it("returns conflict for an archived asset", async () => {
+    const a = asset();
+    a.archivedAt = new Date();
+    const tasks = new MaintenanceTaskRepositoryFake();
+    const result = await new CreateMaintenanceTask(
+      new AssetRepositoryFake(a),
+      tasks,
+      new EventBusFake(),
+      dates,
+    ).execute({
+      assetId: a.id,
+      requesterId: ownerId,
+      title: "T",
+      intervalValue: 1,
+      intervalUnit: "month",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBeInstanceOf(ConflictError);
+  });
+
+  it("returns validation error for future lastCompletedDate", async () => {
+    const { result } = await execute({ lastCompletedDate: "2026-12-31" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(ValidationError);
+      expect((result.error as ValidationError).field).toBe("lastCompletedDate");
+    }
+  });
+});

--- a/apps/api/src/application/usecases/CreateMaintenanceTask.ts
+++ b/apps/api/src/application/usecases/CreateMaintenanceTask.ts
@@ -1,0 +1,70 @@
+import {
+  type AssetId,
+  ConflictError,
+  type DomainError,
+  DomainError as DomainErrorClass,
+  ForbiddenError,
+  NotFoundError,
+  type Result,
+  type UserId,
+  err,
+  ok,
+} from "@snaveevans/pineapple-shared";
+import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
+import { MaintenanceTask } from "../../domain/maintenance/MaintenanceTask.ts";
+import type { MaintenanceTaskRepository } from "../../domain/maintenance/MaintenanceTaskRepository.ts";
+import type { IntervalUnit } from "../../domain/maintenance/IntervalUnit.ts";
+import type { EventBus } from "../ports/EventBus.ts";
+import type { UtcDateProvider } from "../ports/UtcDateProvider.ts";
+
+export type CreateMaintenanceTaskCommand = {
+  assetId: AssetId;
+  requesterId: UserId;
+  title: string;
+  intervalValue: number;
+  intervalUnit: IntervalUnit;
+  lastCompletedDate?: string;
+};
+
+export class CreateMaintenanceTask {
+  constructor(
+    private readonly assets: AssetRepository,
+    private readonly tasks: MaintenanceTaskRepository,
+    private readonly eventBus: EventBus,
+    private readonly dates: UtcDateProvider,
+  ) {}
+
+  async execute(
+    command: CreateMaintenanceTaskCommand,
+  ): Promise<Result<MaintenanceTask, DomainError>> {
+    try {
+      const asset = await this.assets.findById(command.assetId);
+      if (!asset) return err(new NotFoundError("Asset not found"));
+      if (asset.ownerId !== command.requesterId) {
+        return err(new ForbiddenError("Access denied"));
+      }
+      if (asset.archivedAt !== null) {
+        return err(new ConflictError("Cannot add maintenance tasks to an archived asset"));
+      }
+
+      const task = MaintenanceTask.create({
+        assetId: asset.id,
+        ownerId: asset.ownerId,
+        actorId: command.requesterId,
+        title: command.title,
+        intervalValue: command.intervalValue,
+        intervalUnit: command.intervalUnit,
+        ...(command.lastCompletedDate !== undefined
+          ? { lastCompletedDate: command.lastCompletedDate }
+          : {}),
+        todayUtc: this.dates.today(),
+      });
+      await this.tasks.save(task);
+      await this.eventBus.publishAll(task.pullEvents());
+      return ok(task);
+    } catch (error) {
+      if (error instanceof DomainErrorClass) return err(error);
+      throw error;
+    }
+  }
+}

--- a/apps/api/src/application/usecases/DeleteMaintenanceTask.test.ts
+++ b/apps/api/src/application/usecases/DeleteMaintenanceTask.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import {
+  AssetId,
+  ForbiddenError,
+  MaintenanceTaskId,
+  NotFoundError,
+  UserId,
+} from "@snaveevans/pineapple-shared";
+import type { DomainEvent } from "../../domain/events/DomainEvent.ts";
+import { MaintenanceTask } from "../../domain/maintenance/MaintenanceTask.ts";
+import type { MaintenanceTaskRepository } from "../../domain/maintenance/MaintenanceTaskRepository.ts";
+import type { EventBus } from "../ports/EventBus.ts";
+import { DeleteMaintenanceTask } from "./DeleteMaintenanceTask.ts";
+
+class MaintenanceTaskRepositoryFake implements MaintenanceTaskRepository {
+  deleted: MaintenanceTaskId | null = null;
+  constructor(private task: MaintenanceTask | null) {}
+  findByAsset(): Promise<MaintenanceTask[]> {
+    return Promise.resolve([]);
+  }
+  findById(): Promise<MaintenanceTask | null> {
+    return Promise.resolve(this.task);
+  }
+  save(): Promise<void> {
+    return Promise.resolve();
+  }
+  delete(id: MaintenanceTaskId): Promise<void> {
+    this.deleted = id;
+    return Promise.resolve();
+  }
+}
+
+class EventBusFake implements EventBus {
+  readonly events: DomainEvent[] = [];
+  publish(e: DomainEvent): Promise<void> {
+    this.events.push(e);
+    return Promise.resolve();
+  }
+  publishAll(events: readonly DomainEvent[]): Promise<void> {
+    this.events.push(...events);
+    return Promise.resolve();
+  }
+  subscribe(): void {}
+}
+
+describe("DeleteMaintenanceTask", () => {
+  const ownerId = UserId.generate();
+  const assetId = AssetId.generate();
+
+  function makeTask(owner = ownerId) {
+    return MaintenanceTask.reconstitute({
+      id: MaintenanceTaskId.generate(),
+      assetId,
+      ownerId: owner,
+      title: "Replace furnace filter",
+      intervalValue: 2,
+      intervalUnit: "month",
+      lastCompletedDate: null,
+      nextDue: "2026-08-11",
+      createdAt: new Date(),
+    });
+  }
+
+  it("deletes the task and publishes MaintenanceTaskDeleted", async () => {
+    const task = makeTask();
+    const repo = new MaintenanceTaskRepositoryFake(task);
+    const events = new EventBusFake();
+    const result = await new DeleteMaintenanceTask(repo, events).execute({
+      taskId: task.id,
+      assetId,
+      requesterId: ownerId,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(repo.deleted).toBe(task.id);
+    expect(events.events).toEqual([expect.objectContaining({ type: "MaintenanceTaskDeleted" })]);
+  });
+
+  it("returns not found when task does not exist", async () => {
+    const repo = new MaintenanceTaskRepositoryFake(null);
+    const result = await new DeleteMaintenanceTask(repo, new EventBusFake()).execute({
+      taskId: MaintenanceTaskId.generate(),
+      assetId,
+      requesterId: ownerId,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBeInstanceOf(NotFoundError);
+  });
+
+  it("returns forbidden for another owner's task", async () => {
+    const task = makeTask(UserId.generate());
+    const repo = new MaintenanceTaskRepositoryFake(task);
+    const result = await new DeleteMaintenanceTask(repo, new EventBusFake()).execute({
+      taskId: task.id,
+      assetId,
+      requesterId: ownerId,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBeInstanceOf(ForbiddenError);
+  });
+
+  it("returns not found when task belongs to a different asset", async () => {
+    const task = makeTask();
+    const repo = new MaintenanceTaskRepositoryFake(task);
+    const result = await new DeleteMaintenanceTask(repo, new EventBusFake()).execute({
+      taskId: task.id,
+      assetId: AssetId.generate(),
+      requesterId: ownerId,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBeInstanceOf(NotFoundError);
+  });
+});

--- a/apps/api/src/application/usecases/DeleteMaintenanceTask.ts
+++ b/apps/api/src/application/usecases/DeleteMaintenanceTask.ts
@@ -1,0 +1,48 @@
+import {
+  type AssetId,
+  type DomainError,
+  DomainError as DomainErrorClass,
+  ForbiddenError,
+  type MaintenanceTaskId,
+  NotFoundError,
+  type Result,
+  type UserId,
+  err,
+  ok,
+} from "@snaveevans/pineapple-shared";
+import type { MaintenanceTaskRepository } from "../../domain/maintenance/MaintenanceTaskRepository.ts";
+import type { EventBus } from "../ports/EventBus.ts";
+
+export type DeleteMaintenanceTaskCommand = {
+  taskId: MaintenanceTaskId;
+  assetId: AssetId;
+  requesterId: UserId;
+};
+
+export class DeleteMaintenanceTask {
+  constructor(
+    private readonly tasks: MaintenanceTaskRepository,
+    private readonly eventBus: EventBus,
+  ) {}
+
+  async execute(command: DeleteMaintenanceTaskCommand): Promise<Result<void, DomainError>> {
+    try {
+      const task = await this.tasks.findById(command.taskId);
+      if (!task) return err(new NotFoundError("Maintenance task not found"));
+      if (task.ownerId !== command.requesterId) {
+        return err(new ForbiddenError("Access denied"));
+      }
+      if (task.assetId !== command.assetId) {
+        return err(new NotFoundError("Maintenance task not found"));
+      }
+
+      task.remove(command.requesterId);
+      await this.tasks.delete(task.id);
+      await this.eventBus.publishAll(task.pullEvents());
+      return ok(undefined);
+    } catch (error) {
+      if (error instanceof DomainErrorClass) return err(error);
+      throw error;
+    }
+  }
+}

--- a/apps/api/src/application/usecases/ListMaintenanceRecords.test.ts
+++ b/apps/api/src/application/usecases/ListMaintenanceRecords.test.ts
@@ -107,6 +107,7 @@ describe("ListMaintenanceRecords", () => {
       title: created.title,
       performedAt: created.performedAt,
       notes: created.notes,
+      taskId: null,
       createdAt: new Date(createdAt),
     });
   }

--- a/apps/api/src/application/usecases/ListMaintenanceTasks.test.ts
+++ b/apps/api/src/application/usecases/ListMaintenanceTasks.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import {
+  AssetId,
+  ForbiddenError,
+  MaintenanceTaskId,
+  NotFoundError,
+  UserId,
+} from "@snaveevans/pineapple-shared";
+import { Asset } from "../../domain/asset/Asset.ts";
+import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
+import { MaintenanceTask } from "../../domain/maintenance/MaintenanceTask.ts";
+import type { MaintenanceTaskRepository } from "../../domain/maintenance/MaintenanceTaskRepository.ts";
+import { ListMaintenanceTasks } from "./ListMaintenanceTasks.ts";
+
+class AssetRepositoryFake implements AssetRepository {
+  constructor(private readonly asset: Asset | null) {}
+  findById(): Promise<Asset | null> {
+    return Promise.resolve(this.asset);
+  }
+  findByOwner(): Promise<Asset[]> {
+    return Promise.resolve([]);
+  }
+  save(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+class MaintenanceTaskRepositoryFake implements MaintenanceTaskRepository {
+  constructor(private readonly tasks: MaintenanceTask[] = []) {}
+  findByAsset(): Promise<MaintenanceTask[]> {
+    return Promise.resolve(this.tasks);
+  }
+  findById(): Promise<MaintenanceTask | null> {
+    return Promise.resolve(null);
+  }
+  save(): Promise<void> {
+    return Promise.resolve();
+  }
+  delete(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+describe("ListMaintenanceTasks", () => {
+  const ownerId = UserId.generate();
+
+  function asset(owner = ownerId) {
+    return Asset.create({ ownerId: owner, name: "House", metadata: { kind: "equipment" } });
+  }
+
+  function makeTask(assetId: AssetId) {
+    return MaintenanceTask.reconstitute({
+      id: MaintenanceTaskId.generate(),
+      assetId,
+      ownerId,
+      title: "Replace furnace filter",
+      intervalValue: 2,
+      intervalUnit: "month",
+      lastCompletedDate: null,
+      nextDue: "2026-08-11",
+      createdAt: new Date(),
+    });
+  }
+
+  it("returns the asset's tasks", async () => {
+    const a = asset();
+    const task = makeTask(a.id);
+    const result = await new ListMaintenanceTasks(
+      new AssetRepositoryFake(a),
+      new MaintenanceTaskRepositoryFake([task]),
+    ).execute({ assetId: a.id, requesterId: ownerId });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toEqual([task]);
+  });
+
+  it("returns an empty array when the asset has no tasks", async () => {
+    const a = asset();
+    const result = await new ListMaintenanceTasks(
+      new AssetRepositoryFake(a),
+      new MaintenanceTaskRepositoryFake([]),
+    ).execute({ assetId: a.id, requesterId: ownerId });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toEqual([]);
+  });
+
+  it("returns not found when the asset does not exist", async () => {
+    const result = await new ListMaintenanceTasks(
+      new AssetRepositoryFake(null),
+      new MaintenanceTaskRepositoryFake(),
+    ).execute({ assetId: AssetId.generate(), requesterId: ownerId });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBeInstanceOf(NotFoundError);
+  });
+
+  it("returns forbidden when the asset belongs to another user", async () => {
+    const a = asset(UserId.generate());
+    const result = await new ListMaintenanceTasks(
+      new AssetRepositoryFake(a),
+      new MaintenanceTaskRepositoryFake(),
+    ).execute({ assetId: a.id, requesterId: ownerId });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBeInstanceOf(ForbiddenError);
+  });
+});

--- a/apps/api/src/application/usecases/ListMaintenanceTasks.ts
+++ b/apps/api/src/application/usecases/ListMaintenanceTasks.ts
@@ -1,0 +1,42 @@
+import {
+  type AssetId,
+  type DomainError,
+  DomainError as DomainErrorClass,
+  ForbiddenError,
+  NotFoundError,
+  type Result,
+  type UserId,
+  err,
+  ok,
+} from "@snaveevans/pineapple-shared";
+import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
+import type { MaintenanceTask } from "../../domain/maintenance/MaintenanceTask.ts";
+import type { MaintenanceTaskRepository } from "../../domain/maintenance/MaintenanceTaskRepository.ts";
+
+export type ListMaintenanceTasksQuery = {
+  assetId: AssetId;
+  requesterId: UserId;
+};
+
+export class ListMaintenanceTasks {
+  constructor(
+    private readonly assets: AssetRepository,
+    private readonly tasks: MaintenanceTaskRepository,
+  ) {}
+
+  async execute(query: ListMaintenanceTasksQuery): Promise<Result<MaintenanceTask[], DomainError>> {
+    try {
+      const asset = await this.assets.findById(query.assetId);
+      if (!asset) return err(new NotFoundError("Asset not found"));
+      if (asset.ownerId !== query.requesterId) {
+        return err(new ForbiddenError("Access denied"));
+      }
+
+      const tasks = await this.tasks.findByAsset(asset.id, query.requesterId);
+      return ok(tasks);
+    } catch (error) {
+      if (error instanceof DomainErrorClass) return err(error);
+      throw error;
+    }
+  }
+}

--- a/apps/api/src/application/usecases/ListMaintenanceTasks.ts
+++ b/apps/api/src/application/usecases/ListMaintenanceTasks.ts
@@ -32,7 +32,7 @@ export class ListMaintenanceTasks {
         return err(new ForbiddenError("Access denied"));
       }
 
-      const tasks = await this.tasks.findByAsset(asset.id, query.requesterId);
+      const tasks = await this.tasks.findByAsset(asset.id);
       return ok(tasks);
     } catch (error) {
       if (error instanceof DomainErrorClass) return err(error);

--- a/apps/api/src/domain/maintenance/DateOnly.ts
+++ b/apps/api/src/domain/maintenance/DateOnly.ts
@@ -21,12 +21,16 @@ export function validateDateOnly(value: string, field = "performedAt"): void {
   }
 }
 
-function daysInMonth(year: number, month: number): number {
+export function daysInMonth(year: number, month: number): number {
   if (month === 2) return isLeapYear(year) ? 29 : 28;
   if (month === 4 || month === 6 || month === 9 || month === 11) return 30;
   return 31;
 }
 
-function isLeapYear(year: number): boolean {
+export function isLeapYear(year: number): boolean {
   return year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+}
+
+export function formatDateOnly(year: number, month: number, day: number): string {
+  return `${String(year).padStart(4, "0")}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
 }

--- a/apps/api/src/domain/maintenance/IntervalUnit.ts
+++ b/apps/api/src/domain/maintenance/IntervalUnit.ts
@@ -1,0 +1,42 @@
+import { daysInMonth, formatDateOnly } from "./DateOnly.ts";
+
+export type IntervalUnit = "day" | "week" | "month" | "year";
+
+export const INTERVAL_UNITS: IntervalUnit[] = ["day", "week", "month", "year"];
+
+export function addInterval(date: string, value: number, unit: IntervalUnit): string {
+  const year = Number(date.slice(0, 4));
+  const month = Number(date.slice(5, 7));
+  const day = Number(date.slice(8, 10));
+
+  if (unit === "day" || unit === "week") {
+    return addDays(year, month, day, unit === "week" ? value * 7 : value);
+  }
+
+  if (unit === "month") {
+    const rawMonth = month + value;
+    const newYear = year + Math.floor((rawMonth - 1) / 12);
+    const newMonth = ((rawMonth - 1) % 12) + 1;
+    return formatDateOnly(newYear, newMonth, Math.min(day, daysInMonth(newYear, newMonth)));
+  }
+
+  // year
+  return formatDateOnly(year + value, month, Math.min(day, daysInMonth(year + value, month)));
+}
+
+function addDays(year: number, month: number, day: number, days: number): string {
+  let d = day + days;
+  let m = month;
+  let y = year;
+
+  while (d > daysInMonth(y, m)) {
+    d -= daysInMonth(y, m);
+    m++;
+    if (m > 12) {
+      m = 1;
+      y++;
+    }
+  }
+
+  return formatDateOnly(y, m, d);
+}

--- a/apps/api/src/domain/maintenance/MaintenanceRecord.test.ts
+++ b/apps/api/src/domain/maintenance/MaintenanceRecord.test.ts
@@ -80,6 +80,7 @@ describe("MaintenanceRecord", () => {
       title: original.title,
       performedAt: original.performedAt,
       notes: original.notes,
+      taskId: null,
       createdAt: original.createdAt,
     });
 

--- a/apps/api/src/domain/maintenance/MaintenanceRecord.ts
+++ b/apps/api/src/domain/maintenance/MaintenanceRecord.ts
@@ -2,6 +2,7 @@ import {
   type AssetId,
   InvariantError,
   MaintenanceRecordId,
+  type MaintenanceTaskId,
   type UserId,
   ValidationError,
 } from "@snaveevans/pineapple-shared";
@@ -19,6 +20,7 @@ export class MaintenanceRecord {
     readonly title: string,
     readonly performedAt: string,
     readonly notes: string | null,
+    readonly taskId: MaintenanceTaskId | null,
     readonly createdAt: Date,
   ) {}
 
@@ -29,6 +31,7 @@ export class MaintenanceRecord {
     title: string;
     performedAt: string;
     notes?: string;
+    taskId?: MaintenanceTaskId;
     todayUtc: string;
   }): MaintenanceRecord {
     const title = props.title.trim();
@@ -59,6 +62,7 @@ export class MaintenanceRecord {
       title,
       props.performedAt,
       notes,
+      props.taskId ?? null,
       new Date(),
     );
     record._domainEvents.push(
@@ -80,6 +84,7 @@ export class MaintenanceRecord {
     title: string;
     performedAt: string;
     notes: string | null;
+    taskId: MaintenanceTaskId | null;
     createdAt: Date;
   }): MaintenanceRecord {
     return new MaintenanceRecord(
@@ -89,6 +94,7 @@ export class MaintenanceRecord {
       props.title,
       props.performedAt,
       props.notes,
+      props.taskId,
       props.createdAt,
     );
   }

--- a/apps/api/src/domain/maintenance/MaintenanceTask.test.ts
+++ b/apps/api/src/domain/maintenance/MaintenanceTask.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from "vitest";
+import {
+  AssetId,
+  MaintenanceRecordId,
+  UserId,
+  ValidationError,
+} from "@snaveevans/pineapple-shared";
+import { MaintenanceTask } from "./MaintenanceTask.ts";
+
+const assetId = AssetId.generate();
+const ownerId = UserId.generate();
+const actorId = ownerId;
+const today = "2026-06-11";
+
+function makeTask(overrides: Partial<Parameters<typeof MaintenanceTask.create>[0]> = {}) {
+  return MaintenanceTask.create({
+    assetId,
+    ownerId,
+    actorId,
+    title: "Replace furnace filter",
+    intervalValue: 2,
+    intervalUnit: "month",
+    todayUtc: today,
+    ...overrides,
+  });
+}
+
+describe("MaintenanceTask.create", () => {
+  it("seeds nextDue from today when no lastCompletedDate provided", () => {
+    const task = makeTask();
+    expect(task.lastCompletedDate).toBeNull();
+    expect(task.nextDue).toBe("2026-08-11");
+  });
+
+  it("seeds nextDue from lastCompletedDate when provided", () => {
+    const task = makeTask({
+      lastCompletedDate: "2026-04-11",
+      intervalValue: 2,
+      intervalUnit: "month",
+    });
+    expect(task.lastCompletedDate).toBe("2026-04-11");
+    expect(task.nextDue).toBe("2026-06-11");
+  });
+
+  it("emits MaintenanceTaskCreated event", () => {
+    const task = makeTask();
+    const events = task.pullEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ type: "MaintenanceTaskCreated", assetId, ownerId, actorId });
+  });
+
+  it("clears events after pullEvents", () => {
+    const task = makeTask();
+    task.pullEvents();
+    expect(task.pullEvents()).toHaveLength(0);
+  });
+
+  it("trims title", () => {
+    const task = makeTask({ title: "  Oil change  " });
+    expect(task.title).toBe("Oil change");
+  });
+
+  it("throws ValidationError for empty title", () => {
+    expect(() => makeTask({ title: "   " })).toThrow(ValidationError);
+  });
+
+  it("throws ValidationError for title over 100 chars", () => {
+    expect(() => makeTask({ title: "a".repeat(101) })).toThrow(ValidationError);
+  });
+
+  it("throws ValidationError for intervalValue of 0", () => {
+    expect(() => makeTask({ intervalValue: 0 })).toThrow(ValidationError);
+  });
+
+  it("throws ValidationError for negative intervalValue", () => {
+    expect(() => makeTask({ intervalValue: -1 })).toThrow(ValidationError);
+  });
+
+  it("throws ValidationError for non-integer intervalValue", () => {
+    expect(() => makeTask({ intervalValue: 1.5 })).toThrow(ValidationError);
+  });
+
+  it("throws ValidationError for future lastCompletedDate", () => {
+    expect(() => makeTask({ lastCompletedDate: "2026-12-31" })).toThrow(ValidationError);
+  });
+
+  it("throws ValidationError for malformed lastCompletedDate", () => {
+    expect(() => makeTask({ lastCompletedDate: "not-a-date" })).toThrow(ValidationError);
+  });
+});
+
+describe("MaintenanceTask.advance", () => {
+  it("advances lastCompletedDate and nextDue when performedAt is newer", () => {
+    const task = makeTask({ lastCompletedDate: "2026-04-11" });
+    const recordId = MaintenanceRecordId.generate();
+    const result = task.advance("2026-06-11", recordId, actorId);
+
+    expect(result).toBe(true);
+    expect(task.lastCompletedDate).toBe("2026-06-11");
+    expect(task.nextDue).toBe("2026-08-11");
+  });
+
+  it("emits MaintenanceTaskAdvanced when advanced", () => {
+    const task = makeTask({ lastCompletedDate: "2026-04-11" });
+    task.pullEvents(); // clear create event
+    const recordId = MaintenanceRecordId.generate();
+    task.advance("2026-06-11", recordId, actorId);
+    const events = task.pullEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ type: "MaintenanceTaskAdvanced", performedAt: "2026-06-11" });
+  });
+
+  it("does not advance when performedAt equals lastCompletedDate", () => {
+    const task = makeTask({ lastCompletedDate: "2026-06-11" });
+    task.pullEvents(); // clear create event
+    const result = task.advance("2026-06-11", MaintenanceRecordId.generate(), actorId);
+    expect(result).toBe(false);
+    expect(task.nextDue).toBe("2026-08-11");
+    expect(task.pullEvents()).toHaveLength(0);
+  });
+
+  it("does not advance when performedAt is older than lastCompletedDate", () => {
+    const task = makeTask({ lastCompletedDate: "2026-06-11" });
+    const result = task.advance("2026-05-01", MaintenanceRecordId.generate(), actorId);
+    expect(result).toBe(false);
+    expect(task.lastCompletedDate).toBe("2026-06-11");
+  });
+
+  it("advances when lastCompletedDate is null (first ever record)", () => {
+    const task = makeTask();
+    const result = task.advance("2026-06-01", MaintenanceRecordId.generate(), actorId);
+    expect(result).toBe(true);
+    expect(task.lastCompletedDate).toBe("2026-06-01");
+  });
+});
+
+describe("MaintenanceTask.remove", () => {
+  it("emits MaintenanceTaskDeleted", () => {
+    const task = makeTask();
+    task.pullEvents(); // clear create event
+    task.remove(actorId);
+    const events = task.pullEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ type: "MaintenanceTaskDeleted", assetId, ownerId, actorId });
+  });
+});
+
+describe("addInterval calendar arithmetic", () => {
+  it("adds days", () => {
+    const task = MaintenanceTask.create({
+      assetId,
+      ownerId,
+      actorId,
+      title: "T",
+      intervalValue: 30,
+      intervalUnit: "day",
+      todayUtc: "2026-01-15",
+    });
+    expect(task.nextDue).toBe("2026-02-14");
+  });
+
+  it("adds weeks", () => {
+    const task = MaintenanceTask.create({
+      assetId,
+      ownerId,
+      actorId,
+      title: "T",
+      intervalValue: 2,
+      intervalUnit: "week",
+      todayUtc: "2026-01-15",
+    });
+    expect(task.nextDue).toBe("2026-01-29");
+  });
+
+  it("adds months and clamps to month-end", () => {
+    const task = MaintenanceTask.create({
+      assetId,
+      ownerId,
+      actorId,
+      title: "T",
+      intervalValue: 1,
+      intervalUnit: "month",
+      todayUtc: "2026-01-31",
+    });
+    expect(task.nextDue).toBe("2026-02-28");
+  });
+
+  it("adds years and clamps leap-day to Feb 28 in non-leap year", () => {
+    const task = MaintenanceTask.create({
+      assetId,
+      ownerId,
+      actorId,
+      title: "T",
+      intervalValue: 1,
+      intervalUnit: "year",
+      todayUtc: "2024-02-29",
+    });
+    expect(task.nextDue).toBe("2025-02-28");
+  });
+});

--- a/apps/api/src/domain/maintenance/MaintenanceTask.ts
+++ b/apps/api/src/domain/maintenance/MaintenanceTask.ts
@@ -1,0 +1,173 @@
+import {
+  type AssetId,
+  InvariantError,
+  type MaintenanceRecordId,
+  MaintenanceTaskId,
+  type UserId,
+  ValidationError,
+} from "@snaveevans/pineapple-shared";
+import type { DomainEvent } from "../events/DomainEvent.ts";
+import { validateDateOnly } from "./DateOnly.ts";
+import { type IntervalUnit, INTERVAL_UNITS, addInterval } from "./IntervalUnit.ts";
+import { MaintenanceTaskAdvanced } from "./events/MaintenanceTaskAdvanced.ts";
+import { MaintenanceTaskCreated } from "./events/MaintenanceTaskCreated.ts";
+import { MaintenanceTaskDeleted } from "./events/MaintenanceTaskDeleted.ts";
+
+export class MaintenanceTask {
+  private _domainEvents: DomainEvent[] = [];
+  private _lastCompletedDate: string | null;
+  private _nextDue: string;
+
+  private constructor(
+    readonly id: MaintenanceTaskId,
+    readonly assetId: AssetId,
+    readonly ownerId: UserId,
+    readonly title: string,
+    readonly intervalValue: number,
+    readonly intervalUnit: IntervalUnit,
+    lastCompletedDate: string | null,
+    nextDue: string,
+    readonly createdAt: Date,
+  ) {
+    this._lastCompletedDate = lastCompletedDate;
+    this._nextDue = nextDue;
+  }
+
+  get lastCompletedDate(): string | null {
+    return this._lastCompletedDate;
+  }
+
+  get nextDue(): string {
+    return this._nextDue;
+  }
+
+  static create(props: {
+    assetId: AssetId;
+    ownerId: UserId;
+    actorId: UserId;
+    title: string;
+    intervalValue: number;
+    intervalUnit: IntervalUnit;
+    lastCompletedDate?: string;
+    todayUtc: string;
+  }): MaintenanceTask {
+    const title = props.title.trim();
+    if (!title) throw new ValidationError("Title is required", "title");
+    if (title.length > 100) {
+      throw new ValidationError("Title must be 100 characters or fewer", "title");
+    }
+
+    if (!Number.isInteger(props.intervalValue) || props.intervalValue < 1) {
+      throw new ValidationError("Interval value must be a positive integer", "intervalValue");
+    }
+
+    if (!INTERVAL_UNITS.includes(props.intervalUnit)) {
+      throw new ValidationError("Interval unit must be day, week, month, or year", "intervalUnit");
+    }
+
+    try {
+      validateDateOnly(props.todayUtc);
+    } catch {
+      throw new InvariantError("UTC date provider returned an invalid date");
+    }
+
+    let lastCompletedDate: string | null = null;
+    if (props.lastCompletedDate !== undefined) {
+      validateDateOnly(props.lastCompletedDate, "lastCompletedDate");
+      if (props.lastCompletedDate > props.todayUtc) {
+        throw new ValidationError(
+          "Last completed date must be today or earlier",
+          "lastCompletedDate",
+        );
+      }
+      lastCompletedDate = props.lastCompletedDate;
+    }
+
+    const baseline = lastCompletedDate ?? props.todayUtc;
+    const nextDue = addInterval(baseline, props.intervalValue, props.intervalUnit);
+
+    const task = new MaintenanceTask(
+      MaintenanceTaskId.generate(),
+      props.assetId,
+      props.ownerId,
+      title,
+      props.intervalValue,
+      props.intervalUnit,
+      lastCompletedDate,
+      nextDue,
+      new Date(),
+    );
+    task._domainEvents.push(
+      MaintenanceTaskCreated({
+        maintenanceTaskId: task.id,
+        assetId: task.assetId,
+        ownerId: task.ownerId,
+        actorId: props.actorId,
+        intervalValue: task.intervalValue,
+        intervalUnit: task.intervalUnit,
+      }),
+    );
+    return task;
+  }
+
+  /** Advances lastCompletedDate and nextDue when performedAt is strictly newer. Returns true if advanced. */
+  advance(performedAt: string, recordId: MaintenanceRecordId, actorId: UserId): boolean {
+    if (this._lastCompletedDate !== null && performedAt <= this._lastCompletedDate) {
+      return false;
+    }
+    this._lastCompletedDate = performedAt;
+    this._nextDue = addInterval(performedAt, this.intervalValue, this.intervalUnit);
+    this._domainEvents.push(
+      MaintenanceTaskAdvanced({
+        maintenanceTaskId: this.id,
+        maintenanceRecordId: recordId,
+        assetId: this.assetId,
+        ownerId: this.ownerId,
+        actorId,
+        performedAt,
+      }),
+    );
+    return true;
+  }
+
+  remove(actorId: UserId): void {
+    this._domainEvents.push(
+      MaintenanceTaskDeleted({
+        maintenanceTaskId: this.id,
+        assetId: this.assetId,
+        ownerId: this.ownerId,
+        actorId,
+      }),
+    );
+  }
+
+  static reconstitute(props: {
+    id: MaintenanceTaskId;
+    assetId: AssetId;
+    ownerId: UserId;
+    title: string;
+    intervalValue: number;
+    intervalUnit: IntervalUnit;
+    lastCompletedDate: string | null;
+    nextDue: string;
+    createdAt: Date;
+  }): MaintenanceTask {
+    return new MaintenanceTask(
+      props.id,
+      props.assetId,
+      props.ownerId,
+      props.title,
+      props.intervalValue,
+      props.intervalUnit,
+      props.lastCompletedDate,
+      props.nextDue,
+      props.createdAt,
+    );
+  }
+
+  pullEvents(): DomainEvent[] {
+    const events = [...this._domainEvents];
+    this._domainEvents = [];
+    return events;
+  }
+}

--- a/apps/api/src/domain/maintenance/MaintenanceTaskRepository.ts
+++ b/apps/api/src/domain/maintenance/MaintenanceTaskRepository.ts
@@ -1,0 +1,11 @@
+import type { AssetId, MaintenanceTaskId, UserId } from "@snaveevans/pineapple-shared";
+import type { MaintenanceTask } from "./MaintenanceTask.ts";
+
+export interface MaintenanceTaskRepository {
+  /** Returns tasks ordered by nextDue ASC. */
+  findByAsset(assetId: AssetId, ownerId: UserId): Promise<MaintenanceTask[]>;
+  findById(id: MaintenanceTaskId): Promise<MaintenanceTask | null>;
+  save(task: MaintenanceTask): Promise<void>;
+  /** Nulls task_id on linked maintenance_records, then deletes the task. */
+  delete(taskId: MaintenanceTaskId): Promise<void>;
+}

--- a/apps/api/src/domain/maintenance/MaintenanceTaskRepository.ts
+++ b/apps/api/src/domain/maintenance/MaintenanceTaskRepository.ts
@@ -1,9 +1,9 @@
-import type { AssetId, MaintenanceTaskId, UserId } from "@snaveevans/pineapple-shared";
+import type { AssetId, MaintenanceTaskId } from "@snaveevans/pineapple-shared";
 import type { MaintenanceTask } from "./MaintenanceTask.ts";
 
 export interface MaintenanceTaskRepository {
-  /** Returns tasks ordered by nextDue ASC. */
-  findByAsset(assetId: AssetId, ownerId: UserId): Promise<MaintenanceTask[]>;
+  /** Returns tasks ordered by nextDue ASC. Ownership is verified at the use-case layer. */
+  findByAsset(assetId: AssetId): Promise<MaintenanceTask[]>;
   findById(id: MaintenanceTaskId): Promise<MaintenanceTask | null>;
   save(task: MaintenanceTask): Promise<void>;
   /** Nulls task_id on linked maintenance_records, then deletes the task. */

--- a/apps/api/src/domain/maintenance/events/MaintenanceTaskAdvanced.ts
+++ b/apps/api/src/domain/maintenance/events/MaintenanceTaskAdvanced.ts
@@ -1,0 +1,35 @@
+import type {
+  AssetId,
+  MaintenanceRecordId,
+  MaintenanceTaskId,
+  UserId,
+} from "@snaveevans/pineapple-shared";
+import type { DomainEvent } from "../../events/DomainEvent.ts";
+
+export type MaintenanceTaskAdvanced = DomainEvent & {
+  type: "MaintenanceTaskAdvanced";
+  maintenanceTaskId: MaintenanceTaskId;
+  maintenanceRecordId: MaintenanceRecordId;
+  assetId: AssetId;
+  ownerId: UserId;
+  actorId: UserId;
+  performedAt: string;
+};
+
+export const MaintenanceTaskAdvanced = (props: {
+  maintenanceTaskId: MaintenanceTaskId;
+  maintenanceRecordId: MaintenanceRecordId;
+  assetId: AssetId;
+  ownerId: UserId;
+  actorId: UserId;
+  performedAt: string;
+}): MaintenanceTaskAdvanced => ({
+  type: "MaintenanceTaskAdvanced",
+  maintenanceTaskId: props.maintenanceTaskId,
+  maintenanceRecordId: props.maintenanceRecordId,
+  assetId: props.assetId,
+  ownerId: props.ownerId,
+  actorId: props.actorId,
+  performedAt: props.performedAt,
+  occurredAt: new Date(),
+});

--- a/apps/api/src/domain/maintenance/events/MaintenanceTaskCreated.ts
+++ b/apps/api/src/domain/maintenance/events/MaintenanceTaskCreated.ts
@@ -1,0 +1,31 @@
+import type { AssetId, MaintenanceTaskId, UserId } from "@snaveevans/pineapple-shared";
+import type { DomainEvent } from "../../events/DomainEvent.ts";
+import type { IntervalUnit } from "../IntervalUnit.ts";
+
+export type MaintenanceTaskCreated = DomainEvent & {
+  type: "MaintenanceTaskCreated";
+  maintenanceTaskId: MaintenanceTaskId;
+  assetId: AssetId;
+  ownerId: UserId;
+  actorId: UserId;
+  intervalValue: number;
+  intervalUnit: IntervalUnit;
+};
+
+export const MaintenanceTaskCreated = (props: {
+  maintenanceTaskId: MaintenanceTaskId;
+  assetId: AssetId;
+  ownerId: UserId;
+  actorId: UserId;
+  intervalValue: number;
+  intervalUnit: IntervalUnit;
+}): MaintenanceTaskCreated => ({
+  type: "MaintenanceTaskCreated",
+  maintenanceTaskId: props.maintenanceTaskId,
+  assetId: props.assetId,
+  ownerId: props.ownerId,
+  actorId: props.actorId,
+  intervalValue: props.intervalValue,
+  intervalUnit: props.intervalUnit,
+  occurredAt: new Date(),
+});

--- a/apps/api/src/domain/maintenance/events/MaintenanceTaskDeleted.ts
+++ b/apps/api/src/domain/maintenance/events/MaintenanceTaskDeleted.ts
@@ -1,0 +1,24 @@
+import type { AssetId, MaintenanceTaskId, UserId } from "@snaveevans/pineapple-shared";
+import type { DomainEvent } from "../../events/DomainEvent.ts";
+
+export type MaintenanceTaskDeleted = DomainEvent & {
+  type: "MaintenanceTaskDeleted";
+  maintenanceTaskId: MaintenanceTaskId;
+  assetId: AssetId;
+  ownerId: UserId;
+  actorId: UserId;
+};
+
+export const MaintenanceTaskDeleted = (props: {
+  maintenanceTaskId: MaintenanceTaskId;
+  assetId: AssetId;
+  ownerId: UserId;
+  actorId: UserId;
+}): MaintenanceTaskDeleted => ({
+  type: "MaintenanceTaskDeleted",
+  maintenanceTaskId: props.maintenanceTaskId,
+  assetId: props.assetId,
+  ownerId: props.ownerId,
+  actorId: props.actorId,
+  occurredAt: new Date(),
+});

--- a/apps/api/src/infrastructure/persistence/D1MaintenanceRecordRepository.test.ts
+++ b/apps/api/src/infrastructure/persistence/D1MaintenanceRecordRepository.test.ts
@@ -1,0 +1,92 @@
+import {
+  AssetId,
+  MaintenanceRecordId,
+  MaintenanceTaskId,
+  UserId,
+} from "@snaveevans/pineapple-shared";
+import { describe, expect, it, vi } from "vitest";
+import { MaintenanceRecord } from "../../domain/maintenance/MaintenanceRecord.ts";
+import { MaintenanceTask } from "../../domain/maintenance/MaintenanceTask.ts";
+import { D1MaintenanceRecordRepository } from "./D1MaintenanceRecordRepository.ts";
+
+type BoundStatement = {
+  query: string;
+  values: unknown[];
+  run: ReturnType<typeof vi.fn>;
+  statement: D1PreparedStatement;
+};
+
+function createDatabaseHarness() {
+  const statements: BoundStatement[] = [];
+  const batch = vi.fn().mockResolvedValue([]);
+  const prepare = vi.fn((query: string) => {
+    return {
+      bind: (...values: unknown[]) => {
+        const run = vi.fn().mockResolvedValue({ success: true });
+        const statement = { run } as unknown as D1PreparedStatement;
+        statements.push({ query, values, run, statement });
+        return statement;
+      },
+    } as unknown as D1PreparedStatement;
+  });
+  const db = { prepare, batch } as unknown as D1Database;
+
+  return { db, batch, statements };
+}
+
+function createEntities() {
+  const assetId = AssetId.generate();
+  const ownerId = UserId.generate();
+  const taskId = MaintenanceTaskId.generate();
+  const createdAt = new Date("2026-06-09T12:00:00.000Z");
+  const record = MaintenanceRecord.reconstitute({
+    id: MaintenanceRecordId.generate(),
+    assetId,
+    ownerId,
+    title: "Replaced furnace filter",
+    performedAt: "2026-06-09",
+    notes: null,
+    taskId,
+    createdAt,
+  });
+  const task = MaintenanceTask.reconstitute({
+    id: taskId,
+    assetId,
+    ownerId,
+    title: "Replace furnace filter",
+    intervalValue: 2,
+    intervalUnit: "month",
+    lastCompletedDate: "2026-06-09",
+    nextDue: "2026-08-09",
+    createdAt,
+  });
+
+  return { record, task };
+}
+
+describe("D1MaintenanceRecordRepository", () => {
+  it("batches the record insert and advanced task update", async () => {
+    const { db, batch, statements } = createDatabaseHarness();
+    const { record, task } = createEntities();
+
+    await new D1MaintenanceRecordRepository(db).save(record, task);
+
+    expect(batch).toHaveBeenCalledOnce();
+    expect(batch).toHaveBeenCalledWith(statements.map(({ statement }) => statement));
+    expect(statements).toHaveLength(2);
+    expect(statements[0]?.query).toContain("INSERT INTO maintenance_records");
+    expect(statements[1]?.query).toContain("INSERT INTO maintenance_tasks");
+    expect(statements.every(({ run }) => run.mock.calls.length === 0)).toBe(true);
+  });
+
+  it("runs only the record insert when no task advanced", async () => {
+    const { db, batch, statements } = createDatabaseHarness();
+    const { record } = createEntities();
+
+    await new D1MaintenanceRecordRepository(db).save(record);
+
+    expect(batch).not.toHaveBeenCalled();
+    expect(statements).toHaveLength(1);
+    expect(statements[0]?.run).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/api/src/infrastructure/persistence/D1MaintenanceRecordRepository.ts
+++ b/apps/api/src/infrastructure/persistence/D1MaintenanceRecordRepository.ts
@@ -1,4 +1,9 @@
-import { AssetId, MaintenanceRecordId, UserId } from "@snaveevans/pineapple-shared";
+import {
+  AssetId,
+  MaintenanceRecordId,
+  MaintenanceTaskId,
+  UserId,
+} from "@snaveevans/pineapple-shared";
 import { MaintenanceRecord } from "../../domain/maintenance/MaintenanceRecord.ts";
 import type { MaintenanceRecordRepository } from "../../domain/maintenance/MaintenanceRecordRepository.ts";
 
@@ -9,10 +14,11 @@ type MaintenanceRecordRow = {
   title: string;
   performed_at: string;
   notes: string | null;
+  task_id: string | null;
   created_at: string;
 };
 
-const SELECT_COLUMNS = "id, asset_id, owner_id, title, performed_at, notes, created_at";
+const SELECT_COLUMNS = "id, asset_id, owner_id, title, performed_at, notes, task_id, created_at";
 
 export class D1MaintenanceRecordRepository implements MaintenanceRecordRepository {
   constructor(private readonly db: D1Database) {}
@@ -34,8 +40,8 @@ export class D1MaintenanceRecordRepository implements MaintenanceRecordRepositor
     await this.db
       .prepare(
         `INSERT INTO maintenance_records
-           (id, asset_id, owner_id, title, performed_at, notes, created_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+           (id, asset_id, owner_id, title, performed_at, notes, task_id, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
       )
       .bind(
         record.id,
@@ -44,6 +50,7 @@ export class D1MaintenanceRecordRepository implements MaintenanceRecordRepositor
         record.title,
         record.performedAt,
         record.notes,
+        record.taskId,
         record.createdAt.toISOString(),
       )
       .run();
@@ -57,6 +64,7 @@ export class D1MaintenanceRecordRepository implements MaintenanceRecordRepositor
       title: row.title,
       performedAt: row.performed_at,
       notes: row.notes,
+      taskId: row.task_id ? MaintenanceTaskId.from(row.task_id) : null,
       createdAt: new Date(row.created_at),
     });
   }

--- a/apps/api/src/infrastructure/persistence/D1MaintenanceRecordRepository.ts
+++ b/apps/api/src/infrastructure/persistence/D1MaintenanceRecordRepository.ts
@@ -4,8 +4,11 @@ import {
   MaintenanceTaskId,
   UserId,
 } from "@snaveevans/pineapple-shared";
+import type { MaintenanceRecordWriter } from "../../application/ports/MaintenanceRecordWriter.ts";
 import { MaintenanceRecord } from "../../domain/maintenance/MaintenanceRecord.ts";
 import type { MaintenanceRecordRepository } from "../../domain/maintenance/MaintenanceRecordRepository.ts";
+import type { MaintenanceTask } from "../../domain/maintenance/MaintenanceTask.ts";
+import { prepareMaintenanceTaskSave } from "./D1MaintenanceTaskRepository.ts";
 
 type MaintenanceRecordRow = {
   id: string;
@@ -20,7 +23,9 @@ type MaintenanceRecordRow = {
 
 const SELECT_COLUMNS = "id, asset_id, owner_id, title, performed_at, notes, task_id, created_at";
 
-export class D1MaintenanceRecordRepository implements MaintenanceRecordRepository {
+export class D1MaintenanceRecordRepository
+  implements MaintenanceRecordRepository, MaintenanceRecordWriter
+{
   constructor(private readonly db: D1Database) {}
 
   async findByAsset(assetId: AssetId, ownerId: UserId): Promise<MaintenanceRecord[]> {
@@ -36,8 +41,11 @@ export class D1MaintenanceRecordRepository implements MaintenanceRecordRepositor
     return result.results.map((row) => this.#rowToRecord(row));
   }
 
-  async save(record: MaintenanceRecord): Promise<void> {
-    await this.db
+  async save(
+    record: MaintenanceRecord,
+    advancedTask: MaintenanceTask | null = null,
+  ): Promise<void> {
+    const recordStatement = this.db
       .prepare(
         `INSERT INTO maintenance_records
            (id, asset_id, owner_id, title, performed_at, notes, task_id, created_at)
@@ -52,8 +60,14 @@ export class D1MaintenanceRecordRepository implements MaintenanceRecordRepositor
         record.notes,
         record.taskId,
         record.createdAt.toISOString(),
-      )
-      .run();
+      );
+
+    if (advancedTask === null) {
+      await recordStatement.run();
+      return;
+    }
+
+    await this.db.batch([recordStatement, prepareMaintenanceTaskSave(this.db, advancedTask)]);
   }
 
   #rowToRecord(row: MaintenanceRecordRow): MaintenanceRecord {

--- a/apps/api/src/infrastructure/persistence/D1MaintenanceTaskRepository.ts
+++ b/apps/api/src/infrastructure/persistence/D1MaintenanceTaskRepository.ts
@@ -21,15 +21,15 @@ const SELECT_COLUMNS =
 export class D1MaintenanceTaskRepository implements MaintenanceTaskRepository {
   constructor(private readonly db: D1Database) {}
 
-  async findByAsset(assetId: AssetId, ownerId: UserId): Promise<MaintenanceTask[]> {
+  async findByAsset(assetId: AssetId): Promise<MaintenanceTask[]> {
     const result = await this.db
       .prepare(
         `SELECT ${SELECT_COLUMNS}
          FROM maintenance_tasks
-         WHERE asset_id = ? AND owner_id = ?
+         WHERE asset_id = ?
          ORDER BY next_due ASC`,
       )
-      .bind(assetId, ownerId)
+      .bind(assetId)
       .all<MaintenanceTaskRow>();
     return result.results.map((row) => this.#rowToTask(row));
   }

--- a/apps/api/src/infrastructure/persistence/D1MaintenanceTaskRepository.ts
+++ b/apps/api/src/infrastructure/persistence/D1MaintenanceTaskRepository.ts
@@ -1,0 +1,93 @@
+import { AssetId, MaintenanceTaskId, UserId } from "@snaveevans/pineapple-shared";
+import type { IntervalUnit } from "../../domain/maintenance/IntervalUnit.ts";
+import { MaintenanceTask } from "../../domain/maintenance/MaintenanceTask.ts";
+import type { MaintenanceTaskRepository } from "../../domain/maintenance/MaintenanceTaskRepository.ts";
+
+type MaintenanceTaskRow = {
+  id: string;
+  asset_id: string;
+  owner_id: string;
+  title: string;
+  interval_value: number;
+  interval_unit: string;
+  last_completed_date: string | null;
+  next_due: string;
+  created_at: string;
+};
+
+const SELECT_COLUMNS =
+  "id, asset_id, owner_id, title, interval_value, interval_unit, last_completed_date, next_due, created_at";
+
+export class D1MaintenanceTaskRepository implements MaintenanceTaskRepository {
+  constructor(private readonly db: D1Database) {}
+
+  async findByAsset(assetId: AssetId, ownerId: UserId): Promise<MaintenanceTask[]> {
+    const result = await this.db
+      .prepare(
+        `SELECT ${SELECT_COLUMNS}
+         FROM maintenance_tasks
+         WHERE asset_id = ? AND owner_id = ?
+         ORDER BY next_due ASC`,
+      )
+      .bind(assetId, ownerId)
+      .all<MaintenanceTaskRow>();
+    return result.results.map((row) => this.#rowToTask(row));
+  }
+
+  async findById(id: MaintenanceTaskId): Promise<MaintenanceTask | null> {
+    const row = await this.db
+      .prepare(`SELECT ${SELECT_COLUMNS} FROM maintenance_tasks WHERE id = ?`)
+      .bind(id)
+      .first<MaintenanceTaskRow>();
+    return row ? this.#rowToTask(row) : null;
+  }
+
+  async save(task: MaintenanceTask): Promise<void> {
+    // ON CONFLICT only updates the mutable tracking fields (last_completed_date, next_due).
+    // title, interval_value, and interval_unit are immutable after creation; no update path exists.
+    await this.db
+      .prepare(
+        `INSERT INTO maintenance_tasks
+           (id, asset_id, owner_id, title, interval_value, interval_unit, last_completed_date, next_due, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(id) DO UPDATE SET
+           last_completed_date = excluded.last_completed_date,
+           next_due = excluded.next_due`,
+      )
+      .bind(
+        task.id,
+        task.assetId,
+        task.ownerId,
+        task.title,
+        task.intervalValue,
+        task.intervalUnit,
+        task.lastCompletedDate,
+        task.nextDue,
+        task.createdAt.toISOString(),
+      )
+      .run();
+  }
+
+  async delete(taskId: MaintenanceTaskId): Promise<void> {
+    await this.db.batch([
+      this.db
+        .prepare("UPDATE maintenance_records SET task_id = NULL WHERE task_id = ?")
+        .bind(taskId),
+      this.db.prepare("DELETE FROM maintenance_tasks WHERE id = ?").bind(taskId),
+    ]);
+  }
+
+  #rowToTask(row: MaintenanceTaskRow): MaintenanceTask {
+    return MaintenanceTask.reconstitute({
+      id: MaintenanceTaskId.from(row.id),
+      assetId: AssetId.from(row.asset_id),
+      ownerId: UserId.from(row.owner_id),
+      title: row.title,
+      intervalValue: row.interval_value,
+      intervalUnit: row.interval_unit as IntervalUnit,
+      lastCompletedDate: row.last_completed_date,
+      nextDue: row.next_due,
+      createdAt: new Date(row.created_at),
+    });
+  }
+}

--- a/apps/api/src/infrastructure/persistence/D1MaintenanceTaskRepository.ts
+++ b/apps/api/src/infrastructure/persistence/D1MaintenanceTaskRepository.ts
@@ -18,6 +18,34 @@ type MaintenanceTaskRow = {
 const SELECT_COLUMNS =
   "id, asset_id, owner_id, title, interval_value, interval_unit, last_completed_date, next_due, created_at";
 
+export function prepareMaintenanceTaskSave(
+  db: D1Database,
+  task: MaintenanceTask,
+): D1PreparedStatement {
+  // ON CONFLICT only updates the mutable tracking fields (last_completed_date, next_due).
+  // title, interval_value, and interval_unit are immutable after creation; no update path exists.
+  return db
+    .prepare(
+      `INSERT INTO maintenance_tasks
+         (id, asset_id, owner_id, title, interval_value, interval_unit, last_completed_date, next_due, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(id) DO UPDATE SET
+         last_completed_date = excluded.last_completed_date,
+         next_due = excluded.next_due`,
+    )
+    .bind(
+      task.id,
+      task.assetId,
+      task.ownerId,
+      task.title,
+      task.intervalValue,
+      task.intervalUnit,
+      task.lastCompletedDate,
+      task.nextDue,
+      task.createdAt.toISOString(),
+    );
+}
+
 export class D1MaintenanceTaskRepository implements MaintenanceTaskRepository {
   constructor(private readonly db: D1Database) {}
 
@@ -43,29 +71,7 @@ export class D1MaintenanceTaskRepository implements MaintenanceTaskRepository {
   }
 
   async save(task: MaintenanceTask): Promise<void> {
-    // ON CONFLICT only updates the mutable tracking fields (last_completed_date, next_due).
-    // title, interval_value, and interval_unit are immutable after creation; no update path exists.
-    await this.db
-      .prepare(
-        `INSERT INTO maintenance_tasks
-           (id, asset_id, owner_id, title, interval_value, interval_unit, last_completed_date, next_due, created_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-         ON CONFLICT(id) DO UPDATE SET
-           last_completed_date = excluded.last_completed_date,
-           next_due = excluded.next_due`,
-      )
-      .bind(
-        task.id,
-        task.assetId,
-        task.ownerId,
-        task.title,
-        task.intervalValue,
-        task.intervalUnit,
-        task.lastCompletedDate,
-        task.nextDue,
-        task.createdAt.toISOString(),
-      )
-      .run();
+    await prepareMaintenanceTaskSave(this.db, task).run();
   }
 
   async delete(taskId: MaintenanceTaskId): Promise<void> {

--- a/apps/api/src/infrastructure/telemetry/maintenance/MaintenanceTaskAdvancedTelemetryHandler.ts
+++ b/apps/api/src/infrastructure/telemetry/maintenance/MaintenanceTaskAdvancedTelemetryHandler.ts
@@ -1,0 +1,34 @@
+import type { DomainEventHandler } from "../../../application/ports/EventBus.ts";
+import type { MaintenanceTaskAdvanced } from "../../../domain/maintenance/events/MaintenanceTaskAdvanced.ts";
+import type { TelemetryDataPoint, TelemetrySink } from "../AnalyticsEngineTelemetrySink.ts";
+
+export class MaintenanceTaskAdvancedTelemetryHandler implements DomainEventHandler<MaintenanceTaskAdvanced> {
+  readonly eventType = "MaintenanceTaskAdvanced" as const;
+
+  constructor(private readonly sink: TelemetrySink) {}
+
+  handle(event: MaintenanceTaskAdvanced): void {
+    const dataPoint: TelemetryDataPoint = {
+      indexes: [event.ownerId],
+      blobs: [
+        event.type,
+        "MaintenanceTask",
+        event.maintenanceTaskId,
+        event.assetId,
+        event.ownerId,
+        event.actorId,
+        event.maintenanceRecordId,
+        "CreateMaintenanceRecord",
+        "v1",
+        "success",
+      ],
+      doubles: [1, event.occurredAt.getTime(), dateOnlyToUtcMidnight(event.performedAt)],
+    };
+    this.sink.write(dataPoint);
+  }
+}
+
+function dateOnlyToUtcMidnight(value: string): number {
+  const [year, month, day] = value.split("-").map(Number);
+  return Date.UTC(year ?? 0, (month ?? 1) - 1, day ?? 1);
+}

--- a/apps/api/src/infrastructure/telemetry/maintenance/MaintenanceTaskAdvancedTelemetryHandler.ts
+++ b/apps/api/src/infrastructure/telemetry/maintenance/MaintenanceTaskAdvancedTelemetryHandler.ts
@@ -29,6 +29,6 @@ export class MaintenanceTaskAdvancedTelemetryHandler implements DomainEventHandl
 }
 
 function dateOnlyToUtcMidnight(value: string): number {
-  const [year, month, day] = value.split("-").map(Number);
-  return Date.UTC(year ?? 0, (month ?? 1) - 1, day ?? 1);
+  const [year, month, day] = value.split("-").map(Number) as [number, number, number];
+  return Date.UTC(year, month - 1, day);
 }

--- a/apps/api/src/infrastructure/telemetry/maintenance/MaintenanceTaskCreatedTelemetryHandler.ts
+++ b/apps/api/src/infrastructure/telemetry/maintenance/MaintenanceTaskCreatedTelemetryHandler.ts
@@ -1,0 +1,40 @@
+import type { DomainEventHandler } from "../../../application/ports/EventBus.ts";
+import type { MaintenanceTaskCreated } from "../../../domain/maintenance/events/MaintenanceTaskCreated.ts";
+import type { IntervalUnit } from "../../../domain/maintenance/IntervalUnit.ts";
+import type { TelemetryDataPoint, TelemetrySink } from "../AnalyticsEngineTelemetrySink.ts";
+
+const INTERVAL_DAYS_APPROX: Record<IntervalUnit, number> = {
+  day: 1,
+  week: 7,
+  month: 30,
+  year: 365,
+};
+
+export class MaintenanceTaskCreatedTelemetryHandler implements DomainEventHandler<MaintenanceTaskCreated> {
+  readonly eventType = "MaintenanceTaskCreated" as const;
+
+  constructor(private readonly sink: TelemetrySink) {}
+
+  handle(event: MaintenanceTaskCreated): void {
+    const dataPoint: TelemetryDataPoint = {
+      indexes: [event.ownerId],
+      blobs: [
+        event.type,
+        "MaintenanceTask",
+        event.maintenanceTaskId,
+        event.assetId,
+        event.ownerId,
+        event.actorId,
+        "CreateMaintenanceTask",
+        "v1",
+        "success",
+      ],
+      doubles: [
+        1,
+        event.occurredAt.getTime(),
+        event.intervalValue * INTERVAL_DAYS_APPROX[event.intervalUnit],
+      ],
+    };
+    this.sink.write(dataPoint);
+  }
+}

--- a/apps/api/src/infrastructure/telemetry/maintenance/MaintenanceTaskDeletedTelemetryHandler.ts
+++ b/apps/api/src/infrastructure/telemetry/maintenance/MaintenanceTaskDeletedTelemetryHandler.ts
@@ -1,0 +1,28 @@
+import type { DomainEventHandler } from "../../../application/ports/EventBus.ts";
+import type { MaintenanceTaskDeleted } from "../../../domain/maintenance/events/MaintenanceTaskDeleted.ts";
+import type { TelemetryDataPoint, TelemetrySink } from "../AnalyticsEngineTelemetrySink.ts";
+
+export class MaintenanceTaskDeletedTelemetryHandler implements DomainEventHandler<MaintenanceTaskDeleted> {
+  readonly eventType = "MaintenanceTaskDeleted" as const;
+
+  constructor(private readonly sink: TelemetrySink) {}
+
+  handle(event: MaintenanceTaskDeleted): void {
+    const dataPoint: TelemetryDataPoint = {
+      indexes: [event.ownerId],
+      blobs: [
+        event.type,
+        "MaintenanceTask",
+        event.maintenanceTaskId,
+        event.assetId,
+        event.ownerId,
+        event.actorId,
+        "DeleteMaintenanceTask",
+        "v1",
+        "success",
+      ],
+      doubles: [1, event.occurredAt.getTime()],
+    };
+    this.sink.write(dataPoint);
+  }
+}

--- a/apps/api/src/infrastructure/telemetry/registerDomainTelemetry.ts
+++ b/apps/api/src/infrastructure/telemetry/registerDomainTelemetry.ts
@@ -2,12 +2,16 @@ import type { EventBus } from "../../application/ports/EventBus.ts";
 import { AnalyticsEngineTelemetrySink } from "./AnalyticsEngineTelemetrySink.ts";
 import { AssetCreatedTelemetryHandler } from "./asset/AssetCreatedTelemetryHandler.ts";
 import { MaintenanceRecordCreatedTelemetryHandler } from "./maintenance/MaintenanceRecordCreatedTelemetryHandler.ts";
+import { MaintenanceTaskAdvancedTelemetryHandler } from "./maintenance/MaintenanceTaskAdvancedTelemetryHandler.ts";
+import { MaintenanceTaskCreatedTelemetryHandler } from "./maintenance/MaintenanceTaskCreatedTelemetryHandler.ts";
+import { MaintenanceTaskDeletedTelemetryHandler } from "./maintenance/MaintenanceTaskDeletedTelemetryHandler.ts";
 import { UserProvisionedTelemetryHandler } from "./user/UserProvisionedTelemetryHandler.ts";
 
 export function registerDomainTelemetry(deps: {
   eventBus: EventBus;
   assetDomainDataset: AnalyticsEngineDataset;
   maintenanceDomainDataset: AnalyticsEngineDataset;
+  maintenanceTaskDomainDataset: AnalyticsEngineDataset;
   userDomainDataset: AnalyticsEngineDataset;
 }): void {
   const assetDomainSink = new AnalyticsEngineTelemetrySink(deps.assetDomainDataset);
@@ -18,4 +22,11 @@ export function registerDomainTelemetry(deps: {
 
   const maintenanceDomainSink = new AnalyticsEngineTelemetrySink(deps.maintenanceDomainDataset);
   deps.eventBus.subscribe(new MaintenanceRecordCreatedTelemetryHandler(maintenanceDomainSink));
+
+  const maintenanceTaskDomainSink = new AnalyticsEngineTelemetrySink(
+    deps.maintenanceTaskDomainDataset,
+  );
+  deps.eventBus.subscribe(new MaintenanceTaskCreatedTelemetryHandler(maintenanceTaskDomainSink));
+  deps.eventBus.subscribe(new MaintenanceTaskDeletedTelemetryHandler(maintenanceTaskDomainSink));
+  deps.eventBus.subscribe(new MaintenanceTaskAdvancedTelemetryHandler(maintenanceTaskDomainSink));
 }

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -2,7 +2,7 @@ import { OpenAPIHono } from "@hono/zod-openapi";
 import { Scalar } from "@scalar/hono-api-reference";
 import type { Context } from "hono";
 import { secureHeaders } from "hono/secure-headers";
-import { AssetId, DomainError } from "@snaveevans/pineapple-shared";
+import { AssetId, DomainError, MaintenanceTaskId } from "@snaveevans/pineapple-shared";
 import type { User } from "./domain/identity/User.ts";
 import type { Asset } from "./domain/asset/Asset.ts";
 import type { AssetMetadata } from "./domain/asset/AssetMetadata.ts";
@@ -12,6 +12,7 @@ import type { MaintenanceRecord } from "./domain/maintenance/MaintenanceRecord.t
 import { D1UserRepository } from "./infrastructure/persistence/D1UserRepository.ts";
 import { D1AssetRepository } from "./infrastructure/persistence/D1AssetRepository.ts";
 import { D1MaintenanceRecordRepository } from "./infrastructure/persistence/D1MaintenanceRecordRepository.ts";
+import { D1MaintenanceTaskRepository } from "./infrastructure/persistence/D1MaintenanceTaskRepository.ts";
 import { createAuth, type Auth, type AuthEnv } from "./infrastructure/auth/auth.ts";
 import { BetterAuthResolver } from "./infrastructure/auth/BetterAuthResolver.ts";
 import { InMemoryEventBus } from "./infrastructure/events/InMemoryEventBus.ts";
@@ -25,6 +26,9 @@ import { GetAsset } from "./application/usecases/GetAsset.ts";
 import { ListAssets } from "./application/usecases/ListAssets.ts";
 import { CreateMaintenanceRecord } from "./application/usecases/CreateMaintenanceRecord.ts";
 import { ListMaintenanceRecords } from "./application/usecases/ListMaintenanceRecords.ts";
+import { CreateMaintenanceTask } from "./application/usecases/CreateMaintenanceTask.ts";
+import { ListMaintenanceTasks } from "./application/usecases/ListMaintenanceTasks.ts";
+import { DeleteMaintenanceTask } from "./application/usecases/DeleteMaintenanceTask.ts";
 import type { EventBus } from "./application/ports/EventBus.ts";
 
 // API layer
@@ -33,21 +37,27 @@ import { createTechnicalTelemetryMiddleware } from "./api/middleware/technicalTe
 import {
   createAssetRoute,
   createMaintenanceRecordRoute,
+  createMaintenanceTaskRoute,
+  deleteMaintenanceTaskRoute,
   getAssetRoute,
   healthRoute,
   listAssetsRoute,
   listMaintenanceRecordsRoute,
+  listMaintenanceTasksRoute,
   registerOpenApiComponents,
 } from "./api/openapi.ts";
 import openApiSpec from "../../../docs/reference/openapi.json";
 import type { AssetResponseSchema } from "./api/schemas/assetSchemas.ts";
 import type { MaintenanceRecordResponseSchema } from "./api/schemas/maintenanceRecordSchemas.ts";
+import type { MaintenanceTaskResponseSchema } from "./api/schemas/maintenanceTaskSchemas.ts";
+import type { MaintenanceTask } from "./domain/maintenance/MaintenanceTask.ts";
 import type { z } from "@hono/zod-openapi";
 
 type Bindings = AuthEnv & {
   ENVIRONMENT: string;
   ASSET_DOMAIN_TELEMETRY: AnalyticsEngineDataset;
   MAINTENANCE_DOMAIN_TELEMETRY: AnalyticsEngineDataset;
+  MAINTENANCE_TASK_DOMAIN_TELEMETRY: AnalyticsEngineDataset;
   USER_DOMAIN_TELEMETRY: AnalyticsEngineDataset;
   API_REQUEST_TELEMETRY: AnalyticsEngineDataset;
   /** Local dev only; honored only when ENVIRONMENT is exactly "development". */
@@ -131,7 +141,23 @@ function serializeMaintenanceRecord(
     title: record.title,
     performedAt: record.performedAt,
     notes: record.notes,
+    taskId: record.taskId,
     createdAt: record.createdAt.toISOString(),
+  };
+}
+
+function serializeMaintenanceTask(
+  task: MaintenanceTask,
+): z.infer<typeof MaintenanceTaskResponseSchema> {
+  return {
+    id: task.id,
+    assetId: task.assetId,
+    title: task.title,
+    intervalValue: task.intervalValue,
+    intervalUnit: task.intervalUnit,
+    lastCompletedDate: task.lastCompletedDate,
+    nextDue: task.nextDue,
+    createdAt: task.createdAt.toISOString(),
   };
 }
 
@@ -160,6 +186,7 @@ app.use("/api/*", async (c, next) => {
     eventBus,
     assetDomainDataset: c.env.ASSET_DOMAIN_TELEMETRY,
     maintenanceDomainDataset: c.env.MAINTENANCE_DOMAIN_TELEMETRY,
+    maintenanceTaskDomainDataset: c.env.MAINTENANCE_TASK_DOMAIN_TELEMETRY,
     userDomainDataset: c.env.USER_DOMAIN_TELEMETRY,
   });
   c.set("eventBus", eventBus);
@@ -228,10 +255,11 @@ app.openapi(getAssetRoute, async (c) => {
 app.openapi(createMaintenanceRecordRoute, async (c) => {
   const user = c.get("user");
   const { assetId } = c.req.valid("param");
-  const { title, performedAt, notes } = c.req.valid("json");
+  const { title, performedAt, notes, taskId } = c.req.valid("json");
   const result = await new CreateMaintenanceRecord(
     new D1AssetRepository(c.env.DB),
     new D1MaintenanceRecordRepository(c.env.DB),
+    new D1MaintenanceTaskRepository(c.env.DB),
     c.get("eventBus"),
     new SystemUtcDateProvider(),
   ).execute({
@@ -240,6 +268,7 @@ app.openapi(createMaintenanceRecordRoute, async (c) => {
     title,
     performedAt,
     ...(notes !== undefined ? { notes } : {}),
+    ...(taskId !== undefined ? { taskId: MaintenanceTaskId.from(taskId) } : {}),
   });
   if (!result.ok) throw result.error;
   return c.json(serializeMaintenanceRecord(result.value), 201);
@@ -257,6 +286,58 @@ app.openapi(listMaintenanceRecordsRoute, async (c) => {
   });
   if (!result.ok) throw result.error;
   return c.json({ maintenanceRecords: result.value.map(serializeMaintenanceRecord) }, 200);
+});
+
+// ── Maintenance task endpoints ───────────────────────────────────────────────
+
+app.openapi(createMaintenanceTaskRoute, async (c) => {
+  const user = c.get("user");
+  const { assetId } = c.req.valid("param");
+  const { title, intervalValue, intervalUnit, lastCompletedDate } = c.req.valid("json");
+  const result = await new CreateMaintenanceTask(
+    new D1AssetRepository(c.env.DB),
+    new D1MaintenanceTaskRepository(c.env.DB),
+    c.get("eventBus"),
+    new SystemUtcDateProvider(),
+  ).execute({
+    assetId: AssetId.from(assetId),
+    requesterId: user.id,
+    title,
+    intervalValue,
+    intervalUnit,
+    ...(lastCompletedDate !== undefined ? { lastCompletedDate } : {}),
+  });
+  if (!result.ok) throw result.error;
+  return c.json(serializeMaintenanceTask(result.value), 201);
+});
+
+app.openapi(listMaintenanceTasksRoute, async (c) => {
+  const user = c.get("user");
+  const { assetId } = c.req.valid("param");
+  const result = await new ListMaintenanceTasks(
+    new D1AssetRepository(c.env.DB),
+    new D1MaintenanceTaskRepository(c.env.DB),
+  ).execute({
+    assetId: AssetId.from(assetId),
+    requesterId: user.id,
+  });
+  if (!result.ok) throw result.error;
+  return c.json({ maintenanceTasks: result.value.map(serializeMaintenanceTask) }, 200);
+});
+
+app.openapi(deleteMaintenanceTaskRoute, async (c) => {
+  const user = c.get("user");
+  const { assetId, taskId } = c.req.valid("param");
+  const result = await new DeleteMaintenanceTask(
+    new D1MaintenanceTaskRepository(c.env.DB),
+    c.get("eventBus"),
+  ).execute({
+    taskId: MaintenanceTaskId.from(taskId),
+    assetId: AssetId.from(assetId),
+    requesterId: user.id,
+  });
+  if (!result.ok) throw result.error;
+  return c.body(null, 204);
 });
 
 export default app;

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -51,5 +51,9 @@ binding = "MAINTENANCE_DOMAIN_TELEMETRY"
 dataset = "pineapple_maintenance_domain_events"
 
 [[analytics_engine_datasets]]
+binding = "MAINTENANCE_TASK_DOMAIN_TELEMETRY"
+dataset = "pineapple_maintenance_task_domain_events"
+
+[[analytics_engine_datasets]]
 binding = "API_REQUEST_TELEMETRY"
 dataset = "pineapple_api_request_events"

--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -26,7 +26,7 @@
     },
     {
       "name": "Maintenance",
-      "description": "Create and read asset maintenance records owned by the caller"
+      "description": "Create and read maintenance records and tasks for assets owned by the caller"
     }
   ],
   "components": {
@@ -330,6 +330,12 @@
             "nullable": true,
             "example": "Used 7 quarts of synthetic oil."
           },
+          "taskId": {
+            "type": "string",
+            "nullable": true,
+            "format": "uuid",
+            "example": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+          },
           "createdAt": {
             "type": "string",
             "format": "date-time",
@@ -342,6 +348,7 @@
           "title",
           "performedAt",
           "notes",
+          "taskId",
           "createdAt"
         ]
       },
@@ -364,6 +371,11 @@
             "type": "string",
             "maxLength": 1000,
             "example": "Used 7 quarts of 5W-20 synthetic oil."
+          },
+          "taskId": {
+            "type": "string",
+            "format": "uuid",
+            "example": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
           }
         },
         "required": [
@@ -383,6 +395,114 @@
         },
         "required": [
           "maintenanceRecords"
+        ]
+      },
+      "MaintenanceTask": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+          },
+          "assetId": {
+            "type": "string",
+            "format": "uuid",
+            "example": "195d0ef0-47f5-439f-abfd-29f892c9a040"
+          },
+          "title": {
+            "type": "string",
+            "example": "Replace furnace filter"
+          },
+          "intervalValue": {
+            "type": "integer",
+            "example": 2
+          },
+          "intervalUnit": {
+            "type": "string",
+            "enum": [
+              "day",
+              "week",
+              "month",
+              "year"
+            ],
+            "example": "month"
+          },
+          "lastCompletedDate": {
+            "type": "string",
+            "nullable": true,
+            "example": "2026-04-11"
+          },
+          "nextDue": {
+            "type": "string",
+            "example": "2026-06-11"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2026-06-11T18:25:24.887Z"
+          }
+        },
+        "required": [
+          "id",
+          "assetId",
+          "title",
+          "intervalValue",
+          "intervalUnit",
+          "lastCompletedDate",
+          "nextDue",
+          "createdAt"
+        ]
+      },
+      "CreateMaintenanceTaskBody": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 100,
+            "example": "Replace furnace filter"
+          },
+          "intervalValue": {
+            "type": "integer",
+            "minimum": 1,
+            "example": 2
+          },
+          "intervalUnit": {
+            "type": "string",
+            "enum": [
+              "day",
+              "week",
+              "month",
+              "year"
+            ],
+            "example": "month"
+          },
+          "lastCompletedDate": {
+            "type": "string",
+            "format": "date",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+            "example": "2026-04-11"
+          }
+        },
+        "required": [
+          "title",
+          "intervalValue",
+          "intervalUnit"
+        ]
+      },
+      "MaintenanceTaskListResponse": {
+        "type": "object",
+        "properties": {
+          "maintenanceTasks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MaintenanceTask"
+            }
+          }
+        },
+        "required": [
+          "maintenanceTasks"
         ]
       }
     },
@@ -717,6 +837,240 @@
           },
           "404": {
             "description": "No such asset",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/assets/{assetId}/maintenance-tasks": {
+      "post": {
+        "tags": [
+          "Maintenance"
+        ],
+        "summary": "Create a maintenance task",
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "195d0ef0-47f5-439f-abfd-29f892c9a040"
+            },
+            "required": true,
+            "name": "assetId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateMaintenanceTaskBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Maintenance task created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MaintenanceTask"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The asset belongs to another user",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No such asset",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The asset is archived",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Maintenance"
+        ],
+        "summary": "List maintenance tasks for an asset",
+        "description": "Returns tasks ordered by nextDue ascending (soonest due first). Archived asset tasks remain readable.",
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "195d0ef0-47f5-439f-abfd-29f892c9a040"
+            },
+            "required": true,
+            "name": "assetId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The asset's maintenance tasks",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MaintenanceTaskListResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The asset belongs to another user",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No such asset",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/assets/{assetId}/maintenance-tasks/{taskId}": {
+      "delete": {
+        "tags": [
+          "Maintenance"
+        ],
+        "summary": "Delete a maintenance task",
+        "description": "Permanently removes the task. Linked maintenance records are preserved with taskId set to null.",
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "195d0ef0-47f5-439f-abfd-29f892c9a040"
+            },
+            "required": true,
+            "name": "assetId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+            },
+            "required": true,
+            "name": "taskId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Task deleted"
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The task belongs to another user",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No such task",
             "content": {
               "application/json": {
                 "schema": {

--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -431,10 +431,14 @@
           "lastCompletedDate": {
             "type": "string",
             "nullable": true,
+            "format": "date",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
             "example": "2026-04-11"
           },
           "nextDue": {
             "type": "string",
+            "format": "date",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
             "example": "2026-06-11"
           },
           "createdAt": {

--- a/docs/specs/SPECS.md
+++ b/docs/specs/SPECS.md
@@ -35,6 +35,7 @@ relevant cross-cutting specs rather than re-describing the behavior.
 | [asset-library.md](./features/asset-library.md)           | Assets      | draft  |
 | [dashboard.md](./features/dashboard.md)                   | Home        | wip    |
 | [maintenance-record.md](./features/maintenance-record.md) | Maintenance | draft  |
+| [maintenance-task.md](./features/maintenance-task.md)     | Maintenance | draft  |
 | [marketing-home.md](./features/marketing-home.md)         | Marketing   | active |
 
 ## Directory Structure

--- a/docs/specs/features/maintenance-record.md
+++ b/docs/specs/features/maintenance-record.md
@@ -10,7 +10,7 @@ metadata:
 **Status:** draft
 **Owner:** [unknown - assign on review]
 **Last Updated:** 2026-06-04
-**Related Specs:** [authentication.md](../cross-cutting/authentication.md), [validation.md](../cross-cutting/validation.md), [error-handling.md](../cross-cutting/error-handling.md), [loading-states.md](../cross-cutting/loading-states.md), [permissions.md](../cross-cutting/permissions.md), [telemetry.md](../cross-cutting/telemetry.md), [dashboard.md](./dashboard.md)
+**Related Specs:** [authentication.md](../cross-cutting/authentication.md), [validation.md](../cross-cutting/validation.md), [error-handling.md](../cross-cutting/error-handling.md), [loading-states.md](../cross-cutting/loading-states.md), [permissions.md](../cross-cutting/permissions.md), [telemetry.md](../cross-cutting/telemetry.md), [dashboard.md](./dashboard.md), [maintenance-task.md](./maintenance-task.md)
 
 ---
 
@@ -34,9 +34,9 @@ The Maintenance Record feature lets an authenticated user create dated maintenan
 - [ ] The API never accepts `ownerId` in the request body; ownership is derived from the authenticated session
 - [ ] The create use case checks that the target asset exists and belongs to the authenticated user before creating the record
 - [ ] The list use case returns only records for an asset owned by the authenticated user
-- [ ] `POST /api/assets/{assetId}/maintenance-records` accepts `{ title, performedAt, notes? }` and returns the full created maintenance record with status 201
+- [ ] `POST /api/assets/{assetId}/maintenance-records` accepts `{ title, performedAt, notes?, taskId? }` and returns the full created maintenance record with status 201; `taskId` behavior is defined in [maintenance-task.md](./maintenance-task.md)
 - [ ] `GET /api/assets/{assetId}/maintenance-records` returns `{ maintenanceRecords: [...] }` with status 200
-- [ ] Maintenance record responses contain `id`, `assetId`, `title`, `performedAt`, nullable `notes`, and `createdAt`; `ownerId` is never exposed
+- [ ] Maintenance record responses contain `id`, `assetId`, `title`, `performedAt`, nullable `notes`, nullable `taskId`, and `createdAt`; `ownerId` is never exposed
 - [ ] The user can start maintenance record creation from an asset detail page
 - [ ] The maintenance record form requires a **Title** field describing the work performed
 - [ ] Title is limited to 100 characters
@@ -135,7 +135,7 @@ The Maintenance Record feature lets an authenticated user create dated maintenan
 
 - Editing maintenance records
 - Deleting maintenance records
-- Service schedules, reminders, recurrence rules, next-due dates, and maintenance-task definitions
+- Service schedules, reminders, recurrence rules, and next-due dates (scheduling is defined in [maintenance-task.md](./maintenance-task.md))
 - Structured maintenance task/category management
 - Structured component or location tracking for repeated failures
 - Structured quantity, cost, vendor, mileage, odometer, or attachment fields

--- a/docs/specs/features/maintenance-task.md
+++ b/docs/specs/features/maintenance-task.md
@@ -1,0 +1,208 @@
+---
+name: maintenance-task
+description: Time-based recurring maintenance tasks tied to assets, with automatic next-due advancement when a linked maintenance record is logged
+metadata:
+  type: feature
+---
+
+# Maintenance Task
+
+**Status:** draft
+**Owner:** [unknown - assign on review]
+**Last Updated:** 2026-06-10
+**Related Specs:** [authentication.md](../cross-cutting/authentication.md), [validation.md](../cross-cutting/validation.md), [error-handling.md](../cross-cutting/error-handling.md), [loading-states.md](../cross-cutting/loading-states.md), [permissions.md](../cross-cutting/permissions.md), [telemetry.md](../cross-cutting/telemetry.md), [maintenance-record.md](./maintenance-record.md)
+
+---
+
+## Summary
+
+The Maintenance Task feature lets an authenticated owner-operator define scheduled maintenance work for an asset — specifying what to do and how often (time-based interval) — so they always know when maintenance is next due. When a maintenance record is linked to a task at logging time, the task's next-due date automatically advances based on when the work was performed. Tasks are the scheduling counterpart to the Maintenance Record log: records capture what _was_ done; tasks capture what _should_ be done and when.
+
+## User Stories
+
+- As an **authenticated owner-operator**, I can **create a time-based maintenance task for one of my assets** so that **I know what recurring maintenance is scheduled and when it's next due**
+- As **DIYer Dale**, I can **seed a new task with a last-completed date** so that **the next-due date reflects reality from the moment I create the task**
+- As **DIYer Dale**, I can **create a "replace furnace filter every 2 months" task for my house without a last-completed date** so that **the system starts counting from today**
+- As an **authenticated owner-operator**, I can **list the maintenance tasks for one of my assets** so that **I can see all scheduled work and when each item is next due**
+- As **DIYer Dale**, I can **link a maintenance record to a task when logging completed work** so that **the task's next-due date advances automatically to reflect the work I just performed**
+- As **DIYer Dale**, I can **use a task's dedicated "Log maintenance" flow** so that **the record is pre-linked to the task without extra steps**
+- As an **authenticated owner-operator**, I can **delete a maintenance task** so that **stale or incorrect tasks don't clutter my asset**
+- As a **user who deletes a task**, my **existing maintenance records are preserved** so that **my historical maintenance log is not lost**
+
+## Acceptance Criteria
+
+### Task creation
+
+- [ ] A maintenance task is always tied to an existing asset owned by the authenticated user
+- [ ] `POST /api/assets/{assetId}/maintenance-tasks` accepts `{ title, intervalValue, intervalUnit, lastCompletedDate? }` and returns the full created task with status 201
+- [ ] `ownerId` is never accepted in the request body; it is derived from the authenticated session
+- [ ] `title` is required and limited to 100 characters
+- [ ] `intervalValue` is required and must be a positive integer (≥ 1)
+- [ ] `intervalUnit` is required and must be one of `"day" | "week" | "month" | "year"`
+- [ ] `lastCompletedDate` is optional; when provided it must be a valid YYYY-MM-DD date that is today or earlier
+- [ ] When `lastCompletedDate` is provided, `nextDue = lastCompletedDate + interval` (calendar-based arithmetic)
+- [ ] When `lastCompletedDate` is omitted, `nextDue = today (UTC calendar date) + interval`
+- [ ] Creating a task for an archived asset returns 409
+- [ ] The create use case checks that the target asset exists and belongs to the authenticated user before creating the task
+
+### Task list
+
+- [ ] `GET /api/assets/{assetId}/maintenance-tasks` returns `{ maintenanceTasks: [...] }` with status 200
+- [ ] The list use case returns only tasks for an asset owned by the authenticated user
+- [ ] Each task in the response includes `id`, `assetId`, `title`, `intervalValue`, `intervalUnit`, `lastCompletedDate` (nullable), `nextDue`, and `createdAt`; `ownerId` is never exposed
+- [ ] Tasks are returned in ascending `nextDue` order (soonest due first)
+
+### Task deletion
+
+- [ ] `DELETE /api/assets/{assetId}/maintenance-tasks/{taskId}` returns 204 on success
+- [ ] Deleting a task that doesn't exist returns 404
+- [ ] Deleting a task that belongs to another user returns 403
+- [ ] Existing maintenance records previously linked to the deleted task are preserved with their `taskId` set to null
+
+### Record-task linking (change to existing maintenance-record endpoint)
+
+- [ ] `POST /api/assets/{assetId}/maintenance-records` accepts an optional `taskId` field in the request body
+- [ ] When `taskId` is provided, it must reference a maintenance task belonging to the same asset; a task from a different asset returns 422
+- [ ] When `taskId` references a task owned by a different user, 404 is returned (existence is not revealed)
+- [ ] Maintenance record responses include a nullable `taskId` field
+- [ ] When a linked record's `performedAt` is strictly greater than the task's current `lastCompletedDate` (or the task has no `lastCompletedDate`), the task's `lastCompletedDate` updates to `record.performedAt` and `nextDue` advances accordingly
+- [ ] When a linked record's `performedAt` is earlier than the task's current `lastCompletedDate`, `lastCompletedDate` and `nextDue` are unchanged — linking an older record never regresses the next-due date
+- [ ] Linking a record to a task for an archived asset returns 409 (the existing archived-asset rule for record creation applies)
+
+### General
+
+- [ ] A 401 response from the API redirects to `/login` through the API client layer
+- [ ] A 403 response from asset or task ownership checks is shown as an access-denied error
+- [ ] A 404 response is shown as a not-found error when the asset or task does not exist
+
+## Validation & Ownership
+
+**Authentication:** This feature is available only to authenticated users. API requests use the resolved `User.id` as `ownerId`.
+
+**Permissions:** Tasks are owned through the asset they belong to. A user can create, list, and delete tasks only for assets they own. The client cannot supply `ownerId`.
+
+**HTTP validation:** Inputs are validated at the Zod HTTP edge in `apps/api/src/api/schemas/maintenanceTaskSchemas.ts`. Required fields: `title` (string, max 100 chars), `intervalValue` (positive integer), `intervalUnit` (enum: `day | week | month | year`). Optional: `lastCompletedDate` (YYYY-MM-DD, today or earlier). For maintenance record creation, `taskId` is optional (UUID).
+
+**Domain validation:** Domain construction trims title and preserves these invariants: non-empty title of at most 100 characters; positive integer interval value; valid interval unit; date-only `lastCompletedDate` of today or earlier when provided; `nextDue` always present and derived from `lastCompletedDate` (or today's UTC calendar date) + interval.
+
+**Next-due arithmetic:** Interval arithmetic is calendar-based. "2 months from 2026-01-31" yields "2026-03-31"; if the resulting day exceeds the month length, clamp to the last day of that month. The implementation must not parse date strings through `Date` for calendar arithmetic; use manual calendar math or a WinterCG-compatible date library.
+
+**Date-only mitigation:** Same convention as [maintenance-record.md](./maintenance-record.md). `lastCompletedDate` and `nextDue` are timezone-free YYYY-MM-DD strings across the API, domain, and D1 persistence. Today's UTC calendar date is authoritative for seeding and comparisons.
+
+**Field errors:** Validation errors map back to `title`, `intervalValue`, `intervalUnit`, and `lastCompletedDate` when the backend includes a known `field` value.
+
+## Edge Cases & Error States
+
+| Scenario                                                               | Expected Behavior                                                    |
+| ---------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| Asset has no maintenance tasks                                         | List returns `{ maintenanceTasks: [] }`                              |
+| `title` is empty                                                       | 422; title field shows required-field error                          |
+| `title` is over 100 characters                                         | 422; title field shows max-length error                              |
+| `intervalValue` is 0 or negative                                       | 422; intervalValue field shows must-be-positive error                |
+| `intervalValue` is not an integer                                      | 422; intervalValue field shows type error                            |
+| `intervalUnit` is not a valid enum value                               | 422; intervalUnit field shows invalid-value error                    |
+| `lastCompletedDate` is in the future                                   | 422; lastCompletedDate field shows "must be today or earlier" error  |
+| `lastCompletedDate` is malformed                                       | 422; lastCompletedDate field shows format error                      |
+| `lastCompletedDate` omitted                                            | `nextDue` seeded as today (UTC calendar date) + interval             |
+| Asset is archived; task creation attempted                             | 409                                                                  |
+| Asset is archived; task list requested                                 | Existing task list is returned normally                              |
+| Asset is archived; record with `taskId` provided                       | 409 (archived-asset rule on record creation applies)                 |
+| Linked record's `performedAt` equals task's `lastCompletedDate`        | `lastCompletedDate` and `nextDue` unchanged                          |
+| Linked record's `performedAt` is older than task's `lastCompletedDate` | `lastCompletedDate` and `nextDue` unchanged                          |
+| `taskId` in record creation belongs to a different asset (same user)   | 422; taskId field shows "task does not belong to this asset"         |
+| `taskId` in record creation belongs to another user's task             | 404                                                                  |
+| `taskId` in record creation references a non-existent task             | 404                                                                  |
+| Task is deleted while it has linked records                            | 204; linked records preserved with `taskId` set to null              |
+| Deleting a task that doesn't exist                                     | 404                                                                  |
+| Deleting another user's task                                           | 403                                                                  |
+| User lists tasks for another user's asset                              | 403                                                                  |
+| User lists tasks for a non-existent asset                              | 404                                                                  |
+| 422 response with a known field name                                   | Banner shown; server error message pinned to the matching form field |
+| 422 response without a field name                                      | Banner shown; no field highlighted                                   |
+
+## Telemetry
+
+**Request telemetry:**
+
+- `POST /api/assets/{assetId}/maintenance-tasks` → `CreateMaintenanceTask` operation
+- `GET /api/assets/{assetId}/maintenance-tasks` → `ListMaintenanceTasks` operation
+- `DELETE /api/assets/{assetId}/maintenance-tasks/{taskId}` → `DeleteMaintenanceTask` operation
+
+All three route patterns must be added to the operation name mapping in `technicalTelemetry.ts`. See [telemetry.md](../cross-cutting/telemetry.md) for the full request data point shape. The existing `POST /api/assets/{assetId}/maintenance-records` operation name (`CreateMaintenanceRecord`) is unchanged when `taskId` is added to the body.
+
+**Domain events:** Three events are published to dataset `pineapple_maintenance_task_domain_events` (binding: `MAINTENANCE_TASK_DOMAIN_TELEMETRY`). None may include user-entered title text in telemetry blobs.
+
+### `MaintenanceTaskCreated` — on successful task creation
+
+| Field        | Name                   | Value                                                                                         |
+| ------------ | ---------------------- | --------------------------------------------------------------------------------------------- |
+| `indexes[0]` | —                      | `owner_id` (partition key for per-owner queries)                                              |
+| `blobs[0]`   | `event_type`           | `"MaintenanceTaskCreated"`                                                                    |
+| `blobs[1]`   | `aggregate_type`       | `"MaintenanceTask"`                                                                           |
+| `blobs[2]`   | `maintenance_task_id`  | Task UUID                                                                                     |
+| `blobs[3]`   | `asset_id`             | Asset UUID                                                                                    |
+| `blobs[4]`   | `owner_id`             | Owner UUID                                                                                    |
+| `blobs[5]`   | `actor_id`             | UUID of the authenticated user                                                                |
+| `blobs[6]`   | `source_use_case`      | `"CreateMaintenanceTask"`                                                                     |
+| `blobs[7]`   | `schema_version`       | `"v1"`                                                                                        |
+| `blobs[8]`   | `result`               | `"success"`                                                                                   |
+| `doubles[0]` | `count`                | Always `1`                                                                                    |
+| `doubles[1]` | `event_time_ms`        | Event timestamp (ms since epoch)                                                              |
+| `doubles[2]` | `interval_days_approx` | Interval normalized to approximate days for analytics (days×1, weeks×7, months×30, years×365) |
+
+### `MaintenanceTaskDeleted` — on successful task deletion
+
+| Field        | Name                  | Value                            |
+| ------------ | --------------------- | -------------------------------- |
+| `indexes[0]` | —                     | `owner_id`                       |
+| `blobs[0]`   | `event_type`          | `"MaintenanceTaskDeleted"`       |
+| `blobs[1]`   | `aggregate_type`      | `"MaintenanceTask"`              |
+| `blobs[2]`   | `maintenance_task_id` | Task UUID                        |
+| `blobs[3]`   | `asset_id`            | Asset UUID                       |
+| `blobs[4]`   | `owner_id`            | Owner UUID                       |
+| `blobs[5]`   | `actor_id`            | UUID of the authenticated user   |
+| `blobs[6]`   | `source_use_case`     | `"DeleteMaintenanceTask"`        |
+| `blobs[7]`   | `schema_version`      | `"v1"`                           |
+| `blobs[8]`   | `result`              | `"success"`                      |
+| `doubles[0]` | `count`               | Always `1`                       |
+| `doubles[1]` | `event_time_ms`       | Event timestamp (ms since epoch) |
+
+### `MaintenanceTaskAdvanced` — when a linked record advances the task's `lastCompletedDate`
+
+Published only when `record.performedAt >= task.lastCompletedDate` (i.e. when `nextDue` actually changes). Not published when linking an older record.
+
+| Field        | Name                    | Value                                                 |
+| ------------ | ----------------------- | ----------------------------------------------------- |
+| `indexes[0]` | —                       | `owner_id`                                            |
+| `blobs[0]`   | `event_type`            | `"MaintenanceTaskAdvanced"`                           |
+| `blobs[1]`   | `aggregate_type`        | `"MaintenanceTask"`                                   |
+| `blobs[2]`   | `maintenance_task_id`   | Task UUID                                             |
+| `blobs[3]`   | `asset_id`              | Asset UUID                                            |
+| `blobs[4]`   | `owner_id`              | Owner UUID                                            |
+| `blobs[5]`   | `actor_id`              | UUID of the authenticated user who logged the record  |
+| `blobs[6]`   | `maintenance_record_id` | UUID of the linked maintenance record                 |
+| `blobs[7]`   | `source_use_case`       | `"CreateMaintenanceRecord"`                           |
+| `blobs[8]`   | `schema_version`        | `"v1"`                                                |
+| `blobs[9]`   | `result`                | `"success"`                                           |
+| `doubles[0]` | `count`                 | Always `1`                                            |
+| `doubles[1]` | `event_time_ms`         | Event timestamp (ms since epoch)                      |
+| `doubles[2]` | `performed_date_ms`     | `record.performedAt` at UTC midnight (ms since epoch) |
+
+## Flags
+
+**NOT SPECIFIED — UI entry points and post-creation navigation:** This spec covers the API contract only. The exact UI entry points (asset detail page layout, task list placement, "Log maintenance" shortcut interaction, form presentation) are not specified here and should be addressed in a UI design pass.
+
+**FOLLOW-UP NEEDED — Mileage-based intervals (Phase 2):** The original user stories include "change oil every 5,000 miles." Odometer tracking and mileage-based `nextDue` computation are out of scope for phase 1. When implementing, do NOT simply add `"mile"` to the `intervalUnit` enum — time tasks carry `lastCompletedDate`/`nextDue` (dates) while distance tasks would need `lastCompletedOdometer`/`nextDueMileage` (integers). Introduce a `type: "time" | "distance"` discriminator and treat them as two explicit shapes. Existing time-based tasks require no changes.
+
+**FOLLOW-UP NEEDED — Cross-cutting time spec:** Same flag as [maintenance-record.md](./maintenance-record.md). Date-only arithmetic for `nextDue` computation — especially month and year intervals — should be revisited when a cross-cutting time spec is authored.
+
+## Out of Scope
+
+- Mileage/odometer-based intervals (Phase 2)
+- Editing a task's title or interval after creation
+- Reminders and push/email notifications when maintenance is due
+- A global "upcoming maintenance" view across all assets
+- Archiving or disabling tasks (only hard delete is supported in this iteration)
+- Automatic record creation triggered by tasks
+- Bulk task management
+- Task templates or task categories

--- a/docs/specs/features/maintenance-task.md
+++ b/docs/specs/features/maintenance-task.md
@@ -169,7 +169,7 @@ All three route patterns must be added to the operation name mapping in `technic
 
 ### `MaintenanceTaskAdvanced` — when a linked record advances the task's `lastCompletedDate`
 
-Published only when `record.performedAt >= task.lastCompletedDate` (i.e. when `nextDue` actually changes). Not published when linking an older record.
+Published only when `record.performedAt > task.lastCompletedDate` (i.e. when `nextDue` actually changes). Not published when linking an older record.
 
 | Field        | Name                    | Value                                                 |
 | ------------ | ----------------------- | ----------------------------------------------------- |

--- a/migrations/0004_maintenance_tasks.sql
+++ b/migrations/0004_maintenance_tasks.sql
@@ -22,4 +22,9 @@ CREATE TABLE IF NOT EXISTS maintenance_tasks (
 CREATE INDEX IF NOT EXISTS idx_maintenance_tasks_owner_asset_due
   ON maintenance_tasks(owner_id, asset_id, next_due ASC);
 
+-- D1 enforces foreign keys by default, so this is a schema-level safeguard.
+-- The repository also nulls linked records explicitly in the task deletion batch.
 ALTER TABLE maintenance_records ADD COLUMN task_id TEXT REFERENCES maintenance_tasks(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_maintenance_records_task_id
+  ON maintenance_records(task_id);

--- a/migrations/0004_maintenance_tasks.sql
+++ b/migrations/0004_maintenance_tasks.sql
@@ -22,4 +22,4 @@ CREATE TABLE IF NOT EXISTS maintenance_tasks (
 CREATE INDEX IF NOT EXISTS idx_maintenance_tasks_owner_asset_due
   ON maintenance_tasks(owner_id, asset_id, next_due ASC);
 
-ALTER TABLE maintenance_records ADD COLUMN task_id TEXT REFERENCES maintenance_tasks(id);
+ALTER TABLE maintenance_records ADD COLUMN task_id TEXT REFERENCES maintenance_tasks(id) ON DELETE SET NULL;

--- a/migrations/0004_maintenance_tasks.sql
+++ b/migrations/0004_maintenance_tasks.sql
@@ -1,0 +1,25 @@
+CREATE TABLE IF NOT EXISTS maintenance_tasks (
+  id                   TEXT NOT NULL PRIMARY KEY,
+  asset_id             TEXT NOT NULL REFERENCES assets(id),
+  owner_id             TEXT NOT NULL REFERENCES users(id),
+  title                TEXT NOT NULL CHECK (length(title) BETWEEN 1 AND 100),
+  interval_value       INTEGER NOT NULL CHECK (interval_value >= 1),
+  interval_unit        TEXT NOT NULL CHECK (interval_unit IN ('day', 'week', 'month', 'year')),
+  last_completed_date  TEXT CHECK (
+    last_completed_date IS NULL
+    OR (
+      length(last_completed_date) = 10
+      AND last_completed_date GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'
+    )
+  ),
+  next_due             TEXT NOT NULL CHECK (
+    length(next_due) = 10
+    AND next_due GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'
+  ),
+  created_at           TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_maintenance_tasks_owner_asset_due
+  ON maintenance_tasks(owner_id, asset_id, next_due ASC);
+
+ALTER TABLE maintenance_records ADD COLUMN task_id TEXT REFERENCES maintenance_tasks(id);

--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -1,5 +1,6 @@
 export { AssetId } from "./types/AssetId.ts";
 export { MaintenanceRecordId } from "./types/MaintenanceRecordId.ts";
+export { MaintenanceTaskId } from "./types/MaintenanceTaskId.ts";
 export { UserId } from "./types/UserId.ts";
 export { Email } from "./types/Email.ts";
 export { type Result, ok, err } from "./result.ts";

--- a/packages/shared/types/MaintenanceTaskId.ts
+++ b/packages/shared/types/MaintenanceTaskId.ts
@@ -1,0 +1,6 @@
+export type MaintenanceTaskId = string & { readonly _brand: "MaintenanceTaskId" };
+
+export const MaintenanceTaskId = {
+  generate: (): MaintenanceTaskId => crypto.randomUUID() as MaintenanceTaskId,
+  from: (raw: string): MaintenanceTaskId => raw as MaintenanceTaskId,
+};


### PR DESCRIPTION
## Summary

- Introduces the `MaintenanceTask` aggregate: recurring time-based maintenance tasks for assets, each with a `title`, `intervalValue + intervalUnit` schedule, and a derived `nextDue` date
- New endpoints: `POST /api/assets/{assetId}/maintenance-tasks` (201), `GET /api/assets/{assetId}/maintenance-tasks` (200, `nextDue ASC`), `DELETE /api/assets/{assetId}/maintenance-tasks/{taskId}` (204)
- `POST /api/assets/{assetId}/maintenance-records` gains an optional `taskId` body field; when provided, the task's `lastCompletedDate` and `nextDue` advance automatically if `performedAt` is strictly newer than the current `lastCompletedDate`
- Deleting a task nulls `task_id` on linked records atomically (D1 batch), preserving history
- Three new domain events (`MaintenanceTaskCreated`, `MaintenanceTaskAdvanced`, `MaintenanceTaskDeleted`) wired to a new Analytics Engine dataset (`MAINTENANCE_TASK_DOMAIN_TELEMETRY`)

## Fixes from review

- **Deploy-blocker**: `MAINTENANCE_TASK_DOMAIN_TELEMETRY` binding was missing from `wrangler.toml` — would have prevented the Worker from starting
- **Test gap**: Added 6 tests covering the `taskId` path in `CreateMaintenanceRecord` (advance on newer date, no-advance on equal/older, not-found for missing/wrong-owner task, validation error for wrong-asset task)
- **Spec wording**: Corrected acceptance criterion from "greater than or equal to" to "strictly greater than" to match the edge case table and implementation
- **UPSERT clarity**: Added comment to `D1MaintenanceTaskRepository.save()` documenting that only `last_completed_date` and `next_due` are updatable — title and interval are immutable after creation

## Test plan

- [x] `pnpm -r test` — 106 tests pass
- [x] `pnpm lint` — clean
- [x] `pnpm type-check` — clean
- [ ] Apply migration locally: `pnpm --filter @snaveevans/pineapple-api wrangler d1 migrations apply pineapple --local`
- [ ] Smoke test new endpoints against `wrangler dev`
- [ ] Confirm `MAINTENANCE_TASK_DOMAIN_TELEMETRY` Analytics Engine dataset is created in Cloudflare dashboard before deploying

🤖 Generated with [Claude Code](https://claude.com/claude-code)