### PR TITLE
[codex] Specify dashboard API read model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,12 @@ repositories live in `worker.ts`. Keep it that way.
   schemas in `api/schemas/` use `z` from `@hono/zod-openapi` and carry
   `.openapi()` metadata — they are the single source for both validation and
   the generated API spec.
+- **Computed fields belong in the API:** derived values — status labels
+  (`overdue`/`soon`/`ok`), counts per bucket, available filter categories —
+  are computed in the application layer and included in read model responses.
+  Clients render what the API gives them; they do not recompute business logic
+  from raw data. UI-only state (which filter is selected, hover state) stays in
+  the client. (ADR-0009)
 
 ## API documentation is generated — don't hand-edit the spec
 

--- a/apps/api/src/api/middleware/technicalTelemetry.test.ts
+++ b/apps/api/src/api/middleware/technicalTelemetry.test.ts
@@ -72,6 +72,33 @@ describe("buildApiRequestTelemetryDataPoint", () => {
     });
   });
 
+  it("maps GET /api/dashboard to GetDashboard", () => {
+    expect(
+      buildApiRequestTelemetryDataPoint({
+        method: "GET",
+        pathname: "/api/dashboard",
+        status: 200,
+        durationMs: 1,
+        requestSizeBytes: 0,
+        authenticated: true,
+        error: null,
+      }),
+    ).toMatchObject({
+      indexes: ["GetDashboard"],
+      blobs: [
+        "GetDashboard",
+        "/api/dashboard",
+        "GET",
+        "2xx",
+        "200",
+        "success",
+        "none",
+        "true",
+        "v1",
+      ],
+    });
+  });
+
   it.each([
     ["GET", "GetUserProfile"],
     ["PATCH", "UpdateUserProfile"],

--- a/apps/api/src/api/middleware/technicalTelemetry.ts
+++ b/apps/api/src/api/middleware/technicalTelemetry.ts
@@ -109,6 +109,9 @@ function routeTelemetry(method: string, pathname: string): RouteTelemetry {
   if (pathname.startsWith("/api/auth/")) {
     return { operation: "Auth", routePattern: "/api/auth/*" };
   }
+  if (pathname === "/api/dashboard" && method === "GET") {
+    return { operation: "GetDashboard", routePattern: "/api/dashboard" };
+  }
   if (pathname === "/api/users/me" && method === "GET") {
     return { operation: "GetUserProfile", routePattern: "/api/users/me" };
   }

--- a/apps/api/src/api/openapi.ts
+++ b/apps/api/src/api/openapi.ts
@@ -21,6 +21,7 @@ import {
   MaintenanceTaskParamsSchema,
   MaintenanceTaskResponseSchema,
 } from "./schemas/maintenanceTaskSchemas.ts";
+import { DashboardResponseSchema } from "./schemas/dashboardSchemas.ts";
 import {
   UpdateUserProfileBodySchema,
   UserProfileResponseSchema,
@@ -65,6 +66,10 @@ export const openApiConfig = {
     {
       name: "Users",
       description: "Read and update the authenticated user's domain profile",
+    },
+    {
+      name: "Dashboard",
+      description: "Authenticated home-screen read model for fleet health and maintenance queue",
     },
   ],
 };
@@ -299,6 +304,26 @@ export const listMaintenanceTasksRoute = createRoute({
   },
 });
 
+export const getDashboardRoute = createRoute({
+  method: "get",
+  path: "/api/dashboard",
+  tags: ["Dashboard"],
+  summary: "Get my dashboard",
+  description:
+    "Returns fleet totals, maintenance health counts, and the cross-asset maintenance queue for the authenticated user in a single response.",
+  security: [cookieAuth],
+  responses: {
+    200: {
+      description: "The caller's dashboard read model",
+      content: { "application/json": { schema: DashboardResponseSchema } },
+    },
+    401: {
+      description: "Not authenticated",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
 export const getUserProfileRoute = createRoute({
   method: "get",
   path: "/api/users/me",
@@ -410,6 +435,7 @@ export function getApiDocument() {
   doc.openapi(createMaintenanceTaskRoute, stub);
   doc.openapi(listMaintenanceTasksRoute, stub);
   doc.openapi(deleteMaintenanceTaskRoute, stub);
+  doc.openapi(getDashboardRoute, stub);
   doc.openapi(getUserProfileRoute, stub);
   doc.openapi(updateUserProfileRoute, stub);
   registerOpenApiComponents(doc.openAPIRegistry);

--- a/apps/api/src/api/schemas/dashboardSchemas.ts
+++ b/apps/api/src/api/schemas/dashboardSchemas.ts
@@ -7,12 +7,10 @@ const AssetTypeSchema = z
 
 const IntervalUnitSchema = z.enum(["day", "week", "month", "year"]).openapi({ example: "month" });
 
-const TaskUrgencyStatusSchema = z
-  .enum(["overdue", "soon", "ok"])
-  .openapi({
-    example: "soon",
-    description: "Derived from nextDue and todayUtc using calendar-day rules",
-  });
+const TaskUrgencyStatusSchema = z.enum(["overdue", "soon", "ok"]).openapi({
+  example: "soon",
+  description: "Derived from nextDue and todayUtc using calendar-day rules",
+});
 
 export const DashboardFleetTotalsSchema = z
   .object({
@@ -32,6 +30,15 @@ export const DashboardFleetHealthSchema = z
   })
   .openapi("DashboardFleetHealth");
 
+export const DashboardQueueCountsSchema = z
+  .object({
+    all: z.number().int().nonnegative().openapi({ example: 5 }),
+    vehicle: z.number().int().nonnegative().openapi({ example: 2 }),
+    equipment: z.number().int().nonnegative().openapi({ example: 2 }),
+    property: z.number().int().nonnegative().openapi({ example: 1 }),
+  })
+  .openapi("DashboardQueueCounts");
+
 export const DashboardQueueItemSchema = z
   .object({
     taskId: z.string().uuid().openapi({ example: "a1b2c3d4-e5f6-7890-abcd-ef1234567890" }),
@@ -50,19 +57,17 @@ export const DashboardQueueItemSchema = z
 
 export const DashboardResponseSchema = z
   .object({
-    viewerDisplayName: z
-      .string()
-      .nullable()
-      .openapi({
-        example: "Dale",
-        description: "Authenticated user's display name when available",
-      }),
+    viewerDisplayName: z.string().nullable().openapi({
+      example: "Dale",
+      description: "Authenticated user's display name when available",
+    }),
     todayUtc: DateOnlySchema.openapi({
       example: "2026-06-16",
       description: "Server-side UTC calendar date used for urgency calculations",
     }),
     fleetTotals: DashboardFleetTotalsSchema,
     fleetHealth: DashboardFleetHealthSchema,
+    queueCountsByCategory: DashboardQueueCountsSchema,
     queue: z.array(DashboardQueueItemSchema),
   })
   .openapi("DashboardResponse");

--- a/apps/api/src/api/schemas/dashboardSchemas.ts
+++ b/apps/api/src/api/schemas/dashboardSchemas.ts
@@ -1,0 +1,68 @@
+import { z } from "@hono/zod-openapi";
+import { DateOnlySchema } from "./shared.ts";
+
+const AssetTypeSchema = z
+  .enum(["vehicle", "property", "equipment"])
+  .openapi({ example: "vehicle" });
+
+const IntervalUnitSchema = z.enum(["day", "week", "month", "year"]).openapi({ example: "month" });
+
+const TaskUrgencyStatusSchema = z
+  .enum(["overdue", "soon", "ok"])
+  .openapi({
+    example: "soon",
+    description: "Derived from nextDue and todayUtc using calendar-day rules",
+  });
+
+export const DashboardFleetTotalsSchema = z
+  .object({
+    total: z.number().int().nonnegative().openapi({ example: 6 }),
+    vehicle: z.number().int().nonnegative().openapi({ example: 2 }),
+    equipment: z.number().int().nonnegative().openapi({ example: 2 }),
+    property: z.number().int().nonnegative().openapi({ example: 2 }),
+  })
+  .openapi("DashboardFleetTotals");
+
+export const DashboardFleetHealthSchema = z
+  .object({
+    overdue: z.number().int().nonnegative().openapi({ example: 1 }),
+    soon: z.number().int().nonnegative().openapi({ example: 2 }),
+    onTrack: z.number().int().nonnegative().openapi({ example: 2 }),
+    unscheduled: z.number().int().nonnegative().openapi({ example: 1 }),
+  })
+  .openapi("DashboardFleetHealth");
+
+export const DashboardQueueItemSchema = z
+  .object({
+    taskId: z.string().uuid().openapi({ example: "a1b2c3d4-e5f6-7890-abcd-ef1234567890" }),
+    taskTitle: z.string().openapi({ example: "Oil change + tire rotation" }),
+    nextDue: DateOnlySchema,
+    status: TaskUrgencyStatusSchema,
+    intervalValue: z.number().int().openapi({ example: 3 }),
+    intervalUnit: IntervalUnitSchema,
+    lastCompletedDate: DateOnlySchema.nullable().openapi({ example: "2026-03-14" }),
+    createdAt: z.string().datetime().openapi({ example: "2026-01-15T12:00:00.000Z" }),
+    assetId: z.string().uuid().openapi({ example: "195d0ef0-47f5-439f-abfd-29f892c9a040" }),
+    assetName: z.string().openapi({ example: "Ford F-150 · Truck #4" }),
+    assetType: AssetTypeSchema,
+  })
+  .openapi("DashboardQueueItem");
+
+export const DashboardResponseSchema = z
+  .object({
+    viewerDisplayName: z
+      .string()
+      .nullable()
+      .openapi({
+        example: "Dale",
+        description: "Authenticated user's display name when available",
+      }),
+    todayUtc: DateOnlySchema.openapi({
+      example: "2026-06-16",
+      description: "Server-side UTC calendar date used for urgency calculations",
+    }),
+    fleetTotals: DashboardFleetTotalsSchema,
+    fleetHealth: DashboardFleetHealthSchema,
+    queue: z.array(DashboardQueueItemSchema),
+  })
+  .openapi("DashboardResponse");

--- a/apps/api/src/api/schemas/dashboardSchemas.ts
+++ b/apps/api/src/api/schemas/dashboardSchemas.ts
@@ -45,6 +45,10 @@ export const DashboardQueueItemSchema = z
     taskTitle: z.string().openapi({ example: "Oil change + tire rotation" }),
     nextDue: DateOnlySchema,
     status: TaskUrgencyStatusSchema,
+    daysDue: z.number().int().openapi({
+      example: -3,
+      description: "Signed calendar-day distance from todayUtc to nextDue; negative means overdue",
+    }),
     intervalValue: z.number().int().openapi({ example: 3 }),
     intervalUnit: IntervalUnitSchema,
     lastCompletedDate: DateOnlySchema.nullable().openapi({ example: "2026-03-14" }),

--- a/apps/api/src/api/schemas/dashboardSchemas.ts
+++ b/apps/api/src/api/schemas/dashboardSchemas.ts
@@ -1,16 +1,11 @@
 import { z } from "@hono/zod-openapi";
-import { DateOnlySchema } from "./shared.ts";
+import { DateOnlySchema, TaskUrgencyStatusSchema } from "./shared.ts";
 
 const AssetTypeSchema = z
   .enum(["vehicle", "property", "equipment"])
   .openapi({ example: "vehicle" });
 
 const IntervalUnitSchema = z.enum(["day", "week", "month", "year"]).openapi({ example: "month" });
-
-const TaskUrgencyStatusSchema = z.enum(["overdue", "soon", "ok"]).openapi({
-  example: "soon",
-  description: "Derived from nextDue and todayUtc using calendar-day rules",
-});
 
 export const DashboardFleetTotalsSchema = z
   .object({

--- a/apps/api/src/api/schemas/maintenanceTaskSchemas.ts
+++ b/apps/api/src/api/schemas/maintenanceTaskSchemas.ts
@@ -1,5 +1,5 @@
 import { z } from "@hono/zod-openapi";
-import { DateOnlySchema } from "./shared.ts";
+import { DateOnlySchema, TaskUrgencyStatusSchema } from "./shared.ts";
 
 const IntervalUnitSchema = z.enum(["day", "week", "month", "year"]).openapi({ example: "month" });
 
@@ -57,6 +57,11 @@ export const MaintenanceTaskResponseSchema = z
     intervalUnit: IntervalUnitSchema,
     lastCompletedDate: DateOnlySchema.nullable().openapi({ example: "2026-04-11" }),
     nextDue: DateOnlySchema.openapi({ example: "2026-06-11" }),
+    status: TaskUrgencyStatusSchema,
+    daysDue: z.number().int().openapi({
+      example: 5,
+      description: "Signed calendar-day distance from todayUtc to nextDue; negative means overdue",
+    }),
     createdAt: z.string().datetime().openapi({ example: "2026-06-11T18:25:24.887Z" }),
   })
   .openapi("MaintenanceTask");

--- a/apps/api/src/api/schemas/shared.ts
+++ b/apps/api/src/api/schemas/shared.ts
@@ -6,3 +6,8 @@ export const DateOnlySchema = z
   .regex(/^\d{4}-\d{2}-\d{2}$/, "Date must use YYYY-MM-DD format")
   .refine(isValidDateOnly, "Date must be a valid calendar date")
   .openapi({ format: "date", example: "2026-06-09" });
+
+export const TaskUrgencyStatusSchema = z.enum(["overdue", "soon", "ok"]).openapi({
+  example: "soon",
+  description: "Derived from nextDue and todayUtc using calendar-day rules",
+});

--- a/apps/api/src/application/usecases/CreateMaintenanceRecord.test.ts
+++ b/apps/api/src/application/usecases/CreateMaintenanceRecord.test.ts
@@ -52,6 +52,9 @@ class MaintenanceTaskRepositoryFake implements MaintenanceTaskRepository {
   findByAsset(): Promise<MaintenanceTask[]> {
     return Promise.resolve([]);
   }
+  findByOwnerForActiveAssets(): Promise<MaintenanceTask[]> {
+    return Promise.resolve([]);
+  }
   findById(): Promise<MaintenanceTask | null> {
     return Promise.resolve(this.task);
   }

--- a/apps/api/src/application/usecases/CreateMaintenanceTask.test.ts
+++ b/apps/api/src/application/usecases/CreateMaintenanceTask.test.ts
@@ -34,6 +34,9 @@ class MaintenanceTaskRepositoryFake implements MaintenanceTaskRepository {
   findByAsset(): Promise<MaintenanceTask[]> {
     return Promise.resolve([]);
   }
+  findByOwnerForActiveAssets(): Promise<MaintenanceTask[]> {
+    return Promise.resolve([]);
+  }
   findById(): Promise<MaintenanceTask | null> {
     return Promise.resolve(null);
   }

--- a/apps/api/src/application/usecases/DeleteMaintenanceTask.test.ts
+++ b/apps/api/src/application/usecases/DeleteMaintenanceTask.test.ts
@@ -18,6 +18,9 @@ class MaintenanceTaskRepositoryFake implements MaintenanceTaskRepository {
   findByAsset(): Promise<MaintenanceTask[]> {
     return Promise.resolve([]);
   }
+  findByOwnerForActiveAssets(): Promise<MaintenanceTask[]> {
+    return Promise.resolve([]);
+  }
   findById(): Promise<MaintenanceTask | null> {
     return Promise.resolve(this.task);
   }

--- a/apps/api/src/application/usecases/GetDashboard.test.ts
+++ b/apps/api/src/application/usecases/GetDashboard.test.ts
@@ -183,7 +183,9 @@ describe("GetDashboard", () => {
       "Blade sharpen",
     ]);
     expect(result.value.queue[0]?.status).toBe("overdue");
+    expect(result.value.queue[0]?.daysDue).toBe(-6);
     expect(result.value.queue[2]?.status).toBe("soon");
+    expect(result.value.queue[2]?.daysDue).toBe(4);
     expect(result.value.queueCountsByCategory).toEqual({
       all: 3,
       vehicle: 2,
@@ -205,9 +207,9 @@ describe("GetDashboard", () => {
     });
     const result = await new GetDashboard(
       new AssetRepositoryFake([active, archived]),
+      // findByOwnerForActiveAssets omits archived-asset tasks; see D1MaintenanceTaskRepository.test.ts
       new MaintenanceTaskRepositoryFake([
         task(active.id, { title: "Oil change", nextDue: "2026-06-20" }),
-        task(archived.id, { title: "Archived task", nextDue: "2026-06-10" }),
       ]),
       new FixedDateProvider(todayUtc),
     ).execute({ ownerId, viewerDisplayName: "Dale" });

--- a/apps/api/src/application/usecases/GetDashboard.test.ts
+++ b/apps/api/src/application/usecases/GetDashboard.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from "vitest";
+import { AssetId, MaintenanceTaskId, UserId } from "@snaveevans/pineapple-shared";
+import { Asset } from "../../domain/asset/Asset.ts";
+import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
+import { MaintenanceTask } from "../../domain/maintenance/MaintenanceTask.ts";
+import type { MaintenanceTaskRepository } from "../../domain/maintenance/MaintenanceTaskRepository.ts";
+import type { UtcDateProvider } from "../ports/UtcDateProvider.ts";
+import { GetDashboard } from "./GetDashboard.ts";
+
+class FixedDateProvider implements UtcDateProvider {
+  constructor(private readonly todayUtc: string) {}
+  today(): string {
+    return this.todayUtc;
+  }
+}
+
+class AssetRepositoryFake implements AssetRepository {
+  constructor(private readonly assets: Asset[]) {}
+  findById(): Promise<Asset | null> {
+    return Promise.resolve(null);
+  }
+  findByOwner(): Promise<Asset[]> {
+    return Promise.resolve(this.assets);
+  }
+  save(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+class MaintenanceTaskRepositoryFake implements MaintenanceTaskRepository {
+  constructor(private readonly tasks: MaintenanceTask[] = []) {}
+  findByAsset(): Promise<MaintenanceTask[]> {
+    return Promise.resolve([]);
+  }
+  findByOwnerForActiveAssets(): Promise<MaintenanceTask[]> {
+    return Promise.resolve(this.tasks);
+  }
+  findById(): Promise<MaintenanceTask | null> {
+    return Promise.resolve(null);
+  }
+  save(): Promise<void> {
+    return Promise.resolve();
+  }
+  delete(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+describe("GetDashboard", () => {
+  const ownerId = UserId.generate();
+  const todayUtc = "2026-06-16";
+
+  function vehicle(name = "Truck") {
+    return Asset.create({
+      ownerId,
+      name,
+      metadata: { kind: "vehicle", make: "Ford", model: "F-150", year: 2020 },
+    });
+  }
+
+  function equipment(name = "Mower") {
+    return Asset.create({
+      ownerId,
+      name,
+      metadata: { kind: "equipment" },
+    });
+  }
+
+  function task(
+    assetId: AssetId,
+    props: {
+      title: string;
+      nextDue: string;
+      createdAt?: Date;
+      lastCompletedDate?: string | null;
+    },
+  ) {
+    return MaintenanceTask.reconstitute({
+      id: MaintenanceTaskId.generate(),
+      assetId,
+      ownerId,
+      title: props.title,
+      intervalValue: 1,
+      intervalUnit: "month",
+      lastCompletedDate: props.lastCompletedDate ?? null,
+      nextDue: props.nextDue,
+      createdAt: props.createdAt ?? new Date("2026-01-01T00:00:00.000Z"),
+    });
+  }
+
+  it("returns empty dashboard state when the owner has no active assets", async () => {
+    const result = await new GetDashboard(
+      new AssetRepositoryFake([]),
+      new MaintenanceTaskRepositoryFake([]),
+      new FixedDateProvider(todayUtc),
+    ).execute({ ownerId, viewerDisplayName: "Dale" });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toEqual({
+      viewerDisplayName: "Dale",
+      todayUtc,
+      fleetTotals: { total: 0, vehicle: 0, equipment: 0, property: 0 },
+      fleetHealth: { overdue: 0, soon: 0, onTrack: 0, unscheduled: 0 },
+      queue: [],
+    });
+  });
+
+  it("counts unscheduled assets separately from on-track assets", async () => {
+    const truck = vehicle();
+    const mower = equipment();
+    const result = await new GetDashboard(
+      new AssetRepositoryFake([truck, mower]),
+      new MaintenanceTaskRepositoryFake([
+        task(truck.id, { title: "Oil change", nextDue: "2026-08-01" }),
+      ]),
+      new FixedDateProvider(todayUtc),
+    ).execute({ ownerId, viewerDisplayName: null });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.fleetTotals.total).toBe(2);
+    expect(result.value.fleetHealth).toEqual({
+      overdue: 0,
+      soon: 0,
+      onTrack: 1,
+      unscheduled: 1,
+    });
+  });
+
+  it("uses the most urgent task per asset for fleet health counts", async () => {
+    const truck = vehicle();
+    const result = await new GetDashboard(
+      new AssetRepositoryFake([truck]),
+      new MaintenanceTaskRepositoryFake([
+        task(truck.id, { title: "Annual inspection", nextDue: "2026-08-01" }),
+        task(truck.id, { title: "Oil change", nextDue: "2026-06-10" }),
+      ]),
+      new FixedDateProvider(todayUtc),
+    ).execute({ ownerId, viewerDisplayName: "Dale" });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.fleetHealth).toEqual({
+      overdue: 1,
+      soon: 0,
+      onTrack: 0,
+      unscheduled: 0,
+    });
+  });
+
+  it("sorts queue items by urgency, nextDue, then createdAt", async () => {
+    const truck = vehicle();
+    const mower = equipment();
+    const result = await new GetDashboard(
+      new AssetRepositoryFake([truck, mower]),
+      new MaintenanceTaskRepositoryFake([
+        task(mower.id, {
+          title: "Blade sharpen",
+          nextDue: "2026-06-20",
+          createdAt: new Date("2026-02-01T00:00:00.000Z"),
+        }),
+        task(truck.id, {
+          title: "Oil change",
+          nextDue: "2026-06-10",
+          createdAt: new Date("2026-01-01T00:00:00.000Z"),
+        }),
+        task(truck.id, {
+          title: "Tire rotation",
+          nextDue: "2026-06-10",
+          createdAt: new Date("2026-03-01T00:00:00.000Z"),
+        }),
+      ]),
+      new FixedDateProvider(todayUtc),
+    ).execute({ ownerId, viewerDisplayName: "Dale" });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.queue.map((item) => item.taskTitle)).toEqual([
+      "Oil change",
+      "Tire rotation",
+      "Blade sharpen",
+    ]);
+    expect(result.value.queue[0]?.status).toBe("overdue");
+    expect(result.value.queue[2]?.status).toBe("soon");
+  });
+
+  it("excludes archived assets from totals and queue", async () => {
+    const active = vehicle("Active truck");
+    const archived = Asset.reconstitute({
+      id: AssetId.generate(),
+      ownerId,
+      name: "Archived truck",
+      metadata: { kind: "vehicle", make: "Ford", model: "Transit", year: 2019 },
+      archivedAt: new Date("2026-05-01T00:00:00.000Z"),
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-05-01T00:00:00.000Z"),
+    });
+    const result = await new GetDashboard(
+      new AssetRepositoryFake([active, archived]),
+      new MaintenanceTaskRepositoryFake([
+        task(active.id, { title: "Oil change", nextDue: "2026-06-20" }),
+        task(archived.id, { title: "Archived task", nextDue: "2026-06-10" }),
+      ]),
+      new FixedDateProvider(todayUtc),
+    ).execute({ ownerId, viewerDisplayName: "Dale" });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.fleetTotals.total).toBe(1);
+    expect(result.value.queue).toHaveLength(1);
+    expect(result.value.queue[0]?.assetName).toBe("Active truck");
+  });
+});

--- a/apps/api/src/application/usecases/GetDashboard.test.ts
+++ b/apps/api/src/application/usecases/GetDashboard.test.ts
@@ -194,6 +194,32 @@ describe("GetDashboard", () => {
     });
   });
 
+  it("omits tasks whose asset is absent from the active asset snapshot", async () => {
+    const truck = vehicle("Active truck");
+    const archived = Asset.reconstitute({
+      id: AssetId.generate(),
+      ownerId,
+      name: "Archived truck",
+      metadata: { kind: "vehicle", make: "Ford", model: "Transit", year: 2019 },
+      archivedAt: new Date("2026-05-01T00:00:00.000Z"),
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-05-01T00:00:00.000Z"),
+    });
+    const result = await new GetDashboard(
+      new AssetRepositoryFake([truck, archived]),
+      new MaintenanceTaskRepositoryFake([
+        task(truck.id, { title: "Active task", nextDue: "2026-06-20" }),
+        task(archived.id, { title: "Orphan task", nextDue: "2026-06-10" }),
+      ]),
+      new FixedDateProvider(todayUtc),
+    ).execute({ ownerId, viewerDisplayName: "Dale" });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.queue).toHaveLength(1);
+    expect(result.value.queue[0]?.taskTitle).toBe("Active task");
+  });
+
   it("excludes archived assets from totals and queue", async () => {
     const active = vehicle("Active truck");
     const archived = Asset.reconstitute({

--- a/apps/api/src/application/usecases/GetDashboard.test.ts
+++ b/apps/api/src/application/usecases/GetDashboard.test.ts
@@ -102,6 +102,7 @@ describe("GetDashboard", () => {
       todayUtc,
       fleetTotals: { total: 0, vehicle: 0, equipment: 0, property: 0 },
       fleetHealth: { overdue: 0, soon: 0, onTrack: 0, unscheduled: 0 },
+      queueCountsByCategory: { all: 0, vehicle: 0, equipment: 0, property: 0 },
       queue: [],
     });
   });
@@ -183,6 +184,12 @@ describe("GetDashboard", () => {
     ]);
     expect(result.value.queue[0]?.status).toBe("overdue");
     expect(result.value.queue[2]?.status).toBe("soon");
+    expect(result.value.queueCountsByCategory).toEqual({
+      all: 3,
+      vehicle: 2,
+      equipment: 1,
+      property: 0,
+    });
   });
 
   it("excludes archived assets from totals and queue", async () => {

--- a/apps/api/src/application/usecases/GetDashboard.ts
+++ b/apps/api/src/application/usecases/GetDashboard.ts
@@ -1,0 +1,182 @@
+import {
+  type DomainError,
+  DomainError as DomainErrorClass,
+  ok,
+  err,
+  type Result,
+  type UserId,
+} from "@snaveevans/pineapple-shared";
+import type { Asset } from "../../domain/asset/Asset.ts";
+import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
+import type { AssetType } from "../../domain/asset/AssetType.ts";
+import type { MaintenanceTask } from "../../domain/maintenance/MaintenanceTask.ts";
+import type { MaintenanceTaskRepository } from "../../domain/maintenance/MaintenanceTaskRepository.ts";
+import {
+  compareTaskUrgency,
+  deriveTaskStatus,
+  mostUrgentTaskStatus,
+  type TaskUrgencyStatus,
+} from "../../domain/maintenance/TaskUrgency.ts";
+import type { UtcDateProvider } from "../ports/UtcDateProvider.ts";
+
+export type DashboardFleetTotals = {
+  total: number;
+  vehicle: number;
+  equipment: number;
+  property: number;
+};
+
+export type DashboardFleetHealth = {
+  overdue: number;
+  soon: number;
+  onTrack: number;
+  unscheduled: number;
+};
+
+export type DashboardQueueItem = {
+  taskId: string;
+  taskTitle: string;
+  nextDue: string;
+  status: TaskUrgencyStatus;
+  intervalValue: number;
+  intervalUnit: MaintenanceTask["intervalUnit"];
+  lastCompletedDate: string | null;
+  createdAt: string;
+  assetId: string;
+  assetName: string;
+  assetType: AssetType;
+};
+
+export type DashboardReadModel = {
+  viewerDisplayName: string | null;
+  todayUtc: string;
+  fleetTotals: DashboardFleetTotals;
+  fleetHealth: DashboardFleetHealth;
+  queue: DashboardQueueItem[];
+};
+
+export type GetDashboardQuery = {
+  ownerId: UserId;
+  viewerDisplayName: string | null;
+};
+
+export class GetDashboard {
+  constructor(
+    private readonly assets: AssetRepository,
+    private readonly tasks: MaintenanceTaskRepository,
+    private readonly dates: UtcDateProvider,
+  ) {}
+
+  async execute(query: GetDashboardQuery): Promise<Result<DashboardReadModel, DomainError>> {
+    try {
+      const todayUtc = this.dates.today();
+      const activeAssets = (await this.assets.findByOwner(query.ownerId)).filter(
+        (asset) => asset.archivedAt === null,
+      );
+      const activeAssetIds = new Set(activeAssets.map((asset) => asset.id));
+      const assetById = new Map(activeAssets.map((asset) => [asset.id, asset]));
+      const tasks = (await this.tasks.findByOwnerForActiveAssets(query.ownerId)).filter((task) =>
+        activeAssetIds.has(task.assetId),
+      );
+
+      const tasksByAsset = groupTasksByAsset(tasks);
+      const fleetTotals = buildFleetTotals(activeAssets);
+      const fleetHealth = buildFleetHealth(activeAssets, tasksByAsset, todayUtc);
+      const queue = buildQueue(tasks, assetById, todayUtc);
+
+      return ok({
+        viewerDisplayName: query.viewerDisplayName,
+        todayUtc,
+        fleetTotals,
+        fleetHealth,
+        queue,
+      });
+    } catch (error) {
+      if (error instanceof DomainErrorClass) return err(error);
+      throw error;
+    }
+  }
+}
+
+function groupTasksByAsset(tasks: MaintenanceTask[]): Map<string, MaintenanceTask[]> {
+  const grouped = new Map<string, MaintenanceTask[]>();
+  for (const task of tasks) {
+    const existing = grouped.get(task.assetId) ?? [];
+    existing.push(task);
+    grouped.set(task.assetId, existing);
+  }
+  return grouped;
+}
+
+function buildFleetTotals(assets: Asset[]): DashboardFleetTotals {
+  return assets.reduce<DashboardFleetTotals>(
+    (totals, asset) => {
+      totals.total++;
+      totals[asset.type]++;
+      return totals;
+    },
+    { total: 0, vehicle: 0, equipment: 0, property: 0 },
+  );
+}
+
+function buildFleetHealth(
+  assets: Asset[],
+  tasksByAsset: Map<string, MaintenanceTask[]>,
+  todayUtc: string,
+): DashboardFleetHealth {
+  const health: DashboardFleetHealth = {
+    overdue: 0,
+    soon: 0,
+    onTrack: 0,
+    unscheduled: 0,
+  };
+
+  for (const asset of assets) {
+    const assetTasks = tasksByAsset.get(asset.id) ?? [];
+    const mostUrgent = mostUrgentTaskStatus(
+      assetTasks.map((task) => deriveTaskStatus(task.nextDue, todayUtc)),
+    );
+    if (mostUrgent === null) {
+      health.unscheduled++;
+      continue;
+    }
+    if (mostUrgent === "overdue") health.overdue++;
+    else if (mostUrgent === "soon") health.soon++;
+    else health.onTrack++;
+  }
+
+  return health;
+}
+
+function buildQueue(
+  tasks: MaintenanceTask[],
+  assetById: Map<string, Asset>,
+  todayUtc: string,
+): DashboardQueueItem[] {
+  const queue: DashboardQueueItem[] = [];
+
+  for (const task of tasks) {
+    const asset = assetById.get(task.assetId);
+    if (!asset) continue;
+    queue.push({
+      taskId: task.id,
+      taskTitle: task.title,
+      nextDue: task.nextDue,
+      status: deriveTaskStatus(task.nextDue, todayUtc),
+      intervalValue: task.intervalValue,
+      intervalUnit: task.intervalUnit,
+      lastCompletedDate: task.lastCompletedDate,
+      createdAt: task.createdAt.toISOString(),
+      assetId: asset.id,
+      assetName: asset.name,
+      assetType: asset.type,
+    });
+  }
+
+  return queue.sort((left, right) => {
+    const urgency = compareTaskUrgency(left.status, right.status);
+    if (urgency !== 0) return urgency;
+    if (left.nextDue !== right.nextDue) return left.nextDue < right.nextDue ? -1 : 1;
+    return left.createdAt < right.createdAt ? -1 : left.createdAt > right.createdAt ? 1 : 0;
+  });
+}

--- a/apps/api/src/application/usecases/GetDashboard.ts
+++ b/apps/api/src/application/usecases/GetDashboard.ts
@@ -1,4 +1,5 @@
 import {
+  addCalendarDays,
   calendarDaysBetween,
   type DomainError,
   DomainError as DomainErrorClass,
@@ -123,12 +124,19 @@ function enrichTasks(
   assetById: Map<string, Asset>,
   todayUtc: string,
 ): EnrichedTask[] {
-  return tasks.map((task) => ({
-    task,
-    asset: assetById.get(task.assetId)!,
-    status: deriveTaskStatus(task.nextDue, todayUtc),
-    daysDue: calendarDaysBetween(todayUtc, task.nextDue),
-  }));
+  const sevenDaysOut = addCalendarDays(todayUtc, 7);
+  const enriched: EnrichedTask[] = [];
+  for (const task of tasks) {
+    const asset = assetById.get(task.assetId);
+    if (!asset) continue;
+    enriched.push({
+      task,
+      asset,
+      status: deriveTaskStatus(task.nextDue, todayUtc, sevenDaysOut),
+      daysDue: calendarDaysBetween(todayUtc, task.nextDue),
+    });
+  }
+  return enriched;
 }
 
 function buildFleetTotals(assets: Asset[]): DashboardFleetTotals {

--- a/apps/api/src/application/usecases/GetDashboard.ts
+++ b/apps/api/src/application/usecases/GetDashboard.ts
@@ -33,6 +33,13 @@ export type DashboardFleetHealth = {
   unscheduled: number;
 };
 
+export type DashboardQueueCounts = {
+  all: number;
+  vehicle: number;
+  equipment: number;
+  property: number;
+};
+
 export type DashboardQueueItem = {
   taskId: string;
   taskTitle: string;
@@ -52,12 +59,19 @@ export type DashboardReadModel = {
   todayUtc: string;
   fleetTotals: DashboardFleetTotals;
   fleetHealth: DashboardFleetHealth;
+  queueCountsByCategory: DashboardQueueCounts;
   queue: DashboardQueueItem[];
 };
 
 export type GetDashboardQuery = {
   ownerId: UserId;
   viewerDisplayName: string | null;
+};
+
+type EnrichedTask = {
+  task: MaintenanceTask;
+  asset: Asset;
+  status: TaskUrgencyStatus;
 };
 
 export class GetDashboard {
@@ -70,25 +84,26 @@ export class GetDashboard {
   async execute(query: GetDashboardQuery): Promise<Result<DashboardReadModel, DomainError>> {
     try {
       const todayUtc = this.dates.today();
-      const activeAssets = (await this.assets.findByOwner(query.ownerId)).filter(
-        (asset) => asset.archivedAt === null,
-      );
-      const activeAssetIds = new Set(activeAssets.map((asset) => asset.id));
-      const assetById = new Map(activeAssets.map((asset) => [asset.id, asset]));
-      const tasks = (await this.tasks.findByOwnerForActiveAssets(query.ownerId)).filter((task) =>
-        activeAssetIds.has(task.assetId),
-      );
+      const [allAssets, tasks] = await Promise.all([
+        this.assets.findByOwner(query.ownerId),
+        this.tasks.findByOwnerForActiveAssets(query.ownerId),
+      ]);
 
-      const tasksByAsset = groupTasksByAsset(tasks);
+      const activeAssets = allAssets.filter((asset) => asset.archivedAt === null);
+      const assetById = new Map(activeAssets.map((asset) => [asset.id, asset]));
+      const enriched = enrichTasks(tasks, assetById, todayUtc);
+
       const fleetTotals = buildFleetTotals(activeAssets);
-      const fleetHealth = buildFleetHealth(activeAssets, tasksByAsset, todayUtc);
-      const queue = buildQueue(tasks, assetById, todayUtc);
+      const fleetHealth = buildFleetHealth(activeAssets, enriched);
+      const queue = buildQueue(enriched);
+      const queueCountsByCategory = buildQueueCounts(queue);
 
       return ok({
         viewerDisplayName: query.viewerDisplayName,
         todayUtc,
         fleetTotals,
         fleetHealth,
+        queueCountsByCategory,
         queue,
       });
     } catch (error) {
@@ -98,14 +113,22 @@ export class GetDashboard {
   }
 }
 
-function groupTasksByAsset(tasks: MaintenanceTask[]): Map<string, MaintenanceTask[]> {
-  const grouped = new Map<string, MaintenanceTask[]>();
+function enrichTasks(
+  tasks: MaintenanceTask[],
+  assetById: Map<string, Asset>,
+  todayUtc: string,
+): EnrichedTask[] {
+  const enriched: EnrichedTask[] = [];
   for (const task of tasks) {
-    const existing = grouped.get(task.assetId) ?? [];
-    existing.push(task);
-    grouped.set(task.assetId, existing);
+    const asset = assetById.get(task.assetId);
+    if (!asset) continue;
+    enriched.push({
+      task,
+      asset,
+      status: deriveTaskStatus(task.nextDue, todayUtc),
+    });
   }
-  return grouped;
+  return enriched;
 }
 
 function buildFleetTotals(assets: Asset[]): DashboardFleetTotals {
@@ -119,11 +142,14 @@ function buildFleetTotals(assets: Asset[]): DashboardFleetTotals {
   );
 }
 
-function buildFleetHealth(
-  assets: Asset[],
-  tasksByAsset: Map<string, MaintenanceTask[]>,
-  todayUtc: string,
-): DashboardFleetHealth {
+function buildFleetHealth(assets: Asset[], enriched: EnrichedTask[]): DashboardFleetHealth {
+  const statusesByAsset = new Map<string, TaskUrgencyStatus[]>();
+  for (const { task, status } of enriched) {
+    const existing = statusesByAsset.get(task.assetId) ?? [];
+    existing.push(status);
+    statusesByAsset.set(task.assetId, existing);
+  }
+
   const health: DashboardFleetHealth = {
     overdue: 0,
     soon: 0,
@@ -132,10 +158,7 @@ function buildFleetHealth(
   };
 
   for (const asset of assets) {
-    const assetTasks = tasksByAsset.get(asset.id) ?? [];
-    const mostUrgent = mostUrgentTaskStatus(
-      assetTasks.map((task) => deriveTaskStatus(task.nextDue, todayUtc)),
-    );
+    const mostUrgent = mostUrgentTaskStatus(statusesByAsset.get(asset.id) ?? []);
     if (mostUrgent === null) {
       health.unscheduled++;
       continue;
@@ -148,30 +171,20 @@ function buildFleetHealth(
   return health;
 }
 
-function buildQueue(
-  tasks: MaintenanceTask[],
-  assetById: Map<string, Asset>,
-  todayUtc: string,
-): DashboardQueueItem[] {
-  const queue: DashboardQueueItem[] = [];
-
-  for (const task of tasks) {
-    const asset = assetById.get(task.assetId);
-    if (!asset) continue;
-    queue.push({
-      taskId: task.id,
-      taskTitle: task.title,
-      nextDue: task.nextDue,
-      status: deriveTaskStatus(task.nextDue, todayUtc),
-      intervalValue: task.intervalValue,
-      intervalUnit: task.intervalUnit,
-      lastCompletedDate: task.lastCompletedDate,
-      createdAt: task.createdAt.toISOString(),
-      assetId: asset.id,
-      assetName: asset.name,
-      assetType: asset.type,
-    });
-  }
+function buildQueue(enriched: EnrichedTask[]): DashboardQueueItem[] {
+  const queue = enriched.map(({ task, asset, status }) => ({
+    taskId: task.id,
+    taskTitle: task.title,
+    nextDue: task.nextDue,
+    status,
+    intervalValue: task.intervalValue,
+    intervalUnit: task.intervalUnit,
+    lastCompletedDate: task.lastCompletedDate,
+    createdAt: task.createdAt.toISOString(),
+    assetId: asset.id,
+    assetName: asset.name,
+    assetType: asset.type,
+  }));
 
   return queue.sort((left, right) => {
     const urgency = compareTaskUrgency(left.status, right.status);
@@ -179,4 +192,15 @@ function buildQueue(
     if (left.nextDue !== right.nextDue) return left.nextDue < right.nextDue ? -1 : 1;
     return left.createdAt < right.createdAt ? -1 : left.createdAt > right.createdAt ? 1 : 0;
   });
+}
+
+function buildQueueCounts(queue: DashboardQueueItem[]): DashboardQueueCounts {
+  return queue.reduce<DashboardQueueCounts>(
+    (counts, item) => {
+      counts.all++;
+      counts[item.assetType]++;
+      return counts;
+    },
+    { all: 0, vehicle: 0, equipment: 0, property: 0 },
+  );
 }

--- a/apps/api/src/application/usecases/GetDashboard.ts
+++ b/apps/api/src/application/usecases/GetDashboard.ts
@@ -1,4 +1,5 @@
 import {
+  calendarDaysBetween,
   type DomainError,
   DomainError as DomainErrorClass,
   ok,
@@ -29,6 +30,7 @@ export type DashboardFleetTotals = {
 export type DashboardFleetHealth = {
   overdue: number;
   soon: number;
+  /** Task-level "ok" is surfaced as onTrack here; assets without tasks are unscheduled. */
   onTrack: number;
   unscheduled: number;
 };
@@ -45,6 +47,8 @@ export type DashboardQueueItem = {
   taskTitle: string;
   nextDue: string;
   status: TaskUrgencyStatus;
+  /** Signed calendar-day distance from todayUtc to nextDue; negative means overdue. */
+  daysDue: number;
   intervalValue: number;
   intervalUnit: MaintenanceTask["intervalUnit"];
   lastCompletedDate: string | null;
@@ -72,6 +76,7 @@ type EnrichedTask = {
   task: MaintenanceTask;
   asset: Asset;
   status: TaskUrgencyStatus;
+  daysDue: number;
 };
 
 export class GetDashboard {
@@ -118,17 +123,12 @@ function enrichTasks(
   assetById: Map<string, Asset>,
   todayUtc: string,
 ): EnrichedTask[] {
-  const enriched: EnrichedTask[] = [];
-  for (const task of tasks) {
-    const asset = assetById.get(task.assetId);
-    if (!asset) continue;
-    enriched.push({
-      task,
-      asset,
-      status: deriveTaskStatus(task.nextDue, todayUtc),
-    });
-  }
-  return enriched;
+  return tasks.map((task) => ({
+    task,
+    asset: assetById.get(task.assetId)!,
+    status: deriveTaskStatus(task.nextDue, todayUtc),
+    daysDue: calendarDaysBetween(todayUtc, task.nextDue),
+  }));
 }
 
 function buildFleetTotals(assets: Asset[]): DashboardFleetTotals {
@@ -172,11 +172,12 @@ function buildFleetHealth(assets: Asset[], enriched: EnrichedTask[]): DashboardF
 }
 
 function buildQueue(enriched: EnrichedTask[]): DashboardQueueItem[] {
-  const queue = enriched.map(({ task, asset, status }) => ({
+  const queue = enriched.map(({ task, asset, status, daysDue }) => ({
     taskId: task.id,
     taskTitle: task.title,
     nextDue: task.nextDue,
     status,
+    daysDue,
     intervalValue: task.intervalValue,
     intervalUnit: task.intervalUnit,
     lastCompletedDate: task.lastCompletedDate,

--- a/apps/api/src/application/usecases/ListMaintenanceTasks.test.ts
+++ b/apps/api/src/application/usecases/ListMaintenanceTasks.test.ts
@@ -30,6 +30,9 @@ class MaintenanceTaskRepositoryFake implements MaintenanceTaskRepository {
   findByAsset(): Promise<MaintenanceTask[]> {
     return Promise.resolve(this.tasks);
   }
+  findByOwnerForActiveAssets(): Promise<MaintenanceTask[]> {
+    return Promise.resolve([]);
+  }
   findById(): Promise<MaintenanceTask | null> {
     return Promise.resolve(null);
   }

--- a/apps/api/src/domain/maintenance/DateOnly.ts
+++ b/apps/api/src/domain/maintenance/DateOnly.ts
@@ -1,4 +1,13 @@
-import { ValidationError } from "@snaveevans/pineapple-shared";
+import {
+  ValidationError,
+  addCalendarDays,
+  calendarDaysBetween,
+  daysInMonth,
+  formatDateOnly,
+  isLeapYear,
+} from "@snaveevans/pineapple-shared";
+
+export { addCalendarDays, calendarDaysBetween, daysInMonth, formatDateOnly, isLeapYear };
 
 const DATE_ONLY_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
 
@@ -19,61 +28,4 @@ export function validateDateOnly(value: string, field = "performedAt"): void {
   if (!isValidDateOnly(value)) {
     throw new ValidationError("Date must be a valid calendar date", field);
   }
-}
-
-export function daysInMonth(year: number, month: number): number {
-  if (month === 2) return isLeapYear(year) ? 29 : 28;
-  if (month === 4 || month === 6 || month === 9 || month === 11) return 30;
-  return 31;
-}
-
-export function isLeapYear(year: number): boolean {
-  return year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
-}
-
-export function formatDateOnly(year: number, month: number, day: number): string {
-  return `${String(year).padStart(4, "0")}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
-}
-
-/** Adds calendar days to a YYYY-MM-DD value without timestamp arithmetic. */
-export function addCalendarDays(date: string, days: number): string {
-  let year = Number(date.slice(0, 4));
-  let month = Number(date.slice(5, 7));
-  let day = Number(date.slice(8, 10)) + days;
-
-  while (day > daysInMonth(year, month)) {
-    day -= daysInMonth(year, month);
-    month++;
-    if (month > 12) {
-      month = 1;
-      year++;
-    }
-  }
-
-  while (day < 1) {
-    month--;
-    if (month < 1) {
-      month = 12;
-      year--;
-    }
-    day += daysInMonth(year, month);
-  }
-
-  return formatDateOnly(year, month, day);
-}
-
-/** Returns the signed day distance from `start` to `end` using calendar-day steps. */
-export function calendarDaysBetween(start: string, end: string): number {
-  if (start === end) return 0;
-
-  let cursor = start;
-  let days = 0;
-  const step = start < end ? 1 : -1;
-
-  while (cursor !== end) {
-    cursor = addCalendarDays(cursor, step);
-    days += step;
-  }
-
-  return days;
 }

--- a/apps/api/src/domain/maintenance/DateOnly.ts
+++ b/apps/api/src/domain/maintenance/DateOnly.ts
@@ -34,3 +34,46 @@ export function isLeapYear(year: number): boolean {
 export function formatDateOnly(year: number, month: number, day: number): string {
   return `${String(year).padStart(4, "0")}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
 }
+
+/** Adds calendar days to a YYYY-MM-DD value without timestamp arithmetic. */
+export function addCalendarDays(date: string, days: number): string {
+  let year = Number(date.slice(0, 4));
+  let month = Number(date.slice(5, 7));
+  let day = Number(date.slice(8, 10)) + days;
+
+  while (day > daysInMonth(year, month)) {
+    day -= daysInMonth(year, month);
+    month++;
+    if (month > 12) {
+      month = 1;
+      year++;
+    }
+  }
+
+  while (day < 1) {
+    month--;
+    if (month < 1) {
+      month = 12;
+      year--;
+    }
+    day += daysInMonth(year, month);
+  }
+
+  return formatDateOnly(year, month, day);
+}
+
+/** Returns the signed day distance from `start` to `end` using calendar-day steps. */
+export function calendarDaysBetween(start: string, end: string): number {
+  if (start === end) return 0;
+
+  let cursor = start;
+  let days = 0;
+  const step = start < end ? 1 : -1;
+
+  while (cursor !== end) {
+    cursor = addCalendarDays(cursor, step);
+    days += step;
+  }
+
+  return days;
+}

--- a/apps/api/src/domain/maintenance/MaintenanceTaskRepository.ts
+++ b/apps/api/src/domain/maintenance/MaintenanceTaskRepository.ts
@@ -1,9 +1,11 @@
-import type { AssetId, MaintenanceTaskId } from "@snaveevans/pineapple-shared";
+import type { AssetId, MaintenanceTaskId, UserId } from "@snaveevans/pineapple-shared";
 import type { MaintenanceTask } from "./MaintenanceTask.ts";
 
 export interface MaintenanceTaskRepository {
   /** Returns tasks ordered by nextDue ASC. Ownership is verified at the use-case layer. */
   findByAsset(assetId: AssetId): Promise<MaintenanceTask[]>;
+  /** Returns tasks for active assets owned by the caller, ordered by nextDue ASC then createdAt ASC. */
+  findByOwnerForActiveAssets(ownerId: UserId): Promise<MaintenanceTask[]>;
   findById(id: MaintenanceTaskId): Promise<MaintenanceTask | null>;
   save(task: MaintenanceTask): Promise<void>;
   /** Nulls task_id on linked maintenance_records, then deletes the task. */

--- a/apps/api/src/domain/maintenance/TaskUrgency.test.ts
+++ b/apps/api/src/domain/maintenance/TaskUrgency.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { addCalendarDays, calendarDaysBetween } from "./DateOnly.ts";
+import { compareTaskUrgency, deriveTaskStatus, mostUrgentTaskStatus } from "./TaskUrgency.ts";
+
+describe("deriveTaskStatus", () => {
+  const today = "2026-06-16";
+
+  it("returns overdue when nextDue is before todayUtc", () => {
+    expect(deriveTaskStatus("2026-06-15", today)).toBe("overdue");
+  });
+
+  it("returns soon when nextDue is today", () => {
+    expect(deriveTaskStatus(today, today)).toBe("soon");
+  });
+
+  it("returns soon when nextDue is within the next 7 calendar days", () => {
+    expect(deriveTaskStatus(addCalendarDays(today, 7), today)).toBe("soon");
+  });
+
+  it("returns ok when nextDue is more than 7 calendar days after todayUtc", () => {
+    expect(deriveTaskStatus(addCalendarDays(today, 8), today)).toBe("ok");
+  });
+});
+
+describe("mostUrgentTaskStatus", () => {
+  it("prefers overdue over soon and ok", () => {
+    expect(mostUrgentTaskStatus(["ok", "soon", "overdue"])).toBe("overdue");
+  });
+
+  it("returns null for an empty list", () => {
+    expect(mostUrgentTaskStatus([])).toBeNull();
+  });
+});
+
+describe("compareTaskUrgency", () => {
+  it("orders overdue before soon before ok", () => {
+    expect(compareTaskUrgency("overdue", "soon")).toBeLessThan(0);
+    expect(compareTaskUrgency("soon", "ok")).toBeLessThan(0);
+  });
+});
+
+describe("calendarDaysBetween", () => {
+  it("counts calendar days without timestamp arithmetic", () => {
+    expect(calendarDaysBetween("2026-06-10", "2026-06-16")).toBe(6);
+    expect(calendarDaysBetween("2026-06-16", "2026-06-10")).toBe(-6);
+  });
+});

--- a/apps/api/src/domain/maintenance/TaskUrgency.test.ts
+++ b/apps/api/src/domain/maintenance/TaskUrgency.test.ts
@@ -44,4 +44,8 @@ describe("calendarDaysBetween", () => {
     expect(calendarDaysBetween("2026-06-10", "2026-06-16")).toBe(6);
     expect(calendarDaysBetween("2026-06-16", "2026-06-10")).toBe(-6);
   });
+
+  it("handles multi-year distances", () => {
+    expect(calendarDaysBetween("2023-06-16", "2026-06-16")).toBe(1096);
+  });
 });

--- a/apps/api/src/domain/maintenance/TaskUrgency.ts
+++ b/apps/api/src/domain/maintenance/TaskUrgency.ts
@@ -8,9 +8,12 @@ const URGENCY_RANK: Record<TaskUrgencyStatus, number> = {
   ok: 2,
 };
 
-export function deriveTaskStatus(nextDue: string, todayUtc: string): TaskUrgencyStatus {
+export function deriveTaskStatus(
+  nextDue: string,
+  todayUtc: string,
+  sevenDaysOut = addCalendarDays(todayUtc, 7),
+): TaskUrgencyStatus {
   if (nextDue < todayUtc) return "overdue";
-  const sevenDaysOut = addCalendarDays(todayUtc, 7);
   if (nextDue <= sevenDaysOut) return "soon";
   return "ok";
 }

--- a/apps/api/src/domain/maintenance/TaskUrgency.ts
+++ b/apps/api/src/domain/maintenance/TaskUrgency.ts
@@ -1,0 +1,27 @@
+import { addCalendarDays } from "./DateOnly.ts";
+
+export type TaskUrgencyStatus = "overdue" | "soon" | "ok";
+
+const URGENCY_RANK: Record<TaskUrgencyStatus, number> = {
+  overdue: 0,
+  soon: 1,
+  ok: 2,
+};
+
+export function deriveTaskStatus(nextDue: string, todayUtc: string): TaskUrgencyStatus {
+  if (nextDue < todayUtc) return "overdue";
+  const sevenDaysOut = addCalendarDays(todayUtc, 7);
+  if (nextDue <= sevenDaysOut) return "soon";
+  return "ok";
+}
+
+export function compareTaskUrgency(left: TaskUrgencyStatus, right: TaskUrgencyStatus): number {
+  return URGENCY_RANK[left] - URGENCY_RANK[right];
+}
+
+export function mostUrgentTaskStatus(
+  statuses: readonly TaskUrgencyStatus[],
+): TaskUrgencyStatus | null {
+  if (statuses.length === 0) return null;
+  return statuses.reduce((best, status) => (compareTaskUrgency(status, best) < 0 ? status : best));
+}

--- a/apps/api/src/infrastructure/persistence/D1MaintenanceTaskRepository.test.ts
+++ b/apps/api/src/infrastructure/persistence/D1MaintenanceTaskRepository.test.ts
@@ -1,0 +1,40 @@
+import { UserId } from "@snaveevans/pineapple-shared";
+import { describe, expect, it, vi } from "vitest";
+import { D1MaintenanceTaskRepository } from "./D1MaintenanceTaskRepository.ts";
+
+type BoundStatement = {
+  query: string;
+  values: unknown[];
+};
+
+function createDatabaseHarness() {
+  const statements: BoundStatement[] = [];
+  const prepare = vi.fn((query: string) => {
+    return {
+      bind: (...values: unknown[]) => {
+        statements.push({ query, values });
+        return {
+          all: vi.fn().mockResolvedValue({ results: [] }),
+        };
+      },
+    } as unknown as D1PreparedStatement;
+  });
+  const db = { prepare } as unknown as D1Database;
+
+  return { db, statements };
+}
+
+describe("D1MaintenanceTaskRepository", () => {
+  it("findByOwnerForActiveAssets joins active assets and excludes archived rows", async () => {
+    const { db, statements } = createDatabaseHarness();
+    const ownerId = UserId.generate();
+
+    await new D1MaintenanceTaskRepository(db).findByOwnerForActiveAssets(ownerId);
+
+    expect(statements).toHaveLength(1);
+    const query = statements[0]?.query ?? "";
+    expect(query).toContain("INNER JOIN assets a ON a.id = t.asset_id");
+    expect(query).toContain("a.archived_at IS NULL");
+    expect(statements[0]?.values).toEqual([ownerId]);
+  });
+});

--- a/apps/api/src/infrastructure/persistence/D1MaintenanceTaskRepository.ts
+++ b/apps/api/src/infrastructure/persistence/D1MaintenanceTaskRepository.ts
@@ -62,6 +62,21 @@ export class D1MaintenanceTaskRepository implements MaintenanceTaskRepository {
     return result.results.map((row) => this.#rowToTask(row));
   }
 
+  async findByOwnerForActiveAssets(ownerId: UserId): Promise<MaintenanceTask[]> {
+    const result = await this.db
+      .prepare(
+        `SELECT t.id, t.asset_id, t.owner_id, t.title, t.interval_value, t.interval_unit,
+                t.last_completed_date, t.next_due, t.created_at
+         FROM maintenance_tasks t
+         INNER JOIN assets a ON a.id = t.asset_id
+         WHERE t.owner_id = ? AND a.archived_at IS NULL
+         ORDER BY t.next_due ASC, t.created_at ASC`,
+      )
+      .bind(ownerId)
+      .all<MaintenanceTaskRow>();
+    return result.results.map((row) => this.#rowToTask(row));
+  }
+
   async findById(id: MaintenanceTaskId): Promise<MaintenanceTask | null> {
     const row = await this.db
       .prepare(`SELECT ${SELECT_COLUMNS} FROM maintenance_tasks WHERE id = ?`)

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -29,6 +29,7 @@ import { ListMaintenanceRecords } from "./application/usecases/ListMaintenanceRe
 import { CreateMaintenanceTask } from "./application/usecases/CreateMaintenanceTask.ts";
 import { ListMaintenanceTasks } from "./application/usecases/ListMaintenanceTasks.ts";
 import { DeleteMaintenanceTask } from "./application/usecases/DeleteMaintenanceTask.ts";
+import { GetDashboard } from "./application/usecases/GetDashboard.ts";
 import { UpdateUserProfile } from "./application/usecases/UpdateUserProfile.ts";
 import type { EventBus } from "./application/ports/EventBus.ts";
 
@@ -40,6 +41,7 @@ import {
   createMaintenanceRecordRoute,
   createMaintenanceTaskRoute,
   deleteMaintenanceTaskRoute,
+  getDashboardRoute,
   getUserProfileRoute,
   getAssetRoute,
   healthRoute,
@@ -53,7 +55,9 @@ import openApiSpec from "../../../docs/reference/openapi.json";
 import type { AssetResponseSchema } from "./api/schemas/assetSchemas.ts";
 import type { MaintenanceRecordResponseSchema } from "./api/schemas/maintenanceRecordSchemas.ts";
 import type { MaintenanceTaskResponseSchema } from "./api/schemas/maintenanceTaskSchemas.ts";
+import type { DashboardResponseSchema } from "./api/schemas/dashboardSchemas.ts";
 import type { UserProfileResponseSchema } from "./api/schemas/userProfileSchemas.ts";
+import type { DashboardReadModel } from "./application/usecases/GetDashboard.ts";
 import type { MaintenanceTask } from "./domain/maintenance/MaintenanceTask.ts";
 import type { z } from "@hono/zod-openapi";
 
@@ -225,6 +229,28 @@ function serializeUserProfile(user: User): z.infer<typeof UserProfileResponseSch
     onboardingCompletedAt: user.onboardingCompletedAt?.toISOString() ?? null,
   };
 }
+
+// ── Dashboard endpoint ───────────────────────────────────────────────────────
+
+function serializeDashboard(
+  dashboard: DashboardReadModel,
+): z.infer<typeof DashboardResponseSchema> {
+  return dashboard;
+}
+
+app.openapi(getDashboardRoute, async (c) => {
+  const user = c.get("user");
+  const result = await new GetDashboard(
+    new D1AssetRepository(c.env.DB),
+    new D1MaintenanceTaskRepository(c.env.DB),
+    new SystemUtcDateProvider(),
+  ).execute({
+    ownerId: user.id,
+    viewerDisplayName: user.name,
+  });
+  if (!result.ok) throw result.error;
+  return c.json(serializeDashboard(result.value), 200);
+});
 
 // ── User profile endpoints ───────────────────────────────────────────────────
 

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -2,7 +2,13 @@ import { OpenAPIHono } from "@hono/zod-openapi";
 import { Scalar } from "@scalar/hono-api-reference";
 import type { Context } from "hono";
 import { secureHeaders } from "hono/secure-headers";
-import { AssetId, DomainError, MaintenanceTaskId } from "@snaveevans/pineapple-shared";
+import {
+  addCalendarDays,
+  AssetId,
+  calendarDaysBetween,
+  DomainError,
+  MaintenanceTaskId,
+} from "@snaveevans/pineapple-shared";
 import type { User } from "./domain/identity/User.ts";
 import type { Asset } from "./domain/asset/Asset.ts";
 import type { AssetMetadata } from "./domain/asset/AssetMetadata.ts";
@@ -57,6 +63,7 @@ import type { MaintenanceRecordResponseSchema } from "./api/schemas/maintenanceR
 import type { MaintenanceTaskResponseSchema } from "./api/schemas/maintenanceTaskSchemas.ts";
 import type { UserProfileResponseSchema } from "./api/schemas/userProfileSchemas.ts";
 import type { MaintenanceTask } from "./domain/maintenance/MaintenanceTask.ts";
+import { deriveTaskStatus } from "./domain/maintenance/TaskUrgency.ts";
 import type { z } from "@hono/zod-openapi";
 
 type Bindings = AuthEnv & {
@@ -154,7 +161,9 @@ function serializeMaintenanceRecord(
 
 function serializeMaintenanceTask(
   task: MaintenanceTask,
+  todayUtc: string,
 ): z.infer<typeof MaintenanceTaskResponseSchema> {
+  const sevenDaysOut = addCalendarDays(todayUtc, 7);
   return {
     id: task.id,
     assetId: task.assetId,
@@ -163,6 +172,8 @@ function serializeMaintenanceTask(
     intervalUnit: task.intervalUnit,
     lastCompletedDate: task.lastCompletedDate,
     nextDue: task.nextDue,
+    status: deriveTaskStatus(task.nextDue, todayUtc, sevenDaysOut),
+    daysDue: calendarDaysBetween(todayUtc, task.nextDue),
     createdAt: task.createdAt.toISOString(),
   };
 }
@@ -359,12 +370,14 @@ app.openapi(createMaintenanceTaskRoute, async (c) => {
     ...(lastCompletedDate !== undefined ? { lastCompletedDate } : {}),
   });
   if (!result.ok) throw result.error;
-  return c.json(serializeMaintenanceTask(result.value), 201);
+  const todayUtc = new SystemUtcDateProvider().today();
+  return c.json(serializeMaintenanceTask(result.value, todayUtc), 201);
 });
 
 app.openapi(listMaintenanceTasksRoute, async (c) => {
   const user = c.get("user");
   const { assetId } = c.req.valid("param");
+  const todayUtc = new SystemUtcDateProvider().today();
   const result = await new ListMaintenanceTasks(
     new D1AssetRepository(c.env.DB),
     new D1MaintenanceTaskRepository(c.env.DB),
@@ -373,7 +386,10 @@ app.openapi(listMaintenanceTasksRoute, async (c) => {
     requesterId: user.id,
   });
   if (!result.ok) throw result.error;
-  return c.json({ maintenanceTasks: result.value.map(serializeMaintenanceTask) }, 200);
+  return c.json(
+    { maintenanceTasks: result.value.map((task) => serializeMaintenanceTask(task, todayUtc)) },
+    200,
+  );
 });
 
 app.openapi(deleteMaintenanceTaskRoute, async (c) => {

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -55,9 +55,7 @@ import openApiSpec from "../../../docs/reference/openapi.json";
 import type { AssetResponseSchema } from "./api/schemas/assetSchemas.ts";
 import type { MaintenanceRecordResponseSchema } from "./api/schemas/maintenanceRecordSchemas.ts";
 import type { MaintenanceTaskResponseSchema } from "./api/schemas/maintenanceTaskSchemas.ts";
-import type { DashboardResponseSchema } from "./api/schemas/dashboardSchemas.ts";
 import type { UserProfileResponseSchema } from "./api/schemas/userProfileSchemas.ts";
-import type { DashboardReadModel } from "./application/usecases/GetDashboard.ts";
 import type { MaintenanceTask } from "./domain/maintenance/MaintenanceTask.ts";
 import type { z } from "@hono/zod-openapi";
 
@@ -232,12 +230,6 @@ function serializeUserProfile(user: User): z.infer<typeof UserProfileResponseSch
 
 // ── Dashboard endpoint ───────────────────────────────────────────────────────
 
-function serializeDashboard(
-  dashboard: DashboardReadModel,
-): z.infer<typeof DashboardResponseSchema> {
-  return dashboard;
-}
-
 app.openapi(getDashboardRoute, async (c) => {
   const user = c.get("user");
   const result = await new GetDashboard(
@@ -249,7 +241,7 @@ app.openapi(getDashboardRoute, async (c) => {
     viewerDisplayName: user.name,
   });
   if (!result.ok) throw result.error;
-  return c.json(serializeDashboard(result.value), 200);
+  return c.json(result.value, 200);
 });
 
 // ── User profile endpoints ───────────────────────────────────────────────────

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,7 +13,6 @@
     "cf-typegen": "wrangler types"
   },
   "dependencies": {
-    "@snaveevans/pineapple-shared": "workspace:*",
     "@tanstack/react-query": "^5.100.14",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
     "cf-typegen": "wrangler types"
   },
   "dependencies": {
+    "@snaveevans/pineapple-shared": "workspace:*",
     "@tanstack/react-query": "^5.100.14",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/apps/web/src/api/dashboard.ts
+++ b/apps/web/src/api/dashboard.ts
@@ -29,6 +29,7 @@ export type DashboardQueueItem = {
   taskTitle: string;
   nextDue: string;
   status: TaskUrgencyStatus;
+  daysDue: number;
   intervalValue: number;
   intervalUnit: "day" | "week" | "month" | "year";
   lastCompletedDate: string | null;

--- a/apps/web/src/api/dashboard.ts
+++ b/apps/web/src/api/dashboard.ts
@@ -1,0 +1,46 @@
+import { apiRequest } from "./client.ts";
+
+export type TaskUrgencyStatus = "overdue" | "soon" | "ok";
+export type AssetType = "vehicle" | "property" | "equipment";
+
+export type DashboardFleetTotals = {
+  total: number;
+  vehicle: number;
+  equipment: number;
+  property: number;
+};
+
+export type DashboardFleetHealth = {
+  overdue: number;
+  soon: number;
+  onTrack: number;
+  unscheduled: number;
+};
+
+export type DashboardQueueItem = {
+  taskId: string;
+  taskTitle: string;
+  nextDue: string;
+  status: TaskUrgencyStatus;
+  intervalValue: number;
+  intervalUnit: "day" | "week" | "month" | "year";
+  lastCompletedDate: string | null;
+  createdAt: string;
+  assetId: string;
+  assetName: string;
+  assetType: AssetType;
+};
+
+export type DashboardResponse = {
+  viewerDisplayName: string | null;
+  todayUtc: string;
+  fleetTotals: DashboardFleetTotals;
+  fleetHealth: DashboardFleetHealth;
+  queue: DashboardQueueItem[];
+};
+
+export const dashboardQueryKey = ["dashboard"] as const;
+
+export function getDashboard(): Promise<DashboardResponse> {
+  return apiRequest<DashboardResponse>("/api/dashboard");
+}

--- a/apps/web/src/api/dashboard.ts
+++ b/apps/web/src/api/dashboard.ts
@@ -17,6 +17,13 @@ export type DashboardFleetHealth = {
   unscheduled: number;
 };
 
+export type DashboardQueueCounts = {
+  all: number;
+  vehicle: number;
+  equipment: number;
+  property: number;
+};
+
 export type DashboardQueueItem = {
   taskId: string;
   taskTitle: string;
@@ -36,6 +43,7 @@ export type DashboardResponse = {
   todayUtc: string;
   fleetTotals: DashboardFleetTotals;
   fleetHealth: DashboardFleetHealth;
+  queueCountsByCategory: DashboardQueueCounts;
   queue: DashboardQueueItem[];
 };
 

--- a/apps/web/src/api/maintenanceTasks.ts
+++ b/apps/web/src/api/maintenanceTasks.ts
@@ -1,6 +1,7 @@
 import { apiRequest } from "./client.ts";
 
 export type IntervalUnit = "day" | "week" | "month" | "year";
+export type TaskUrgencyStatus = "overdue" | "soon" | "ok";
 
 export type MaintenanceTask = {
   id: string;
@@ -10,6 +11,8 @@ export type MaintenanceTask = {
   intervalUnit: IntervalUnit;
   lastCompletedDate: string | null;
   nextDue: string;
+  status: TaskUrgencyStatus;
+  daysDue: number;
   createdAt: string;
 };
 

--- a/apps/web/src/app/AppHome.tsx
+++ b/apps/web/src/app/AppHome.tsx
@@ -6,7 +6,7 @@ import { createMaintenanceRecord, maintenanceRecordsQueryKey } from "../api/main
 import { maintenanceTasksQueryKey } from "../api/maintenanceTasks.ts";
 import { ApiError } from "../api/client.ts";
 import { Icon } from "../design/Icon.tsx";
-import { HFAssetIcon, HFStatusPill, type AssetStatus } from "../design/hf.tsx";
+import { HFAssetIcon, HFStatusPill } from "../design/hf.tsx";
 import { HFTopBar, HFBottomNav } from "./AppChrome.tsx";
 import {
   type DashboardCategoryFilter,
@@ -247,21 +247,6 @@ export function AppHome({ mobileMode = "inline" }: { mobileMode?: "inline" }) {
   const selected = filteredQueue.find((item) => item.taskId === selectedTaskId) ?? filteredQueue[0];
   const isNextUp = selected?.taskId === filteredQueue[0]?.taskId;
 
-  const categoryCounts = useMemo(
-    () => ({
-      all: queue.length,
-      vehicle: queue.filter((item) => item.category === "vehicle").length,
-      equipment: queue.filter((item) => item.category === "equipment").length,
-      property: queue.filter((item) => item.category === "property").length,
-    }),
-    [queue],
-  );
-
-  const chipCount = (id: DashboardCategoryFilter) => {
-    if (id === "all") return categoryCounts.all;
-    return categoryCounts[id];
-  };
-
   if (dashboardQuery.isPending) {
     return (
       <div className={`hf hf-app hf-mobile-${mobileMode}`}>
@@ -351,7 +336,7 @@ export function AppHome({ mobileMode = "inline" }: { mobileMode?: "inline" }) {
                 onClick={() => setCategory(filter.id)}
               >
                 {filter.label}
-                <span className="hf-chip-count">{chipCount(filter.id)}</span>
+                <span className="hf-chip-count">{dashboard.queueCountsByCategory[filter.id]}</span>
               </button>
             ))}
           </div>
@@ -383,7 +368,7 @@ export function AppHome({ mobileMode = "inline" }: { mobileMode?: "inline" }) {
           />
         ) : (
           <div className="hf-grid">
-            <section className="hf-detail-card" data-status={selected.status as AssetStatus}>
+            <section className="hf-detail-card" data-status={selected.status}>
               <HFDetailBody
                 item={selected}
                 isNextUp={isNextUp}

--- a/apps/web/src/app/AppHome.tsx
+++ b/apps/web/src/app/AppHome.tsx
@@ -163,6 +163,10 @@ function HFDashboardState({
   );
 }
 
+function todayUtcDate(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
 const CATEGORY_FILTERS: { id: DashboardCategoryFilter; label: string }[] = [
   { id: "all", label: "All" },
   { id: "vehicle", label: "Vehicles" },
@@ -175,7 +179,11 @@ export function AppHome({ mobileMode = "inline" }: { mobileMode?: "inline" }) {
   const queryClient = useQueryClient();
   const [category, setCategory] = useState<DashboardCategoryFilter>("all");
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
-  const [completeError, setCompleteError] = useState<string | null>(null);
+  const [completingTaskId, setCompletingTaskId] = useState<string | null>(null);
+  const [completeError, setCompleteError] = useState<{
+    taskId: string;
+    message: string;
+  } | null>(null);
 
   const dashboardQuery = useQuery({
     queryKey: dashboardQueryKey,
@@ -186,15 +194,19 @@ export function AppHome({ mobileMode = "inline" }: { mobileMode?: "inline" }) {
 
   const completeMutation = useMutation({
     mutationFn: async (item: DashboardQueuePresentation) => {
-      const dashboard = dashboardQuery.data;
-      if (!dashboard) throw new Error("Dashboard is not loaded");
+      if (!dashboardQuery.data) throw new Error("Dashboard is not loaded");
       return createMaintenanceRecord(item.assetId, {
         title: item.service,
-        performedAt: dashboard.todayUtc,
+        performedAt: todayUtcDate(),
         taskId: item.taskId,
       });
     },
+    onMutate: (item) => {
+      setCompletingTaskId(item.taskId);
+      setCompleteError(null);
+    },
     onSuccess: async (_record, item) => {
+      setCompletingTaskId(null);
       setCompleteError(null);
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: dashboardQueryKey }),
@@ -202,12 +214,16 @@ export function AppHome({ mobileMode = "inline" }: { mobileMode?: "inline" }) {
         queryClient.invalidateQueries({ queryKey: maintenanceTasksQueryKey(item.assetId) }),
       ]);
     },
-    onError: async (error) => {
+    onError: async (error, item) => {
+      setCompletingTaskId(null);
       if (error instanceof ApiError && error.status === 401) {
         navigate(paths.login(), { replace: true });
         return;
       }
-      setCompleteError(error instanceof Error ? error.message : "Could not mark task complete.");
+      setCompleteError({
+        taskId: item.taskId,
+        message: error instanceof Error ? error.message : "Could not mark task complete.",
+      });
       await queryClient.invalidateQueries({ queryKey: dashboardQueryKey });
     },
   });
@@ -244,6 +260,9 @@ export function AppHome({ mobileMode = "inline" }: { mobileMode?: "inline" }) {
 
   const selected = filteredQueue.find((item) => item.taskId === selectedTaskId) ?? filteredQueue[0];
   const isNextUp = selected?.taskId === filteredQueue[0]?.taskId;
+
+  const completeErrorFor = (taskId: string) =>
+    completeError?.taskId === taskId ? completeError.message : null;
 
   if (dashboardQuery.isPending) {
     return (
@@ -370,12 +389,9 @@ export function AppHome({ mobileMode = "inline" }: { mobileMode?: "inline" }) {
               <HFDetailBody
                 item={selected}
                 isNextUp={isNextUp}
-                onMarkComplete={() => {
-                  setCompleteError(null);
-                  completeMutation.mutate(selected);
-                }}
-                completing={completeMutation.isPending}
-                completeError={completeError}
+                onMarkComplete={() => completeMutation.mutate(selected)}
+                completing={completingTaskId === selected.taskId}
+                completeError={completeErrorFor(selected.taskId)}
               />
             </section>
 
@@ -394,7 +410,10 @@ export function AppHome({ mobileMode = "inline" }: { mobileMode?: "inline" }) {
                       key={item.taskId}
                       className={`hf-row ${isSel ? "selected" : ""}`}
                       data-status={item.status}
-                      onClick={() => setSelectedTaskId(item.taskId)}
+                      onClick={() => {
+                        setSelectedTaskId(item.taskId);
+                        setCompleteError(null);
+                      }}
                     >
                       <div className="hf-row-summary">
                         <HFAssetIcon asset={item} size={36} />
@@ -413,12 +432,9 @@ export function AppHome({ mobileMode = "inline" }: { mobileMode?: "inline" }) {
                             item={item}
                             compact
                             isNextUp={isNextUp}
-                            onMarkComplete={() => {
-                              setCompleteError(null);
-                              completeMutation.mutate(item);
-                            }}
-                            completing={completeMutation.isPending}
-                            completeError={completeError}
+                            onMarkComplete={() => completeMutation.mutate(item)}
+                            completing={completingTaskId === item.taskId}
+                            completeError={completeErrorFor(item.taskId)}
                           />
                         </div>
                       )}

--- a/apps/web/src/app/AppHome.tsx
+++ b/apps/web/src/app/AppHome.tsx
@@ -1,154 +1,39 @@
-import { useQuery } from "@tanstack/react-query";
-import { useEffect, useState } from "react";
-import { getUserProfile, userProfileQueryKey } from "../api/userProfile";
-import { Icon, type IconName } from "../design/Icon";
-import { HFAssetIcon, HFStatusPill, type AssetCategory, type AssetStatus } from "../design/hf";
-import { HFTopBar, HFBottomNav } from "./AppChrome";
-import { formatDashboardGreeting } from "./profilePresentation";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useMemo, useState } from "react";
+import { Link, useNavigate } from "react-router";
+import { dashboardQueryKey, getDashboard } from "../api/dashboard.ts";
+import { createMaintenanceRecord, maintenanceRecordsQueryKey } from "../api/maintenanceRecords.ts";
+import { maintenanceTasksQueryKey } from "../api/maintenanceTasks.ts";
+import { ApiError } from "../api/client.ts";
+import { Icon } from "../design/Icon.tsx";
+import { HFAssetIcon, HFStatusPill, type AssetStatus } from "../design/hf.tsx";
+import { HFTopBar, HFBottomNav } from "./AppChrome.tsx";
+import {
+  type DashboardCategoryFilter,
+  type DashboardQueuePresentation,
+  filterQueueByCategory,
+  formatFleetSubline,
+  toQueuePresentation,
+} from "./dashboardPresentation.ts";
+import { formatDashboardGreeting as formatGreeting } from "./profilePresentation.ts";
+import { paths } from "../routes.ts";
 
-// FieldOps — Home (Master / Detail). The authenticated app shell: a top bar,
-// greeting + fleet stats, category filters, and a master/detail grid (detail
-// card on the left, urgency-sorted queue on the right). On mobile the detail
-// card collapses and the selected queue row expands inline. Ported from the
-// FieldOps design prototype (Master Detail.html / hifi.jsx); styling comes from
-// the shared .hf tokens in styles/hifi.css.
 import "../design/styles/hifi.css";
 
-/* ============ data ============ */
-interface Asset {
-  id: string;
-  name: string;
-  category: AssetCategory;
-  icon: IconName;
-  service: string;
-  due: string;
-  dueDays: number;
-  status: AssetStatus;
-  last: string;
-  meter: string;
-  recurs: string;
-  est: string;
-  where: string;
-  notes: string;
-  assignee: string;
-}
-
-const HF_ASSETS: Asset[] = [
-  {
-    id: "MOWER-A",
-    name: "Toro ZTR Mower",
-    category: "equipment",
-    icon: "mower",
-    service: "Blade sharpen + belt check",
-    due: "Overdue · 3 days",
-    dueDays: -3,
-    status: "overdue",
-    last: "Apr 02",
-    meter: "312 hrs",
-    recurs: "Every 50 hrs",
-    est: "45 min",
-    where: "Shed B",
-    notes:
-      "Belt was squealing on the last run. Sharpen both blades while you're in there.",
-    assignee: "Self",
-  },
-  {
-    id: "TRK-04",
-    name: "Ford F-150 · Truck #4",
-    category: "vehicle",
-    icon: "truck",
-    service: "Oil change + tire rotation",
-    due: "In 2 days",
-    dueDays: 2,
-    status: "soon",
-    last: "Feb 14",
-    meter: "48,210 mi",
-    recurs: "Every 5,000 mi",
-    est: "30 min",
-    where: "Joe's Auto",
-    notes: "Front-left tire wearing fast — flag it for replacement next cycle.",
-    assignee: "Joe's Auto",
-  },
-  {
-    id: "PROP-12",
-    name: "12 Oak St · HVAC",
-    category: "property",
-    icon: "home",
-    service: "Quarterly HVAC inspection",
-    due: "In 5 days",
-    dueDays: 5,
-    status: "soon",
-    last: "Feb 22",
-    meter: "—",
-    recurs: "Quarterly",
-    est: "1 hr",
-    where: "On-site visit",
-    notes:
-      "Filter sizes: 16×25×1. Tenant prefers morning appointments — text before heading out.",
-    assignee: "Mike R.",
-  },
-  {
-    id: "LAWN-A",
-    name: "Riverside Lawn",
-    category: "lawn",
-    icon: "leaf",
-    service: "Spring fertilizer treatment",
-    due: "In 9 days",
-    dueDays: 9,
-    status: "ok",
-    last: "Mar 11",
-    meter: "—",
-    recurs: "Spring + Fall",
-    est: "2 hrs",
-    where: "Riverside",
-    notes: "Slow-release N. Avoid the day before or of forecasted rain.",
-    assignee: "Self",
-  },
-  {
-    id: "VAN-02",
-    name: "Sprinter Van #2",
-    category: "vehicle",
-    icon: "van",
-    service: "Annual state safety inspection",
-    due: "In 14 days",
-    dueDays: 14,
-    status: "ok",
-    last: "Nov 20",
-    meter: "82,400 mi",
-    recurs: "Annual",
-    est: "1 hr",
-    where: "DMV-cert shop",
-    notes: "Inspection sticker expires end of the month — don't let it lapse.",
-    assignee: "Joe's Auto",
-  },
-  {
-    id: "GEN-1",
-    name: "Generac 22kW Genny",
-    category: "equipment",
-    icon: "bolt",
-    service: "Annual load test + oil",
-    due: "In 21 days",
-    dueDays: 21,
-    status: "ok",
-    last: "May 03 ’25",
-    meter: "118 hrs",
-    recurs: "Annual",
-    est: "2 hrs",
-    where: "On-site",
-    notes: "Coordinate with tenants — there's a ~30 min power dip during the test.",
-    assignee: "Self",
-  },
-];
-
-/* ============ detail body (shared by hero card + inline expand) ============ */
 function HFDetailBody({
-  asset,
+  item,
   compact = false,
   isNextUp = false,
+  onMarkComplete,
+  completing = false,
+  completeError,
 }: {
-  asset: Asset;
+  item: DashboardQueuePresentation;
   compact?: boolean;
   isNextUp?: boolean;
+  onMarkComplete: () => void;
+  completing?: boolean;
+  completeError?: string | null;
 }) {
   return (
     <div className="hf-detail-body" data-compact={compact}>
@@ -159,18 +44,16 @@ function HFDetailBody({
               <Icon name="arrow-right" size={12} stroke={2.2} />
               {isNextUp ? "Next up" : "Selected"}
             </span>
-            <HFStatusPill status={asset.status} due={asset.due} />
+            <HFStatusPill status={item.status} due={item.due} />
           </div>
           <div className="hf-asset-row">
-            <HFAssetIcon asset={asset} size={56} />
+            <HFAssetIcon asset={item} size={56} />
             <div className="hf-asset-id">
-              <h2 className="hf-asset-name">{asset.name}</h2>
+              <h2 className="hf-asset-name">{item.name}</h2>
               <div className="hf-asset-meta">
-                <span className="hf-mono">{asset.id}</span>
+                <span className="hf-mono">{item.displayId}</span>
                 <span className="hf-dot-sep" />
-                <span>{asset.meter}</span>
-                <span className="hf-dot-sep" />
-                <span>last service {asset.last}</span>
+                <span>last service {item.last}</span>
               </div>
             </div>
           </div>
@@ -180,7 +63,7 @@ function HFDetailBody({
 
       <div className="hf-service-block">
         <div className="hf-label">Service due</div>
-        <div className="hf-service-name">{asset.service}</div>
+        <div className="hf-service-name">{item.service}</div>
       </div>
 
       <div className="hf-meta-grid">
@@ -188,89 +71,73 @@ function HFDetailBody({
           <Icon name="repeat" size={14} color="var(--hf-ink-faint)" />
           <div className="hf-meta-text">
             <div className="hf-label-sm">Recurs</div>
-            <div className="hf-meta-val">{asset.recurs}</div>
-          </div>
-        </div>
-        <div className="hf-meta-item">
-          <Icon name="clock-sm" size={14} color="var(--hf-ink-faint)" />
-          <div className="hf-meta-text">
-            <div className="hf-label-sm">Est. time</div>
-            <div className="hf-meta-val">{asset.est}</div>
-          </div>
-        </div>
-        <div className="hf-meta-item">
-          <Icon name="pin" size={14} color="var(--hf-ink-faint)" />
-          <div className="hf-meta-text">
-            <div className="hf-label-sm">Where</div>
-            <div className="hf-meta-val">{asset.where}</div>
-          </div>
-        </div>
-        <div className="hf-meta-item">
-          <Icon name="wrench" size={14} color="var(--hf-ink-faint)" />
-          <div className="hf-meta-text">
-            <div className="hf-label-sm">Assigned</div>
-            <div className="hf-meta-val">{asset.assignee}</div>
+            <div className="hf-meta-val">{item.recurs}</div>
           </div>
         </div>
       </div>
 
-      <div className="hf-notes">
-        <div className="hf-label">Notes</div>
-        <p className="hf-notes-text">{asset.notes}</p>
-      </div>
+      {completeError ? (
+        <p className="hf-notes-text" role="alert" style={{ color: "var(--hf-bad)" }}>
+          <Icon name="alert" size={14} stroke={2} /> {completeError}
+        </p>
+      ) : null}
 
       <div className="hf-actions">
-        <button className="hf-btn hf-btn-primary">
+        <button
+          className="hf-btn hf-btn-primary"
+          onClick={onMarkComplete}
+          disabled={completing}
+        >
           <Icon name="check" size={14} stroke={2.2} />
-          Mark complete
+          {completing ? "Saving…" : "Mark complete"}
         </button>
-        <button className="hf-btn hf-btn-secondary">
+        <button className="hf-btn hf-btn-secondary" disabled title="Coming soon">
           <Icon name="calendar" size={14} />
           Reschedule
         </button>
-        <button className="hf-btn hf-btn-ghost">
+        <button className="hf-btn hf-btn-ghost" disabled title="Coming soon">
           <Icon name="snooze" size={14} />
           Snooze
         </button>
         {!compact && (
-          <button className="hf-btn hf-btn-ghost hf-btn-end">
+          <Link className="hf-btn hf-btn-ghost hf-btn-end" to={paths.assetMaintenance(item.assetId)}>
             View asset
             <Icon name="chevron-right" size={14} />
-          </button>
+          </Link>
         )}
       </div>
     </div>
   );
 }
 
-/* ============ greeting + stat row ============ */
-function HFGreeting({ displayName }: { displayName: string | null | undefined }) {
-  const counts = HF_ASSETS.reduce(
-    (acc, a) => {
-      acc[a.status]++;
-      return acc;
-    },
-    { overdue: 0, soon: 0, ok: 0 } as Record<AssetStatus, number>,
-  );
+function HFGreeting({
+  displayName,
+  subline,
+  health,
+}: {
+  displayName: string | null | undefined;
+  subline: string;
+  health: { overdue: number; soon: number; onTrack: number };
+}) {
   return (
     <div className="hf-greeting">
       <div className="hf-greeting-text">
         <h1 className="hf-h1">
-          {formatDashboardGreeting(displayName)} <span className="hf-wave">·</span>
+          {formatGreeting(displayName)} <span className="hf-wave">·</span>
         </h1>
-        <div className="hf-greeting-sub">Tuesday · May 19, 2026 · 6 assets in your fleet</div>
+        <div className="hf-greeting-sub">{subline}</div>
       </div>
       <div className="hf-stats">
         <div className="hf-stat hf-stat-bad">
-          <div className="hf-stat-val">{counts.overdue}</div>
+          <div className="hf-stat-val">{health.overdue}</div>
           <div className="hf-stat-lbl">Overdue</div>
         </div>
         <div className="hf-stat hf-stat-warn">
-          <div className="hf-stat-val">{counts.soon}</div>
+          <div className="hf-stat-val">{health.soon}</div>
           <div className="hf-stat-lbl">Due soon</div>
         </div>
         <div className="hf-stat hf-stat-ok">
-          <div className="hf-stat-val">{counts.ok}</div>
+          <div className="hf-stat-val">{health.onTrack}</div>
           <div className="hf-stat-lbl">On track</div>
         </div>
       </div>
@@ -278,97 +145,307 @@ function HFGreeting({ displayName }: { displayName: string | null | undefined })
   );
 }
 
-/* ============ main: master/detail ============ */
+function HFDashboardState({
+  title,
+  description,
+  action,
+}: {
+  title: string;
+  description: string;
+  action?: React.ReactNode;
+}) {
+  return (
+    <div className="hf-assets-state">
+      <div className="hf-assets-state-title">{title}</div>
+      <div className="hf-assets-state-sub">{description}</div>
+      {action}
+    </div>
+  );
+}
+
+const CATEGORY_FILTERS: { id: DashboardCategoryFilter; label: string }[] = [
+  { id: "all", label: "All" },
+  { id: "vehicle", label: "Vehicles" },
+  { id: "equipment", label: "Equipment" },
+  { id: "property", label: "Properties" },
+];
+
 export function AppHome({ mobileMode = "inline" }: { mobileMode?: "inline" }) {
-  const { data: profile } = useQuery({
-    queryKey: userProfileQueryKey,
-    queryFn: getUserProfile,
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [category, setCategory] = useState<DashboardCategoryFilter>("all");
+  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+  const [completeError, setCompleteError] = useState<string | null>(null);
+
+  const dashboardQuery = useQuery({
+    queryKey: dashboardQueryKey,
+    queryFn: getDashboard,
+    retry: (failureCount, error) =>
+      !(error instanceof ApiError && error.status === 401) && failureCount < 2,
   });
-  const sorted = [...HF_ASSETS].sort((a, b) => a.dueDays - b.dueDays);
-  const [selId, setSelId] = useState(sorted[0]?.id ?? "");
-  const selected = HF_ASSETS.find((a) => a.id === selId) ?? sorted[0];
-  const isNextUp = selId === sorted[0]?.id;
+
+  const completeMutation = useMutation({
+    mutationFn: async (item: DashboardQueuePresentation) => {
+      const dashboard = dashboardQuery.data;
+      if (!dashboard) throw new Error("Dashboard is not loaded");
+      return createMaintenanceRecord(item.assetId, {
+        title: item.service,
+        performedAt: dashboard.todayUtc,
+        taskId: item.taskId,
+      });
+    },
+    onSuccess: async (_record, item) => {
+      setCompleteError(null);
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: dashboardQueryKey }),
+        queryClient.invalidateQueries({ queryKey: maintenanceRecordsQueryKey(item.assetId) }),
+        queryClient.invalidateQueries({ queryKey: maintenanceTasksQueryKey(item.assetId) }),
+      ]);
+    },
+    onError: async (error) => {
+      if (error instanceof ApiError && error.status === 401) {
+        navigate(paths.login(), { replace: true });
+        return;
+      }
+      setCompleteError(error instanceof Error ? error.message : "Could not mark task complete.");
+      await queryClient.invalidateQueries({ queryKey: dashboardQueryKey });
+    },
+  });
 
   useEffect(() => {
     document.title = "FieldOps — Home";
   }, []);
 
-  if (!selected) return null;
+  useEffect(() => {
+    if (dashboardQuery.error instanceof ApiError && dashboardQuery.error.status === 401) {
+      navigate(paths.login(), { replace: true });
+    }
+  }, [dashboardQuery.error, navigate]);
+
+  const queue = useMemo(() => {
+    if (!dashboardQuery.data) return [];
+    return dashboardQuery.data.queue.map((item) =>
+      toQueuePresentation(item, dashboardQuery.data!.todayUtc),
+    );
+  }, [dashboardQuery.data]);
+
+  const filteredQueue = useMemo(
+    () => filterQueueByCategory(queue, category),
+    [queue, category],
+  );
+
+  useEffect(() => {
+    if (filteredQueue.length === 0) {
+      setSelectedTaskId(null);
+      return;
+    }
+    if (!selectedTaskId || !filteredQueue.some((item) => item.taskId === selectedTaskId)) {
+      setSelectedTaskId(filteredQueue[0]!.taskId);
+    }
+  }, [filteredQueue, selectedTaskId]);
+
+  const selected = filteredQueue.find((item) => item.taskId === selectedTaskId) ?? filteredQueue[0];
+  const isNextUp = selected?.taskId === filteredQueue[0]?.taskId;
+
+  const categoryCounts = useMemo(
+    () => ({
+      all: queue.length,
+      vehicle: queue.filter((item) => item.category === "vehicle").length,
+      equipment: queue.filter((item) => item.category === "equipment").length,
+      property: queue.filter((item) => item.category === "property").length,
+    }),
+    [queue],
+  );
+
+  const chipCount = (id: DashboardCategoryFilter) => {
+    if (id === "all") return categoryCounts.all;
+    return categoryCounts[id];
+  };
+
+  if (dashboardQuery.isPending) {
+    return (
+      <div className={`hf hf-app hf-mobile-${mobileMode}`}>
+        <HFTopBar />
+        <main className="hf-main hf-shell">
+          <HFDashboardState
+            title="Loading dashboard"
+            description="Fetching your fleet health and maintenance queue..."
+          />
+        </main>
+        <HFBottomNav />
+      </div>
+    );
+  }
+
+  if (dashboardQuery.isError) {
+    return (
+      <div className={`hf hf-app hf-mobile-${mobileMode}`}>
+        <HFTopBar />
+        <main className="hf-main hf-shell">
+          <HFDashboardState
+            title="Dashboard could not be loaded"
+            description={dashboardQuery.error.message}
+            action={
+              <button
+                className="hf-btn hf-btn-secondary"
+                onClick={() => void dashboardQuery.refetch()}
+              >
+                Try again
+              </button>
+            }
+          />
+        </main>
+        <HFBottomNav />
+      </div>
+    );
+  }
+
+  const dashboard = dashboardQuery.data;
+
+  if (dashboard.fleetTotals.total === 0) {
+    return (
+      <div className={`hf hf-app hf-mobile-${mobileMode}`}>
+        <HFTopBar />
+        <main className="hf-main hf-shell">
+          <HFGreeting
+            displayName={dashboard.viewerDisplayName}
+            subline={formatFleetSubline(dashboard.todayUtc, 0)}
+            health={{ overdue: 0, soon: 0, onTrack: 0 }}
+          />
+          <HFDashboardState
+            title="No assets yet"
+            description="Add your first vehicle, property, or piece of equipment to start tracking maintenance."
+            action={
+              <Link className="hf-btn hf-btn-primary" to={paths.addAsset}>
+                <Icon name="plus" size={14} stroke={2.2} />
+                Add asset
+              </Link>
+            }
+          />
+        </main>
+        <HFBottomNav />
+      </div>
+    );
+  }
 
   return (
     <div className={`hf hf-app hf-mobile-${mobileMode}`}>
       <HFTopBar />
       <main className="hf-main hf-shell">
-        <HFGreeting displayName={profile?.name} />
+        <HFGreeting
+          displayName={dashboard.viewerDisplayName}
+          subline={formatFleetSubline(dashboard.todayUtc, dashboard.fleetTotals.total)}
+          health={{
+            overdue: dashboard.fleetHealth.overdue,
+            soon: dashboard.fleetHealth.soon,
+            onTrack: dashboard.fleetHealth.onTrack,
+          }}
+        />
 
         <div className="hf-filters">
           <div className="hf-filter-chips">
-            <button className="hf-chip active">
-              All <span className="hf-chip-count">6</span>
-            </button>
-            <button className="hf-chip">
-              Vehicles <span className="hf-chip-count">2</span>
-            </button>
-            <button className="hf-chip">
-              Equipment <span className="hf-chip-count">2</span>
-            </button>
-            <button className="hf-chip">
-              Properties <span className="hf-chip-count">1</span>
-            </button>
-            <button className="hf-chip">
-              Grounds <span className="hf-chip-count">1</span>
-            </button>
+            {CATEGORY_FILTERS.map((filter) => (
+              <button
+                key={filter.id}
+                className={`hf-chip ${category === filter.id ? "active" : ""}`}
+                onClick={() => setCategory(filter.id)}
+              >
+                {filter.label}
+                <span className="hf-chip-count">{chipCount(filter.id)}</span>
+              </button>
+            ))}
           </div>
-          <button className="hf-btn hf-btn-secondary hf-btn-sm">
+          <button className="hf-btn hf-btn-secondary hf-btn-sm" disabled title="Coming soon">
             <Icon name="plus" size={14} stroke={2} />
             Add service
           </button>
         </div>
 
-        <div className="hf-grid">
-          {/* detail card */}
-          <section className="hf-detail-card" data-status={selected.status}>
-            <HFDetailBody asset={selected} isNextUp={isNextUp} />
-          </section>
+        {queue.length === 0 ? (
+          <HFDashboardState
+            title="No scheduled maintenance yet"
+            description="Add maintenance tasks to your assets so the dashboard can track what's due next."
+            action={
+              <Link className="hf-btn hf-btn-primary" to={paths.assets}>
+                Go to assets
+              </Link>
+            }
+          />
+        ) : filteredQueue.length === 0 || !selected ? (
+          <HFDashboardState
+            title="No tasks in this category"
+            description="Try another filter to see scheduled maintenance for that asset type."
+            action={
+              <button className="hf-btn hf-btn-secondary" onClick={() => setCategory("all")}>
+                Show all tasks
+              </button>
+            }
+          />
+        ) : (
+          <div className="hf-grid">
+            <section className="hf-detail-card" data-status={selected.status as AssetStatus}>
+              <HFDetailBody
+                item={selected}
+                isNextUp={isNextUp}
+                onMarkComplete={() => {
+                  setCompleteError(null);
+                  completeMutation.mutate(selected);
+                }}
+                completing={completeMutation.isPending}
+                completeError={completeError}
+              />
+            </section>
 
-          {/* queue */}
-          <section className="hf-queue">
-            <div className="hf-queue-head">
-              <h3 className="hf-h3">Queue</h3>
-              <span className="hf-mono hf-ink-faint">By urgency · {HF_ASSETS.length}</span>
-            </div>
-            <ul className="hf-queue-list">
-              {sorted.map((a) => {
-                const isSel = a.id === selId;
-                return (
-                  <li
-                    key={a.id}
-                    className={`hf-row ${isSel ? "selected" : ""}`}
-                    data-status={a.status}
-                    onClick={() => setSelId(a.id)}
-                  >
-                    <div className="hf-row-summary">
-                      <HFAssetIcon asset={a} size={36} />
-                      <div className="hf-row-text">
-                        <div className="hf-row-name">{a.name}</div>
-                        <div className="hf-row-sub">{a.service}</div>
+            <section className="hf-queue">
+              <div className="hf-queue-head">
+                <h3 className="hf-h3">Queue</h3>
+                <span className="hf-mono hf-ink-faint">
+                  By urgency · {filteredQueue.length}
+                </span>
+              </div>
+              <ul className="hf-queue-list">
+                {filteredQueue.map((item) => {
+                  const isSel = item.taskId === selectedTaskId;
+                  return (
+                    <li
+                      key={item.taskId}
+                      className={`hf-row ${isSel ? "selected" : ""}`}
+                      data-status={item.status}
+                      onClick={() => setSelectedTaskId(item.taskId)}
+                    >
+                      <div className="hf-row-summary">
+                        <HFAssetIcon asset={item} size={36} />
+                        <div className="hf-row-text">
+                          <div className="hf-row-name">{item.name}</div>
+                          <div className="hf-row-sub">{item.service}</div>
+                        </div>
+                        <div className="hf-row-right">
+                          <div className="hf-row-due">{item.due}</div>
+                          <span className="hf-status-dot" data-status={item.status} />
+                        </div>
                       </div>
-                      <div className="hf-row-right">
-                        <div className="hf-row-due">{a.due}</div>
-                        <span className="hf-status-dot" data-status={a.status} />
-                      </div>
-                    </div>
-                    {isSel && (
-                      <div className="hf-row-detail">
-                        <HFDetailBody asset={a} compact isNextUp={isNextUp} />
-                      </div>
-                    )}
-                  </li>
-                );
-              })}
-            </ul>
-          </section>
-        </div>
+                      {isSel && (
+                        <div className="hf-row-detail">
+                          <HFDetailBody
+                            item={item}
+                            compact
+                            isNextUp={isNextUp}
+                            onMarkComplete={() => {
+                              setCompleteError(null);
+                              completeMutation.mutate(item);
+                            }}
+                            completing={completeMutation.isPending}
+                            completeError={completeError}
+                          />
+                        </div>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            </section>
+          </div>
+        )}
       </main>
       <HFBottomNav />
     </div>

--- a/apps/web/src/app/AppHome.tsx
+++ b/apps/web/src/app/AppHome.tsx
@@ -224,9 +224,7 @@ export function AppHome({ mobileMode = "inline" }: { mobileMode?: "inline" }) {
 
   const queue = useMemo(() => {
     if (!dashboardQuery.data) return [];
-    return dashboardQuery.data.queue.map((item) =>
-      toQueuePresentation(item, dashboardQuery.data!.todayUtc),
-    );
+    return dashboardQuery.data.queue.map((item) => toQueuePresentation(item));
   }, [dashboardQuery.data]);
 
   const filteredQueue = useMemo(

--- a/apps/web/src/app/AppMaintenanceRecords.tsx
+++ b/apps/web/src/app/AppMaintenanceRecords.tsx
@@ -63,33 +63,25 @@ function relAgo(s: string): string {
   return `${yr} ${yr > 1 ? "years" : "year"} ago`;
 }
 
-// ─── task helpers (client display, match prototype logic) ────────────────────
-
-type TaskStatus = "overdue" | "soon" | "ok";
-
-function taskStatus(nextDue: string): TaskStatus {
-  const n = Math.round((ymdToUTC(todayDateOnly()) - ymdToUTC(nextDue)) / 86400000);
-  if (n > 0) return "overdue";
-  if (n >= -14) return "soon";
-  return "ok";
-}
+// ─── task helpers (presentation only — status/daysDue come from the API) ─────
 
 function fmtInterval(value: number, unit: string): string {
   return value === 1 ? `Every ${unit}` : `Every ${value} ${unit}s`;
 }
 
-function nextDueLabel(nextDue: string): string {
-  const n = Math.round((ymdToUTC(todayDateOnly()) - ymdToUTC(nextDue)) / 86400000);
-  if (n > 0) return `Overdue · ${n === 1 ? "1 day" : n + " days"}`;
-  if (n === 0) return "Due today";
-  const ahead = -n;
-  if (ahead === 1) return "Due tomorrow";
-  if (ahead <= 14) return `Due in ${ahead} days`;
+function nextDueLabel(daysDue: number, nextDue: string): string {
+  if (daysDue < 0) {
+    const overdueDays = -daysDue;
+    return overdueDays === 1 ? "Overdue · 1 day" : `Overdue · ${overdueDays} days`;
+  }
+  if (daysDue === 0) return "Due today";
+  if (daysDue === 1) return "Due tomorrow";
+  if (daysDue <= 14) return `Due in ${daysDue} days`;
   const parts = nextDue.split("-").map(Number);
   const y = parts[0]!, m = parts[1]!, d = parts[2]!;
   const todayY = Number(todayDateOnly().slice(0, 4));
-  if (y === todayY) return `Due ${["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"][m-1]} ${d}`;
-  return `Due ${["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"][m-1]} ${d}, ${y}`;
+  if (y === todayY) return `Due ${MONTHS_SHORT[m - 1]} ${d}`;
+  return `Due ${MONTHS_SHORT[m - 1]} ${d}, ${y}`;
 }
 
 function addIntervalClient(dateStr: string, value: number, unit: "day" | "week" | "month" | "year"): string {
@@ -319,9 +311,9 @@ function MRErrorState({
 // ─── Overview / Schedule / Recent (ported & adapted from design) ─────────────
 
 function MRHealthSummary({ tasks }: { tasks: MaintenanceTask[] }) {
-  const overdue = tasks.filter((tk) => taskStatus(tk.nextDue) === "overdue").length;
-  const soon = tasks.filter((tk) => taskStatus(tk.nextDue) === "soon").length;
-  const ok = tasks.filter((tk) => taskStatus(tk.nextDue) === "ok").length;
+  const overdue = tasks.filter((tk) => tk.status === "overdue").length;
+  const soon = tasks.filter((tk) => tk.status === "soon").length;
+  const ok = tasks.filter((tk) => tk.status === "ok").length;
   if (tasks.length === 0) return null;
   return (
     <div className="mr-health-row" role="status" aria-label="Task health summary">
@@ -398,7 +390,7 @@ function MRRecentActivity({ records, onViewAll }: { records: MaintenanceRecord[]
 
 function MRTaskCard({ task, onLog, onDelete }: { task: MaintenanceTask; onLog: (id: string) => void; onDelete: (id: string) => void }) {
   const [confirming, setConfirming] = useState(false);
-  const s = taskStatus(task.nextDue);
+  const s = task.status;
   return (
     <div className="mr-task-card" data-status={s}>
       <div className="mr-task-card-main">
@@ -411,7 +403,7 @@ function MRTaskCard({ task, onLog, onDelete }: { task: MaintenanceTask; onLog: (
       <div className="mr-task-card-right">
         <span className={`mr-due-badge mr-due-badge-${s}`}>
           <Icon name={s === "overdue" ? "alert" : s === "soon" ? "clock-sm" : "check"} size={11} stroke={2} />
-          {nextDueLabel(task.nextDue)}
+          {nextDueLabel(task.daysDue, task.nextDue)}
         </span>
         {confirming ? (
           <div className="mr-task-confirm">
@@ -472,7 +464,7 @@ function MRScheduleSection({
   onAdd: () => void;
 }) {
   const sorted = [...tasks].sort((a, b) => (a.nextDue < b.nextDue ? -1 : 1));
-  const overdueCount = sorted.filter((t) => taskStatus(t.nextDue) === "overdue").length;
+  const overdueCount = sorted.filter((t) => t.status === "overdue").length;
   return (
     <div className="mr-schedule">
       <div className="mr-schedule-head">

--- a/apps/web/src/app/dashboardPresentation.test.ts
+++ b/apps/web/src/app/dashboardPresentation.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+  calendarDaysBetween,
+  formatDueLabel,
+  formatFleetSubline,
+  formatRecurrence,
+} from "./dashboardPresentation.ts";
+
+describe("dashboardPresentation", () => {
+  const todayUtc = "2026-06-16";
+
+  it("formats overdue, today, tomorrow, and future due labels", () => {
+    expect(formatDueLabel("2026-06-13", todayUtc)).toBe("Overdue · 3 days");
+    expect(formatDueLabel(todayUtc, todayUtc)).toBe("Today");
+    expect(formatDueLabel("2026-06-17", todayUtc)).toBe("Tomorrow");
+    expect(formatDueLabel("2026-06-21", todayUtc)).toBe("In 5 days");
+  });
+
+  it("counts calendar days without timestamp arithmetic", () => {
+    expect(calendarDaysBetween("2026-06-10", todayUtc)).toBe(6);
+    expect(calendarDaysBetween(todayUtc, "2026-06-10")).toBe(-6);
+  });
+
+  it("formats fleet subline from API totals and todayUtc", () => {
+    expect(formatFleetSubline(todayUtc, 6)).toBe(
+      "Tuesday · June 16, 2026 · 6 assets in your fleet",
+    );
+  });
+
+  it("formats recurrence labels", () => {
+    expect(formatRecurrence(1, "year")).toBe("Annual");
+    expect(formatRecurrence(2, "month")).toBe("Every 2 months");
+  });
+});

--- a/apps/web/src/app/dashboardPresentation.test.ts
+++ b/apps/web/src/app/dashboardPresentation.test.ts
@@ -1,10 +1,6 @@
+import { calendarDaysBetween } from "@snaveevans/pineapple-shared";
 import { describe, expect, it } from "vitest";
-import {
-  calendarDaysBetween,
-  formatDueLabel,
-  formatFleetSubline,
-  formatRecurrence,
-} from "./dashboardPresentation.ts";
+import { formatDueLabel, formatFleetSubline, formatRecurrence } from "./dashboardPresentation.ts";
 
 describe("dashboardPresentation", () => {
   const todayUtc = "2026-06-16";

--- a/apps/web/src/app/dashboardPresentation.test.ts
+++ b/apps/web/src/app/dashboardPresentation.test.ts
@@ -1,20 +1,14 @@
-import { calendarDaysBetween } from "@snaveevans/pineapple-shared";
 import { describe, expect, it } from "vitest";
 import { formatDueLabel, formatFleetSubline, formatRecurrence } from "./dashboardPresentation.ts";
 
 describe("dashboardPresentation", () => {
   const todayUtc = "2026-06-16";
 
-  it("formats overdue, today, tomorrow, and future due labels", () => {
-    expect(formatDueLabel("2026-06-13", todayUtc)).toBe("Overdue · 3 days");
-    expect(formatDueLabel(todayUtc, todayUtc)).toBe("Today");
-    expect(formatDueLabel("2026-06-17", todayUtc)).toBe("Tomorrow");
-    expect(formatDueLabel("2026-06-21", todayUtc)).toBe("In 5 days");
-  });
-
-  it("counts calendar days without timestamp arithmetic", () => {
-    expect(calendarDaysBetween("2026-06-10", todayUtc)).toBe(6);
-    expect(calendarDaysBetween(todayUtc, "2026-06-10")).toBe(-6);
+  it("formats overdue, today, tomorrow, and future due labels from daysDue", () => {
+    expect(formatDueLabel(-3)).toBe("Overdue · 3 days");
+    expect(formatDueLabel(0)).toBe("Today");
+    expect(formatDueLabel(1)).toBe("Tomorrow");
+    expect(formatDueLabel(5)).toBe("In 5 days");
   });
 
   it("formats fleet subline from API totals and todayUtc", () => {

--- a/apps/web/src/app/dashboardPresentation.ts
+++ b/apps/web/src/app/dashboardPresentation.ts
@@ -1,4 +1,3 @@
-import { calendarDaysBetween } from "@snaveevans/pineapple-shared";
 import type { AssetType, DashboardQueueItem } from "../api/dashboard.ts";
 import type { IconName } from "../design/Icon.tsx";
 import type { AssetCategory, AssetStatus } from "../design/hf.tsx";
@@ -61,15 +60,14 @@ export function formatFleetSubline(todayUtc: string, total: number): string {
   return `${formatDashboardDate(todayUtc)} · ${total} ${noun} in your fleet`;
 }
 
-export function formatDueLabel(nextDue: string, todayUtc: string): string {
-  const daysAhead = calendarDaysBetween(todayUtc, nextDue);
-  if (daysAhead < 0) {
-    const overdueDays = -daysAhead;
+export function formatDueLabel(daysDue: number): string {
+  if (daysDue < 0) {
+    const overdueDays = -daysDue;
     return overdueDays === 1 ? "Overdue · 1 day" : `Overdue · ${overdueDays} days`;
   }
-  if (daysAhead === 0) return "Today";
-  if (daysAhead === 1) return "Tomorrow";
-  return `In ${daysAhead} days`;
+  if (daysDue === 0) return "Today";
+  if (daysDue === 1) return "Tomorrow";
+  return `In ${daysDue} days`;
 }
 
 export function formatLastService(lastCompletedDate: string | null): string {
@@ -107,10 +105,7 @@ function iconForAssetType(type: AssetType): IconName {
   }
 }
 
-export function toQueuePresentation(
-  item: DashboardQueueItem,
-  todayUtc: string,
-): DashboardQueuePresentation {
+export function toQueuePresentation(item: DashboardQueueItem): DashboardQueuePresentation {
   return {
     taskId: item.taskId,
     assetId: item.assetId,
@@ -119,7 +114,7 @@ export function toQueuePresentation(
     category: item.assetType,
     icon: iconForAssetType(item.assetType),
     service: item.taskTitle,
-    due: formatDueLabel(item.nextDue, todayUtc),
+    due: formatDueLabel(item.daysDue),
     status: item.status,
     last: formatLastService(item.lastCompletedDate),
     recurs: formatRecurrence(item.intervalValue, item.intervalUnit),

--- a/apps/web/src/app/dashboardPresentation.ts
+++ b/apps/web/src/app/dashboardPresentation.ts
@@ -1,3 +1,4 @@
+import { calendarDaysBetween } from "@snaveevans/pineapple-shared";
 import type { AssetType, DashboardQueueItem } from "../api/dashboard.ts";
 import type { IconName } from "../design/Icon.tsx";
 import type { AssetCategory, AssetStatus } from "../design/hf.tsx";
@@ -47,51 +48,6 @@ export type DashboardQueuePresentation = {
 function ymdParts(value: string): [number, number, number] {
   const [year, month, day] = value.split("-").map(Number);
   return [year!, month!, day!];
-}
-
-export function calendarDaysBetween(start: string, end: string): number {
-  if (start === end) return 0;
-
-  let cursor = start;
-  let days = 0;
-  const step = start < end ? 1 : -1;
-
-  while (cursor !== end) {
-    const [year, month, day] = ymdParts(cursor);
-    let nextYear = year;
-    let nextMonth = month;
-    let nextDay = day + step;
-
-    const daysInMonth = (y: number, m: number) => {
-      if (m === 2) {
-        const leap = y % 4 === 0 && (y % 100 !== 0 || y % 400 === 0);
-        return leap ? 29 : 28;
-      }
-      return [4, 6, 9, 11].includes(m) ? 30 : 31;
-    };
-
-    while (nextDay > daysInMonth(nextYear, nextMonth)) {
-      nextDay -= daysInMonth(nextYear, nextMonth);
-      nextMonth++;
-      if (nextMonth > 12) {
-        nextMonth = 1;
-        nextYear++;
-      }
-    }
-    while (nextDay < 1) {
-      nextMonth--;
-      if (nextMonth < 1) {
-        nextMonth = 12;
-        nextYear--;
-      }
-      nextDay += daysInMonth(nextYear, nextMonth);
-    }
-
-    cursor = `${String(nextYear).padStart(4, "0")}-${String(nextMonth).padStart(2, "0")}-${String(nextDay).padStart(2, "0")}`;
-    days += step;
-  }
-
-  return days;
 }
 
 export function formatDashboardDate(todayUtc: string): string {

--- a/apps/web/src/app/dashboardPresentation.ts
+++ b/apps/web/src/app/dashboardPresentation.ts
@@ -1,0 +1,179 @@
+import type { AssetType, DashboardQueueItem } from "../api/dashboard.ts";
+import type { IconName } from "../design/Icon.tsx";
+import type { AssetCategory, AssetStatus } from "../design/hf.tsx";
+import { shortenAssetId } from "./assetPresentation.ts";
+
+const MONTHS_LONG = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+] as const;
+
+const WEEKDAYS = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+] as const;
+
+export type DashboardCategoryFilter = "all" | AssetType;
+
+export type DashboardQueuePresentation = {
+  taskId: string;
+  assetId: string;
+  name: string;
+  displayId: string;
+  category: AssetCategory;
+  icon: IconName;
+  service: string;
+  due: string;
+  status: AssetStatus;
+  last: string;
+  recurs: string;
+};
+
+function ymdParts(value: string): [number, number, number] {
+  const [year, month, day] = value.split("-").map(Number);
+  return [year!, month!, day!];
+}
+
+export function calendarDaysBetween(start: string, end: string): number {
+  if (start === end) return 0;
+
+  let cursor = start;
+  let days = 0;
+  const step = start < end ? 1 : -1;
+
+  while (cursor !== end) {
+    const [year, month, day] = ymdParts(cursor);
+    let nextYear = year;
+    let nextMonth = month;
+    let nextDay = day + step;
+
+    const daysInMonth = (y: number, m: number) => {
+      if (m === 2) {
+        const leap = y % 4 === 0 && (y % 100 !== 0 || y % 400 === 0);
+        return leap ? 29 : 28;
+      }
+      return [4, 6, 9, 11].includes(m) ? 30 : 31;
+    };
+
+    while (nextDay > daysInMonth(nextYear, nextMonth)) {
+      nextDay -= daysInMonth(nextYear, nextMonth);
+      nextMonth++;
+      if (nextMonth > 12) {
+        nextMonth = 1;
+        nextYear++;
+      }
+    }
+    while (nextDay < 1) {
+      nextMonth--;
+      if (nextMonth < 1) {
+        nextMonth = 12;
+        nextYear--;
+      }
+      nextDay += daysInMonth(nextYear, nextMonth);
+    }
+
+    cursor = `${String(nextYear).padStart(4, "0")}-${String(nextMonth).padStart(2, "0")}-${String(nextDay).padStart(2, "0")}`;
+    days += step;
+  }
+
+  return days;
+}
+
+export function formatDashboardDate(todayUtc: string): string {
+  const [year, month, day] = ymdParts(todayUtc);
+  const weekday = WEEKDAYS[new Date(Date.UTC(year, month - 1, day)).getUTCDay()]!;
+  return `${weekday} · ${MONTHS_LONG[month - 1]} ${day}, ${year}`;
+}
+
+export function formatFleetSubline(todayUtc: string, total: number): string {
+  const noun = total === 1 ? "asset" : "assets";
+  return `${formatDashboardDate(todayUtc)} · ${total} ${noun} in your fleet`;
+}
+
+export function formatDueLabel(nextDue: string, todayUtc: string): string {
+  const daysAhead = calendarDaysBetween(todayUtc, nextDue);
+  if (daysAhead < 0) {
+    const overdueDays = -daysAhead;
+    return overdueDays === 1 ? "Overdue · 1 day" : `Overdue · ${overdueDays} days`;
+  }
+  if (daysAhead === 0) return "Today";
+  if (daysAhead === 1) return "Tomorrow";
+  return `In ${daysAhead} days`;
+}
+
+export function formatLastService(lastCompletedDate: string | null): string {
+  if (!lastCompletedDate) return "—";
+  const [, month, day] = ymdParts(lastCompletedDate);
+  return `${MONTHS_LONG[month - 1]!.slice(0, 3)} ${day}`;
+}
+
+export function formatRecurrence(intervalValue: number, intervalUnit: string): string {
+  if (intervalValue === 1) {
+    switch (intervalUnit) {
+      case "day":
+        return "Daily";
+      case "week":
+        return "Weekly";
+      case "month":
+        return "Monthly";
+      case "year":
+        return "Annual";
+      default:
+        return `Every ${intervalUnit}`;
+    }
+  }
+  return `Every ${intervalValue} ${intervalUnit}s`;
+}
+
+function iconForAssetType(type: AssetType): IconName {
+  switch (type) {
+    case "vehicle":
+      return "truck";
+    case "property":
+      return "home";
+    case "equipment":
+      return "wrench";
+  }
+}
+
+export function toQueuePresentation(
+  item: DashboardQueueItem,
+  todayUtc: string,
+): DashboardQueuePresentation {
+  return {
+    taskId: item.taskId,
+    assetId: item.assetId,
+    name: item.assetName,
+    displayId: shortenAssetId(item.assetId),
+    category: item.assetType,
+    icon: iconForAssetType(item.assetType),
+    service: item.taskTitle,
+    due: formatDueLabel(item.nextDue, todayUtc),
+    status: item.status,
+    last: formatLastService(item.lastCompletedDate),
+    recurs: formatRecurrence(item.intervalValue, item.intervalUnit),
+  };
+}
+
+export function filterQueueByCategory(
+  items: DashboardQueuePresentation[],
+  category: DashboardCategoryFilter,
+): DashboardQueuePresentation[] {
+  if (category === "all") return items;
+  return items.filter((item) => item.category === category);
+}

--- a/docs/decisions/0009-computed-fields-belong-in-api-read-models.md
+++ b/docs/decisions/0009-computed-fields-belong-in-api-read-models.md
@@ -1,0 +1,140 @@
+# Computed Fields Belong in API Read Models
+
+- Status: accepted
+- Date: 2026-06-16
+
+## Context and Problem Statement
+
+As the app grows beyond the dashboard, derived values like task status (`overdue`, `soon`, `ok`),
+status counts, and filter category labels appear in multiple places. The question is where this
+derivation happens: in the API before the response is sent, or in the client after it receives
+raw data.
+
+If the client derives these values, each client surface (dashboard, asset detail, task list)
+duplicates the same logic. Any future client — a mobile app, a notification worker, a webhook
+— has to reimplement it. A change to the "soon" window (e.g. from 7 days to 14 days) must be
+found and updated in every place it was computed.
+
+## Decision Drivers
+
+- Business logic — what "overdue" means, how many items fall into each status bucket — belongs
+  in the domain, not in rendering code
+- The OpenAPI contract is the single source of truth for the API (ADR-0008); having clients
+  silently derive fields outside that contract undermines it
+- Future clients (mobile, background workers) should consume the same pre-computed values
+  without re-implementing derivation logic
+- Client code should be a thin rendering layer: it decides _how_ to display a value, not _what_
+  the value is
+
+## Considered Options
+
+- **API computes derived fields, client renders them** — the API response includes status
+  labels, counts, and status filter metadata; the client reads and displays them
+- **Client computes derived fields from raw API data** — the API returns raw date strings and
+  scalar values; each client computes labels, thresholds, and counts locally
+- **Hybrid: client computes from a shared utility package** — derivation logic lives in a
+  shared package consumed by both the API and the client
+
+## Decision Outcome
+
+Chosen option: **API computes derived fields, client renders them**, because it keeps business
+logic in the layer that owns it and gives all consumers a consistent, authoritative result
+without duplication.
+
+### Positive Consequences
+
+- Threshold and label changes are made in one place (domain/application layer) and propagate
+  to all consumers automatically
+- Client code is simpler — no calendar arithmetic, no branching on raw values; it maps a status
+  string to a colour or icon
+- API responses are self-describing; the OpenAPI spec documents the computed fields alongside
+  the raw data
+- Unit tests for derived logic live in the API's test suite, not scattered across frontend tests
+
+### Negative Consequences
+
+- Read models may carry more fields than the simplest possible response; the API must be
+  designed to include the fields a client needs rather than deferring to the client to compute them
+- If a client needs a derived value the API doesn't yet provide, the API must be updated first —
+  the client cannot unilaterally work around it
+
+---
+
+## Boundary: what the API owns vs. what the client owns
+
+| Concern                                                     | Owner  | Examples                                                                                                                                       |
+| ----------------------------------------------------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| Status bucket derived from `nextDue`                        | API    | `"overdue"` / `"soon"` / `"ok"` via calendar-day comparison against `todayUtc`                                                                 |
+| Counts per status bucket                                    | API    | `{ overdue: 3, soon: 1, ok: 12 }`                                                                                                              |
+| Status filter metadata (value, label, count)                | API    | `[{ value: "overdue", label: "Overdue", count: 3 }, …]`                                                                                        |
+| Threshold definition (e.g. "soon" = within 7 calendar days) | API    | Defined in domain; reflected in OpenAPI descriptions as needed                                                                                 |
+| Asset category filters (vehicle / equipment / property)     | Split  | Aggregate read models (e.g. dashboard) include per-category counts; client owns which category is active and filters the returned list locally |
+| Which status filter is currently active                     | Client | `useState`, URL search params — ephemeral UI state                                                                                             |
+| Relative due-date copy ("Overdue · 3 days", "In 5 days")    | Client | Formatted from API `nextDue` + `todayUtc`; client must not re-derive the status bucket                                                         |
+| How to visually render a status (`"overdue"` → red badge)   | Client | Tailwind class, icon, colour token — pure presentation                                                                                         |
+
+**Asset category filters** are a distinct case from status filters. Aggregate read model endpoints
+(such as `GET /api/dashboard`) include pre-computed per-category counts (e.g. vehicle: 3,
+equipment: 2, property: 1) as part of their fleet summary; the client uses those counts to render
+filter pill badges. The full item list is returned in a single response, and the client filters it
+locally by category. The API does not track or return which category pill is currently selected.
+
+## Delivery patterns
+
+Computed fields can ship via **enriched resource responses** (e.g. a `status` field on each task
+in `GET /api/assets/{assetId}/maintenance-tasks`) or via **dedicated read models** (e.g.
+`GET /api/dashboard` that aggregates counts across assets) — the choice depends on what shape
+the consumer needs, but the same domain derivation logic is used in both cases.
+
+## Pattern
+
+```ts
+// application layer — derivation uses date-only calendar arithmetic, not timestamp subtraction
+function deriveTaskStatus(nextDue: string, todayUtc: string): "overdue" | "soon" | "ok" {
+  if (nextDue < todayUtc) return "overdue";
+  const sevenDaysOut = addCalendarDays(todayUtc, 7); // calendar-day addition, not milliseconds
+  if (nextDue <= sevenDaysOut) return "soon";
+  return "ok";
+}
+
+// API read model — computed field is part of the response shape
+type TaskSummary = {
+  id: TaskId;
+  title: string;
+  nextDue: string; // YYYY-MM-DD; retained so the client can format display copy
+  status: "overdue" | "soon" | "ok"; // derived by the API; client does not re-derive
+};
+```
+
+The client receives `status` and maps it to UI: a colour, an icon, a label string. It may
+format relative copy such as "Overdue · 3 days" or "In 5 days" from `nextDue` and today's
+date — but it must not inspect `nextDue` to decide _which bucket_ a task falls into.
+
+---
+
+## Pros and Cons of the Options
+
+### API computes derived fields, client renders them _(chosen)_
+
+- ✅ Good, because threshold changes propagate from one place to all consumers
+- ✅ Good, because the client has no calendar arithmetic — it maps a known enum to presentation
+- ✅ Good, because computed fields appear in the OpenAPI spec and are therefore contractual
+- ❌ Bad, because the API must anticipate which derived values a client will need
+
+### Client computes derived fields from raw API data
+
+- ✅ Good, because the API can return minimal payloads — no server-side pre-computation
+- ❌ Bad, because every client surface duplicates the same derivation logic
+- ❌ Bad, because threshold changes must be hunted down across all client code
+- ❌ Bad, because future clients (mobile, notifications) inherit the same duplication problem
+
+### Hybrid: client computes from a shared utility package
+
+- ✅ Good, because derivation logic is defined once and imported rather than duplicated
+- ❌ Bad, because `packages/shared/` is the innermost layer (ADR-0003) and must not contain
+  application-level concepts like status thresholds — importing them into the web client would
+  make `shared/` a de-facto application layer dependency for the frontend
+- ❌ Bad, because any consumer of the package still runs derivation at the edge; a backend
+  change requires re-deploying every client simultaneously to stay consistent
+- ❌ Bad, because the discipline required to keep the shared package from accumulating business
+  logic is high; it tends to become a catch-all over time

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -60,3 +60,4 @@ Use [`0000-template.md`](0000-template.md) as your starting point.
 | [0006](0006-deployment-platform.md)                              | Deployment platform                              | accepted |
 | [0007](0007-api-validation-boundary.md)                          | API validation boundary                          | accepted |
 | [0008](0008-documentation-method.md)                             | Documentation method                             | accepted |
+| [0009](0009-computed-fields-belong-in-api-read-models.md)        | Computed fields belong in API read models        | accepted |

--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -449,6 +449,21 @@
             "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
             "example": "2026-06-11"
           },
+          "status": {
+            "type": "string",
+            "enum": [
+              "overdue",
+              "soon",
+              "ok"
+            ],
+            "description": "Derived from nextDue and todayUtc using calendar-day rules",
+            "example": "soon"
+          },
+          "daysDue": {
+            "type": "integer",
+            "description": "Signed calendar-day distance from todayUtc to nextDue; negative means overdue",
+            "example": 5
+          },
           "createdAt": {
             "type": "string",
             "format": "date-time",
@@ -463,6 +478,8 @@
           "intervalUnit",
           "lastCompletedDate",
           "nextDue",
+          "status",
+          "daysDue",
           "createdAt"
         ]
       },

--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -638,6 +638,11 @@
             "description": "Derived from nextDue and todayUtc using calendar-day rules",
             "example": "soon"
           },
+          "daysDue": {
+            "type": "integer",
+            "description": "Signed calendar-day distance from todayUtc to nextDue; negative means overdue",
+            "example": -3
+          },
           "intervalValue": {
             "type": "integer",
             "example": 3
@@ -688,6 +693,7 @@
           "taskTitle",
           "nextDue",
           "status",
+          "daysDue",
           "intervalValue",
           "intervalUnit",
           "lastCompletedDate",

--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -31,6 +31,10 @@
     {
       "name": "Users",
       "description": "Read and update the authenticated user's domain profile"
+    },
+    {
+      "name": "Dashboard",
+      "description": "Authenticated home-screen read model for fleet health and maintenance queue"
     }
   ],
   "components": {
@@ -511,6 +515,192 @@
         },
         "required": [
           "maintenanceTasks"
+        ]
+      },
+      "DashboardFleetTotals": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "integer",
+            "minimum": 0,
+            "example": 6
+          },
+          "vehicle": {
+            "type": "integer",
+            "minimum": 0,
+            "example": 2
+          },
+          "equipment": {
+            "type": "integer",
+            "minimum": 0,
+            "example": 2
+          },
+          "property": {
+            "type": "integer",
+            "minimum": 0,
+            "example": 2
+          }
+        },
+        "required": [
+          "total",
+          "vehicle",
+          "equipment",
+          "property"
+        ]
+      },
+      "DashboardFleetHealth": {
+        "type": "object",
+        "properties": {
+          "overdue": {
+            "type": "integer",
+            "minimum": 0,
+            "example": 1
+          },
+          "soon": {
+            "type": "integer",
+            "minimum": 0,
+            "example": 2
+          },
+          "onTrack": {
+            "type": "integer",
+            "minimum": 0,
+            "example": 2
+          },
+          "unscheduled": {
+            "type": "integer",
+            "minimum": 0,
+            "example": 1
+          }
+        },
+        "required": [
+          "overdue",
+          "soon",
+          "onTrack",
+          "unscheduled"
+        ]
+      },
+      "DashboardQueueItem": {
+        "type": "object",
+        "properties": {
+          "taskId": {
+            "type": "string",
+            "format": "uuid",
+            "example": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+          },
+          "taskTitle": {
+            "type": "string",
+            "example": "Oil change + tire rotation"
+          },
+          "nextDue": {
+            "type": "string",
+            "format": "date",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+            "example": "2026-06-09"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "overdue",
+              "soon",
+              "ok"
+            ],
+            "description": "Derived from nextDue and todayUtc using calendar-day rules",
+            "example": "soon"
+          },
+          "intervalValue": {
+            "type": "integer",
+            "example": 3
+          },
+          "intervalUnit": {
+            "type": "string",
+            "enum": [
+              "day",
+              "week",
+              "month",
+              "year"
+            ],
+            "example": "month"
+          },
+          "lastCompletedDate": {
+            "type": "string",
+            "nullable": true,
+            "format": "date",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+            "example": "2026-03-14"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2026-01-15T12:00:00.000Z"
+          },
+          "assetId": {
+            "type": "string",
+            "format": "uuid",
+            "example": "195d0ef0-47f5-439f-abfd-29f892c9a040"
+          },
+          "assetName": {
+            "type": "string",
+            "example": "Ford F-150 · Truck #4"
+          },
+          "assetType": {
+            "type": "string",
+            "enum": [
+              "vehicle",
+              "property",
+              "equipment"
+            ],
+            "example": "vehicle"
+          }
+        },
+        "required": [
+          "taskId",
+          "taskTitle",
+          "nextDue",
+          "status",
+          "intervalValue",
+          "intervalUnit",
+          "lastCompletedDate",
+          "createdAt",
+          "assetId",
+          "assetName",
+          "assetType"
+        ]
+      },
+      "DashboardResponse": {
+        "type": "object",
+        "properties": {
+          "viewerDisplayName": {
+            "type": "string",
+            "nullable": true,
+            "description": "Authenticated user's display name when available",
+            "example": "Dale"
+          },
+          "todayUtc": {
+            "type": "string",
+            "format": "date",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+            "description": "Server-side UTC calendar date used for urgency calculations",
+            "example": "2026-06-16"
+          },
+          "fleetTotals": {
+            "$ref": "#/components/schemas/DashboardFleetTotals"
+          },
+          "fleetHealth": {
+            "$ref": "#/components/schemas/DashboardFleetHealth"
+          },
+          "queue": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DashboardQueueItem"
+            }
+          }
+        },
+        "required": [
+          "viewerDisplayName",
+          "todayUtc",
+          "fleetTotals",
+          "fleetHealth",
+          "queue"
         ]
       },
       "UserProfile": {
@@ -1117,6 +1307,42 @@
           },
           "404": {
             "description": "No such task",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/dashboard": {
+      "get": {
+        "tags": [
+          "Dashboard"
+        ],
+        "summary": "Get my dashboard",
+        "description": "Returns fleet totals, maintenance health counts, and the cross-asset maintenance queue for the authenticated user in a single response.",
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The caller's dashboard read model",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
             "content": {
               "application/json": {
                 "schema": {

--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -579,6 +579,37 @@
           "unscheduled"
         ]
       },
+      "DashboardQueueCounts": {
+        "type": "object",
+        "properties": {
+          "all": {
+            "type": "integer",
+            "minimum": 0,
+            "example": 5
+          },
+          "vehicle": {
+            "type": "integer",
+            "minimum": 0,
+            "example": 2
+          },
+          "equipment": {
+            "type": "integer",
+            "minimum": 0,
+            "example": 2
+          },
+          "property": {
+            "type": "integer",
+            "minimum": 0,
+            "example": 1
+          }
+        },
+        "required": [
+          "all",
+          "vehicle",
+          "equipment",
+          "property"
+        ]
+      },
       "DashboardQueueItem": {
         "type": "object",
         "properties": {
@@ -688,6 +719,9 @@
           "fleetHealth": {
             "$ref": "#/components/schemas/DashboardFleetHealth"
           },
+          "queueCountsByCategory": {
+            "$ref": "#/components/schemas/DashboardQueueCounts"
+          },
           "queue": {
             "type": "array",
             "items": {
@@ -700,6 +734,7 @@
           "todayUtc",
           "fleetTotals",
           "fleetHealth",
+          "queueCountsByCategory",
           "queue"
         ]
       },

--- a/docs/specs/SPECS.md
+++ b/docs/specs/SPECS.md
@@ -1,4 +1,4 @@
-> **Audience:** everyone · **Purpose:** authoritative map of all feature and cross-cutting specs · **Source of truth:** this file · **Last reviewed:** 2026-06-03
+> **Audience:** everyone · **Purpose:** authoritative map of all feature and cross-cutting specs · **Source of truth:** this file · **Last reviewed:** 2026-06-17
 
 # Spec Index
 
@@ -33,7 +33,7 @@ relevant cross-cutting specs rather than re-describing the behavior.
 | [sign-in.md](./features/sign-in.md)                       | Auth        | review |
 | [create-asset.md](./features/create-asset.md)             | Assets      | draft  |
 | [asset-library.md](./features/asset-library.md)           | Assets      | draft  |
-| [dashboard.md](./features/dashboard.md)                   | Home        | wip    |
+| [dashboard.md](./features/dashboard.md)                   | Home        | draft  |
 | [maintenance-record.md](./features/maintenance-record.md) | Maintenance | draft  |
 | [maintenance-task.md](./features/maintenance-task.md)     | Maintenance | draft  |
 | [marketing-home.md](./features/marketing-home.md)         | Marketing   | active |

--- a/docs/specs/cross-cutting/telemetry.md
+++ b/docs/specs/cross-cutting/telemetry.md
@@ -132,6 +132,7 @@ Every API route maps to a named operation used as the `indexes[0]` value in requ
 | `POST /api/assets`                               | `CreateAsset`             |
 | `GET /api/assets`                                | `ListAssets`              |
 | `GET /api/assets/{id}`                           | `GetAsset`                |
+| `GET /api/dashboard`                             | `GetDashboard`            |
 | `GET /api/users/me`                              | `GetUserProfile`          |
 | `PATCH /api/users/me`                            | `UpdateUserProfile`       |
 | `POST /api/assets/{assetId}/maintenance-records` | `CreateMaintenanceRecord` |
@@ -167,10 +168,10 @@ A complete Analytics Engine outage will produce `console.error` log entries but 
 
 ## Exceptions
 
-| Feature                                | Deviation                 | Reason                                                                           |
-| -------------------------------------- | ------------------------- | -------------------------------------------------------------------------------- |
-| Frontend                               | No telemetry              | Client-side instrumentation not yet implemented                                  |
-| Read operations (GetAsset, ListAssets) | No domain event telemetry | Reads do not produce domain events; request telemetry provides sufficient signal |
+| Feature                                              | Deviation                 | Reason                                                                           |
+| ---------------------------------------------------- | ------------------------- | -------------------------------------------------------------------------------- |
+| Frontend                                             | No telemetry              | Client-side instrumentation not yet implemented                                  |
+| Read operations (GetAsset, ListAssets, GetDashboard) | No domain event telemetry | Reads do not produce domain events; request telemetry provides sufficient signal |
 
 ## Anti-Patterns
 

--- a/docs/specs/features/dashboard.md
+++ b/docs/specs/features/dashboard.md
@@ -45,7 +45,7 @@ The Dashboard is the authenticated home screen at `/app`. It gives the operator 
 - [ ] Only active, non-archived assets owned by the caller are included in fleet totals, category counts, health counts, and queue items
 - [ ] Tasks belonging to archived assets are excluded from the dashboard queue, even though asset-scoped task history may remain readable elsewhere
 - [ ] The response includes a viewer display name suitable for the greeting, derived from the authenticated session profile when available
-- [ ] The response includes `todayUtc` or an equivalent server-side date basis used to calculate task urgency; date-only calculations must follow the maintenance date rules in [maintenance-task.md](./maintenance-task.md)
+- [ ] The response includes `todayUtc`, the server-side calendar date used to calculate task urgency; date-only calculations must follow the maintenance date rules in [maintenance-task.md](./maintenance-task.md)
 - [ ] Fleet totals include the total active asset count and counts for the supported asset types: vehicle, equipment, and property
 - [ ] Fleet health counts are computed per asset by that asset's most urgent scheduled task: overdue wins over due soon, due soon wins over on track
 - [ ] Assets with no scheduled maintenance tasks are counted separately from on-track assets so the dashboard can avoid presenting "no schedule" as healthy service status

--- a/docs/specs/features/dashboard.md
+++ b/docs/specs/features/dashboard.md
@@ -1,84 +1,126 @@
 ---
 name: dashboard
-description: Work-in-progress authenticated home screen for fleet overview and future service queue workflows
+description: Authenticated home screen read model for fleet health and the cross-asset maintenance queue
 metadata:
   type: feature
 ---
 
 # Dashboard
 
-**Status:** wip
+**Status:** draft
 **Owner:** [unknown — assign on review]
-**Last Updated:** 2026-06-03
-**Related Specs:** [authentication.md](../cross-cutting/authentication.md), [loading-states.md](../cross-cutting/loading-states.md), [permissions.md](../cross-cutting/permissions.md)
+**Last Updated:** 2026-06-17
+**Related Specs:** [authentication.md](../cross-cutting/authentication.md), [validation.md](../cross-cutting/validation.md), [error-handling.md](../cross-cutting/error-handling.md), [loading-states.md](../cross-cutting/loading-states.md), [permissions.md](../cross-cutting/permissions.md), [telemetry.md](../cross-cutting/telemetry.md), [asset-library.md](./asset-library.md), [maintenance-task.md](./maintenance-task.md), [maintenance-record.md](./maintenance-record.md)
 
 ---
 
 ## Summary
 
-The Dashboard is the work-in-progress authenticated home screen at `/app`. It is intended to become the operator's "what needs attention now" view, with fleet-wide status counters and a service queue. The current screen is a prototype backed by placeholder data, so this spec records the intended direction without treating the feature as finished.
+The Dashboard is the authenticated home screen at `/app`. It gives the operator an at-a-glance view of fleet size, asset categories, fleet maintenance health, and the most urgent scheduled maintenance across all active assets. The first API-backed version is read-oriented: it can launch existing maintenance flows and can mark a time-based task complete through the existing maintenance-record creation endpoint, but rescheduling, snoozing, reminders, and richer service-task metadata are future work.
 
-This feature is not a current priority. Do not use this spec as a completion checklist until the unresolved WIP gaps are reviewed and promoted into active requirements.
+## Implementation Notes
+
+`apps/web/src/app/AppHome.tsx` currently renders hardcoded prototype data. The desired API behavior below intentionally replaces that mock rather than preserving it. The existing mock is useful only as evidence of required capabilities:
+
+- The dashboard needs one protected read model instead of browser-side fan-out across `GET /api/assets` and per-asset task endpoints.
+- The supported asset categories remain `vehicle`, `equipment`, and `property`; the mock's `lawn` / `Grounds` category is not part of this spec.
+- The current maintenance-task model supports time-based schedules only. Meter readings, mileage/hour recurrence, estimated time, location, assignee, and task notes are future task-model work.
+- `Mark complete` can use the existing linked maintenance-record flow. `Reschedule`, `Snooze`, and dashboard-level task creation need future specs before they become live actions.
 
 ## User Stories
 
-- As an **authenticated user**, I can **see how many assets are overdue, due soon, and on track** so that **I know the health of my fleet at a glance**
-- As a **user**, I can **see the highest-urgency service item by default** so that **I know what to act on first without searching**
-- As a **user**, I can **click any queue item to see its full service detail** so that **I can review notes, timing, and next steps in one view**
-- As a **user**, I can **eventually filter the queue by asset category** so that **I can focus on a subset of my fleet**
-- As a **user**, I can **eventually complete, reschedule, or snooze service items** so that **I can close out work and advance the schedule**
+- As an **authenticated owner-operator**, I can **open the dashboard and see fleet maintenance health from live data** so that **I know whether anything needs attention now**
+- As an **authenticated owner-operator**, I can **see active asset totals and category counts** so that **I understand what the dashboard is summarizing**
+- As an **authenticated owner-operator**, I can **see overdue and upcoming maintenance tasks across all active assets in urgency order** so that **I can act on the right task first**
+- As an **authenticated owner-operator with no assets or no scheduled tasks**, I can **see an explicit empty state** so that **I know whether to add an asset or add maintenance tasks**
+- As an **authenticated owner-operator**, I can **start completion for a due task from the dashboard** so that **completed work advances the existing maintenance schedule**
 
-## Acceptance Criteria
+## API Requirements
 
-- [ ] The dashboard displays a greeting, date, and total fleet count
-- [ ] Three stat counters are shown: Overdue, Due soon, On track
-- [ ] The service queue is ordered from most urgent to least urgent
-- [ ] The most urgent item is selected by default when the page loads
-- [ ] Clicking a queue row selects that item and shows its detail
-- [ ] The detail view shows: status label, asset name, asset ID, meter reading, last service date, service description, recurrence interval, estimated time, location/where, assignee, notes
-- [ ] Category filter chips may be present as visual placeholders, but filtering is not required for the WIP version
-- [ ] Service action controls may be present as visual placeholders, but they must not imply completed service workflows
-- [ ] On mobile, the selected queue row expands inline to show compact service details
-- [ ] The page title is set to "FieldOps — Home"
+### Dashboard read model
+
+- [ ] Add `GET /api/dashboard` as a protected application API endpoint
+- [ ] The endpoint returns the caller's dashboard state in a single response; the web app must not need to call `GET /api/assets` and then fan out to per-asset task endpoints for initial dashboard render
+- [ ] The endpoint uses the resolved authenticated `User.id` as the ownership input; no `ownerId` is accepted from the request
+- [ ] Only active, non-archived assets owned by the caller are included in fleet totals, category counts, health counts, and queue items
+- [ ] Tasks belonging to archived assets are excluded from the dashboard queue, even though asset-scoped task history may remain readable elsewhere
+- [ ] The response includes a viewer display name suitable for the greeting, derived from the authenticated session profile when available
+- [ ] The response includes `todayUtc` or an equivalent server-side date basis used to calculate task urgency; date-only calculations must follow the maintenance date rules in [maintenance-task.md](./maintenance-task.md)
+- [ ] Fleet totals include the total active asset count and counts for the supported asset types: vehicle, equipment, and property
+- [ ] Fleet health counts are computed per asset by that asset's most urgent scheduled task: overdue wins over due soon, due soon wins over on track
+- [ ] Assets with no scheduled maintenance tasks are counted separately from on-track assets so the dashboard can avoid presenting "no schedule" as healthy service status
+- [ ] The maintenance queue contains scheduled maintenance tasks across all active assets, not one synthesized row per asset
+- [ ] Each queue item includes enough task and asset summary data to render the queue row and selected-detail panel without an additional asset lookup
+- [ ] Queue items are sorted by urgency first, then by `nextDue` ascending, then by task creation time for stable ordering
+- [ ] The dashboard does not include `Grounds` / `lawn` category data unless a future asset-type spec and API contract add that type
+- [ ] The dashboard does not include meter readings, mileage/hour intervals, estimated time, location, assignee, or free-form task notes until those fields are added to the maintenance-task contract
+
+### Status calculation
+
+- [ ] A task is `overdue` when `nextDue` is before `todayUtc`
+- [ ] A task is `soon` when `nextDue` is today or within the next 7 calendar days
+- [ ] A task is `ok` when `nextDue` is more than 7 calendar days after `todayUtc`
+- [ ] The relative due-day value is calculated with date-only calendar arithmetic, not timestamp subtraction through user-local time zones
+- [ ] Due labels such as "Overdue · 3 days", "Today", "Tomorrow", or "In 5 days" may be formatted by the frontend from the API's date/status data; the API should not be required to return presentation copy
+
+### Dashboard actions
+
+- [ ] Selecting a queue item is frontend state; the API does not persist or return a selected item
+- [ ] The default selected item is the first queue item after urgency sorting
+- [ ] Category filtering is frontend state for the first API-backed version; the dashboard response must contain category and count data needed to filter the returned queue without a new request
+- [ ] `Mark complete` for a time-based task uses `POST /api/assets/{assetId}/maintenance-records` with the selected `taskId`, as defined in [maintenance-record.md](./maintenance-record.md) and [maintenance-task.md](./maintenance-task.md)
+- [ ] After successful completion, the frontend invalidates the dashboard read model and the affected asset's maintenance records/tasks
+- [ ] `Reschedule`, `Snooze`, dashboard-level `Add service`, and richer task-detail editing remain placeholders until the maintenance-task API is extended
+
+## Validation & Ownership
+
+**Authentication:** The dashboard is available only to authenticated users. A missing or invalid session returns 401 through the shared authentication middleware.
+
+**Permissions:** Dashboard data is scoped entirely by the resolved `User.id`. Collection queries must filter by owner and active asset state. The response must never expose another user's assets, tasks, maintenance records, `ownerId`, or auth-provider identifiers.
+
+**Validation:** `GET /api/dashboard` has no request body. If query parameters are added later for server-side filtering or pagination, they must be validated at the Zod HTTP edge and reflected in the generated OpenAPI document.
+
+**Date-only behavior:** Dashboard status calculations use the same date-only conventions as maintenance tasks. `nextDue` is a `YYYY-MM-DD` value; urgency is derived from calendar dates rather than timestamps.
 
 ## Edge Cases & Error States
 
-| Scenario                                   | Expected Behavior                                                                       |
-| ------------------------------------------ | --------------------------------------------------------------------------------------- |
-| Empty fleet (no assets / no service queue) | [NOT SPECIFIED: no empty state has been defined for the WIP version]                    |
-| All assets on track (no overdue or soon)   | Overdue and Due soon counters show 0                                                    |
-| Selected item is the most-urgent item      | Detail card header shows "Next up" instead of "Selected"                                |
-| Mobile viewport                            | Detail card is hidden; selected queue row expands inline with compact detail            |
-| Action buttons clicked                     | [NOT SPECIFIED: service actions are future work]                                        |
-| Filter chips clicked                       | [NOT SPECIFIED: filtering is future work]                                               |
-| "Add service" clicked                      | [NOT SPECIFIED: service creation is future work]                                        |
-| "View asset" clicked                       | [NOT SPECIFIED: navigates to asset detail, but the destination page does not yet exist] |
+| Scenario                                                      | Expected Behavior                                                                                                                              |
+| ------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| No valid session                                              | API returns 401; frontend redirects to `/login` through the shared API-client behavior                                                         |
+| User has zero active assets                                   | Dashboard renders an empty fleet state with a primary path to add an asset; all counts are 0 and queue is empty                                |
+| User has active assets but no scheduled tasks                 | Fleet totals/category counts render; queue empty state prompts the user to add scheduled maintenance; unscheduled asset count reflects the gap |
+| All scheduled tasks are on track                              | Overdue and due-soon counts are 0; queue still shows upcoming tasks ordered by `nextDue`                                                       |
+| Multiple tasks on one asset                                   | The queue may show multiple rows for that asset; fleet health counts the asset once using its most urgent task                                 |
+| Task due today                                                | Status is `soon`; frontend may render "Today"                                                                                                  |
+| Task from archived asset                                      | Excluded from dashboard queue and health counts                                                                                                |
+| Asset type is not one of the supported API types              | Not possible under the current asset schema; dashboard must not synthesize `lawn`/`grounds`                                                    |
+| Dashboard request fails with non-401 error                    | Frontend shows a dashboard-level error state with retry                                                                                        |
+| Queue becomes empty after filtering                           | Frontend shows a filtered-empty state; this is not an API error                                                                                |
+| Linked task completion succeeds                               | New maintenance record appears in asset history; task advances per [maintenance-task.md](./maintenance-task.md); dashboard is refetched        |
+| Linked task completion returns 409 because asset was archived | Completion error is shown and dashboard is refetched so archived data disappears                                                               |
+
+## Telemetry
+
+**Request telemetry:** `GET /api/dashboard` maps to the `GetDashboard` operation via `createTechnicalTelemetryMiddleware`. Implementing the endpoint requires adding this route to the operation-name mapping and updating [telemetry.md](../cross-cutting/telemetry.md).
+
+**Domain events:** None for the dashboard read model. Reads do not publish domain events. Completing a task from the dashboard uses the existing `CreateMaintenanceRecord` operation and may publish the existing `MaintenanceRecordCreated` and `MaintenanceTaskAdvanced` domain events.
 
 ## Flags
 
-**NOT SPECIFIED — Empty state:** No empty state has been defined for a dashboard with no assets or no service queue.
+**FOLLOW-UP NEEDED — Maintenance task detail fields:** The prototype shows estimated time, location/where, assignee/vendor, and notes. These fields do not exist in the maintenance-task API or D1 schema. Add them through [maintenance-task.md](./maintenance-task.md) before rendering them from live data.
 
-**NOT SPECIFIED — Action behavior:** "Mark complete", "Reschedule", "Snooze", and "View asset" represent the future interaction model but are not part of the completed feature yet.
+**FOLLOW-UP NEEDED — Distance/hour-based schedules:** The prototype includes mile/hour readings and recurrence. This remains phase 2 and must follow the discriminator guidance in [maintenance-task.md](./maintenance-task.md), not an ad hoc `"mile"` or `"hour"` addition to the time interval enum.
 
-**NOT SPECIFIED — Filter chip behavior:** The intended behavior is to filter the queue to a single category; the count in the "All" chip should reflect the total.
+**FOLLOW-UP NEEDED — Reschedule and snooze:** The prototype includes these actions, but no task mutation semantics exist. A future spec should define whether these are task updates, one-off overrides, or separate scheduled exceptions.
 
-**NOT SPECIFIED — Real data integration:** When real data is wired, the following must be resolved: the data model for service schedule (due dates, recurrence, last-service meter), how urgency is computed, how status (overdue/soon/ok) is derived, and what user name appears in the greeting.
-
-**REVIEW NEEDED — "Lawn" / "Grounds" category:** The dashboard includes a "Grounds" category that does not correspond to any creatable asset type (which are vehicle, property, equipment). It is unclear whether "Grounds" is a planned fourth type or prototype-only category.
-
-**REVIEW NEEDED — Placeholder user identity:** The greeting uses a placeholder user name and date. The finished feature needs to define how the authenticated user's name and current date should appear.
-
-**REVIEW NEEDED — Roadmap user stories in current spec:** Several user stories use "eventually" phrasing (filter the queue, complete/reschedule/snooze items). These describe future work, not the current WIP feature. They should be moved to a roadmap section or a separate future spec to avoid inflating the apparent scope.
-
-**NOT SPECIFIED — Telemetry contract not referenced:** When real data is wired and API endpoints are added, each must be registered in the operation name mapping and any new domain events must have telemetry handlers, per the `telemetry.md` integration contract. This spec does not currently reference `telemetry.md`.
-
-**NOT SPECIFIED — Error handling cross-cutting spec not referenced:** When real data is wired, the dashboard will make API calls whose error states must be documented per `error-handling.md`. The spec does not currently reference `error-handling.md` and no error states are defined for any data-loading scenario.
+**FOLLOW-UP NEEDED — Dashboard-level task creation:** The prototype's "Add service" button needs a concrete entry path, target asset selection behavior, and field set before it becomes an API-backed workflow.
 
 ## Out of Scope
 
-- Service scheduling data model and CRUD (prerequisite for the real data layer)
-- Reminder delivery (notifications, email)
-- Multi-user or team assignment beyond the `assignee` display field
-- Completed service history view
-- Snooze and reschedule dialogs
-- Asset detail page ("View asset" destination)
+- Adding a fourth `lawn` / `grounds` asset type
+- Mileage/hour meter tracking and distance-based maintenance schedules
+- Reminder delivery through notifications, email, or background jobs
+- Reschedule, snooze, or bulk task management
+- Editing task detail fields from the dashboard
+- Team assignment, delegation, or multi-user visibility
+- Frontend interaction telemetry

--- a/docs/specs/features/maintenance-task.md
+++ b/docs/specs/features/maintenance-task.md
@@ -9,8 +9,8 @@ metadata:
 
 **Status:** draft
 **Owner:** [unknown - assign on review]
-**Last Updated:** 2026-06-10
-**Related Specs:** [authentication.md](../cross-cutting/authentication.md), [validation.md](../cross-cutting/validation.md), [error-handling.md](../cross-cutting/error-handling.md), [loading-states.md](../cross-cutting/loading-states.md), [permissions.md](../cross-cutting/permissions.md), [telemetry.md](../cross-cutting/telemetry.md), [maintenance-record.md](./maintenance-record.md)
+**Last Updated:** 2026-06-17
+**Related Specs:** [authentication.md](../cross-cutting/authentication.md), [validation.md](../cross-cutting/validation.md), [error-handling.md](../cross-cutting/error-handling.md), [loading-states.md](../cross-cutting/loading-states.md), [permissions.md](../cross-cutting/permissions.md), [telemetry.md](../cross-cutting/telemetry.md), [maintenance-record.md](./maintenance-record.md), [dashboard.md](./dashboard.md)
 
 ---
 
@@ -51,6 +51,7 @@ The Maintenance Task feature lets an authenticated owner-operator define schedul
 - [ ] The list use case returns only tasks for an asset owned by the authenticated user
 - [ ] Each task in the response includes `id`, `assetId`, `title`, `intervalValue`, `intervalUnit`, `lastCompletedDate` (nullable), `nextDue`, and `createdAt`; `ownerId` is never exposed
 - [ ] Tasks are returned in ascending `nextDue` order (soonest due first)
+- [ ] The dashboard's cross-asset queue is exposed through [dashboard.md](./dashboard.md), not by requiring the web app to call this asset-scoped endpoint once per asset
 
 ### Task deletion
 
@@ -194,6 +195,8 @@ Published only when `record.performedAt > task.lastCompletedDate` (i.e. when `ne
 
 **FOLLOW-UP NEEDED — Mileage-based intervals (Phase 2):** The original user stories include "change oil every 5,000 miles." Odometer tracking and mileage-based `nextDue` computation are out of scope for phase 1. When implementing, do NOT simply add `"mile"` to the `intervalUnit` enum — time tasks carry `lastCompletedDate`/`nextDue` (dates) while distance tasks would need `lastCompletedOdometer`/`nextDueMileage` (integers). Introduce a `type: "time" | "distance"` discriminator and treat them as two explicit shapes. Existing time-based tasks require no changes.
 
+**FOLLOW-UP NEEDED — Dashboard detail fields:** The dashboard prototype displays estimated duration, location/where, assignee/vendor, and task notes. Those fields are not part of the current maintenance-task contract and must be specified here before the dashboard can render them from live API data.
+
 **FOLLOW-UP NEEDED — Cross-cutting time spec:** Same flag as [maintenance-record.md](./maintenance-record.md). Date-only arithmetic for `nextDue` computation — especially month and year intervals — should be revisited when a cross-cutting time spec is authored.
 
 ## Out of Scope
@@ -201,7 +204,7 @@ Published only when `record.performedAt > task.lastCompletedDate` (i.e. when `ne
 - Mileage/odometer-based intervals (Phase 2)
 - Editing a task's title or interval after creation
 - Reminders and push/email notifications when maintenance is due
-- A global "upcoming maintenance" view across all assets
+- A standalone schedule/task-management screen beyond the dashboard read model
 - Archiving or disabling tasks (only hard delete is supported in this iteration)
 - Automatic record creation triggered by tasks
 - Bulk task management

--- a/docs/web/FEATURES.md
+++ b/docs/web/FEATURES.md
@@ -91,6 +91,8 @@ For the API contract behind each feature, see the linked spec in `docs/specs/fea
 - Category filter chips and "Add service" button are present in the UI but not yet functional
 - 401 from the API (when wired) should redirect to `/login`
 
+**Spec:** [`docs/specs/features/dashboard.md`](../specs/features/dashboard.md)
+
 ---
 
 ## Asset Library

--- a/docs/web/FEATURES.md
+++ b/docs/web/FEATURES.md
@@ -81,15 +81,23 @@ For the API contract behind each feature, see the linked spec in `docs/specs/fea
 
 **Key states:**
 
-- Urgency-sorted queue of assets with overdue/soon/ok status indicators
+- Loading: fetches `GET /api/dashboard` before rendering fleet stats and queue
+- Empty fleet: prompts the user to add their first asset
+- Assets without scheduled tasks: fleet totals render; queue empty state points to the asset library
+- Populated: urgency-sorted maintenance queue with overdue/soon/on-track status from the API
 - Detail card (desktop) or inline expand (mobile) for the selected queue item
-- Actions on the detail: Mark complete, Reschedule, Snooze (UI present; not yet wired to API)
+- Filtered empty: category filter active but no matching queue rows
+- Error: dashboard-level error with retry
+- Mark complete: creates a linked maintenance record for the selected task and refetches dashboard + asset maintenance data
 
 **Non-obvious behavior:**
 
-- Currently renders hardcoded prototype data — not yet connected to the live API
-- Category filter chips and "Add service" button are present in the UI but not yet functional
-- 401 from the API (when wired) should redirect to `/login`
+- Initial render uses one dashboard read model — no fan-out across assets and per-asset task endpoints
+- Status buckets and fleet health counts come from the API; the client formats due-date copy only
+- Category filter chips filter the returned queue client-side without a new request
+- Reschedule, Snooze, and Add service remain disabled placeholders until future specs land
+- Task detail fields not yet in the maintenance-task API (estimated time, location, assignee, notes) are not shown from live data
+- 401 from the API redirects to `/login`
 
 **Spec:** [`docs/specs/features/dashboard.md`](../specs/features/dashboard.md)
 

--- a/packages/shared/dateOnly.ts
+++ b/packages/shared/dateOnly.ts
@@ -14,6 +14,13 @@ export function formatDateOnly(year: number, month: number, day: number): string
   return `${String(year).padStart(4, "0")}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
 }
 
+function utcMsFromDateOnly(value: string): number {
+  const year = Number(value.slice(0, 4));
+  const month = Number(value.slice(5, 7));
+  const day = Number(value.slice(8, 10));
+  return Date.UTC(year, month - 1, day);
+}
+
 /** Adds calendar days to a YYYY-MM-DD value without timestamp arithmetic. */
 export function addCalendarDays(date: string, days: number): string {
   let year = Number(date.slice(0, 4));
@@ -41,18 +48,8 @@ export function addCalendarDays(date: string, days: number): string {
   return formatDateOnly(year, month, day);
 }
 
-/** Returns the signed day distance from `start` to `end` using calendar-day steps. */
+/** Returns the signed calendar-day distance from `start` to `end` (UTC date-only). */
 export function calendarDaysBetween(start: string, end: string): number {
   if (start === end) return 0;
-
-  let cursor = start;
-  let days = 0;
-  const step = start < end ? 1 : -1;
-
-  while (cursor !== end) {
-    cursor = addCalendarDays(cursor, step);
-    days += step;
-  }
-
-  return days;
+  return Math.round((utcMsFromDateOnly(end) - utcMsFromDateOnly(start)) / 86_400_000);
 }

--- a/packages/shared/dateOnly.ts
+++ b/packages/shared/dateOnly.ts
@@ -1,0 +1,58 @@
+/** Pure YYYY-MM-DD calendar arithmetic — no timestamps, no business rules. */
+
+export function daysInMonth(year: number, month: number): number {
+  if (month === 2) return isLeapYear(year) ? 29 : 28;
+  if (month === 4 || month === 6 || month === 9 || month === 11) return 30;
+  return 31;
+}
+
+export function isLeapYear(year: number): boolean {
+  return year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+}
+
+export function formatDateOnly(year: number, month: number, day: number): string {
+  return `${String(year).padStart(4, "0")}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+}
+
+/** Adds calendar days to a YYYY-MM-DD value without timestamp arithmetic. */
+export function addCalendarDays(date: string, days: number): string {
+  let year = Number(date.slice(0, 4));
+  let month = Number(date.slice(5, 7));
+  let day = Number(date.slice(8, 10)) + days;
+
+  while (day > daysInMonth(year, month)) {
+    day -= daysInMonth(year, month);
+    month++;
+    if (month > 12) {
+      month = 1;
+      year++;
+    }
+  }
+
+  while (day < 1) {
+    month--;
+    if (month < 1) {
+      month = 12;
+      year--;
+    }
+    day += daysInMonth(year, month);
+  }
+
+  return formatDateOnly(year, month, day);
+}
+
+/** Returns the signed day distance from `start` to `end` using calendar-day steps. */
+export function calendarDaysBetween(start: string, end: string): number {
+  if (start === end) return 0;
+
+  let cursor = start;
+  let days = 0;
+  const step = start < end ? 1 : -1;
+
+  while (cursor !== end) {
+    cursor = addCalendarDays(cursor, step);
+    days += step;
+  }
+
+  return days;
+}

--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -13,3 +13,10 @@ export {
   InvariantError,
   ValidationError,
 } from "./errors.ts";
+export {
+  addCalendarDays,
+  calendarDaysBetween,
+  daysInMonth,
+  formatDateOnly,
+  isLeapYear,
+} from "./dateOnly.ts";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@snaveevans/pineapple-shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
       '@tanstack/react-query':
         specifier: ^5.100.14
         version: 5.100.14(react@19.2.6)
@@ -3890,14 +3893,6 @@ snapshots:
     optionalDependencies:
       vite: 7.3.3(@types/node@22.19.19)(tsx@4.22.3)(yaml@2.9.0)
 
-  '@vitest/mocker@3.2.4(vite@7.3.3(@types/node@25.9.1)(tsx@4.22.3)(yaml@2.9.0))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.3.3(@types/node@25.9.1)(tsx@4.22.3)(yaml@2.9.0)
-
   '@vitest/pretty-format@3.2.4':
     dependencies:
       tinyrainbow: 2.0.0
@@ -5098,7 +5093,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.3(@types/node@25.9.1)(tsx@4.22.3)(yaml@2.9.0))
+      '@vitest/mocker': 3.2.4(vite@7.3.3(@types/node@22.19.19)(tsx@4.22.3)(yaml@2.9.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,9 +81,6 @@ importers:
 
   apps/web:
     dependencies:
-      '@snaveevans/pineapple-shared':
-        specifier: workspace:*
-        version: link:../../packages/shared
       '@tanstack/react-query':
         specifier: ^5.100.14
         version: 5.100.14(react@19.2.6)


### PR DESCRIPTION
## Summary

- Implements `GET /api/dashboard` end-to-end: Zod schema, `GetDashboard` use case, `TaskUrgency` domain logic, D1 repository method, worker route, web client, and `AppHome` wired to live data.
- Adds ADR-0009 (computed fields belong in API read models) and updates dashboard / maintenance-task specs.
- Dashboard queue items include server-computed `status`, `daysDue`, and `queueCountsByCategory` so the web layer only formats presentation copy.

## Why

The dashboard UI used hardcoded prototype data. This PR replaces that mock with a single protected read model and aligns urgency/status derivation with the maintenance date rules.

## Impact

- New protected endpoint: `GET /api/dashboard`
- `AppHome` reads fleet health, queue, and filter counts from the API
- `Mark complete` invalidates dashboard + affected asset queries
- Calendar-day arithmetic lives in `packages/shared`; relative due labels format from API `daysDue`

## Validation

- `pnpm lint`
- `pnpm type-check`
- `pnpm -r test`
- `pnpm --filter @snaveevans/pineapple-api openapi:generate`