### PR TITLE
Replace property state dropdown with free-text input

### DIFF
--- a/apps/web/src/app/AppAddAsset.tsx
+++ b/apps/web/src/app/AppAddAsset.tsx
@@ -292,10 +292,10 @@ function HFPropertyFields({
           onChange={setField("city")}
           error={errors.city}
         />
-        <HFSelectField
+        <HFTextField
           label="State"
           required
-          options={["OR", "WA", "CA", "ID", "NV", "AZ"]}
+          placeholder="OR, BC, Jalisco"
           value={form.state}
           onChange={setField("state")}
           error={errors.state}

--- a/apps/web/src/app/assetForm.test.ts
+++ b/apps/web/src/app/assetForm.test.ts
@@ -31,6 +31,7 @@ describe("toCreateAssetBody", () => {
         nickname: " ",
         street: " 12 Oak St ",
         city: " Portland ",
+        state: " OR ",
         postal: " 97204 ",
       }),
     ).toEqual({
@@ -65,6 +66,18 @@ describe("toCreateAssetBody", () => {
 });
 
 describe("validateAssetForm", () => {
+  it("requires state for a property", () => {
+    const errors = validateAssetForm("property", {
+      ...EMPTY_ASSET_FORM,
+      name: "Cabin",
+      street: "12 Oak St",
+      city: "Portland",
+      postal: "97204",
+    });
+
+    expect(errors.state).toBe("Required.");
+  });
+
   it("rejects a vehicle year beyond the API limit", () => {
     const errors = validateAssetForm("vehicle", {
       ...EMPTY_ASSET_FORM,

--- a/apps/web/src/app/assetForm.ts
+++ b/apps/web/src/app/assetForm.ts
@@ -28,7 +28,7 @@ export const EMPTY_ASSET_FORM: AssetForm = {
   nickname: "",
   street: "",
   city: "",
-  state: "OR",
+  state: "",
   postal: "",
   country: "United States",
   manufacturer: "",

--- a/docs/specs/features/create-asset.md
+++ b/docs/specs/features/create-asset.md
@@ -30,7 +30,7 @@ The Create Asset feature lets an authenticated user add a new asset to their fle
 - [ ] Selecting a type clears any existing validation errors and shows the type-specific field section
 - [ ] All types require an **Asset name** field
 - [ ] **Vehicle** fields: Make (req), Model (req), Year (req), VIN (opt, 17 chars)
-- [ ] **Property** fields: Street (req), City (req), State (req, dropdown), Postal (req), Country (req, dropdown), Nickname (opt)
+- [ ] **Property** fields: Street (req), City (req), State (req, text), Postal (req), Country (req, dropdown), Nickname (opt)
 - [ ] **Equipment** fields: Manufacturer (opt), Model number (opt), Serial number (opt)
 - [ ] Year must be a whole number between 1900 and current year + 1; out-of-range values show a specific error
 - [ ] VIN, if entered, must be exactly 17 characters; a partial VIN (non-empty, non-17) blocks save
@@ -69,7 +69,7 @@ The Create Asset feature lets an authenticated user add a new asset to their fle
 
 ## Flags
 
-**REVIEW NEEDED — State dropdown limited to western US:** The state field is a dropdown with only OR, WA, CA, ID, NV, AZ. This may be intentional for the target user base or an early-stage placeholder. There is no free-text fallback for users in other states.
+**RESOLVED — State is free-text:** The state field is a text input so users can enter US states, Canadian provinces, or Mexican estados in whatever form matches their address.
 
 **REVIEW NEEDED — Country dropdown limited to three countries:** Country is a dropdown of "United States", "Canada", "Mexico". No free-text fallback.
 


### PR DESCRIPTION
## Summary

The property address state field was a dropdown limited to six western US states (OR, WA, CA, ID, NV, AZ). This replaces it with a free-text input so users can enter US states, Canadian provinces, or Mexican estados in whatever form matches their address.

The API already accepts any non-empty string for `metadata.address.state`, so this is a frontend-only change.

## Changes

- Swap `HFSelectField` for `HFTextField` on the state field in the add-asset form
- Clear the hardcoded `"OR"` default so the field starts blank
- Update `assetForm` tests and add validation coverage for blank state
- Resolve the create-asset spec flag for the western-US dropdown limitation

## Test plan

- [x] `pnpm --filter @snaveevans/pineapple-web exec vitest run src/app/assetForm.test.ts`
- [x] `pnpm lint && pnpm type-check`
- [ ] Manual: `/app/assets/new` → Property → enter state values like `BC` or `Jalisco` and save successfully