### PR TITLE
Centralize specs in docs/specs/ and introduce docs/web/FEATURES.md

### DIFF
--- a/.claude/skills/spec-author/SKILL.md
+++ b/.claude/skills/spec-author/SKILL.md
@@ -1,26 +1,17 @@
 ---
 name: spec-author
-description: Draft, document, or revise a feature spec. Walks through persona brainstorming, scenarios, user stories, and all six cross-cutting concerns, and keeps specs organized by package.
+description: Draft, document, or revise a feature spec. Walks through persona brainstorming, scenarios, user stories, and all six cross-cutting concerns.
 ---
 
 Work conversationally. Ask questions and confirm assumptions before writing. Do not generate a full draft until the steps below are complete.
 
 ## Existing specs
 
-!`find apps/api/specs apps/web/specs -name "*.md" 2>/dev/null | sort`
+!`find docs/specs/features -name "*.md" 2>/dev/null | sort`
 
-## Specs are organized by package
+## Where specs live
 
-Specs live with the package they describe (see `docs/specs/SPECS.md`):
-
-- **API capability** (endpoint + validation/ownership/telemetry) → `apps/api/specs/features/`
-- **UX** (a screen/flow) → `apps/web/specs/features/`
-- A full-stack feature is **two specs**, one per package, that link to each other.
-- Cross-cutting concerns are per-package (`apps/<pkg>/specs/cross-cutting/`); the
-  genuine API↔web wire contracts live in `docs/specs/universal/`.
-
-**Before drafting, decide which package(s) the feature touches.** If both, plan to
-write an API capability spec and a web UX spec and cross-link them.
+Specs live in `docs/specs/features/`. They describe API capabilities — endpoints, validation, ownership, domain behavior, and telemetry. UX intent for the web app is documented separately in `docs/web/FEATURES.md` — not as full specs.
 
 ## Figure out what you're doing
 
@@ -63,7 +54,7 @@ and proceed. If not, ask which of the three they want and what the feature is. T
 
 **6. Cross-cutting analysis** — Read and work through [cross-cutting-checklist.md](cross-cutting-checklist.md). Ask the user about unknowns rather than guessing.
 
-**7. Draft** — Read the template at `docs/specs/templates/feature-spec.template.md`, fill it in, and write the spec to the right package: `apps/api/specs/features/[name].md` for an API capability, `apps/web/specs/features/[name].md` for UX. If the feature spans both, write both and cross-link them via the **Counterpart** line. Add an entry to the package's index (`apps/api/specs/SPECS.md` and/or `apps/web/specs/SPECS.md`).
+**7. Draft** — Read the template at `docs/specs/templates/feature-spec.template.md`, fill it in, and write the spec to `docs/specs/features/[name].md`. Add an entry to `docs/specs/SPECS.md`. If the feature has a web UI, note in the spec summary that UX intent belongs in `docs/web/FEATURES.md`.
 
 ---
 
@@ -71,7 +62,7 @@ and proceed. If not, ask which of the three they want and what the feature is. T
 
 **1. Locate the code** — Find relevant files: route handler in `apps/api/src/api/` or `worker.ts`, use case in `apps/api/src/application/usecases/`, UI component in `apps/web/src/`. Ask if unclear.
 
-**2. Check for an existing spec** — Look in `apps/api/specs/features/` and `apps/web/specs/features/`. If it's unclear which package the feature lives in, ask, then use the `Existing specs` list (scoped to that package) to locate or rule out an existing spec. If one exists, read it and note any gaps between spec and code. Remember a full-stack feature may have one spec per package.
+**2. Check for an existing spec** — Look in `docs/specs/features/` using the `Existing specs` list above to locate or rule out an existing spec. If one exists, read it and note any gaps between spec and code.
 
 **3. Describe current behavior** — Summarize what the code actually does: inputs → validation → domain logic → outputs → side effects. Confirm with the user before proceeding.
 
@@ -79,10 +70,10 @@ and proceed. If not, ask which of the three they want and what the feature is. T
 
 **5. Draft or update**
 
-- No spec: draft from `docs/specs/templates/feature-spec.template.md` and write to the right package's `features/` directory (API capability → `apps/api/specs/`, UX → `apps/web/specs/`)
+- No spec: draft from `docs/specs/templates/feature-spec.template.md` and write to `docs/specs/features/[name].md`
 - Existing spec: update to match current behavior. Flag spec-vs-code divergences as `REVIEW NEEDED` flags rather than silently resolving them.
 
