### PR TITLE
docs: add scope-discipline rules to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,37 @@ secrets, never committed.
 - **Web app feature intent** → [`docs/web/FEATURES.md`](docs/web/FEATURES.md)
 - **How we document** → [`docs/README.md`](docs/README.md)
 
+## Scope discipline
+
+A branch delivers **one concern**. Scope creep — folding "and also…" work into a
+live branch as you refine it — is the failure mode this section exists to prevent.
+It produces sprawling PRs that are hard to review, hard to revert, and hard to
+reason about. Bias toward small, single-purpose branches; several stacked PRs beat
+one that does everything.
+
+**Split by concern, not by convenience:**
+
+- A new mechanism (queue, table, migration, ADR-level pattern) and a feature that
+  uses it are **two branches**. Land the mechanism first; build the feature on top.
+- Refactors, renames, and infra plumbing do **not** ride along with feature work —
+  separate branch, separate PR.
+- Docs-only or spec-only changes that aren't required to make the feature work can
+  land on their own.
+
+**Commit to a scope before implementing, and split when it drifts:**
+
+- Before writing code, name the concern in one sentence and the rough set of
+  files/areas you expect to touch. This is your scope budget.
+- When the work wants to grow past that budget — a new concern surfaces, an
+  unrelated bug begs fixing, a "quick" refactor balloons — **stop and make an
+  explicit decision**: either it's genuinely part of this concern, or it becomes a
+  follow-up branch. Do not silently absorb it.
+- Crossing ~40 files or ~800 net lines is a **signal to stop and split**, not a
+  target to reach. A large diff must be a defended choice (a genuinely
+  cross-cutting feature), never an accident.
+
+When in doubt, ask the user whether to split rather than expanding the branch.
+
 ## Workflow
 
 Work on a branch, open a PR (CI must pass), merge → auto-deploys to Cloudflare.


### PR DESCRIPTION
## Why

Retrospective on the `feat/notifications-email-loop` branch (PR #47, 142 files / 11k+ lines): it grew that large through scope creep — several independent concerns (email verification, reminder queue, telemetry handlers, DLQ/outbox plumbing, docs) got folded into one live branch as the work was refined. This adds guidance so agents catch that drift *before* the diff sprawls.

## What

A new `## Scope discipline` section in `CLAUDE.md`:

- **One concern per branch.** Split a new mechanism (queue/table/migration/ADR-pattern) from the feature that uses it — land the mechanism first, build on top. Refactors and infra plumbing don't ride along with feature work.
- **Commit to a scope before implementing.** Name the concern and expected file set up front; when work drifts past it, make an explicit split decision rather than silently absorbing it.
- **~40 files / ~800 net lines is a stop-and-split signal**, not a target — a large diff must be a defended choice, never an accident.

Deliberately behavioral (applied at planning/implementation time), not a CI size gate — a hard size check only fires after the work is already done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)