### PR TITLE
Implement telemetry enrichment

### DIFF
--- a/apps/api/src/api/middleware/technicalTelemetry.test.ts
+++ b/apps/api/src/api/middleware/technicalTelemetry.test.ts
@@ -1,9 +1,36 @@
+import { Hono } from "hono";
 import { describe, expect, it } from "vitest";
-import { ValidationError } from "@snaveevans/pineapple-shared";
-import { buildApiRequestTelemetryDataPoint } from "./technicalTelemetry.ts";
+import { Email, UserId, ValidationError } from "@snaveevans/pineapple-shared";
+import { User } from "../../domain/identity/User.ts";
+import {
+  buildApiRequestTelemetryDataPoint,
+  createTechnicalTelemetryMiddleware,
+  requestCountry,
+  requestUserId,
+  type ApiRequestTelemetryDataPoint,
+} from "./technicalTelemetry.ts";
+
+const userId = UserId.from("195d0ef0-47f5-439f-abfd-29f892c9a040");
+
+const testUser = User.reconstitute({
+  id: userId,
+  email: Email.from("test@example.com"),
+  name: null,
+  onboardingCompletedAt: null,
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+});
+
+function requestWithCf(url: string, init?: RequestInit & { cf?: { country?: string } }): Request {
+  const { cf, ...requestInit } = init ?? {};
+  const req = new Request(url, requestInit);
+  if (cf !== undefined) {
+    Object.defineProperty(req, "cf", { value: cf, configurable: true });
+  }
+  return req;
+}
 
 describe("buildApiRequestTelemetryDataPoint", () => {
-  it("maps successful use-case requests to the documented field order", () => {
+  it("maps successful use-case requests to the documented v2 field order", () => {
     expect(
       buildApiRequestTelemetryDataPoint({
         method: "POST",
@@ -12,12 +39,56 @@ describe("buildApiRequestTelemetryDataPoint", () => {
         durationMs: 42.5,
         requestSizeBytes: 128,
         authenticated: true,
+        country: "US",
+        userId,
         error: null,
       }),
     ).toEqual({
       indexes: ["CreateAsset"],
-      blobs: ["CreateAsset", "/api/assets", "POST", "2xx", "201", "success", "none", "true", "v1"],
+      blobs: [
+        "CreateAsset",
+        "/api/assets",
+        "POST",
+        "2xx",
+        "201",
+        "success",
+        "none",
+        "true",
+        "v2",
+        "US",
+        userId,
+      ],
       doubles: [42.5, 1, 201, 128],
+    });
+  });
+
+  it("keeps country and user identity independent for unauthenticated requests", () => {
+    expect(
+      buildApiRequestTelemetryDataPoint({
+        method: "POST",
+        pathname: "/api/auth/sign-in/social",
+        status: 401,
+        durationMs: 1,
+        requestSizeBytes: 0,
+        authenticated: false,
+        country: "US",
+        userId: "anonymous",
+        error: null,
+      }),
+    ).toMatchObject({
+      blobs: [
+        "SignIn",
+        "/api/auth/sign-in/social",
+        "POST",
+        "4xx",
+        "401",
+        "failure",
+        "none",
+        "false",
+        "v2",
+        "US",
+        "anonymous",
+      ],
     });
   });
 
@@ -38,6 +109,8 @@ describe("buildApiRequestTelemetryDataPoint", () => {
           durationMs: 1,
           requestSizeBytes: 0,
           authenticated: false,
+          country: "GB",
+          userId: "anonymous",
           error: null,
         }).indexes[0],
       ).toBe(operation);
@@ -53,6 +126,8 @@ describe("buildApiRequestTelemetryDataPoint", () => {
         durationMs: 3,
         requestSizeBytes: 0,
         authenticated: false,
+        country: "unknown",
+        userId: "anonymous",
         error: new ValidationError("Invalid id", "id"),
       }),
     ).toEqual({
@@ -66,7 +141,9 @@ describe("buildApiRequestTelemetryDataPoint", () => {
         "failure",
         "ValidationError",
         "false",
-        "v1",
+        "v2",
+        "unknown",
+        "anonymous",
       ],
       doubles: [3, 1, 422, 0],
     });
@@ -81,6 +158,8 @@ describe("buildApiRequestTelemetryDataPoint", () => {
         durationMs: 1,
         requestSizeBytes: 0,
         authenticated: true,
+        country: "CA",
+        userId,
         error: null,
       }),
     ).toMatchObject({
@@ -94,7 +173,9 @@ describe("buildApiRequestTelemetryDataPoint", () => {
         "success",
         "none",
         "true",
-        "v1",
+        "v2",
+        "CA",
+        userId,
       ],
     });
   });
@@ -111,11 +192,25 @@ describe("buildApiRequestTelemetryDataPoint", () => {
         durationMs: 1,
         requestSizeBytes: 0,
         authenticated: true,
+        country: "US",
+        userId,
         error: null,
       }),
     ).toMatchObject({
       indexes: [operation],
-      blobs: [operation, "/api/users/me", method, "2xx", "200", "success", "none", "true", "v1"],
+      blobs: [
+        operation,
+        "/api/users/me",
+        method,
+        "2xx",
+        "200",
+        "success",
+        "none",
+        "true",
+        "v2",
+        "US",
+        userId,
+      ],
     });
   });
 