-Add or update the entry in the relevant package index (`apps/api/specs/SPECS.md` and/or `apps/web/specs/SPECS.md`).
+Add or update the entry in `docs/specs/SPECS.md`.
 
 ---
 
@@ -90,14 +81,9 @@ Add or update the entry in the relevant package index (`apps/api/specs/SPECS.md`
 
 Use this mode when a spec already exists but has open flags, gaps, or NOT SPECIFIED sections that need design decisions before implementation can begin. The spec is the source of truth — the goal is to produce something complete enough to hand to an implementer.
 
-**0. Locate the spec** — If the user hasn't pinpointed a file:
+**0. Locate the spec** — If the user hasn't pinpointed a file, list the specs from the `Existing specs` output above and have the user pick. Confirm the exact file path before reading.
 
-1. Ask which project the spec lives in — `apps/api` (capabilities) or `apps/web` (UX). A full-stack feature may have one in each.
-2. List the specs in that project from the `Existing specs` output above and have the user pick. Confirm the exact file path(s) before reading.
-
-If the user already named the feature, locate matching files across both packages and confirm which to revise.
-
-**1. Read the spec** — Read the spec in its package (`apps/api/specs/features/[name].md` or `apps/web/specs/features/[name].md`) in full; if the feature spans both packages, read both counterparts. Catalogue every open item:
+**1. Read the spec** — Read `docs/specs/features/[name].md` in full. Catalogue every open item:
 
 - `NOT SPECIFIED` flags — behavior that has never been decided
 - `REVIEW NEEDED` flags — behavior that exists but needs a decision
@@ -118,7 +104,7 @@ Work through decisions conversationally. Do not resolve a flag by guessing — i
 
 **5. Cross-cutting analysis** — Read and work through [cross-cutting-checklist.md](cross-cutting-checklist.md) against the **intended** behavior (decisions made in step 3), not the current code. Flag anything still unresolved.
 
-**6. Update the spec** — Rewrite or update the spec in its package (and its counterpart if the change crosses the API↔web seam):
+**6. Update the spec** — Rewrite or update `docs/specs/features/[name].md`:
 
 - Replace resolved flags with acceptance criteria or edge case table rows
 - Remove flags that are explicitly out of scope (add to Out of Scope section instead)
@@ -131,9 +117,9 @@ Work through decisions conversationally. Do not resolve a flag by guessing — i
 
 Before writing the file, verify:
 
-- The spec is in the correct package directory for what it covers (API capability vs UX)
+- The spec lives in `docs/specs/features/`
 - Every user story maps to at least one acceptance criterion
-- Every cross-cutting concern for that package has been addressed or explicitly flagged
-- **API specs only:** the Telemetry section names the operation(s) and states whether domain events apply
-- If the feature spans both packages, the API and web specs reference each other via the Counterpart line and neither duplicates the other's half
+- Every cross-cutting concern has been addressed or explicitly flagged
+- The Telemetry section names the operation(s) and states whether domain events apply
+- If the feature has a web UI, confirm the relevant entry in `docs/web/FEATURES.md` is up to date
 - Anything unresolved is a named flag, not a missing section

--- a/.claude/skills/spec-implement/SKILL.md
+++ b/.claude/skills/spec-implement/SKILL.md
@@ -9,11 +9,11 @@ Do NOT expect a command argument. Work out which spec to implement from git stat
 
 ```!
 echo "── Uncommitted spec changes ──"
-git status --porcelain -- 'apps/*/specs/**/*.md'
+git status --porcelain -- 'docs/specs/**/*.md'
 echo "── Spec files changed vs main ──"
-git diff --name-only main -- 'apps/*/specs/**/*.md' 2>/dev/null
+git diff --name-only main -- 'docs/specs/**/*.md' 2>/dev/null
 echo "── Recently committed specs ──"
-git log --oneline -10 --name-only -- 'apps/*/specs/**/*.md' 2>/dev/null
+git log --oneline -10 --name-only -- 'docs/specs/**/*.md' 2>/dev/null
 ```
 
 Use the output to pick the target and the mode:
@@ -27,11 +27,8 @@ Propose the spec file(s) and the mode you inferred in one line and confirm with 
 
 ## Pre-flight (both modes)
 
-Specs are organized by package (see `docs/specs/SPECS.md`). A feature may have an
-API capability spec (`apps/api/specs/features/[name].md`), a web UX spec
-(`apps/web/specs/features/[name].md`), or both. Read **every** spec that exists for
-the feature — the API spec drives the backend layers, the web spec drives the
-frontend. Then verify each:
+Specs live in `docs/specs/features/` (see `docs/specs/SPECS.md`). Read the spec for
+the feature before proceeding. Then verify:
 
 1. **Status is not `wip`** — WIP specs are not ready to implement. Stop and tell the user to run `/spec-author` first to complete the spec.
 2. **No blocking `NOT SPECIFIED` flags** — any flag whose resolution would change what code to write is a blocker. Surface them and ask the user to resolve before continuing.
@@ -73,13 +70,11 @@ Implement only the delta between the spec's last committed state and its current
 
 **1. Get the spec diff**
 
-Run a diff against the spec file(s) you identified in **Find the target spec** (substitute the detected path; a full-stack feature has one per package, so run it for each):
+Run a diff against the spec file identified in **Find the target spec** (substitute the detected path):
 
 ```
 git diff main -- "<detected-spec-path>" 2>/dev/null || git diff HEAD~1 -- "<detected-spec-path>" 2>/dev/null || echo "No diff found — spec may not have changed since main"
 ```
-
-A full-stack feature may show a diff in both the API and web specs. Interpret each.
 
 If no diff is found, ask the user to confirm which version of the spec changed and how.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,7 @@ secrets, never committed.
 - **API contract** → [`docs/reference/api.md`](docs/reference/api.md), `docs/reference/openapi.json`
 - **Data shapes** → [`docs/reference/data-model.md`](docs/reference/data-model.md)
 - **Product behavior / features** → [`docs/specs/SPECS.md`](docs/specs/SPECS.md)
+- **Web app feature intent** → [`docs/web/FEATURES.md`](docs/web/FEATURES.md)
 - **How we document** → [`docs/README.md`](docs/README.md)
 
 ## Workflow
@@ -128,3 +129,7 @@ secrets, never committed.
 Work on a branch, open a PR (CI must pass), merge → auto-deploys to Cloudflare.
 Don't commit to `main` directly. End commit messages with the Co-Authored-By
 trailer.
+
+When making a meaningful change to `apps/web` — adding a screen, changing a user
+flow, adding or removing a feature — read `docs/web/FEATURES.md` and update it to
+reflect the current state.

--- a/docs/web/FEATURES.md
+++ b/docs/web/FEATURES.md
@@ -1,0 +1,134 @@
+# Web App Features
+
+Intent ledger for `apps/web`. Each entry captures the user goal, key states, and
+non-obvious edge cases — not component structure or visual design. Update this file
+when adding a screen, changing a flow, or removing a feature.
+
+For the API contract behind each feature, see the linked spec in `docs/specs/features/`.
+
+---
+
+## Marketing Home
+
+**Route:** `/`
+**Goal:** Communicate the product's value to prospective users and route them to sign-up or login.
+
+**Key states:**
+
+- Default (unauthenticated / session check in flight): full nav and hero CTAs for sign-up and login
+- Authenticated: all login-destined CTAs swap to a single "Go to App" button (→ `/app`); footer login link is removed
+- Session check failure (network error, 4xx/5xx): silently falls back to unauthenticated state — no error shown
+
+**Non-obvious behavior:**
+
+- The unauthenticated button set renders immediately on load (no spinner/placeholder), so there's no layout shift in the common case
+- Authenticated users are not redirected away — they may intentionally visit the marketing page
+
+**Spec:** [`docs/specs/features/marketing-home.md`](../specs/features/marketing-home.md)
+
+---
+
+## Sign In
+
+**Route:** `/login`
+**Goal:** Let the user authenticate via Google OAuth and land in the app.
+
+**Key states:**
+
+- Default: Google sign-in button
+- In-flight: button disabled while OAuth redirect is pending
+- Error: auth failure surfaces an error message inline
+
+**Non-obvious behavior:**
+
+- Supports `?mode=signup` and `?mode=login` query params; both go through the same Google OAuth flow — the distinction is cosmetic copy only
+- On success, redirects to `/app`
+
+**Spec:** [`docs/specs/features/sign-in.md`](../specs/features/sign-in.md)
+
+---
+
+## Dashboard (Home)
+
+**Route:** `/app`
+**Goal:** Give the authenticated user an at-a-glance view of upcoming and overdue service across their fleet, with a master/detail layout for acting on the next item.
+
+**Key states:**
+
+- Urgency-sorted queue of assets with overdue/soon/ok status indicators
+- Detail card (desktop) or inline expand (mobile) for the selected queue item
+- Actions on the detail: Mark complete, Reschedule, Snooze (UI present; not yet wired to API)
+
+**Non-obvious behavior:**
+
+- Currently renders hardcoded prototype data — not yet connected to the live API
+- Category filter chips and "Add service" button are present in the UI but not yet functional
+- 401 from the API (when wired) should redirect to `/login`
+
+---
+
+## Asset Library
+
+**Route:** `/app/assets`
+**Goal:** Let the user see all their assets and navigate to any asset's maintenance history.
+
+**Key states:**
+
+- Loading: skeleton/loading state while fetching
+- Empty: prompt to add first asset with a direct link to the add form
+- Populated: grid view (default) and row view; each card links to `/app/assets/:id/maintenance`
+- Error: inline error message with a "Try again" retry button
+
+**Non-obvious behavior:**
+
+- Search input and category filter chips render but are disabled (not yet implemented)
+- View toggle (grid/list) renders but is disabled
+- 401 response redirects to `/login` without retrying
+
+---
+
+## Add Asset
+
+**Route:** `/app/assets/new`
+**Goal:** Let the user register a new asset (vehicle, equipment, or property) with a name, type, and optional notes.
+
+**Key states:**
+
+- Idle: blank form
+- Validation error: inline field errors on submit with focus moved to the first invalid field
+- Submitting: form disabled while the API call is in flight
+- Success: redirects to `/app/assets` and invalidates the assets query cache
+- API error: inline error message; form re-enabled for correction
+
+**Non-obvious behavior:**
+
+- 401 on submit redirects to `/login`
+- Client-side validation runs before the API call; field errors map from the API's 422 response if server validation also fails
+
+**Spec:** [`docs/specs/features/create-asset.md`](../specs/features/create-asset.md)
+
+---
+
+## Asset Maintenance Records & Tasks
+
+**Route:** `/app/assets/:id/maintenance`
+**Goal:** Let the user view and log maintenance history for a specific asset, and manage upcoming maintenance tasks for it.
+
+**Key states:**
+
+- Loading: fetching asset, records, and tasks in parallel
+- Asset not found / 403: redirect to `/app/assets`
+- Empty records: prompt to log first record
+- Empty tasks: prompt to add first task
+- Populated: chronological list of records; task list with overdue/upcoming indicators
+- Create record form: inline or modal; validates date and description; submits to API
+- Create task form: inline; validates title and due date
+- Delete task: confirmation before removal
+
+**Non-obvious behavior:**
+
+- Records and tasks are fetched independently; one can load before the other
+- Dates are stored as ISO strings (YYYY-MM-DD) and displayed as human-readable relative dates ("3 days ago", "yesterday")
+- 401 on any fetch redirects to `/login`
+
+**Spec:** [`docs/specs/features/maintenance-record.md`](../specs/features/maintenance-record.md), [`docs/specs/features/maintenance-task.md`](../specs/features/maintenance-task.md)


### PR DESCRIPTION
## Summary

- **Reverts per-package spec directories** — the `spec-author` and `spec-implement` skills were recently updated to use `apps/api/specs/` and `apps/web/specs/`. This PR reverts that: specs belong in `docs/specs/features/` (centralized), not co-located with packages.
- **Specs are API-only** — full UX specs for the web app aren't worth their maintenance cost. The spec skills now clearly document this: specs describe API capabilities; web UX intent goes in `docs/web/FEATURES.md`.
- **Introduces `docs/web/FEATURES.md`** — lightweight intent ledger for the web app covering all six current screens (Marketing Home, Sign In, Dashboard, Asset Library, Add Asset, Maintenance Records & Tasks). Each entry has a user goal, key states, non-obvious edge cases, and links to the relevant API spec.
- **Updates `CLAUDE.md`** — adds `docs/web/FEATURES.md` to "Where to look" and adds a workflow note directing agents to update the file on meaningful web app changes.

## Test plan

- [ ] Run `/spec-author` and confirm it proposes `docs/specs/features/` paths, not `apps/*/specs/`
- [ ] Run `/spec-implement` and confirm the git diff commands target `docs/specs/**/*.md`
- [ ] Review `docs/web/FEATURES.md` entries for accuracy against the current app

🤖 Generated with [Claude Code](https://claude.com/claude-code)