### PR TITLE
Provision Cloudflare Queues as IaC in the deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -128,6 +128,23 @@ jobs:
         working-directory: apps/api
         run: pnpm wrangler d1 migrations apply pineapple --remote
 
+      # wrangler deploy binds to queues but never creates them, and it hard-fails
+      # if a queue named in wrangler.toml is missing. Reconcile first: create any
+      # queue the Worker references that doesn't exist yet. Idempotent — existing
+      # queues are left untouched, so this is safe to run on every deploy.
+      - name: Ensure Queues exist (production)
+        working-directory: apps/api
+        run: |
+          existing="$(pnpm wrangler queues list --format json | jq -r '.[].queue_name')"
+          for q in pineapple-activity-history pineapple-activity-history-dlq; do
+            if grep -qxF "$q" <<<"$existing"; then
+              echo "Queue $q already exists"
+            else
+              echo "Creating queue $q"
+              pnpm wrangler queues create "$q"
+            fi
+          done
+
       - name: Deploy Worker
         working-directory: apps/api
         run: pnpm wrangler deploy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,12 @@ app served by a Cloudflare Worker — it currently hosts the marketing home page
   from the Worker `env` binding (`c.env.*`), typed in `worker.ts`.
 - **D1 (SQLite)** via the `DB` binding. Migrations in `/migrations`, applied
   with `wrangler d1 migrations apply pineapple --local|--remote`.
+- **Cloudflare Queues** are declared in `apps/api/wrangler.toml` but `wrangler
+deploy` does NOT create them — it binds to existing queues and fails if one
+  is missing. Provisioning is IaC: the "Ensure Queues exist" step in
+  `.github/workflows/deploy.yml` idempotently creates every declared queue before
+  deploying. Adding a queue means editing both places (see the comment in
+  `wrangler.toml`).
 - **Source-first TypeScript**: no build step. Imports use explicit `.ts`
   extensions (e.g. `import { User } from "./User.ts"`). Keep that convention.
 - **pnpm workspaces**: `packages/*`, `apps/*`. Package manager pinned via

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -61,6 +61,11 @@ dataset = "pineapple_maintenance_task_domain_events"
 binding = "API_REQUEST_TELEMETRY"
 dataset = "pineapple_api_request_events"
 
+# Queues are declared here but NOT created by `wrangler deploy` — it only binds
+# to queues that already exist and hard-fails if one is missing. Provisioning is
+# handled as IaC by the "Ensure Queues exist" step in .github/workflows/deploy.yml,
+# which idempotently creates any queue named below before deploying. To add a
+# queue: declare it here AND add its name to that step's loop.
 [[queues.producers]]
 binding = "ACTIVITY_HISTORY_QUEUE"
 queue = "pineapple-activity-history"


### PR DESCRIPTION
## Why

The `deploy-api` job [failed](https://github.com/snaveevans/pineapple/actions/runs/28536678604/job/84599869354) with:

> Queue "pineapple-activity-history" does not exist.

`wrangler deploy` binds to queues but never creates them, and hard-fails when a queue named in `wrangler.toml` is missing. The activity-history queue added for the History feature was never provisioned.

## What

- Add an idempotent **"Ensure Queues exist"** step to `.github/workflows/deploy.yml`, run before `wrangler deploy` (mirroring how D1 migrations are applied first). It lists existing queues and creates any declared one that's missing — safe on every deploy, existing queues untouched.
- Document the pattern where future agents will look: a comment at the `wrangler.toml` queues block and a bullet in `CLAUDE.md`. Adding a queue = declare it in `wrangler.toml` **and** add its name to the step's loop.

## Effect

Merging this triggers a fresh deploy that creates `pineapple-activity-history` and `pineapple-activity-history-dlq`, then deploys — unblocking production with no manual `wrangler queues create`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)