@@ -131,6 +226,8 @@ describe("buildApiRequestTelemetryDataPoint", () => {
         durationMs: 1,
         requestSizeBytes: 0,
         authenticated: true,
+        country: "US",
+        userId,
         error: null,
       }),
     ).toMatchObject({
@@ -144,8 +241,88 @@ describe("buildApiRequestTelemetryDataPoint", () => {
         "success",
         "none",
         "true",
-        "v1",
+        "v2",
+        "US",
+        userId,
       ],
     });
+  });
+});
+
+describe("requestCountry", () => {
+  it("returns the cf country when present", () => {
+    expect(requestCountry({ country: "US" })).toBe("US");
+  });
+
+  it('returns "unknown" when cf country is absent or empty', () => {
+    expect(requestCountry(undefined)).toBe("unknown");
+    expect(requestCountry({ country: "" })).toBe("unknown");
+  });
+});
+
+describe("requestUserId", () => {
+  it("returns the authenticated user id", () => {
+    expect(requestUserId(testUser)).toBe(userId);
+  });
+
+  it('returns "anonymous" when no user is on the context', () => {
+    expect(requestUserId(undefined)).toBe("anonymous");
+  });
+});
+
+describe("createTechnicalTelemetryMiddleware", () => {
+  it("writes country from request.cf and user id from context", async () => {
+    const written: ApiRequestTelemetryDataPoint[] = [];
+    const app = new Hono<{ Variables: { user?: User } }>();
+    app.use(
+      "*",
+      createTechnicalTelemetryMiddleware(() => ({ write: (dp) => written.push(dp) })),
+    );
+    app.get("/api/dashboard", (c) => {
+      c.set("user", testUser);
+      return c.json({ ok: true }, 200);
+    });
+
+    const response = await app.request(
+      requestWithCf("http://localhost/api/dashboard", { cf: { country: "US" } }),
+    );
+    expect(response.status).toBe(200);
+    expect(written[0]?.blobs[9]).toBe("US");
+    expect(written[0]?.blobs[10]).toBe(userId);
+  });
+
+  it("writes anonymous user id independently of a known country", async () => {
+    const written: ApiRequestTelemetryDataPoint[] = [];
+    const app = new Hono<{ Variables: { user?: User } }>();
+    app.use(
+      "*",
+      createTechnicalTelemetryMiddleware(() => ({ write: (dp) => written.push(dp) })),
+    );
+    app.post("/api/auth/sign-in/social", (c) => c.json({ error: "Unauthorized" }, 401));
+
+    const response = await app.request(
+      requestWithCf("http://localhost/api/auth/sign-in/social", {
+        method: "POST",
+        cf: { country: "US" },
+      }),
+    );
+    expect(response.status).toBe(401);
+    expect(written[0]?.blobs[9]).toBe("US");
+    expect(written[0]?.blobs[10]).toBe("anonymous");
+  });
+
+  it('writes "unknown" country when request.cf is absent', async () => {
+    const written: ApiRequestTelemetryDataPoint[] = [];
+    const app = new Hono<{ Variables: { user?: User } }>();
+    app.use(
+      "*",
+      createTechnicalTelemetryMiddleware(() => ({ write: (dp) => written.push(dp) })),
+    );
+    app.get("/health", (c) => c.json({ status: "ok" }, 200));
+
+    const response = await app.request("http://localhost/health");
+    expect(response.status).toBe(200);
+    expect(written[0]?.blobs[9]).toBe("unknown");
+    expect(written[0]?.blobs[10]).toBe("anonymous");
   });
 });

--- a/apps/api/src/api/middleware/technicalTelemetry.ts
+++ b/apps/api/src/api/middleware/technicalTelemetry.ts
@@ -6,6 +6,7 @@ import {
   UnauthorizedError,
   ValidationError,
 } from "@snaveevans/pineapple-shared";
