### PR TITLE
Fix queue existence check in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -135,9 +135,8 @@ jobs:
       - name: Ensure Queues exist (production)
         working-directory: apps/api
         run: |
-          existing="$(pnpm wrangler queues list --format json | jq -r '.[].queue_name')"
           for q in pineapple-activity-history pineapple-activity-history-dlq; do
-            if grep -qxF "$q" <<<"$existing"; then
+            if pnpm wrangler queues info "$q" >/dev/null 2>&1; then
               echo "Queue $q already exists"
             else
               echo "Creating queue $q"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -132,15 +132,25 @@ jobs:
       # if a queue named in wrangler.toml is missing. Reconcile first: create any
       # queue the Worker references that doesn't exist yet. Idempotent — existing
       # queues are left untouched, so this is safe to run on every deploy.
+      #
+      # `wrangler queues info` exits 1 both when a queue is missing AND on other
+      # errors (auth, network), so we don't blindly create on any failure — that
+      # would turn a transient error into a spurious "queue already exists" crash.
+      # Only the specific "does not exist" message triggers a create; anything
+      # else fails the step loudly.
       - name: Ensure Queues exist (production)
         working-directory: apps/api
         run: |
           for q in pineapple-activity-history pineapple-activity-history-dlq; do
-            if pnpm wrangler queues info "$q" >/dev/null 2>&1; then
+            if info="$(pnpm wrangler queues info "$q" 2>&1)"; then
               echo "Queue $q already exists"
-            else
+            elif grep -q "does not exist" <<<"$info"; then
               echo "Creating queue $q"
               pnpm wrangler queues create "$q"
+            else
+              echo "::error::Unexpected error checking queue $q"
+              echo "$info"
+              exit 1
             fi
           done
 


### PR DESCRIPTION
## Why

Follow-up to #42. The provisioning step used `wrangler queues list --format json`, but wrangler 4.95's `queues list` has **no `--format` flag**, so the production deploy [failed](https://github.com/snaveevans/pineapple/actions/runs/28537213480/job/84601747260) with `Unknown argument: format` before reaching `wrangler deploy`.

## What

Switch the reconcile loop to `wrangler queues info <name>`, which exits non-zero when the queue is missing — a direct per-queue existence check, no JSON parsing or `jq`.

## Effect

Merging triggers a fresh `deploy-api` run that creates `pineapple-activity-history` + its DLQ, then deploys — unblocking production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)