### PR TITLE
feat(web): dashboard Add a service form

### DIFF
--- a/apps/web/src/app/AddServiceModal.tsx
+++ b/apps/web/src/app/AddServiceModal.tsx
@@ -9,18 +9,13 @@ import {
 import { Icon } from "../design/Icon.tsx";
 import { HFAssetIcon } from "../design/hf.tsx";
 import { paths } from "../routes.ts";
-import { assetTypeLabel, type AssetPresentation } from "./assetPresentation.ts";
-import type { AssetCategory } from "../design/hf.tsx";
-
-function categoryLabel(category: AssetCategory): string {
-  if (category === "lawn") return "Grounds";
-  return assetTypeLabel(category);
-}
+import { categoryLabel, type AssetPresentation } from "./assetPresentation.ts";
 import {
   EMPTY_MAINTENANCE_TASK_FORM,
   formatIntervalPhrase,
   formatPreviewDueDate,
   previewNextDueDate,
+  resolveAssetId,
   TASK_TITLE_MAX,
   TASK_UNITS,
   toCreateMaintenanceTaskBody,
@@ -36,7 +31,7 @@ type AddServiceModalProps = {
   defaultAssetId?: string | null;
   todayUtc: string;
   onClose: () => void;
-  onSaved: (task: MaintenanceTask) => void;
+  onSaved: (task: MaintenanceTask) => void | Promise<void>;
 };
 
 export function AddServiceModal({
@@ -48,7 +43,7 @@ export function AddServiceModal({
 }: AddServiceModalProps) {
   const navigate = useNavigate();
   const titleRef = useRef<HTMLInputElement>(null);
-  const [assetId, setAssetId] = useState(defaultAssetId || assets[0]?.id || "");
+  const [assetId, setAssetId] = useState(() => resolveAssetId(assets, defaultAssetId));
   const [pickingAsset, setPickingAsset] = useState(false);
   const [values, setValues] = useState<MaintenanceTaskFormValues>(EMPTY_MAINTENANCE_TASK_FORM);
   const [errors, setErrors] = useState<MaintenanceTaskFormErrors>({});
@@ -56,9 +51,14 @@ export function AddServiceModal({
   const [savedTask, setSavedTask] = useState<MaintenanceTask | null>(null);
 
   const asset = useMemo(
-    () => assets.find((item) => item.id === assetId) ?? assets[0] ?? null,
+    () => assets.find((item) => item.id === assetId) ?? null,
     [assets, assetId],
   );
+
+  useEffect(() => {
+    if (assets.some((item) => item.id === assetId)) return;
+    setAssetId(resolveAssetId(assets, defaultAssetId));
+  }, [assets, assetId, defaultAssetId]);
 
   useEffect(() => {
     titleRef.current?.focus();
@@ -66,12 +66,19 @@ export function AddServiceModal({
 
   const mutation = useMutation({
     mutationFn: () => {
-      if (!asset) throw new Error("Choose an asset before saving.");
-      return createMaintenanceTask(asset.id, toCreateMaintenanceTaskBody(values));
+      const target = assets.find((item) => item.id === assetId);
+      if (!target) throw new Error("Choose an asset before saving.");
+      return createMaintenanceTask(target.id, toCreateMaintenanceTaskBody(values));
     },
-    onSuccess: (task) => {
+    onSuccess: async (task) => {
       setSavedTask(task);
-      onSaved(task);
+      try {
+        await onSaved(task);
+      } catch {
+        setBanner(
+          "Service saved, but the dashboard could not refresh. Close and reopen if the queue looks stale.",
+        );
+      }
     },
     onError: (error) => {
       if (error instanceof ApiError && error.status === 401) {
@@ -91,6 +98,7 @@ export function AddServiceModal({
   }, [mutation.isPending, onClose]);
 
   const nextDue = previewNextDueDate(values, todayUtc);
+  const formDisabled = mutation.isPending;
 
   const clearError = (field: keyof MaintenanceTaskFormErrors) => {
     setErrors((prev) => {
@@ -111,7 +119,7 @@ export function AddServiceModal({
   };
 
   const submit = () => {
-    if (mutation.isPending || !asset) return;
+    if (formDisabled || !asset) return;
     const nextErrors = validateMaintenanceTaskForm(values, todayUtc);
     setErrors(nextErrors);
     if (Object.keys(nextErrors).length) return;
@@ -123,7 +131,7 @@ export function AddServiceModal({
 
   return (
     <div className="hf-svc-overlay">
-      <div className="hf-svc-scrim" onClick={() => !mutation.isPending && onClose()} />
+      <div className="hf-svc-scrim" onClick={() => !formDisabled && onClose()} />
       <div
         className="hf-svc-drawer"
         role="dialog"
@@ -143,7 +151,7 @@ export function AddServiceModal({
             className="hf-icon-btn"
             onClick={onClose}
             aria-label="Close"
-            disabled={mutation.isPending}
+            disabled={formDisabled}
           >
             <Icon name="x" size={16} stroke={2} />
           </button>
@@ -187,6 +195,7 @@ export function AddServiceModal({
                       role="option"
                       aria-selected={item.id === assetId}
                       className={`hf-svc-picker-row ${item.id === assetId ? "active" : ""}`}
+                      disabled={formDisabled}
                       onClick={() => {
                         setAssetId(item.id);
                         setPickingAsset(false);
@@ -211,6 +220,7 @@ export function AddServiceModal({
                 <button
                   type="button"
                   className="hf-svc-asset"
+                  disabled={formDisabled}
                   onClick={() => setPickingAsset(true)}
                 >
                   <HFAssetIcon asset={{ category: asset.cat, icon: asset.icon }} size={40} />
@@ -245,6 +255,7 @@ export function AddServiceModal({
                 placeholder='e.g. "Replace furnace filter"'
                 maxLength={TASK_TITLE_MAX + 20}
                 value={values.title}
+                disabled={formDisabled}
                 onChange={(event) => updateValue("title", event.target.value)}
               />
               {errors.title && (
@@ -266,6 +277,7 @@ export function AddServiceModal({
                   step="1"
                   className={`hf-input hf-mono-input hf-svc-num ${errors.intervalValue ? "is-invalid" : ""}`}
                   value={values.intervalValue}
+                  disabled={formDisabled}
                   onChange={(event) => updateValue("intervalValue", event.target.value)}
                 />
                 <div className="hf-seg" role="group" aria-label="Interval unit">
@@ -274,6 +286,7 @@ export function AddServiceModal({
                       key={unit.value}
                       type="button"
                       className={`hf-seg-btn ${values.intervalUnit === unit.value ? "active" : ""}`}
+                      disabled={formDisabled}
                       onClick={() => updateValue("intervalUnit", unit.value)}
                     >
                       {unit.label}
@@ -299,6 +312,7 @@ export function AddServiceModal({
                 max={todayUtc}
                 className={`hf-input ${errors.lastCompletedDate ? "is-invalid" : ""}`}
                 value={values.lastCompletedDate}
+                disabled={formDisabled}
                 onChange={(event) => updateValue("lastCompletedDate", event.target.value)}
               />
               {errors.lastCompletedDate ? (
@@ -332,14 +346,14 @@ export function AddServiceModal({
               <button
                 className="hf-btn hf-btn-ghost"
                 onClick={onClose}
-                disabled={mutation.isPending}
+                disabled={formDisabled}
               >
                 Cancel
               </button>
               <button
                 className="hf-btn hf-btn-primary"
                 onClick={submit}
-                disabled={mutation.isPending}
+                disabled={formDisabled || !asset}
               >
                 {mutation.isPending ? (
                   <>

--- a/apps/web/src/app/AddServiceModal.tsx
+++ b/apps/web/src/app/AddServiceModal.tsx
@@ -1,0 +1,362 @@
+import { useMutation } from "@tanstack/react-query";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate } from "react-router";
+import { ApiError } from "../api/client.ts";
+import {
+  createMaintenanceTask,
+  type MaintenanceTask,
+} from "../api/maintenanceTasks.ts";
+import { Icon } from "../design/Icon.tsx";
+import { HFAssetIcon } from "../design/hf.tsx";
+import { paths } from "../routes.ts";
+import { assetTypeLabel, type AssetPresentation } from "./assetPresentation.ts";
+import type { AssetCategory } from "../design/hf.tsx";
+
+function categoryLabel(category: AssetCategory): string {
+  if (category === "lawn") return "Grounds";
+  return assetTypeLabel(category);
+}
+import {
+  EMPTY_MAINTENANCE_TASK_FORM,
+  formatIntervalPhrase,
+  formatPreviewDueDate,
+  previewNextDueDate,
+  TASK_TITLE_MAX,
+  TASK_UNITS,
+  toCreateMaintenanceTaskBody,
+  validateMaintenanceTaskForm,
+  type MaintenanceTaskFormErrors,
+  type MaintenanceTaskFormValues,
+} from "./maintenanceTaskForm.ts";
+
+import "../design/styles/hifi-add-service.css";
+
+type AddServiceModalProps = {
+  assets: AssetPresentation[];
+  defaultAssetId?: string | null;
+  todayUtc: string;
+  onClose: () => void;
+  onSaved: (task: MaintenanceTask) => void;
+};
+
+export function AddServiceModal({
+  assets,
+  defaultAssetId,
+  todayUtc,
+  onClose,
+  onSaved,
+}: AddServiceModalProps) {
+  const navigate = useNavigate();
+  const titleRef = useRef<HTMLInputElement>(null);
+  const [assetId, setAssetId] = useState(defaultAssetId || assets[0]?.id || "");
+  const [pickingAsset, setPickingAsset] = useState(false);
+  const [values, setValues] = useState<MaintenanceTaskFormValues>(EMPTY_MAINTENANCE_TASK_FORM);
+  const [errors, setErrors] = useState<MaintenanceTaskFormErrors>({});
+  const [banner, setBanner] = useState<string | null>(null);
+  const [savedTask, setSavedTask] = useState<MaintenanceTask | null>(null);
+
+  const asset = useMemo(
+    () => assets.find((item) => item.id === assetId) ?? assets[0] ?? null,
+    [assets, assetId],
+  );
+
+  useEffect(() => {
+    titleRef.current?.focus();
+  }, []);
+
+  const mutation = useMutation({
+    mutationFn: () => {
+      if (!asset) throw new Error("Choose an asset before saving.");
+      return createMaintenanceTask(asset.id, toCreateMaintenanceTaskBody(values));
+    },
+    onSuccess: (task) => {
+      setSavedTask(task);
+      onSaved(task);
+    },
+    onError: (error) => {
+      if (error instanceof ApiError && error.status === 401) {
+        navigate(paths.login(), { replace: true });
+        return;
+      }
+      setBanner(error instanceof Error ? error.message : "Failed to save service.");
+    },
+  });
+
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && !mutation.isPending) onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [mutation.isPending, onClose]);
+
+  const nextDue = previewNextDueDate(values, todayUtc);
+
+  const clearError = (field: keyof MaintenanceTaskFormErrors) => {
+    setErrors((prev) => {
+      if (!prev[field]) return prev;
+      const next = { ...prev };
+      delete next[field];
+      return next;
+    });
+  };
+
+  const updateValue = <K extends keyof MaintenanceTaskFormValues>(
+    field: K,
+    value: MaintenanceTaskFormValues[K],
+  ) => {
+    setValues((prev) => ({ ...prev, [field]: value }));
+    clearError(field as keyof MaintenanceTaskFormErrors);
+    if (banner) setBanner(null);
+  };
+
+  const submit = () => {
+    if (mutation.isPending || !asset) return;
+    const nextErrors = validateMaintenanceTaskForm(values, todayUtc);
+    setErrors(nextErrors);
+    if (Object.keys(nextErrors).length) return;
+    setBanner(null);
+    mutation.mutate();
+  };
+
+  if (!asset) return null;
+
+  return (
+    <div className="hf-svc-overlay">
+      <div className="hf-svc-scrim" onClick={() => !mutation.isPending && onClose()} />
+      <div
+        className="hf-svc-drawer"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Add a service"
+      >
+        <div className="hf-svc-head">
+          <div>
+            <div className="hf-svc-title">
+              {savedTask ? "Service scheduled" : "Add a service"}
+            </div>
+            {!savedTask && (
+              <div className="hf-svc-sub">Schedule recurring work for an asset.</div>
+            )}
+          </div>
+          <button
+            className="hf-icon-btn"
+            onClick={onClose}
+            aria-label="Close"
+            disabled={mutation.isPending}
+          >
+            <Icon name="x" size={16} stroke={2} />
+          </button>
+        </div>
+
+        {savedTask ? (
+          <div className="hf-svc-body">
+            <div className="hf-svc-done">
+              <div className="hf-svc-done-icon">
+                <Icon name="check" size={26} stroke={2.4} />
+              </div>
+              <div className="hf-svc-done-title">Added to {asset.name}</div>
+              <div className="hf-svc-done-sub">
+                <strong>{savedTask.title}</strong> —{" "}
+                {formatIntervalPhrase(savedTask.intervalValue, savedTask.intervalUnit)}.
+                First service due{" "}
+                <strong>{formatPreviewDueDate(savedTask.nextDue)}</strong>.
+              </div>
+            </div>
+          </div>
+        ) : (
+          <div className="hf-svc-body">
+            {banner && (
+              <div className="hf-svc-banner" role="alert">
+                <Icon name="alert" size={15} stroke={2} />
+                <span>{banner}</span>
+              </div>
+            )}
+
+            <div className="hf-field">
+              <label className="hf-field-label">
+                Asset <span className="hf-field-req">*</span>
+                <span className="hf-field-hint">what needs servicing</span>
+              </label>
+              {pickingAsset ? (
+                <div className="hf-svc-picker" role="listbox" aria-label="Choose an asset">
+                  {assets.map((item) => (
+                    <button
+                      key={item.id}
+                      type="button"
+                      role="option"
+                      aria-selected={item.id === assetId}
+                      className={`hf-svc-picker-row ${item.id === assetId ? "active" : ""}`}
+                      onClick={() => {
+                        setAssetId(item.id);
+                        setPickingAsset(false);
+                      }}
+                    >
+                      <HFAssetIcon asset={{ category: item.cat, icon: item.icon }} size={34} />
+                      <div className="hf-svc-picker-text">
+                        <div className="hf-svc-picker-name">{item.name}</div>
+                        <div className="hf-svc-picker-meta">
+                          {item.displayId} · {categoryLabel(item.cat)}
+                        </div>
+                      </div>
+                      {item.id === assetId && (
+                        <span className="hf-svc-picker-check">
+                          <Icon name="check" size={16} stroke={2.4} />
+                        </span>
+                      )}
+                    </button>
+                  ))}
+                </div>
+              ) : (
+                <button
+                  type="button"
+                  className="hf-svc-asset"
+                  onClick={() => setPickingAsset(true)}
+                >
+                  <HFAssetIcon asset={{ category: asset.cat, icon: asset.icon }} size={40} />
+                  <div className="hf-svc-asset-text">
+                    <div className="hf-svc-asset-name">{asset.name}</div>
+                    <div className="hf-svc-asset-meta">
+                      <span className="hf-mono">{asset.displayId}</span>
+                      <span className="hf-dot-sep" />
+                      {categoryLabel(asset.cat)}
+                    </div>
+                  </div>
+                  <span className="hf-svc-change">
+                    Change
+                    <Icon name="chevron-right" size={13} stroke={2.2} />
+                  </span>
+                </button>
+              )}
+            </div>
+
+            <div className="hf-field">
+              <label className="hf-field-label" htmlFor="hf-svc-title">
+                Service <span className="hf-field-req">*</span>
+                <span className="hf-field-hint">
+                  {values.title.length}/{TASK_TITLE_MAX}
+                </span>
+              </label>
+              <input
+                id="hf-svc-title"
+                ref={titleRef}
+                type="text"
+                className={`hf-input ${errors.title ? "is-invalid" : ""}`}
+                placeholder='e.g. "Replace furnace filter"'
+                maxLength={TASK_TITLE_MAX + 20}
+                value={values.title}
+                onChange={(event) => updateValue("title", event.target.value)}
+              />
+              {errors.title && (
+                <span className="hf-svc-field-err">
+                  <Icon name="alert" size={12} stroke={2} />
+                  {errors.title}
+                </span>
+              )}
+            </div>
+
+            <div className="hf-field">
+              <label className="hf-field-label">
+                Repeat every <span className="hf-field-req">*</span>
+              </label>
+              <div className="hf-svc-interval">
+                <input
+                  type="number"
+                  min="1"
+                  step="1"
+                  className={`hf-input hf-mono-input hf-svc-num ${errors.intervalValue ? "is-invalid" : ""}`}
+                  value={values.intervalValue}
+                  onChange={(event) => updateValue("intervalValue", event.target.value)}
+                />
+                <div className="hf-seg" role="group" aria-label="Interval unit">
+                  {TASK_UNITS.map((unit) => (
+                    <button
+                      key={unit.value}
+                      type="button"
+                      className={`hf-seg-btn ${values.intervalUnit === unit.value ? "active" : ""}`}
+                      onClick={() => updateValue("intervalUnit", unit.value)}
+                    >
+                      {unit.label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+              {errors.intervalValue && (
+                <span className="hf-svc-field-err">
+                  <Icon name="alert" size={12} stroke={2} />
+                  {errors.intervalValue}
+                </span>
+              )}
+            </div>
+
+            <div className="hf-field">
+              <label className="hf-field-label" htmlFor="hf-svc-last">
+                Last completed <span className="hf-field-opt">optional</span>
+              </label>
+              <input
+                id="hf-svc-last"
+                type="date"
+                max={todayUtc}
+                className={`hf-input ${errors.lastCompletedDate ? "is-invalid" : ""}`}
+                value={values.lastCompletedDate}
+                onChange={(event) => updateValue("lastCompletedDate", event.target.value)}
+              />
+              {errors.lastCompletedDate ? (
+                <span className="hf-svc-field-err">
+                  <Icon name="alert" size={12} stroke={2} />
+                  {errors.lastCompletedDate}
+                </span>
+              ) : (
+                <span className="hf-svc-hint">Leave blank to start counting from today.</span>
+              )}
+            </div>
+
+            {nextDue && (
+              <div className="hf-svc-preview">
+                <Icon name="calendar" size={16} stroke={1.8} />
+                <span className="hf-svc-preview-txt">
+                  First service due <strong>{formatPreviewDueDate(nextDue)}</strong>
+                </span>
+              </div>
+            )}
+          </div>
+        )}
+
+        <div className="hf-svc-foot">
+          {savedTask ? (
+            <button className="hf-btn hf-btn-primary" onClick={onClose}>
+              Done
+            </button>
+          ) : (
+            <>
+              <button
+                className="hf-btn hf-btn-ghost"
+                onClick={onClose}
+                disabled={mutation.isPending}
+              >
+                Cancel
+              </button>
+              <button
+                className="hf-btn hf-btn-primary"
+                onClick={submit}
+                disabled={mutation.isPending}
+              >
+                {mutation.isPending ? (
+                  <>
+                    <span className="hf-svc-spinner" />
+                    Saving…
+                  </>
+                ) : (
+                  <>
+                    <Icon name="check" size={14} stroke={2.3} />
+                    Save service
+                  </>
+                )}
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/AppHome.tsx
+++ b/apps/web/src/app/AppHome.tsx
@@ -166,10 +166,6 @@ function HFDashboardState({
   );
 }
 
-function todayUtcDate(): string {
-  return new Date().toISOString().slice(0, 10);
-}
-
 const CATEGORY_FILTERS: { id: DashboardCategoryFilter; label: string }[] = [
   { id: "all", label: "All" },
   { id: "vehicle", label: "Vehicles" },
@@ -209,7 +205,7 @@ export function AppHome({ mobileMode = "inline" }: { mobileMode?: "inline" }) {
       if (!dashboardQuery.data) throw new Error("Dashboard is not loaded");
       return createMaintenanceRecord(item.assetId, {
         title: item.service,
-        performedAt: todayUtcDate(),
+        performedAt: dashboardQuery.data.todayUtc,
         taskId: item.taskId,
       });
     },
@@ -288,10 +284,14 @@ export function AppHome({ mobileMode = "inline" }: { mobileMode?: "inline" }) {
   );
 
   const handleServiceSaved = async (task: { assetId: string }) => {
-    await Promise.all([
+    const results = await Promise.allSettled([
       queryClient.invalidateQueries({ queryKey: dashboardQueryKey }),
       queryClient.invalidateQueries({ queryKey: maintenanceTasksQueryKey(task.assetId) }),
     ]);
+    const failed = results.find((result) => result.status === "rejected");
+    if (failed) {
+      throw failed.reason;
+    }
   };
 
   if (dashboardQuery.isPending) {
@@ -484,13 +484,20 @@ export function AppHome({ mobileMode = "inline" }: { mobileMode?: "inline" }) {
       {addServiceOpen && dashboardQuery.data && (
         assetsQuery.isPending ? (
           <div className="hf-svc-overlay">
-            <div className="hf-svc-scrim" />
+            <div className="hf-svc-scrim" onClick={() => setAddServiceOpen(false)} />
             <div className="hf-svc-drawer" role="dialog" aria-modal="true" aria-label="Add a service">
               <div className="hf-svc-head">
                 <div>
                   <div className="hf-svc-title">Add a service</div>
                   <div className="hf-svc-sub">Schedule recurring work for an asset.</div>
                 </div>
+                <button
+                  className="hf-icon-btn"
+                  onClick={() => setAddServiceOpen(false)}
+                  aria-label="Close"
+                >
+                  <Icon name="x" size={16} stroke={2} />
+                </button>
               </div>
               <div className="hf-svc-body">
                 <HFDashboardState
@@ -539,9 +546,45 @@ export function AppHome({ mobileMode = "inline" }: { mobileMode?: "inline" }) {
             defaultAssetId={selected?.assetId ?? null}
             todayUtc={dashboardQuery.data.todayUtc}
             onClose={() => setAddServiceOpen(false)}
-            onSaved={(task) => void handleServiceSaved(task)}
+            onSaved={handleServiceSaved}
           />
-        ) : null
+        ) : (
+          <div className="hf-svc-overlay">
+            <div className="hf-svc-scrim" onClick={() => setAddServiceOpen(false)} />
+            <div className="hf-svc-drawer" role="dialog" aria-modal="true" aria-label="Add a service">
+              <div className="hf-svc-head">
+                <div>
+                  <div className="hf-svc-title">Add a service</div>
+                  <div className="hf-svc-sub">Schedule recurring work for an asset.</div>
+                </div>
+                <button
+                  className="hf-icon-btn"
+                  onClick={() => setAddServiceOpen(false)}
+                  aria-label="Close"
+                >
+                  <Icon name="x" size={16} stroke={2} />
+                </button>
+              </div>
+              <div className="hf-svc-body">
+                <HFDashboardState
+                  title="No assets available"
+                  description="Add an asset before scheduling a service."
+                  action={
+                    <Link className="hf-btn hf-btn-primary" to={paths.addAsset}>
+                      <Icon name="plus" size={14} stroke={2.2} />
+                      Add asset
+                    </Link>
+                  }
+                />
+              </div>
+              <div className="hf-svc-foot">
+                <button className="hf-btn hf-btn-primary" onClick={() => setAddServiceOpen(false)}>
+                  Close
+                </button>
+              </div>
+            </div>
+          </div>
+        )
       )}
     </div>
   );

--- a/apps/web/src/app/AppHome.tsx
+++ b/apps/web/src/app/AppHome.tsx
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate } from "react-router";
+import { assetsQueryKey, listAssets } from "../api/assets.ts";
 import { dashboardQueryKey, getDashboard } from "../api/dashboard.ts";
 import { createMaintenanceRecord, maintenanceRecordsQueryKey } from "../api/maintenanceRecords.ts";
 import { maintenanceTasksQueryKey } from "../api/maintenanceTasks.ts";
@@ -15,6 +16,8 @@ import {
   formatFleetSubline,
   toQueuePresentation,
 } from "./dashboardPresentation.ts";
+import { toAssetPresentation } from "./assetPresentation.ts";
+import { AddServiceModal } from "./AddServiceModal.tsx";
 import { formatDashboardGreeting as formatGreeting } from "./profilePresentation.ts";
 import { paths } from "../routes.ts";
 
@@ -184,10 +187,19 @@ export function AppHome({ mobileMode = "inline" }: { mobileMode?: "inline" }) {
     taskId: string;
     message: string;
   } | null>(null);
+  const [addServiceOpen, setAddServiceOpen] = useState(false);
 
   const dashboardQuery = useQuery({
     queryKey: dashboardQueryKey,
     queryFn: getDashboard,
+    retry: (failureCount, error) =>
+      !(error instanceof ApiError && error.status === 401) && failureCount < 2,
+  });
+
+  const assetsQuery = useQuery({
+    queryKey: assetsQueryKey,
+    queryFn: listAssets,
+    enabled: addServiceOpen,
     retry: (failureCount, error) =>
       !(error instanceof ApiError && error.status === 401) && failureCount < 2,
   });
@@ -238,6 +250,12 @@ export function AppHome({ mobileMode = "inline" }: { mobileMode?: "inline" }) {
     }
   }, [dashboardQuery.error, navigate]);
 
+  useEffect(() => {
+    if (assetsQuery.error instanceof ApiError && assetsQuery.error.status === 401) {
+      navigate(paths.login(), { replace: true });
+    }
+  }, [assetsQuery.error, navigate]);
+
   const queue = useMemo(() => {
     if (!dashboardQuery.data) return [];
     return dashboardQuery.data.queue.map((item) => toQueuePresentation(item));
@@ -263,6 +281,18 @@ export function AppHome({ mobileMode = "inline" }: { mobileMode?: "inline" }) {
 
   const completeErrorFor = (taskId: string) =>
     completeError?.taskId === taskId ? completeError.message : null;
+
+  const assetPresentations = useMemo(
+    () => (assetsQuery.data?.assets ?? []).map(toAssetPresentation),
+    [assetsQuery.data],
+  );
+
+  const handleServiceSaved = async (task: { assetId: string }) => {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: dashboardQueryKey }),
+      queryClient.invalidateQueries({ queryKey: maintenanceTasksQueryKey(task.assetId) }),
+    ]);
+  };
 
   if (dashboardQuery.isPending) {
     return (
@@ -357,7 +387,10 @@ export function AppHome({ mobileMode = "inline" }: { mobileMode?: "inline" }) {
               </button>
             ))}
           </div>
-          <button className="hf-btn hf-btn-secondary hf-btn-sm" disabled title="Coming soon">
+          <button
+            className="hf-btn hf-btn-secondary hf-btn-sm"
+            onClick={() => setAddServiceOpen(true)}
+          >
             <Icon name="plus" size={14} stroke={2} />
             Add service
           </button>
@@ -447,6 +480,69 @@ export function AppHome({ mobileMode = "inline" }: { mobileMode?: "inline" }) {
         )}
       </main>
       <HFBottomNav />
+
+      {addServiceOpen && dashboardQuery.data && (
+        assetsQuery.isPending ? (
+          <div className="hf-svc-overlay">
+            <div className="hf-svc-scrim" />
+            <div className="hf-svc-drawer" role="dialog" aria-modal="true" aria-label="Add a service">
+              <div className="hf-svc-head">
+                <div>
+                  <div className="hf-svc-title">Add a service</div>
+                  <div className="hf-svc-sub">Schedule recurring work for an asset.</div>
+                </div>
+              </div>
+              <div className="hf-svc-body">
+                <HFDashboardState
+                  title="Loading assets"
+                  description="Fetching your fleet so you can choose where to schedule this service…"
+                />
+              </div>
+            </div>
+          </div>
+        ) : assetsQuery.isError ? (
+          <div className="hf-svc-overlay">
+            <div className="hf-svc-scrim" onClick={() => setAddServiceOpen(false)} />
+            <div className="hf-svc-drawer" role="dialog" aria-modal="true" aria-label="Add a service">
+              <div className="hf-svc-head">
+                <div>
+                  <div className="hf-svc-title">Add a service</div>
+                  <div className="hf-svc-sub">Schedule recurring work for an asset.</div>
+                </div>
+                <button
+                  className="hf-icon-btn"
+                  onClick={() => setAddServiceOpen(false)}
+                  aria-label="Close"
+                >
+                  <Icon name="x" size={16} stroke={2} />
+                </button>
+              </div>
+              <div className="hf-svc-body">
+                <HFDashboardState
+                  title="Assets could not be loaded"
+                  description={assetsQuery.error.message}
+                  action={
+                    <button
+                      className="hf-btn hf-btn-secondary"
+                      onClick={() => void assetsQuery.refetch()}
+                    >
+                      Try again
+                    </button>
+                  }
+                />
+              </div>
+            </div>
+          </div>
+        ) : assetPresentations.length > 0 ? (
+          <AddServiceModal
+            assets={assetPresentations}
+            defaultAssetId={selected?.assetId ?? null}
+            todayUtc={dashboardQuery.data.todayUtc}
+            onClose={() => setAddServiceOpen(false)}
+            onSaved={(task) => void handleServiceSaved(task)}
+          />
+        ) : null
+      )}
     </div>
   );
 }

--- a/apps/web/src/app/AppMaintenanceRecords.tsx
+++ b/apps/web/src/app/AppMaintenanceRecords.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate, useParams } from "react-router";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { ApiError } from "../api/client.ts";
 import { getAsset, assetQueryKey } from "../api/assets.ts";
+import { dashboardQueryKey, getDashboard } from "../api/dashboard.ts";
 import {
   listMaintenanceRecords,
   createMaintenanceRecord,
@@ -24,11 +25,13 @@ import { HFTopBar, HFBottomNav } from "./AppChrome.tsx";
 import { toAssetPresentation, type AssetPresentation } from "./assetPresentation.ts";
 import {
   EMPTY_MAINTENANCE_TASK_FORM,
+  formatIntervalPhrase,
   TASK_TITLE_MAX,
   TASK_UNITS,
   todayDateOnly,
   toCreateMaintenanceTaskBody,
   validateMaintenanceTaskForm,
+  ymdToUTC,
   type MaintenanceTaskFormValues,
 } from "./maintenanceTaskForm.ts";
 import { paths } from "../routes.ts";
@@ -43,11 +46,6 @@ const MONTHS_SHORT = [
   "Jan", "Feb", "Mar", "Apr", "May", "Jun",
   "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
 ];
-
-function ymdToUTC(s: string): number {
-  const parts = s.split("-").map(Number);
-  return Date.UTC(parts[0]!, parts[1]! - 1, parts[2]!);
-}
 
 function fmtDate(s: string): string {
   const parts = s.split("-").map(Number);
@@ -69,10 +67,6 @@ function relAgo(s: string): string {
 }
 
 // ─── task helpers (presentation only — status/daysDue come from the API) ─────
-
-function fmtInterval(value: number, unit: string): string {
-  return value === 1 ? `Every ${unit}` : `Every ${value} ${unit}s`;
-}
 
 function nextDueLabel(daysDue: number, nextDue: string): string {
   if (daysDue < 0) {
@@ -377,7 +371,7 @@ function MRTaskCard({ task, onLog, onDelete }: { task: MaintenanceTask; onLog: (
         <span className="mr-task-dot" data-status={s} />
         <div className="mr-task-info">
           <div className="mr-task-title">{task.title}</div>
-          <div className="mr-task-interval">{fmtInterval(task.intervalValue, task.intervalUnit)}</div>
+          <div className="mr-task-interval">{formatIntervalPhrase(task.intervalValue, task.intervalUnit)}</div>
         </div>
       </div>
       <div className="mr-task-card-right">
@@ -509,12 +503,13 @@ function MROverviewTab({
 
 interface MRCreateTaskFormProps {
   asset: AssetPresentation;
+  todayUtc: string;
   variant: "drawer" | "sheet";
   onClose: () => void;
   onCreated: (task: MaintenanceTask) => void;
 }
 
-function MRCreateTaskForm({ asset, variant, onClose, onCreated }: MRCreateTaskFormProps) {
+function MRCreateTaskForm({ asset, todayUtc, variant, onClose, onCreated }: MRCreateTaskFormProps) {
   const [values, setValues] = useState<MaintenanceTaskFormValues>(EMPTY_MAINTENANCE_TASK_FORM);
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [banner, setBanner] = useState<string | null>(null);
@@ -530,7 +525,7 @@ function MRCreateTaskForm({ asset, variant, onClose, onCreated }: MRCreateTaskFo
 
   const submit = () => {
     if (mutation.isPending) return;
-    const nextErrors = validateMaintenanceTaskForm(values);
+    const nextErrors = validateMaintenanceTaskForm(values, todayUtc);
     const mappedErrors: Record<string, string> = {};
     if (nextErrors.title) mappedErrors.title = nextErrors.title;
     if (nextErrors.intervalValue) mappedErrors.iv = nextErrors.intervalValue;
@@ -610,7 +605,7 @@ function MRCreateTaskForm({ asset, variant, onClose, onCreated }: MRCreateTaskFo
           <div className="mr-field-top">
             <label className="mr-field-label" htmlFor="mt-last">Last completed</label>
           </div>
-          <input id="mt-last" type="date" max={todayDateOnly()} className={`mr-input mr-input-date ${errors.last ? "err" : ""}`}
+          <input id="mt-last" type="date" max={todayUtc} className={`mr-input mr-input-date ${errors.last ? "err" : ""}`}
             value={values.lastCompletedDate} onChange={(e) => updateValue("lastCompletedDate", e.target.value)} />
           {errors.last ? <div className="mr-field-err"><Icon name="alert" size={13} stroke={2} />{errors.last}</div> :
             <div className="mr-field-hint">Optional — when was this last done? Leave blank to start counting from today.</div>}
@@ -914,6 +909,16 @@ export function AppMaintenanceRecords() {
     retry: (count, err) =>
       !(err instanceof ApiError && (err.status === 401 || err.status === 403)) && count < 2,
   });
+
+  const dashboardTodayQuery = useQuery({
+    queryKey: dashboardQueryKey,
+    queryFn: getDashboard,
+    enabled: taskFormOpen,
+    staleTime: 60_000,
+    select: (data) => data.todayUtc,
+  });
+
+  const taskFormTodayUtc = dashboardTodayQuery.data ?? todayDateOnly();
 
   // Redirect on 401
   useEffect(() => {
@@ -1232,6 +1237,7 @@ export function AppMaintenanceRecords() {
           <div className={`mr-overlay-panel-${overlayVariant}`}>
             <MRCreateTaskForm
               asset={asset}
+              todayUtc={taskFormTodayUtc}
               variant={overlayVariant}
               onClose={() => setTaskFormOpen(false)}
               onCreated={handleTaskCreated}

--- a/apps/web/src/app/AppMaintenanceRecords.tsx
+++ b/apps/web/src/app/AppMaintenanceRecords.tsx
@@ -22,6 +22,15 @@ import { Icon } from "../design/Icon.tsx";
 import { HFAssetIcon } from "../design/hf.tsx";
 import { HFTopBar, HFBottomNav } from "./AppChrome.tsx";
 import { toAssetPresentation, type AssetPresentation } from "./assetPresentation.ts";
+import {
+  EMPTY_MAINTENANCE_TASK_FORM,
+  TASK_TITLE_MAX,
+  TASK_UNITS,
+  todayDateOnly,
+  toCreateMaintenanceTaskBody,
+  validateMaintenanceTaskForm,
+  type MaintenanceTaskFormValues,
+} from "./maintenanceTaskForm.ts";
 import { paths } from "../routes.ts";
 
 import "../design/styles/hifi.css";
@@ -34,10 +43,6 @@ const MONTHS_SHORT = [
   "Jan", "Feb", "Mar", "Apr", "May", "Jun",
   "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
 ];
-
-function todayDateOnly(): string {
-  return new Date().toISOString().slice(0, 10);
-}
 
 function ymdToUTC(s: string): number {
   const parts = s.split("-").map(Number);
@@ -82,31 +87,6 @@ function nextDueLabel(daysDue: number, nextDue: string): string {
   const todayY = Number(todayDateOnly().slice(0, 4));
   if (y === todayY) return `Due ${MONTHS_SHORT[m - 1]} ${d}`;
   return `Due ${MONTHS_SHORT[m - 1]} ${d}, ${y}`;
-}
-
-function addIntervalClient(dateStr: string, value: number, unit: "day" | "week" | "month" | "year"): string {
-  // Simple client version for optimistic create preview (not used for persistence)
-  const [y, m, d] = dateStr.split("-").map(Number);
-  let yy = y!, mm = m!, dd = d!;
-  if (unit === "day" || unit === "week") {
-    const mult = unit === "week" ? 7 : 1;
-    const ms = ymdToUTC(dateStr) + value * mult * 86400000;
-    const dt = new Date(ms);
-    return [
-      dt.getUTCFullYear(),
-      String(dt.getUTCMonth() + 1).padStart(2, "0"),
-      String(dt.getUTCDate()).padStart(2, "0"),
-    ].join("-");
-  }
-  if (unit === "month") {
-    mm += value;
-    while (mm > 12) { mm -= 12; yy += 1; }
-  } else {
-    yy += value;
-  }
-  const cap = new Date(Date.UTC(yy, mm, 0)).getUTCDate();
-  dd = Math.min(dd, cap);
-  return [yy, String(mm).padStart(2, "0"), String(dd).padStart(2, "0")].join("-");
 }
 
 type GroupedRecord = MaintenanceRecord & { sameDay: boolean };
@@ -527,14 +507,6 @@ function MROverviewTab({
 
 // ─── Task create form (simple drawer/sheet version) ──────────────────────────
 
-const TASK_TITLE_MAX = 100;
-const TASK_UNITS: Array<{ value: "day" | "week" | "month" | "year"; label: string }> = [
-  { value: "day", label: "Day" },
-  { value: "week", label: "Week" },
-  { value: "month", label: "Month" },
-  { value: "year", label: "Year" },
-];
-
 interface MRCreateTaskFormProps {
   asset: AssetPresentation;
   variant: "drawer" | "sheet";
@@ -543,26 +515,12 @@ interface MRCreateTaskFormProps {
 }
 
 function MRCreateTaskForm({ asset, variant, onClose, onCreated }: MRCreateTaskFormProps) {
-  const [title, setTitle] = useState("");
-  const [iv, setIv] = useState("3");
-  const [unit, setUnit] = useState<"day" | "week" | "month" | "year">("month");
-  const [lastDate, setLastDate] = useState("");
+  const [values, setValues] = useState<MaintenanceTaskFormValues>(EMPTY_MAINTENANCE_TASK_FORM);
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [banner, setBanner] = useState<string | null>(null);
   const titleRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => { titleRef.current?.focus(); }, []);
-
-  const validate = () => {
-    const e: Record<string, string> = {};
-    const t = title.trim();
-    if (!t) e.title = "Title is required.";
-    else if (t.length > TASK_TITLE_MAX) e.title = `Title must be ${TASK_TITLE_MAX} characters or fewer.`;
-    const n = Number(iv);
-    if (!iv || isNaN(n) || n < 1 || !Number.isInteger(n) || iv.includes('.')) e.iv = "Must be a positive whole number.";
-    if (lastDate && lastDate > todayDateOnly()) e.last = "Must be today or earlier.";
-    return e;
-  };
 
   const mutation = useMutation({
     mutationFn: (body: CreateMaintenanceTaskBody) => createMaintenanceTask(asset.id, body),
@@ -572,24 +530,37 @@ function MRCreateTaskForm({ asset, variant, onClose, onCreated }: MRCreateTaskFo
 
   const submit = () => {
     if (mutation.isPending) return;
-    const e = validate();
-    setErrors(e);
-    if (Object.keys(e).length) {
+    const nextErrors = validateMaintenanceTaskForm(values);
+    const mappedErrors: Record<string, string> = {};
+    if (nextErrors.title) mappedErrors.title = nextErrors.title;
+    if (nextErrors.intervalValue) mappedErrors.iv = nextErrors.intervalValue;
+    if (nextErrors.lastCompletedDate) mappedErrors.last = nextErrors.lastCompletedDate;
+    setErrors(mappedErrors);
+    if (Object.keys(mappedErrors).length) {
       setBanner("Please fix the highlighted fields before saving.");
       return;
     }
     setBanner(null);
-    const n = Number(iv);
-    const body: CreateMaintenanceTaskBody = {
-      title: title.trim(),
-      intervalValue: n,
-      intervalUnit: unit,
-      ...(lastDate ? { lastCompletedDate: lastDate } : {}),
-    };
-    mutation.mutate(body);
+    mutation.mutate(toCreateMaintenanceTaskBody(values));
   };
 
-  const clear = (f: string) => setErrors((prev) => { const n = { ...prev }; delete n[f]; return n; });
+  const clear = (field: string) =>
+    setErrors((prev) => {
+      const next = { ...prev };
+      delete next[field];
+      return next;
+    });
+
+  const updateValue = <K extends keyof MaintenanceTaskFormValues>(
+    field: K,
+    value: MaintenanceTaskFormValues[K],
+  ) => {
+    setValues((prev) => ({ ...prev, [field]: value }));
+    const errorKey =
+      field === "intervalValue" ? "iv" : field === "lastCompletedDate" ? "last" : field;
+    clear(errorKey);
+    if (banner) setBanner(null);
+  };
 
   return (
     <div className={`mr-form mr-form-${variant}`}>
@@ -612,11 +583,11 @@ function MRCreateTaskForm({ asset, variant, onClose, onCreated }: MRCreateTaskFo
         <div className="mr-field">
           <div className="mr-field-top">
             <label className="mr-field-label" htmlFor="mt-title">Title <span className="mr-req">*</span></label>
-            <span className={`mr-field-count ${title.length > TASK_TITLE_MAX ? "over" : ""}`}>{title.length}/{TASK_TITLE_MAX}</span>
+            <span className={`mr-field-count ${values.title.length > TASK_TITLE_MAX ? "over" : ""}`}>{values.title.length}/{TASK_TITLE_MAX}</span>
           </div>
           <input id="mt-title" ref={titleRef} type="text" className={`mr-input ${errors.title ? "err" : ""}`}
             placeholder='e.g. "Replace furnace filter"' maxLength={TASK_TITLE_MAX + 20}
-            value={title} onChange={(e) => { setTitle(e.target.value); clear("title"); if (banner) setBanner(null); }} />
+            value={values.title} onChange={(e) => updateValue("title", e.target.value)} />
           {errors.title && <div className="mr-field-err"><Icon name="alert" size={13} stroke={2} />{errors.title}</div>}
         </div>
         <div className="mr-field">
@@ -625,11 +596,11 @@ function MRCreateTaskForm({ asset, variant, onClose, onCreated }: MRCreateTaskFo
           </div>
           <div className="mr-interval-row">
             <input id="mt-iv" type="number" min="1" step="1" className={`mr-input mr-interval-num ${errors.iv ? "err" : ""}`}
-              value={iv} onChange={(e) => { setIv(e.target.value); clear("iv"); if (banner) setBanner(null); }} />
+              value={values.intervalValue} onChange={(e) => updateValue("intervalValue", e.target.value)} />
             <div className="mr-unit-seg" role="group" aria-label="Interval unit">
               {TASK_UNITS.map((u) => (
-                <button key={u.value} type="button" className={`mr-unit-btn ${unit === u.value ? "active" : ""}`}
-                  onClick={() => setUnit(u.value)}>{u.label}</button>
+                <button key={u.value} type="button" className={`mr-unit-btn ${values.intervalUnit === u.value ? "active" : ""}`}
+                  onClick={() => updateValue("intervalUnit", u.value)}>{u.label}</button>
               ))}
             </div>
           </div>
@@ -640,7 +611,7 @@ function MRCreateTaskForm({ asset, variant, onClose, onCreated }: MRCreateTaskFo
             <label className="mr-field-label" htmlFor="mt-last">Last completed</label>
           </div>
           <input id="mt-last" type="date" max={todayDateOnly()} className={`mr-input mr-input-date ${errors.last ? "err" : ""}`}
-            value={lastDate} onChange={(e) => { setLastDate(e.target.value); clear("last"); if (banner) setBanner(null); }} />
+            value={values.lastCompletedDate} onChange={(e) => updateValue("lastCompletedDate", e.target.value)} />
           {errors.last ? <div className="mr-field-err"><Icon name="alert" size={13} stroke={2} />{errors.last}</div> :
             <div className="mr-field-hint">Optional — when was this last done? Leave blank to start counting from today.</div>}
         </div>

--- a/apps/web/src/app/assetPresentation.ts
+++ b/apps/web/src/app/assetPresentation.ts
@@ -2,6 +2,11 @@ import type { AssetResponse, AssetType } from "../api/assets";
 import type { IconName } from "../design/Icon";
 import type { AssetCategory } from "../design/hf";
 
+export function categoryLabel(category: AssetCategory): string {
+  if (category === "lawn") return "Grounds";
+  return assetTypeLabel(category);
+}
+
 export type AssetPresentation = {
   id: string;
   displayId: string;

--- a/apps/web/src/app/maintenanceTaskForm.test.ts
+++ b/apps/web/src/app/maintenanceTaskForm.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import {
+  addIntervalDate,
+  formatIntervalPhrase,
+  previewNextDueDate,
+  toCreateMaintenanceTaskBody,
+  validateMaintenanceTaskForm,
+} from "./maintenanceTaskForm.ts";
+
+describe("validateMaintenanceTaskForm", () => {
+  it("requires a title", () => {
+    expect(
+      validateMaintenanceTaskForm(
+        {
+          title: "  ",
+          intervalValue: "3",
+          intervalUnit: "month",
+          lastCompletedDate: "",
+        },
+        "2026-06-18",
+      ),
+    ).toEqual({ title: "Title is required." });
+  });
+
+  it("rejects non-integer interval values", () => {
+    expect(
+      validateMaintenanceTaskForm(
+        {
+          title: "Oil change",
+          intervalValue: "1.5",
+          intervalUnit: "month",
+          lastCompletedDate: "",
+        },
+        "2026-06-18",
+      ),
+    ).toEqual({ intervalValue: "Must be a positive whole number." });
+  });
+
+  it("rejects future last-completed dates", () => {
+    expect(
+      validateMaintenanceTaskForm(
+        {
+          title: "Oil change",
+          intervalValue: "3",
+          intervalUnit: "month",
+          lastCompletedDate: "2026-06-19",
+        },
+        "2026-06-18",
+      ),
+    ).toEqual({ lastCompletedDate: "Must be today or earlier." });
+  });
+});
+
+describe("previewNextDueDate", () => {
+  it("starts from today when last completed is blank", () => {
+    expect(
+      previewNextDueDate(
+        {
+          intervalValue: "3",
+          intervalUnit: "month",
+          lastCompletedDate: "",
+        },
+        "2026-06-18",
+      ),
+    ).toBe("2026-09-18");
+  });
+
+  it("starts from last completed when provided", () => {
+    expect(
+      previewNextDueDate(
+        {
+          intervalValue: "2",
+          intervalUnit: "week",
+          lastCompletedDate: "2026-06-01",
+        },
+        "2026-06-18",
+      ),
+    ).toBe("2026-06-15");
+  });
+});
+
+describe("addIntervalDate", () => {
+  it("caps month-end overflow", () => {
+    expect(addIntervalDate("2026-01-31", 1, "month")).toBe("2026-02-28");
+  });
+});
+
+describe("toCreateMaintenanceTaskBody", () => {
+  it("omits lastCompletedDate when blank", () => {
+    expect(
+      toCreateMaintenanceTaskBody({
+        title: "  Filter change  ",
+        intervalValue: "6",
+        intervalUnit: "month",
+        lastCompletedDate: "",
+      }),
+    ).toEqual({
+      title: "Filter change",
+      intervalValue: 6,
+      intervalUnit: "month",
+    });
+  });
+});
+
+describe("formatIntervalPhrase", () => {
+  it("pluralizes units when needed", () => {
+    expect(formatIntervalPhrase(3, "month")).toBe("every 3 months");
+    expect(formatIntervalPhrase(1, "year")).toBe("every 1 year");
+  });
+});

--- a/apps/web/src/app/maintenanceTaskForm.test.ts
+++ b/apps/web/src/app/maintenanceTaskForm.test.ts
@@ -3,6 +3,7 @@ import {
   addIntervalDate,
   formatIntervalPhrase,
   previewNextDueDate,
+  resolveAssetId,
   toCreateMaintenanceTaskBody,
   validateMaintenanceTaskForm,
 } from "./maintenanceTaskForm.ts";
@@ -103,8 +104,24 @@ describe("toCreateMaintenanceTaskBody", () => {
 });
 
 describe("formatIntervalPhrase", () => {
-  it("pluralizes units when needed", () => {
-    expect(formatIntervalPhrase(3, "month")).toBe("every 3 months");
-    expect(formatIntervalPhrase(1, "year")).toBe("every 1 year");
+  it("matches maintenance task card phrasing", () => {
+    expect(formatIntervalPhrase(3, "month")).toBe("Every 3 months");
+    expect(formatIntervalPhrase(1, "year")).toBe("Every year");
+  });
+});
+
+describe("resolveAssetId", () => {
+  const assets = [{ id: "a" }, { id: "b" }];
+
+  it("uses a valid preferred id", () => {
+    expect(resolveAssetId(assets, "b")).toBe("b");
+  });
+
+  it("falls back to the first asset when preferred id is missing", () => {
+    expect(resolveAssetId(assets, "missing")).toBe("a");
+  });
+
+  it("treats empty string as absent", () => {
+    expect(resolveAssetId(assets, "")).toBe("a");
   });
 });

--- a/apps/web/src/app/maintenanceTaskForm.ts
+++ b/apps/web/src/app/maintenanceTaskForm.ts
@@ -36,7 +36,7 @@ function ymdParts(value: string): [number, number, number] {
   return [year ?? 0, month ?? 1, day ?? 1];
 }
 
-function ymdToUTC(value: string): number {
+export function ymdToUTC(value: string): number {
   const [year, month, day] = ymdParts(value);
   return Date.UTC(year, month - 1, day);
 }
@@ -104,8 +104,20 @@ export function formatPreviewDueDate(dateStr: string): string {
 }
 
 export function formatIntervalPhrase(intervalValue: number, intervalUnit: IntervalUnit): string {
-  const unit = intervalUnit + (intervalValue > 1 ? "s" : "");
-  return `every ${intervalValue} ${unit}`;
+  if (intervalValue === 1) {
+    return `Every ${intervalUnit}`;
+  }
+  return `Every ${intervalValue} ${intervalUnit}s`;
+}
+
+export function resolveAssetId(
+  assets: ReadonlyArray<{ id: string }>,
+  preferredId?: string | null,
+): string {
+  if (preferredId && assets.some((asset) => asset.id === preferredId)) {
+    return preferredId;
+  }
+  return assets[0]?.id ?? "";
 }
 
 export function validateMaintenanceTaskForm(

--- a/apps/web/src/app/maintenanceTaskForm.ts
+++ b/apps/web/src/app/maintenanceTaskForm.ts
@@ -1,0 +1,152 @@
+import type { CreateMaintenanceTaskBody, IntervalUnit } from "../api/maintenanceTasks.ts";
+
+export const TASK_TITLE_MAX = 100;
+
+export const TASK_UNITS: ReadonlyArray<{ value: IntervalUnit; label: string }> = [
+  { value: "day", label: "Day" },
+  { value: "week", label: "Week" },
+  { value: "month", label: "Month" },
+  { value: "year", label: "Year" },
+];
+
+export type MaintenanceTaskFormValues = {
+  title: string;
+  intervalValue: string;
+  intervalUnit: IntervalUnit;
+  lastCompletedDate: string;
+};
+
+export type MaintenanceTaskFormErrors = Partial<
+  Record<"title" | "intervalValue" | "lastCompletedDate", string>
+>;
+
+export const EMPTY_MAINTENANCE_TASK_FORM: MaintenanceTaskFormValues = {
+  title: "",
+  intervalValue: "3",
+  intervalUnit: "month",
+  lastCompletedDate: "",
+};
+
+export function todayDateOnly(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function ymdParts(value: string): [number, number, number] {
+  const [year, month, day] = value.split("-").map(Number);
+  return [year ?? 0, month ?? 1, day ?? 1];
+}
+
+function ymdToUTC(value: string): number {
+  const [year, month, day] = ymdParts(value);
+  return Date.UTC(year, month - 1, day);
+}
+
+export function addIntervalDate(dateStr: string, value: number, unit: IntervalUnit): string {
+  const [year, month, day] = ymdParts(dateStr);
+  let yy = year;
+  let mm = month;
+  let dd = day;
+
+  if (unit === "day" || unit === "week") {
+    const mult = unit === "week" ? 7 : 1;
+    const ms = ymdToUTC(dateStr) + value * mult * 86_400_000;
+    const dt = new Date(ms);
+    return [
+      dt.getUTCFullYear(),
+      String(dt.getUTCMonth() + 1).padStart(2, "0"),
+      String(dt.getUTCDate()).padStart(2, "0"),
+    ].join("-");
+  }
+
+  if (unit === "month") {
+    mm += value;
+    while (mm > 12) {
+      mm -= 12;
+      yy += 1;
+    }
+  } else {
+    yy += value;
+  }
+
+  const cap = new Date(Date.UTC(yy, mm, 0)).getUTCDate();
+  dd = Math.min(dd, cap);
+  return [yy, String(mm).padStart(2, "0"), String(dd).padStart(2, "0")].join("-");
+}
+
+export function previewNextDueDate(
+  values: Pick<MaintenanceTaskFormValues, "intervalValue" | "intervalUnit" | "lastCompletedDate">,
+  todayUtc = todayDateOnly(),
+): string | null {
+  const intervalValue = Number(values.intervalValue);
+  if (
+    !values.intervalValue ||
+    Number.isNaN(intervalValue) ||
+    intervalValue < 1 ||
+    !Number.isInteger(intervalValue) ||
+    values.intervalValue.includes(".")
+  ) {
+    return null;
+  }
+
+  const baseline = values.lastCompletedDate || todayUtc;
+  return addIntervalDate(baseline, intervalValue, values.intervalUnit);
+}
+
+export function formatPreviewDueDate(dateStr: string): string {
+  const [year, month, day] = ymdParts(dateStr);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+export function formatIntervalPhrase(intervalValue: number, intervalUnit: IntervalUnit): string {
+  const unit = intervalUnit + (intervalValue > 1 ? "s" : "");
+  return `every ${intervalValue} ${unit}`;
+}
+
+export function validateMaintenanceTaskForm(
+  values: MaintenanceTaskFormValues,
+  todayUtc = todayDateOnly(),
+): MaintenanceTaskFormErrors {
+  const errors: MaintenanceTaskFormErrors = {};
+  const title = values.title.trim();
+
+  if (!title) {
+    errors.title = "Title is required.";
+  } else if (title.length > TASK_TITLE_MAX) {
+    errors.title = `Title must be ${TASK_TITLE_MAX} characters or fewer.`;
+  }
+
+  const intervalValue = Number(values.intervalValue);
+  if (
+    !values.intervalValue ||
+    Number.isNaN(intervalValue) ||
+    intervalValue < 1 ||
+    !Number.isInteger(intervalValue) ||
+    values.intervalValue.includes(".")
+  ) {
+    errors.intervalValue = "Must be a positive whole number.";
+  }
+
+  if (values.lastCompletedDate && values.lastCompletedDate > todayUtc) {
+    errors.lastCompletedDate = "Must be today or earlier.";
+  }
+
+  return errors;
+}
+
+export function toCreateMaintenanceTaskBody(
+  values: MaintenanceTaskFormValues,
+): CreateMaintenanceTaskBody {
+  const intervalValue = Number(values.intervalValue);
+  return {
+    title: values.title.trim(),
+    intervalValue,
+    intervalUnit: values.intervalUnit,
+    ...(values.lastCompletedDate ? { lastCompletedDate: values.lastCompletedDate } : {}),
+  };
+}

--- a/apps/web/src/design/styles/hifi-add-service.css
+++ b/apps/web/src/design/styles/hifi-add-service.css
@@ -1,0 +1,183 @@
+/* FieldOps — "Add a service" modal (dashboard). */
+
+.hf-svc-overlay { position: fixed; inset: 0; z-index: 60; overflow: hidden; }
+.hf-svc-scrim { position: absolute; inset: 0; background: rgba(20, 18, 14, 0.34); animation: hf-svc-fade 240ms ease-out; }
+@keyframes hf-svc-fade { from { opacity: 0; } }
+
+.hf-svc-drawer {
+  position: absolute; top: 0; right: 0; bottom: 0;
+  width: min(440px, 100%);
+  background: var(--hf-bg);
+  box-shadow: -12px 0 50px rgba(20, 18, 14, 0.2);
+  display: flex; flex-direction: column;
+  will-change: transform;
+  animation: hf-svc-slide-r 360ms cubic-bezier(0.32, 0.72, 0, 1);
+}
+@keyframes hf-svc-slide-r { from { transform: translateX(100%); } }
+
+@media (prefers-reduced-motion: reduce) {
+  .hf-svc-scrim, .hf-svc-drawer, .hf-svc-done-icon { animation: none; }
+}
+
+.hf-svc-head {
+  display: flex; align-items: flex-start; justify-content: space-between;
+  gap: 12px; padding: 18px 20px 14px;
+  border-bottom: 1px solid var(--hf-line);
+  flex-shrink: 0;
+}
+.hf-svc-title { font-size: 17px; font-weight: 700; letter-spacing: -0.02em; color: var(--hf-ink); }
+.hf-svc-sub { margin-top: 2px; font-size: 12.5px; color: var(--hf-ink-soft); }
+
+.hf-svc-body {
+  flex: 1; min-height: 0;
+  padding: 18px 20px;
+  display: flex; flex-direction: column; gap: 16px;
+  overflow-y: auto;
+}
+
+.hf-svc-foot {
+  flex-shrink: 0;
+  display: flex; justify-content: flex-end; gap: 8px;
+  padding: 14px 20px;
+  border-top: 1px solid var(--hf-line);
+  background: var(--hf-surface-2);
+}
+
+.hf-svc-body .hf-field { display: flex; flex-direction: column; gap: 6px; min-width: 0; }
+.hf-svc-body .hf-field-label {
+  display: flex; align-items: baseline; gap: 6px;
+  font-size: 12.5px; font-weight: 500; color: var(--hf-ink);
+}
+.hf-svc-body .hf-field-req { color: var(--hf-bad); font-weight: 600; }
+.hf-svc-body .hf-field-opt {
+  font-family: var(--hf-mono); font-size: 10px; text-transform: uppercase;
+  letter-spacing: 0.06em; color: var(--hf-ink-faint);
+}
+.hf-svc-body .hf-field-hint { font-size: 11.5px; color: var(--hf-ink-faint); margin-left: auto; }
+.hf-svc-body .hf-input {
+  width: 100%; height: 40px;
+  padding: 0 12px;
+  border: 1px solid var(--hf-line);
+  border-radius: var(--hf-r);
+  background: var(--hf-surface);
+  color: var(--hf-ink);
+  font-family: var(--hf-sans); font-size: 13.5px;
+  transition: border-color 100ms, box-shadow 100ms;
+}
+.hf-svc-body .hf-input::placeholder { color: var(--hf-ink-faint); }
+.hf-svc-body .hf-input:hover { border-color: oklch(85% 0.008 80); }
+.hf-svc-body .hf-input:focus { outline: none; border-color: var(--hf-brand); box-shadow: 0 0 0 3px var(--hf-brand-bg); }
+.hf-svc-body .hf-input.is-invalid { border-color: var(--hf-bad); background: var(--hf-bad-bg); }
+.hf-svc-body .hf-input.is-invalid:focus { box-shadow: 0 0 0 3px oklch(52% 0.18 28 / 0.16); }
+.hf-svc-body .hf-mono-input { font-family: var(--hf-mono); font-size: 13px; }
+.hf-svc-field-err {
+  display: flex; align-items: center; gap: 5px;
+  font-size: 11.5px; line-height: 1.3; font-weight: 500; color: var(--hf-bad);
+}
+.hf-svc-hint { font-size: 11.5px; color: var(--hf-ink-faint); line-height: 1.4; }
+
+.hf-svc-asset {
+  display: flex; align-items: center; gap: 12px;
+  width: 100%; padding: 10px 12px;
+  border: 1px solid var(--hf-line);
+  border-radius: var(--hf-r);
+  background: var(--hf-surface);
+  cursor: pointer; text-align: left;
+  transition: border-color 100ms, background 100ms;
+}
+.hf-svc-asset:hover { border-color: oklch(85% 0.008 80); background: var(--hf-surface-2); }
+.hf-svc-asset-text { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 2px; }
+.hf-svc-asset-name { font-size: 14px; font-weight: 600; color: var(--hf-ink); letter-spacing: -0.01em; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.hf-svc-asset-meta { display: flex; align-items: center; gap: 7px; font-size: 12px; color: var(--hf-ink-soft); white-space: nowrap; }
+.hf-svc-asset-meta .hf-mono { font-family: var(--hf-mono); font-size: 11.5px; color: var(--hf-ink); }
+.hf-svc-change {
+  font-size: 11px; font-weight: 600; color: var(--hf-brand-2);
+  text-transform: uppercase; letter-spacing: 0.05em;
+  display: inline-flex; align-items: center; gap: 3px;
+}
+
+.hf-svc-picker {
+  display: flex; flex-direction: column;
+  max-height: 232px; overflow-y: auto;
+  border: 1px solid var(--hf-line);
+  border-radius: var(--hf-r);
+  background: var(--hf-surface);
+}
+.hf-svc-picker-row {
+  display: flex; align-items: center; gap: 11px;
+  padding: 9px 12px;
+  background: transparent; border: none; cursor: pointer; text-align: left;
+  border-bottom: 1px solid var(--hf-line-soft);
+}
+.hf-svc-picker-row:last-child { border-bottom: none; }
+.hf-svc-picker-row:hover { background: var(--hf-surface-2); }
+.hf-svc-picker-row.active { background: var(--hf-brand-bg); }
+.hf-svc-picker-text { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 1px; }
+.hf-svc-picker-name { font-size: 13px; font-weight: 600; color: var(--hf-ink); }
+.hf-svc-picker-meta { font-family: var(--hf-mono); font-size: 10.5px; color: var(--hf-ink-faint); text-transform: uppercase; letter-spacing: 0.04em; }
+.hf-svc-picker-check { color: var(--hf-brand); flex-shrink: 0; }
+
+.hf-svc-body .hf-field-label { white-space: nowrap; }
+
+.hf-svc-interval { display: flex; gap: 10px; align-items: stretch; }
+.hf-svc-interval .hf-svc-num { flex: 0 0 72px; width: 72px; text-align: center; }
+.hf-seg {
+  display: flex; flex: 1;
+  padding: 3px; gap: 2px;
+  background: var(--hf-surface-2);
+  border: 1px solid var(--hf-line);
+  border-radius: var(--hf-r);
+}
+.hf-seg-btn {
+  flex: 1; height: 32px;
+  border: none; background: transparent; cursor: pointer;
+  border-radius: 7px;
+  font-family: var(--hf-sans); font-size: 12.5px; font-weight: 500;
+  color: var(--hf-ink-soft);
+  transition: background 100ms, color 100ms;
+}
+.hf-seg-btn:hover { color: var(--hf-ink); }
+.hf-seg-btn.active {
+  background: var(--hf-surface); color: var(--hf-ink); font-weight: 600;
+  box-shadow: var(--hf-shadow-1);
+}
+
+.hf-svc-preview {
+  display: flex; align-items: center; gap: 10px;
+  padding: 11px 13px;
+  background: var(--hf-brand-bg);
+  border: 1px solid oklch(88% 0.04 150);
+  border-radius: var(--hf-r);
+  color: var(--hf-brand-2);
+}
+.hf-svc-preview-txt { font-size: 12.5px; color: var(--hf-ink-soft); }
+.hf-svc-preview-txt strong { color: var(--hf-brand-2); font-weight: 600; }
+
+.hf-svc-spinner {
+  width: 14px; height: 14px; border-radius: 50%;
+  border: 2px solid oklch(100% 0 0 / 0.4); border-top-color: white;
+  animation: hf-svc-spin 600ms linear infinite;
+}
+@keyframes hf-svc-spin { to { transform: rotate(360deg); } }
+
+.hf-svc-done { display: flex; flex-direction: column; align-items: center; text-align: center; gap: 12px; padding: 18px 8px 8px; }
+.hf-svc-done-icon {
+  width: 52px; height: 52px; border-radius: 50%;
+  background: var(--hf-brand-bg); color: var(--hf-brand);
+  display: flex; align-items: center; justify-content: center;
+}
+@keyframes hf-svc-bounce { from { transform: scale(0.72); } to { transform: scale(1); } }
+.hf-svc-done-icon { animation: hf-svc-bounce 220ms cubic-bezier(0.16, 1, 0.3, 1); }
+.hf-svc-done-title { font-size: 17px; font-weight: 700; letter-spacing: -0.02em; color: var(--hf-ink); }
+.hf-svc-done-sub { font-size: 13px; color: var(--hf-ink-soft); line-height: 1.5; max-width: 300px; }
+.hf-svc-done-sub strong { color: var(--hf-ink); font-weight: 600; }
+
+.hf-svc-banner {
+  display: flex; align-items: center; gap: 8px;
+  padding: 10px 12px;
+  border-radius: var(--hf-r);
+  background: var(--hf-bad-bg);
+  border: 1px solid oklch(88% 0.06 28);
+  color: var(--hf-bad);
+  font-size: 12.5px;
+}

--- a/apps/web/src/design/styles/hifi-add-service.css
+++ b/apps/web/src/design/styles/hifi-add-service.css
@@ -85,7 +85,9 @@
   cursor: pointer; text-align: left;
   transition: border-color 100ms, background 100ms;
 }
-.hf-svc-asset:hover { border-color: oklch(85% 0.008 80); background: var(--hf-surface-2); }
+.hf-svc-asset:hover:not(:disabled) { border-color: oklch(85% 0.008 80); background: var(--hf-surface-2); }
+.hf-svc-asset:disabled { opacity: 0.6; cursor: not-allowed; }
+.hf-svc-picker-row:disabled { opacity: 0.6; cursor: not-allowed; }
 .hf-svc-asset-text { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 2px; }
 .hf-svc-asset-name { font-size: 14px; font-weight: 600; color: var(--hf-ink); letter-spacing: -0.01em; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .hf-svc-asset-meta { display: flex; align-items: center; gap: 7px; font-size: 12px; color: var(--hf-ink-soft); white-space: nowrap; }

--- a/docs/web/FEATURES.md
+++ b/docs/web/FEATURES.md
@@ -89,13 +89,15 @@ For the API contract behind each feature, see the linked spec in `docs/specs/fea
 - Filtered empty: category filter active but no matching queue rows
 - Error: dashboard-level error with retry
 - Mark complete: creates a linked maintenance record for the selected task and refetches dashboard + asset maintenance data
+- Add service: drawer modal to create a recurring maintenance task for any asset; defaults to the currently selected queue item's asset when one is selected
 
 **Non-obvious behavior:**
 
 - Initial render uses one dashboard read model — no fan-out across assets and per-asset task endpoints
 - Status buckets and fleet health counts come from the API; the client formats due-date copy only
 - Category filter chips filter the returned queue client-side without a new request
-- Reschedule, Snooze, and Add service remain disabled placeholders until future specs land
+- Add service fetches the asset list on demand when opened; task creation reuses the same validation and API contract as the asset maintenance task form
+- Reschedule and Snooze remain disabled placeholders until future specs land
 - Task detail fields not yet in the maintenance-task API (estimated time, location, assignee, notes) are not shown from live data
 - 401 from the API redirects to `/login`
 


### PR DESCRIPTION
## Summary

Implements the dashboard **Add service** flow from the FieldOps design: a drawer modal for scheduling recurring maintenance tasks against any asset in the fleet.

- Wires the dashboard **Add service** button to a new `AddServiceModal` with asset picker, task fields, next-due preview, and success confirmation
- Extracts shared maintenance task form logic (`maintenanceTaskForm.ts`) reused by the asset maintenance task form and dashboard modal
- Fetches assets on demand when the modal opens; invalidates dashboard + per-asset task queries after save
- Uses server-supplied `todayUtc` for date validation and mark-complete actions

## Review fixes included

- Asset selection no longer silently falls back to `assets[0]` on submit
- Dashboard refresh errors surface in the modal instead of being swallowed
- Loading / empty / in-flight modal states have proper close affordances and disabled controls
- Interval phrasing unified across dashboard and maintenance records UI

## Test plan

- [x] `pnpm lint && pnpm type-check && pnpm -r test`
- [ ] Open `/app`, click **Add service**, schedule a task for an asset, confirm it appears in the queue
- [ ] Verify asset maintenance page **Add task** form still works and shares validation behavior