+import type { User } from "../../domain/identity/User.ts";
 
 export type ApiRequestTelemetryDataPoint = {
   indexes: string[];
@@ -18,7 +19,7 @@ export interface ApiRequestTelemetrySink {
 }
 
 type TelemetryVariables = {
-  user?: unknown;
+  user?: User;
 };
 
 type TelemetryRecord = {
@@ -28,6 +29,8 @@ type TelemetryRecord = {
   durationMs: number;
   requestSizeBytes: number;
   authenticated: boolean;
+  country: string;
+  userId: string;
   error: unknown;
 };
 
@@ -60,6 +63,8 @@ export function createTechnicalTelemetryMiddleware<TEnv extends { Variables: Tel
         durationMs: performance.now() - start,
         requestSizeBytes: requestSizeBytes(c.req.header("content-length")),
         authenticated: c.var.user !== undefined,
+        country: requestCountry(c.req.raw.cf),
+        userId: requestUserId(c.var.user),
         error,
       });
 
@@ -87,10 +92,25 @@ export function buildApiRequestTelemetryDataPoint(
       outcome(record.status),
       errorName(record.error),
       record.authenticated ? "true" : "false",
-      "v1",
+      "v2",
+      record.country,
+      record.userId,
     ],
     doubles: [record.durationMs, 1, record.status, record.requestSizeBytes],
   };
+}
+
+export function requestCountry(cf: CfProperties<unknown> | undefined): string {
+  if (cf !== undefined && "country" in cf) {
+    const country = cf.country;
+    if (typeof country === "string" && country.length > 0) return country;
+  }
+  return "unknown";
+}
+
+export function requestUserId(user: User | undefined): string {
+  if (user === undefined) return "anonymous";
+  return user.id;
 }
 
 function routeTelemetry(method: string, pathname: string): RouteTelemetry {

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -14,6 +14,7 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap"
       rel="stylesheet"
     />
+    <!-- cloudflare-web-analytics -->
   </head>
   <body>
     <div id="root"></div>

--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -3,4 +3,4 @@
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Strict-Transport-Security: max-age=31536000; includeSubDomains
-  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; form-action 'self'; base-uri 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self' https://cloudflareinsights.com; frame-ancestors 'none'; form-action 'self'; base-uri 'self'

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -13,6 +13,6 @@
     "resolveJsonModule": true,
     "noEmit": true
   },
-  "include": ["src", "worker", "vite.config.ts"],
+  "include": ["src", "worker", "vite", "vite.config.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,12 +1,13 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import { cloudflare } from "@cloudflare/vite-plugin";
+import { cloudflareWebAnalyticsPlugin } from "./vite/cloudflareWebAnalyticsPlugin.ts";
 
 // Vite + React, bundled and served by a Cloudflare Worker via
 // @cloudflare/vite-plugin. The Worker (worker/index.ts) handles any /api/*
 // routes; everything else falls back to the SPA (see wrangler.jsonc).
 export default defineConfig({
-  plugins: [react(), cloudflare()],
+  plugins: [react(), cloudflare(), cloudflareWebAnalyticsPlugin()],
   server: {
     proxy: {
       "/api": "http://localhost:8787",

--- a/apps/web/vite/cloudflareWebAnalyticsPlugin.test.ts
+++ b/apps/web/vite/cloudflareWebAnalyticsPlugin.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  WEB_ANALYTICS_MARKER,
+  cloudflareWebAnalyticsPlugin,
+  resolveWebAnalyticsBeacon,
+  transformWebAnalyticsHtml,
+} from "./cloudflareWebAnalyticsPlugin.ts";
+
+const htmlWithMarker = `<head>${WEB_ANALYTICS_MARKER}</head>`;
+
+describe("resolveWebAnalyticsBeacon", () => {
+  it("returns an empty string for missing or placeholder tokens", () => {
+    expect(resolveWebAnalyticsBeacon(undefined)).toBe("");
+    expect(resolveWebAnalyticsBeacon("REPLACE_WITH_SITE_TOKEN")).toBe("");
+  });
+
+  it("returns the beacon script for a real token", () => {
+    expect(resolveWebAnalyticsBeacon("abc123")).toContain(
+      "static.cloudflareinsights.com/beacon.min.js",
+    );
+    expect(resolveWebAnalyticsBeacon("abc123")).toContain("abc123");
+  });
+});
+
+describe("transformWebAnalyticsHtml", () => {
+  it("removes the marker when no token is configured", () => {
+    expect(transformWebAnalyticsHtml(htmlWithMarker, undefined)).toBe("<head></head>");
+    expect(transformWebAnalyticsHtml(htmlWithMarker, "REPLACE_WITH_SITE_TOKEN")).toBe(
+      "<head></head>",
+    );
+  });
+
+  it("injects the beacon and removes the marker when a token is configured", () => {
+    const result = transformWebAnalyticsHtml(htmlWithMarker, "abc123");
+
+    expect(result).toContain("static.cloudflareinsights.com/beacon.min.js");
+    expect(result).toContain("abc123");
+    expect(result).not.toContain(WEB_ANALYTICS_MARKER);
+  });
+
+  it("warns and leaves html unchanged when the marker is missing", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const html = "<head></head>";
+
+    expect(transformWebAnalyticsHtml(html, "abc123")).toBe(html);
+    expect(warn).toHaveBeenCalledWith(
+      `[cloudflare-web-analytics] ${WEB_ANALYTICS_MARKER} not found in index.html — beacon will not be injected`,
+    );
+
+    warn.mockRestore();
+  });
+});
+
+describe("cloudflareWebAnalyticsPlugin", () => {
+  it("wires transformIndexHtml to the shared html transformer", () => {
+    const plugin = cloudflareWebAnalyticsPlugin();
+    const transform = plugin.transformIndexHtml;
+    if (typeof transform !== "function") {
+      throw new Error("transformIndexHtml hook missing");
+    }
+
+    const result = transform(htmlWithMarker, { path: "/index.html", filename: "index.html" });
+
+    expect(result).toContain("static.cloudflareinsights.com/beacon.min.js");
+    expect(result).not.toContain(WEB_ANALYTICS_MARKER);
+  });
+});

--- a/apps/web/vite/cloudflareWebAnalyticsPlugin.ts
+++ b/apps/web/vite/cloudflareWebAnalyticsPlugin.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { Plugin } from "vite";
+import { parseWranglerJsonc } from "./parseWranglerJsonc.ts";
+
+export { parseWranglerJsonc } from "./parseWranglerJsonc.ts";
+
+export const WEB_ANALYTICS_MARKER = "<!-- cloudflare-web-analytics -->";
+const PLACEHOLDER_TOKEN = "REPLACE_WITH_SITE_TOKEN";
+
+const pluginDir = dirname(fileURLToPath(import.meta.url));
+const wranglerConfigPath = resolve(pluginDir, "../wrangler.jsonc");
+
+function readWranglerVar(name: string): string | undefined {
+  const config = parseWranglerJsonc(readFileSync(wranglerConfigPath, "utf8"));
+  return config.vars?.[name]?.trim();
+}
+
+function webAnalyticsBeacon(token: string): string {
+  return `<script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "${token}"}'></script>`;
+}
+
+export function resolveWebAnalyticsBeacon(token: string | undefined): string {
+  if (!token || token === PLACEHOLDER_TOKEN) return "";
+  return webAnalyticsBeacon(token);
+}
+
+export function transformWebAnalyticsHtml(html: string, token: string | undefined): string {
+  if (!html.includes(WEB_ANALYTICS_MARKER)) {
+    console.warn(
+      `[cloudflare-web-analytics] ${WEB_ANALYTICS_MARKER} not found in index.html — beacon will not be injected`,
+    );
+    return html;
+  }
+
+  return html.replace(WEB_ANALYTICS_MARKER, resolveWebAnalyticsBeacon(token));
+}
+
+export function cloudflareWebAnalyticsPlugin(): Plugin {
+  const token = readWranglerVar("CF_WEB_ANALYTICS_TOKEN");
+
+  return {
+    name: "cloudflare-web-analytics",
+    transformIndexHtml(html) {
+      return transformWebAnalyticsHtml(html, token);
+    },
+  };
+}

--- a/apps/web/vite/parseWranglerJsonc.test.ts
+++ b/apps/web/vite/parseWranglerJsonc.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { parseWranglerJsonc } from "./parseWranglerJsonc.ts";
+
+describe("parseWranglerJsonc", () => {
+  it("strips full-line and trailing inline comments", () => {
+    const config = parseWranglerJsonc(`{
+      // account config
+      "vars": {
+        "CF_WEB_ANALYTICS_TOKEN": "abc123" // staging token
+      },
+    }`);
+
+    expect(config.vars?.CF_WEB_ANALYTICS_TOKEN).toBe("abc123");
+  });
+
+  it("preserves commas inside quoted string values", () => {
+    const config = parseWranglerJsonc(`{
+      "vars": {
+        "SOME_KEY": "items, ]"
+      }
+    }`);
+
+    expect(config.vars?.SOME_KEY).toBe("items, ]");
+  });
+});

--- a/apps/web/vite/parseWranglerJsonc.ts
+++ b/apps/web/vite/parseWranglerJsonc.ts
@@ -1,0 +1,79 @@
+type WranglerConfig = {
+  vars?: Record<string, string>;
+};
+
+function copyJsonString(raw: string, start: number): [segment: string, nextIndex: number] {
+  let i = start + 1;
+  while (i < raw.length) {
+    if (raw[i] === "\\") {
+      i += 2;
+      continue;
+    }
+    if (raw[i] === '"') {
+      return [raw.slice(start, i + 1), i + 1];
+    }
+    i++;
+  }
+  return [raw.slice(start), raw.length];
+}
+
+function stripJsoncComments(raw: string): string {
+  let out = "";
+  let i = 0;
+
+  while (i < raw.length) {
+    const ch = raw[i];
+    if (ch === '"') {
+      const [segment, next] = copyJsonString(raw, i);
+      out += segment;
+      i = next;
+      continue;
+    }
+    if (ch === "/" && raw[i + 1] === "/") {
+      i += 2;
+      while (i < raw.length && raw[i] !== "\n") i++;
+      continue;
+    }
+    if (ch === "/" && raw[i + 1] === "*") {
+      i += 2;
+      while (i < raw.length && !(raw[i] === "*" && raw[i + 1] === "/")) i++;
+      i += 2;
+      continue;
+    }
+    out += ch;
+    i++;
+  }
+
+  return out;
+}
+
+function stripTrailingCommas(json: string): string {
+  let out = "";
+  let i = 0;
+
+  while (i < json.length) {
+    const ch = json[i];
+    if (ch === '"') {
+      const [segment, next] = copyJsonString(json, i);
+      out += segment;
+      i = next;
+      continue;
+    }
+    if (ch === ",") {
+      let j = i + 1;
+      while (j < json.length && /\s/.test(json[j] ?? "")) j++;
+      if (json[j] === "}" || json[j] === "]") {
+        i++;
+        continue;
+      }
+    }
+    out += ch;
+    i++;
+  }
+
+  return out;
+}
+
+export function parseWranglerJsonc(raw: string): WranglerConfig {
+  return JSON.parse(stripTrailingCommas(stripJsoncComments(raw))) as WranglerConfig;
+}

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -16,4 +16,9 @@
   "observability": {
     "enabled": true,
   },
+  // Public site identifier for Cloudflare Web Analytics (not a secret).
+  // Obtain from Dashboard → Web Analytics → pineapple.tylerevans.co → Site Token.
+  "vars": {
+    "CF_WEB_ANALYTICS_TOKEN": "e3cf4d25c6274c26a34ca6c7307ff5e8",
+  },
 }

--- a/docs/specs/SPECS.md
+++ b/docs/specs/SPECS.md
@@ -28,16 +28,17 @@ relevant cross-cutting specs rather than re-describing the behavior.
 
 ## Feature Specs
 
-| Spec                                                      | Area        | Status |
-| --------------------------------------------------------- | ----------- | ------ |
-| [sign-in.md](./features/sign-in.md)                       | Auth        | review |
-| [create-asset.md](./features/create-asset.md)             | Assets      | draft  |
-| [asset-library.md](./features/asset-library.md)           | Assets      | draft  |
-| [dashboard.md](./features/dashboard.md)                   | Home        | draft  |
-| [maintenance-record.md](./features/maintenance-record.md) | Maintenance | draft  |
-| [maintenance-task.md](./features/maintenance-task.md)     | Maintenance | draft  |
-| [marketing-home.md](./features/marketing-home.md)         | Marketing   | active |
-| [user-profile.md](./features/user-profile.md)             | Identity    | draft  |
+| Spec                                                          | Area          | Status |
+| ------------------------------------------------------------- | ------------- | ------ |
+| [sign-in.md](./features/sign-in.md)                           | Auth          | review |
+| [create-asset.md](./features/create-asset.md)                 | Assets        | draft  |
+| [asset-library.md](./features/asset-library.md)               | Assets        | draft  |
+| [dashboard.md](./features/dashboard.md)                       | Home          | draft  |
+| [maintenance-record.md](./features/maintenance-record.md)     | Maintenance   | draft  |
+| [maintenance-task.md](./features/maintenance-task.md)         | Maintenance   | draft  |
+| [marketing-home.md](./features/marketing-home.md)             | Marketing     | active |
+| [user-profile.md](./features/user-profile.md)                 | Identity      | draft  |
+| [telemetry-enrichment.md](./features/telemetry-enrichment.md) | Observability | draft  |
 
 ## Directory Structure
 

--- a/docs/specs/cross-cutting/telemetry.md
+++ b/docs/specs/cross-cutting/telemetry.md
@@ -53,7 +53,9 @@ Both systems write to Cloudflare Analytics Engine using the same envelope:
 | `blobs[5]`   | `outcome`            | `"success"`, `"failure"`, `"error"`                                                            |
 | `blobs[6]`   | `error_name`         | Error constructor name, `"unknown"` for non-`Error` values, or `"none"` when no error occurred |
 | `blobs[7]`   | `authenticated`      | `"true"` or `"false"`                                                                          |
-| `blobs[8]`   | `schema_version`     | `"v1"`                                                                                         |
+| `blobs[8]`   | `schema_version`     | `"v2"`                                                                                         |
+| `blobs[9]`   | `country`            | ISO 3166-1 alpha-2 (e.g. `"US"`, `"GB"`) or `"unknown"`                                        |
+| `blobs[10]`  | `user_id`            | Authenticated `UserId` UUID, or `"anonymous"` if unauthenticated                               |
 | `doubles[0]` | `duration_ms`        | Duration (ms)                                                                                  |
 | `doubles[1]` | `count`              | Always `1`                                                                                     |
 | `doubles[2]` | `status_code_number` | HTTP status code (numeric)                                                                     |
@@ -168,10 +170,10 @@ A complete Analytics Engine outage will produce `console.error` log entries but 
 
 ## Exceptions
 
-| Feature                                              | Deviation                 | Reason                                                                           |
-| ---------------------------------------------------- | ------------------------- | -------------------------------------------------------------------------------- |
-| Frontend                                             | No telemetry              | Client-side instrumentation not yet implemented                                  |
-| Read operations (GetAsset, ListAssets, GetDashboard) | No domain event telemetry | Reads do not produce domain events; request telemetry provides sufficient signal |
+| Feature                                              | Deviation                 | Reason                                                                                          |
+| ---------------------------------------------------- | ------------------------- | ----------------------------------------------------------------------------------------------- |
+| Frontend page views                                  | Cloudflare Web Analytics  | Anonymous page view data available in the Cloudflare Dashboard; not written to Analytics Engine |
+| Read operations (GetAsset, ListAssets, GetDashboard) | No domain event telemetry | Reads do not produce domain events; request telemetry provides sufficient signal                |
 
 ## Anti-Patterns
 
@@ -187,5 +189,5 @@ A complete Analytics Engine outage will produce `console.error` log entries but 
 
 - **`actor_id` (`blobs[5]`) always equals `owner_id` (`blobs[3]`) today.** `actor_id` records who performed the action, which is semantically distinct from who owns the entity. In a system where only the owner can act, the two are the same. When delegation or assignment is introduced — where one user acts on another's behalf — `actor_id` will diverge from `owner_id`. The field is intentionally reserved for this future case.
 - **No request correlation across the two systems.** A domain event data point cannot be linked to the API request that produced it — there is no trace ID or correlation ID shared between them. **Planned:** generate a request-scoped correlation ID in the telemetry middleware, thread it through to domain events via the use case, and include it in both data points.
-- **No frontend telemetry.** User-facing errors and interactions are invisible unless they produce an API call that fails. **Planned:** define what frontend events are worth capturing before implementing, to avoid instrumenting noise.
+
 - **Telemetry is always active in all environments.** There is no reduced or disabled telemetry mode for local development — `wrangler dev` writes to Miniflare's Analytics Engine emulation at the same 100% sample rate as production. This is acceptable now but should be revisited if local test runs begin polluting a shared dev dataset.

--- a/docs/specs/features/telemetry-enrichment.md
+++ b/docs/specs/features/telemetry-enrichment.md
@@ -1,0 +1,137 @@
+---
+audience: engineering
+purpose: enrich API request telemetry with geographic origin and user identity; add anonymous page view tracking via Cloudflare Web Analytics
+source: this file
+date: 2026-06-17
+---
+
+# Telemetry Enrichment
+
+**Status:** `draft`
+**Owner:** engineering
+**Last Updated:** 2026-06-17
+**Related Specs:** [telemetry.md](../cross-cutting/telemetry.md), [authentication.md](../cross-cutting/authentication.md)
+
+---
+
+## Summary
+
+The existing `pineapple_api_request_events` dataset captures every HTTP request but omits two signals the owner-operator needs: where the request originated and which user made it. This spec adds country of origin (from `request.cf.country`) and authenticated user identity to each API request data point under a new `v2` schema, preserving all existing field positions so v1 data remains queryable alongside v2. It also adds Cloudflare Web Analytics to the web app — a JS beacon that captures anonymous page views, visitor counts, geographic breakdown, and Core Web Vitals in the Cloudflare Dashboard, separate from Analytics Engine. The CSP in `apps/web/public/_headers` is updated to allow the beacon and its reporting endpoint.
+
+## User Stories
+
+- As the **owner-operator**, I can **see the country of origin for each API request** so that **I understand where the app is being used**
+- As the **owner-operator**, I can **identify which user made each API request** so that **I can understand per-user API usage patterns**
+- As the **owner-operator**, I can **see aggregate page views, visitor counts, and geographic breakdown in the Cloudflare Dashboard** so that **I have a baseline sense of how often the web app is being visited**
+
+## Acceptance Criteria
+
+### API request telemetry (v2 schema)
+
+- [ ] Each API request data point written after this change includes a `country` field at `blobs[9]` containing the ISO 3166-1 alpha-2 code from `request.cf.country`
+- [ ] Requests where `request.cf.country` is absent or empty write `"unknown"` to `blobs[9]`
+- [ ] Each API request data point includes a `user_id` field at `blobs[10]` containing the authenticated user's `UserId` UUID when a session is resolved
+- [ ] Unauthenticated requests write `"anonymous"` to `blobs[10]`
+- [ ] The `schema_version` field (`blobs[8]`) is `"v2"` for all data points written after this change
+- [ ] Existing v1 data points are not modified — `blob9 = 'v1'` remains a stable filter to exclude them from v2 queries
+- [ ] `telemetry.md` is updated to reflect the v2 API request data point schema
+- [ ] All telemetry failure guarantees remain intact — an AE write failure is logged with `console.error` and swallowed; it never affects the API response
+- [ ] `telemetry.md` API request data point table is updated to the v2 schema
+- [ ] `telemetry.md` Exceptions table replaces the `"Frontend — No telemetry"` row with a Cloudflare Web Analytics entry
+- [ ] `telemetry.md` removes the `"No frontend telemetry"` Known Issue
+
+### Cloudflare Web Analytics
+
+- [ ] The Cloudflare Web Analytics beacon is present in `apps/web/index.html` with a valid Site Token
+- [ ] Page view data appears in the Cloudflare Dashboard under Web Analytics for `pineapple.tylerevans.co`
+- [ ] `script-src` in `apps/web/public/_headers` includes `https://static.cloudflareinsights.com`
+- [ ] `connect-src` in `apps/web/public/_headers` includes `https://cloudflareinsights.com`
+- [ ] No other CSP directives are changed
+
+## API Request Telemetry v2 Schema
+
+Dataset: `pineapple_api_request_events` (binding: `API_REQUEST_TELEMETRY`). Field positions from v1 are unchanged; `blobs[9]` and `blobs[10]` are additive.
+
+| Field        | Name                 | v1                                               | v2                                                               |
+| ------------ | -------------------- | ------------------------------------------------ | ---------------------------------------------------------------- |
+| `indexes[0]` | —                    | Operation name                                   | Operation name (unchanged)                                       |
+| `blobs[0]`   | `operation`          | Operation name                                   | (unchanged)                                                      |
+| `blobs[1]`   | `route_pattern`      | Route pattern                                    | (unchanged)                                                      |
+| `blobs[2]`   | `method`             | HTTP method                                      | (unchanged)                                                      |
+| `blobs[3]`   | `status_class`       | `"2xx"`, `"4xx"`, `"5xx"`                        | (unchanged)                                                      |
+| `blobs[4]`   | `status_code`        | HTTP status as string                            | (unchanged)                                                      |
+| `blobs[5]`   | `outcome`            | `"success"`, `"failure"`, `"error"`              | (unchanged)                                                      |
+| `blobs[6]`   | `error_name`         | Error constructor name, `"unknown"`, or `"none"` | (unchanged)                                                      |
+| `blobs[7]`   | `authenticated`      | `"true"` or `"false"`                            | (unchanged)                                                      |
+| `blobs[8]`   | `schema_version`     | `"v1"`                                           | `"v2"`                                                           |
+| `blobs[9]`   | `country`            | _(absent)_                                       | ISO 3166-1 alpha-2 (e.g. `"US"`, `"GB"`) or `"unknown"`          |
+| `blobs[10]`  | `user_id`            | _(absent)_                                       | Authenticated `UserId` UUID, or `"anonymous"` if unauthenticated |
+| `doubles[0]` | `duration_ms`        | Duration (ms)                                    | (unchanged)                                                      |
+| `doubles[1]` | `count`              | Always `1`                                       | (unchanged)                                                      |
+| `doubles[2]` | `status_code_number` | HTTP status (numeric)                            | (unchanged)                                                      |
+| `doubles[3]` | `request_size_bytes` | Request size (bytes)                             | (unchanged)                                                      |
+
+> `user_id` stores a stable non-PII UUID per the telemetry anti-patterns in `telemetry.md`. Emails, names, and other user-supplied strings must never appear in this field.
+
+## CSP Changes
+
+File: `apps/web/public/_headers`
+
+| Directive     | Current  | Updated                                        |
+| ------------- | -------- | ---------------------------------------------- |
+| `script-src`  | `'self'` | `'self' https://static.cloudflareinsights.com` |
+| `connect-src` | `'self'` | `'self' https://cloudflareinsights.com`        |
+
+All other directives are unchanged.
+
+## Cloudflare Web Analytics Beacon
+
+File: `apps/web/index.html` — add before `</head>`:
+
+```html
+<script
+  defer
+  src="https://static.cloudflareinsights.com/beacon.min.js"
+  data-cf-beacon='{"token": "<SITE_TOKEN>"}'
+></script>
+```
+
+The Site Token is obtained from Cloudflare Dashboard → Web Analytics → Add a site → `pineapple.tylerevans.co`. It is not a secret — it is a public site identifier embedded in the HTML and committed to the repository.
+
+Web Analytics data appears in the Cloudflare Dashboard only. It is not written to any Analytics Engine dataset and is not queryable alongside `pineapple_api_request_events`.
+
+## Edge Cases & Error States
+
+| Scenario                                                | Expected Behavior                                                                              |
+| ------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `request.cf.country` absent or empty                    | Write `"unknown"` to `blobs[9]`                                                                |
+| Request is unauthenticated (`c.var.user` is undefined)  | Write `"anonymous"` to `blobs[10]`; `blobs[7]` remains `"false"`                               |
+| AE write fails                                          | Logged with `console.error` and swallowed per existing failure policy; API response unaffected |
+| v1 data already in the dataset                          | Untouched; filter `blob9 = 'v1'` or `blob9 = 'v2'` to segregate by schema version              |
+| Web Analytics beacon blocked by ad blocker              | No app error; page view is silently not recorded                                               |
+| Cloudflare Web Analytics reporting endpoint unreachable | No app error; beacon silently drops the event                                                  |
+
+## Telemetry
+
+This spec is telemetry infrastructure. It requires the following updates to [telemetry.md](../cross-cutting/telemetry.md):
+
+- Replace the v1 API request data point table with the v2 schema defined above
+- Update the Exceptions table: replace `"Frontend — No telemetry — Client-side instrumentation not yet implemented"` with `"Frontend page views — Cloudflare Web Analytics — Anonymous page view data available in the Cloudflare Dashboard; not written to Analytics Engine"`
+- Remove the `"No frontend telemetry"` entry from Known Issues
+
+No new domain events. No new operation name mappings.
+
+## Out of Scope
+
+- Frontend click tracking, custom events, or interaction instrumentation beyond page views
+- User identity in Cloudflare Web Analytics (anonymous by design)
+- Session replay or heatmaps
+- City-level geographic granularity (country only)
+- Backfilling v1 data points with country or user_id
+- A custom analytics dashboard or GraphQL query layer over the AE data
+- Request correlation IDs linking API request data points to domain event data points
+- Disabling or sampling telemetry in local development
+
+## Open Questions
+
+None — all design decisions resolved in conversation on 2026-06-17.


### PR DESCRIPTION
## Summary

Implements [telemetry-enrichment.md](docs/specs/features/telemetry-enrichment.md):

- **API request telemetry v2** — adds `country` (`blobs[9]`) from `request.cf.country` and `user_id` (`blobs[10]`) from the authenticated domain user; bumps `schema_version` to `v2`
- **telemetry.md** — updates the API request data point table, replaces the frontend telemetry exception with Cloudflare Web Analytics, and removes the "no frontend telemetry" known issue
- **Cloudflare Web Analytics** — site token lives in `apps/web/wrangler.jsonc` and is injected into `index.html` at build time; CSP updated in `apps/web/public/_headers`

## Test plan

- [x] `pnpm lint && pnpm type-check && pnpm -r test`
- [ ] Deploy web worker and confirm page views appear in Cloudflare Dashboard → Web Analytics for `pineapple.tylerevans.co`
- [ ] Hit an authenticated API route in production and query AE for `blob9 = 'v2'` with populated `blob10` / `blob11`

Co-Authored-By: Grok <noreply@x.ai>