### PR TITLE
Add contact email management to profile editing

### DIFF
--- a/apps/web/src/api/userProfile.ts
+++ b/apps/web/src/api/userProfile.ts
@@ -4,6 +4,8 @@ export type UserProfile = {
   email: string;
   name: string | null;
   onboardingCompletedAt: string | null;
+  notificationEmail: string | null;
+  notificationEmailVerified: boolean;
 };
 
 export const userProfileQueryKey = ["userProfile"] as const;
@@ -17,6 +19,26 @@ export function updateUserProfile(name: string): Promise<UserProfile> {
     method: "PATCH",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ name }),
+  });
+}
+
+export function setNotificationEmail(email: string): Promise<UserProfile> {
+  return apiRequest<UserProfile>("/api/users/me/notification-email", {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email }),
+  });
+}
+
+export function removeNotificationEmail(): Promise<UserProfile> {
+  return apiRequest<UserProfile>("/api/users/me/notification-email", {
+    method: "DELETE",
+  });
+}
+
+export function requestEmailVerification(): Promise<{ status: "accepted" }> {
+  return apiRequest<{ status: "accepted" }>("/api/users/me/notification-email/verification", {
+    method: "POST",
   });
 }
 

--- a/apps/web/src/app/AppProfileEdit.test.tsx
+++ b/apps/web/src/app/AppProfileEdit.test.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiError } from "../api/client";
 import {
   getUserProfile,
   removeNotificationEmail,
@@ -148,9 +149,29 @@ async function typeEmail(value: string) {
   });
 }
 
+async function pressEnterInEmail() {
+  const input = document.querySelector<HTMLInputElement>("#pe-email-input");
+  if (input === null) throw new Error("Contact email input was not rendered");
+
+  await act(async () => {
+    input.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "Enter" }));
+  });
+  await flushAsync();
+}
+
 async function click(label: string) {
   await act(async () => {
     buttonByText(label).dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+  await flushAsync();
+}
+
+async function clickByLabel(label: string) {
+  const button = document.querySelector<HTMLButtonElement>(`button[aria-label="${label}"]`);
+  if (button === null) throw new Error(`Button ${label} was not rendered`);
+
+  await act(async () => {
+    button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
   });
   await flushAsync();
 }
@@ -179,6 +200,33 @@ describe("AppProfileEdit contact email", () => {
     );
   });
 
+  it("saves the contact email instead of the display name when pressing enter in the email field", async () => {
+    await renderProfileEdit();
+
+    await typeEmail("dale@homemail.com");
+    await pressEnterInEmail();
+
+    expect(setNotificationEmailMock).toHaveBeenCalledWith("dale@homemail.com");
+    expect(updateUserProfileMock).not.toHaveBeenCalled();
+    expect(document.body.textContent).toContain(
+      "Verification email sent to dale@homemail.com; check your inbox.",
+    );
+  });
+
+  it("removes an existing contact email", async () => {
+    getUserProfileMock.mockResolvedValue(
+      profile({ notificationEmail: "dale@homemail.com", notificationEmailVerified: true }),
+    );
+
+    await renderProfileEdit();
+    await clickByLabel("Remove contact email");
+
+    expect(removeNotificationEmailMock).toHaveBeenCalledTimes(1);
+    expect(document.body.textContent).toContain(
+      "Contact email removed. Maintenance reminders will not be sent until you add one.",
+    );
+  });
+
   it("resends verification for an unverified contact email", async () => {
     getUserProfileMock.mockResolvedValue(
       profile({ notificationEmail: "dale@homemail.com", notificationEmailVerified: false }),
@@ -191,5 +239,23 @@ describe("AppProfileEdit contact email", () => {
     expect(document.body.textContent).toContain(
       "Verification email sent to dale@homemail.com; check your inbox.",
     );
+  });
+
+  it("shows cooldown feedback when verification resend is rate-limited", async () => {
+    getUserProfileMock.mockResolvedValue(
+      profile({ notificationEmail: "dale@homemail.com", notificationEmailVerified: false }),
+    );
+    requestEmailVerificationMock.mockRejectedValueOnce(
+      new ApiError(429, { error: "Verification email requested too frequently" }),
+    );
+
+    await renderProfileEdit();
+    await click("Resend verification email");
+
+    expect(requestEmailVerificationMock).toHaveBeenCalledTimes(1);
+    expect(document.body.textContent).toContain(
+      "You can request another verification email in a few minutes.",
+    );
+    expect(buttonByText("Resend verification email").disabled).toBe(true);
   });
 });

--- a/apps/web/src/app/AppProfileEdit.test.tsx
+++ b/apps/web/src/app/AppProfileEdit.test.tsx
@@ -1,0 +1,195 @@
+// @vitest-environment happy-dom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getUserProfile,
+  removeNotificationEmail,
+  requestEmailVerification,
+  setNotificationEmail,
+  updateUserProfile,
+  type UserProfile,
+} from "../api/userProfile";
+import { AppProfileEdit } from "./AppProfileEdit";
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean | undefined;
+}
+
+const navigate = vi.fn();
+
+vi.mock("react-router", () => ({
+  Link: ({ children, to, ...props }: { children: React.ReactNode; to: string }) => (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  ),
+  useNavigate: () => navigate,
+}));
+
+vi.mock("./AppChrome", () => ({
+  HFTopBar: () => <header />,
+  HFBottomNav: () => <nav />,
+}));
+
+vi.mock("../api/userProfile", () => ({
+  getUserProfile: vi.fn(),
+  removeNotificationEmail: vi.fn(),
+  requestEmailVerification: vi.fn(),
+  setNotificationEmail: vi.fn(),
+  updateUserProfile: vi.fn(),
+  userProfileQueryKey: ["userProfile"],
+}));
+
+const getUserProfileMock = vi.mocked(getUserProfile);
+const removeNotificationEmailMock = vi.mocked(removeNotificationEmail);
+const requestEmailVerificationMock = vi.mocked(requestEmailVerification);
+const setNotificationEmailMock = vi.mocked(setNotificationEmail);
+const updateUserProfileMock = vi.mocked(updateUserProfile);
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+let queryClient: QueryClient | null = null;
+
+function profile(overrides: Partial<UserProfile> = {}): UserProfile {
+  return {
+    email: "dale@fieldops-demo.com",
+    name: "Dale Evans",
+    onboardingCompletedAt: "2026-07-01T00:00:00.000Z",
+    notificationEmail: null,
+    notificationEmailVerified: false,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+  queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  getUserProfileMock.mockResolvedValue(profile());
+  updateUserProfileMock.mockImplementation((name) => Promise.resolve(profile({ name })));
+  setNotificationEmailMock.mockImplementation((email) =>
+    Promise.resolve(profile({ notificationEmail: email, notificationEmailVerified: false })),
+  );
+  removeNotificationEmailMock.mockResolvedValue(profile());
+  requestEmailVerificationMock.mockResolvedValue({ status: "accepted" });
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root?.unmount();
+  });
+  container?.remove();
+  root = null;
+  container = null;
+  queryClient?.clear();
+  queryClient = null;
+  globalThis.IS_REACT_ACT_ENVIRONMENT = false;
+  vi.clearAllMocks();
+});
+
+async function flushAsync() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+async function renderProfileEdit() {
+  if (queryClient === null) throw new Error("Query client was not initialized");
+  const client = queryClient;
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+
+  await act(async () => {
+    root?.render(
+      <QueryClientProvider client={client}>
+        <AppProfileEdit />
+      </QueryClientProvider>,
+    );
+  });
+  await waitFor(() => document.querySelector("#pe-email-input") !== null);
+}
+
+async function waitFor(assertion: () => boolean) {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    if (assertion()) return;
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  }
+  if (!assertion()) throw new Error("Timed out waiting for expected UI");
+}
+
+function buttonByText(label: string): HTMLButtonElement {
+  const button = Array.from(document.querySelectorAll<HTMLButtonElement>("button")).find(
+    (candidate) => candidate.textContent?.replace(/\s+/g, " ").trim() === label,
+  );
+  if (button === undefined) throw new Error(`Button ${label} was not rendered`);
+  return button;
+}
+
+async function typeEmail(value: string) {
+  const input = document.querySelector<HTMLInputElement>("#pe-email-input");
+  if (input === null) throw new Error("Contact email input was not rendered");
+  const valueSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+  if (valueSetter === undefined) throw new Error("Email input does not have a value setter");
+
+  await act(async () => {
+    valueSetter.call(input, value);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+async function click(label: string) {
+  await act(async () => {
+    buttonByText(label).dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+  await flushAsync();
+}
+
+describe("AppProfileEdit contact email", () => {
+  it("validates the contact email before saving", async () => {
+    await renderProfileEdit();
+
+    await typeEmail("not-an-email");
+    await click("Save");
+
+    expect(setNotificationEmailMock).not.toHaveBeenCalled();
+    expect(document.body.textContent).toContain("A valid email address is required.");
+  });
+
+  it("saves a new contact email and shows the verification state", async () => {
+    await renderProfileEdit();
+
+    await typeEmail("dale@homemail.com");
+    await click("Save");
+
+    expect(setNotificationEmailMock).toHaveBeenCalledWith("dale@homemail.com");
+    expect(document.body.textContent).toContain("Unverified");
+    expect(document.body.textContent).toContain(
+      "Verification email sent to dale@homemail.com; check your inbox.",
+    );
+  });
+
+  it("resends verification for an unverified contact email", async () => {
+    getUserProfileMock.mockResolvedValue(
+      profile({ notificationEmail: "dale@homemail.com", notificationEmailVerified: false }),
+    );
+
+    await renderProfileEdit();
+    await click("Resend verification email");
+
+    expect(requestEmailVerificationMock).toHaveBeenCalledTimes(1);
+    expect(document.body.textContent).toContain(
+      "Verification email sent to dale@homemail.com; check your inbox.",
+    );
+  });
+});

--- a/apps/web/src/app/AppProfileEdit.tsx
+++ b/apps/web/src/app/AppProfileEdit.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type FormEvent } from "react";
+import { useEffect, useRef, useState, type FormEvent, type KeyboardEvent } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useNavigate } from "react-router";
 import {
@@ -27,8 +27,6 @@ import { HFTopBar, HFBottomNav } from "./AppChrome";
 import "../design/styles/hifi.css";
 import "../design/styles/hifi-add-asset.css";
 import "./styles/profile-edit.css";
-
-const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 type EmailNotice = "saved" | "verification-sent" | "removed" | "cooldown" | null;
 
@@ -77,6 +75,7 @@ function ProfileLoading() {
 export function AppProfileEdit() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const contactEmailInputRef = useRef<HTMLInputElement | null>(null);
   const [name, setName] = useState("");
   const [fieldError, setFieldError] = useState<DisplayNameFieldError | null>(null);
   const [showSaved, setShowSaved] = useState(false);
@@ -245,7 +244,7 @@ export function AppProfileEdit() {
     emailNotice === "cooldown"
       ? "You can request another verification email in a few minutes."
       : emailNotice === "verification-sent"
-        ? `Verification email sent to ${savedContactEmail || contactEmail.trim()}; check your inbox.`
+        ? `Verification email sent to ${savedContactEmail}; check your inbox.`
         : `We sent a verification link to ${savedContactEmail}. Didn't get it?`;
 
   const handleSubmit = (event: FormEvent) => {
@@ -273,7 +272,7 @@ export function AppProfileEdit() {
 
   const handleSaveContactEmail = () => {
     const nextEmail = contactEmail.trim();
-    if (!EMAIL_PATTERN.test(nextEmail)) {
+    if (nextEmail.length === 0 || contactEmailInputRef.current?.validity.valid === false) {
       setEmailError("A valid email address is required.");
       setEmailNotice(null);
       return;
@@ -281,6 +280,12 @@ export function AppProfileEdit() {
     setEmailError(null);
     setEmailNotice(null);
     setEmailMutation.mutate(nextEmail);
+  };
+
+  const handleContactEmailKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key !== "Enter") return;
+    event.preventDefault();
+    handleSaveContactEmail();
   };
 
   const handleRemoveContactEmail = () => {
@@ -402,6 +407,7 @@ export function AppProfileEdit() {
               <div className="pe-email-row">
                 <input
                   id="pe-email-input"
+                  ref={contactEmailInputRef}
                   className={`hf-input${emailError !== null ? " is-invalid" : ""}`}
                   type="email"
                   value={contactEmail}
@@ -413,10 +419,11 @@ export function AppProfileEdit() {
                   placeholder="you@example.com"
                   autoComplete="email"
                   disabled={emailBusy}
+                  onKeyDown={handleContactEmailKeyDown}
                 />
                 <button
                   type="button"
-                  className="hf-btn hf-btn-secondary hf-btn-sm"
+                  className="hf-btn hf-btn-secondary pe-btn-sm"
                   disabled={emailBusy}
                   onClick={handleSaveContactEmail}
                 >
@@ -435,7 +442,7 @@ export function AppProfileEdit() {
                 {hasContactEmail && (
                   <button
                     type="button"
-                    className="hf-btn hf-btn-secondary hf-btn-sm pe-btn-ghost"
+                    className="hf-btn hf-btn-secondary pe-btn-sm pe-btn-ghost"
                     title="Remove contact email"
                     aria-label="Remove contact email"
                     disabled={emailBusy}
@@ -460,7 +467,7 @@ export function AppProfileEdit() {
                 <span className="pe-verify-row-text">{verificationRowText}</span>
                 <button
                   type="button"
-                  className="hf-btn hf-btn-secondary hf-btn-sm"
+                  className="hf-btn hf-btn-secondary pe-btn-sm"
                   disabled={resendEmailMutation.isPending || emailNotice === "cooldown"}
                   onClick={handleResendVerification}
                 >

--- a/apps/web/src/app/AppProfileEdit.tsx
+++ b/apps/web/src/app/AppProfileEdit.tsx
@@ -1,7 +1,15 @@
 import { useEffect, useState, type FormEvent } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useNavigate } from "react-router";
-import { getUserProfile, updateUserProfile, userProfileQueryKey } from "../api/userProfile";
+import {
+  getUserProfile,
+  removeNotificationEmail,
+  requestEmailVerification,
+  setNotificationEmail,
+  updateUserProfile,
+  userProfileQueryKey,
+  type UserProfile,
+} from "../api/userProfile";
 import { ApiError } from "../api/client";
 import { Icon } from "../design/Icon";
 import { paths } from "../routes";
@@ -19,6 +27,10 @@ import { HFTopBar, HFBottomNav } from "./AppChrome";
 import "../design/styles/hifi.css";
 import "../design/styles/hifi-add-asset.css";
 import "./styles/profile-edit.css";
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+type EmailNotice = "saved" | "verification-sent" | "removed" | "cooldown" | null;
 
 function GoogleG({ size = 14 }: { size?: number }) {
   return (
@@ -69,6 +81,9 @@ export function AppProfileEdit() {
   const [fieldError, setFieldError] = useState<DisplayNameFieldError | null>(null);
   const [showSaved, setShowSaved] = useState(false);
   const [apiError, setApiError] = useState(false);
+  const [contactEmail, setContactEmail] = useState("");
+  const [emailError, setEmailError] = useState<string | null>(null);
+  const [emailNotice, setEmailNotice] = useState<EmailNotice>(null);
 
   const {
     data: profile,
@@ -96,23 +111,39 @@ export function AppProfileEdit() {
   }, [profile?.name]);
 
   useEffect(() => {
+    if (profile?.notificationEmail !== undefined) {
+      setContactEmail(profile.notificationEmail ?? "");
+      setEmailError(null);
+    }
+  }, [profile?.notificationEmail]);
+
+  useEffect(() => {
     document.title = "FieldOps — Edit profile";
   }, []);
+
+  const applyUpdatedProfile = async (updated: UserProfile) => {
+    await queryClient.setQueryData(userProfileQueryKey, updated);
+  };
+
+  const handleAuthError = (requestError: unknown) => {
+    if (requestError instanceof ApiError && requestError.status === 401) {
+      void navigate(paths.login(), { replace: true });
+      return true;
+    }
+    return false;
+  };
 
   const mutation = useMutation({
     mutationFn: (nextName: string) => updateUserProfile(nextName),
     onSuccess: async (updated) => {
-      await queryClient.setQueryData(userProfileQueryKey, updated);
+      await applyUpdatedProfile(updated);
       setName(updated.name ?? "");
       setFieldError(null);
       setApiError(false);
       setShowSaved(true);
     },
     onError: (mutationError) => {
-      if (mutationError instanceof ApiError && mutationError.status === 401) {
-        void navigate(paths.login(), { replace: true });
-        return;
-      }
+      if (handleAuthError(mutationError)) return;
       const mapped = mutationError instanceof ApiError ? toProfileFormError(mutationError) : null;
       if (mapped) {
         setFieldError(mapped);
@@ -124,11 +155,66 @@ export function AppProfileEdit() {
     },
   });
 
+  const setEmailMutation = useMutation({
+    mutationFn: (nextEmail: string) => setNotificationEmail(nextEmail),
+    onSuccess: async (updated) => {
+      await applyUpdatedProfile(updated);
+      setContactEmail(updated.notificationEmail ?? "");
+      setEmailError(null);
+      setEmailNotice(updated.notificationEmailVerified ? "saved" : "verification-sent");
+    },
+    onError: async (mutationError) => {
+      if (handleAuthError(mutationError)) return;
+      if (mutationError instanceof ApiError && mutationError.status === 422) {
+        setEmailError("A valid email address is required.");
+      } else if (mutationError instanceof ApiError && mutationError.status === 429) {
+        setEmailNotice("cooldown");
+        await queryClient.invalidateQueries({ queryKey: userProfileQueryKey });
+      } else {
+        setEmailError("Contact email could not be saved. Try again.");
+      }
+    },
+  });
+
+  const removeEmailMutation = useMutation({
+    mutationFn: removeNotificationEmail,
+    onSuccess: async (updated) => {
+      await applyUpdatedProfile(updated);
+      setContactEmail("");
+      setEmailError(null);
+      setEmailNotice("removed");
+    },
+    onError: (mutationError) => {
+      if (handleAuthError(mutationError)) return;
+      setEmailError("Contact email could not be removed. Try again.");
+    },
+  });
+
+  const resendEmailMutation = useMutation({
+    mutationFn: requestEmailVerification,
+    onSuccess: () => {
+      setEmailError(null);
+      setEmailNotice("verification-sent");
+    },
+    onError: (mutationError) => {
+      if (handleAuthError(mutationError)) return;
+      if (mutationError instanceof ApiError && mutationError.status === 429) {
+        setEmailNotice("cooldown");
+      } else {
+        setEmailError("Verification email could not be sent. Try again.");
+      }
+    },
+  });
+
   if (isLoading || !profile) {
     return <ProfileLoading />;
   }
 
   const savedName = profile.name ?? "";
+  const savedContactEmail = profile.notificationEmail ?? "";
+  const hasContactEmail = profile.notificationEmail !== null;
+  const isContactEmailVerified = hasContactEmail && profile.notificationEmailVerified;
+  const isContactEmailUnverified = hasContactEmail && !profile.notificationEmailVerified;
   const trimmedName = name.trim();
   const trimmedSaved = savedName.trim();
   const hasChanges = trimmedName !== trimmedSaved;
@@ -142,6 +228,25 @@ export function AppProfileEdit() {
       : hasChanges
         ? "Changes haven't been saved yet."
         : "This name appears on your dashboard and in your profile avatar.";
+
+  const emailBusy =
+    setEmailMutation.isPending || removeEmailMutation.isPending || resendEmailMutation.isPending;
+
+  const contactEmailSubText =
+    emailNotice === "removed"
+      ? "Contact email removed. Maintenance reminders will not be sent until you add one."
+      : emailNotice === "saved"
+        ? "This address is verified; reminders will be sent here."
+        : isContactEmailVerified
+          ? "This address is verified; reminders will be sent here."
+          : "Where maintenance reminders are sent; separate from your Google sign-in email.";
+
+  const verificationRowText =
+    emailNotice === "cooldown"
+      ? "You can request another verification email in a few minutes."
+      : emailNotice === "verification-sent"
+        ? `Verification email sent to ${savedContactEmail || contactEmail.trim()}; check your inbox.`
+        : `We sent a verification link to ${savedContactEmail}. Didn't get it?`;
 
   const handleSubmit = (event: FormEvent) => {
     event.preventDefault();
@@ -164,6 +269,30 @@ export function AppProfileEdit() {
 
   const handleCancel = () => {
     void navigate(paths.appHome);
+  };
+
+  const handleSaveContactEmail = () => {
+    const nextEmail = contactEmail.trim();
+    if (!EMAIL_PATTERN.test(nextEmail)) {
+      setEmailError("A valid email address is required.");
+      setEmailNotice(null);
+      return;
+    }
+    setEmailError(null);
+    setEmailNotice(null);
+    setEmailMutation.mutate(nextEmail);
+  };
+
+  const handleRemoveContactEmail = () => {
+    setEmailError(null);
+    setEmailNotice(null);
+    removeEmailMutation.mutate();
+  };
+
+  const handleResendVerification = () => {
+    setEmailError(null);
+    setEmailNotice(null);
+    resendEmailMutation.mutate();
   };
 
   return (
@@ -249,6 +378,103 @@ export function AppProfileEdit() {
                 fieldSubText && <span className="pe-field-sub">{fieldSubText}</span>
               )}
             </div>
+          </div>
+
+          <div className="hf-aa-section">
+            <div className="hf-aa-section-head">
+              <span className="hf-aa-section-title">Contact email</span>
+              {hasContactEmail && (
+                <span
+                  className={`pe-verify-badge ${
+                    isContactEmailVerified ? "is-verified" : "is-unverified"
+                  }`}
+                >
+                  <Icon name={isContactEmailVerified ? "check" : "alert"} size={11} stroke={2.4} />
+                  {isContactEmailVerified ? "Verified" : "Unverified"}
+                </span>
+              )}
+            </div>
+
+            <div className={`hf-field${emailError !== null ? " has-error" : ""}`}>
+              <label className="hf-field-label" htmlFor="pe-email-input">
+                Email address
+              </label>
+              <div className="pe-email-row">
+                <input
+                  id="pe-email-input"
+                  className={`hf-input${emailError !== null ? " is-invalid" : ""}`}
+                  type="email"
+                  value={contactEmail}
+                  onChange={(event) => {
+                    setContactEmail(event.target.value);
+                    if (emailError) setEmailError(null);
+                    if (emailNotice) setEmailNotice(null);
+                  }}
+                  placeholder="you@example.com"
+                  autoComplete="email"
+                  disabled={emailBusy}
+                />
+                <button
+                  type="button"
+                  className="hf-btn hf-btn-secondary hf-btn-sm"
+                  disabled={emailBusy}
+                  onClick={handleSaveContactEmail}
+                >
+                  {setEmailMutation.isPending ? (
+                    <>
+                      <span className="pe-btn-spinner pe-btn-spinner-dark" />
+                      Saving...
+                    </>
+                  ) : (
+                    <>
+                      <Icon name="mail" size={13} stroke={2} />
+                      {hasContactEmail ? "Update" : "Save"}
+                    </>
+                  )}
+                </button>
+                {hasContactEmail && (
+                  <button
+                    type="button"
+                    className="hf-btn hf-btn-secondary hf-btn-sm pe-btn-ghost"
+                    title="Remove contact email"
+                    aria-label="Remove contact email"
+                    disabled={emailBusy}
+                    onClick={handleRemoveContactEmail}
+                  >
+                    <Icon name="x" size={13} stroke={2.2} />
+                  </button>
+                )}
+              </div>
+              {emailError !== null ? (
+                <span className="hf-field-error" role="alert">
+                  <Icon name="alert" size={12} stroke={2} />
+                  {emailError}
+                </span>
+              ) : (
+                <span className="pe-field-sub">{contactEmailSubText}</span>
+              )}
+            </div>
+
+            {isContactEmailUnverified && (
+              <div className="pe-verify-row">
+                <span className="pe-verify-row-text">{verificationRowText}</span>
+                <button
+                  type="button"
+                  className="hf-btn hf-btn-secondary hf-btn-sm"
+                  disabled={resendEmailMutation.isPending || emailNotice === "cooldown"}
+                  onClick={handleResendVerification}
+                >
+                  {resendEmailMutation.isPending ? (
+                    <>
+                      <span className="pe-btn-spinner pe-btn-spinner-dark" />
+                      Sending...
+                    </>
+                  ) : (
+                    "Resend verification email"
+                  )}
+                </button>
+              </div>
+            )}
           </div>
 
           {showSaved && !hasFieldError && !apiError && (

--- a/apps/web/src/app/styles/profile-edit.css
+++ b/apps/web/src/app/styles/profile-edit.css
@@ -142,7 +142,7 @@
   min-width: 0;
 }
 
-.hf-btn-sm {
+.pe-btn-sm {
   height: 32px;
   padding: 0 12px;
   font-size: 12.5px;

--- a/apps/web/src/app/styles/profile-edit.css
+++ b/apps/web/src/app/styles/profile-edit.css
@@ -99,10 +99,88 @@
   flex-shrink: 0;
 }
 
+.pe-btn-spinner-dark {
+  border-color: oklch(80% 0.008 80);
+  border-top-color: var(--hf-ink-soft);
+}
+
 @keyframes pe-spin {
   to {
     transform: rotate(360deg);
   }
+}
+
+.pe-verify-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 9px 3px 7px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0;
+  flex-shrink: 0;
+}
+
+.pe-verify-badge.is-verified {
+  background: var(--hf-ok-bg);
+  color: var(--hf-ok);
+}
+
+.pe-verify-badge.is-unverified {
+  background: oklch(95% 0.035 75);
+  color: oklch(52% 0.14 70);
+}
+
+.pe-email-row {
+  display: flex;
+  gap: 8px;
+}
+
+.pe-email-row .hf-input {
+  flex: 1;
+  min-width: 0;
+}
+
+.hf-btn-sm {
+  height: 32px;
+  padding: 0 12px;
+  font-size: 12.5px;
+}
+
+.pe-btn-ghost {
+  color: var(--hf-ink-soft);
+  border-color: transparent;
+  background: transparent;
+}
+
+.pe-btn-ghost:hover:not(:disabled) {
+  background: var(--hf-surface-2);
+  color: var(--hf-bad);
+}
+
+.pe-verify-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px;
+  background: var(--hf-surface-2);
+  border: 1px solid var(--hf-line-soft);
+  border-radius: var(--hf-r);
+}
+
+.pe-verify-row-text {
+  min-width: 0;
+  flex: 1;
+  font-size: 12px;
+  color: var(--hf-ink-soft);
+  line-height: 1.4;
+}
+
+.pe-verify-row .hf-btn {
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 @container hfapp (max-width: 580px) {
@@ -112,5 +190,11 @@
 
   .pe-identity-google {
     display: none;
+  }
+
+  .pe-email-row,
+  .pe-verify-row {
+    align-items: stretch;
+    flex-direction: column;
   }
 }

--- a/apps/web/src/design/Icon.tsx
+++ b/apps/web/src/design/Icon.tsx
@@ -36,7 +36,8 @@ export type IconName =
   | "car"
   | "info"
   | "image"
-  | "lock";
+  | "lock"
+  | "mail";
 
 export interface IconProps {
   name: IconName;
@@ -204,6 +205,12 @@ const PATHS: Record<IconName, ReactNode> = {
     <>
       <rect x="5" y="11" width="14" height="10" rx="2" />
       <path d="M8 11V7a4 4 0 0 1 8 0v4" />
+    </>
+  ),
+  mail: (
+    <>
+      <rect x="3" y="5" width="18" height="14" rx="2" />
+      <path d="M3 6.5 12 13l9-6.5" />
     </>
   ),
 };

--- a/docs/web/FEATURES.md
+++ b/docs/web/FEATURES.md
@@ -61,10 +61,15 @@ For the API contract behind each feature, see the linked spec in `docs/specs/fea
 - Saving: disable duplicate submits while `PATCH /api/users/me` is in flight
 - Complete: enter the originally requested authenticated route, or `/app` by default
 - Later profile edit: read and update the same domain profile name
+- Later profile edit: add, change, remove, and resend verification for the contact email used for maintenance reminders
+- Contact email unset: show an empty optional email field with a save action
+- Contact email unverified: show the saved address, an unverified badge, and a resend-verification action
+- Contact email verified: show a verified badge and reminder-delivery confirmation copy
 
 **Non-obvious behavior:**
 
 - Email identifies the account but is never displayed as, or transformed into, the user's name
+- The contact email is separate from the Google sign-in email; reminders are delivered only after that contact address is verified
 - Provider session data can seed the first value, but later provider sign-ins must not overwrite the Pineapple profile name
 - The route guard is a UX control only; the API deliberately remains accessible to authenticated users with incomplete onboarding for now
 - A future multi-client or security requirement may require API middleware that limits incomplete users to auth and self-profile endpoints


### PR DESCRIPTION
**Summary**
- Add contact email CRUD and verification actions to the profile edit screen.
- Show verified/unverified state, resend-verification affordance, and removal handling.
- Extend the profile API client and icon set to support the new UI.
- Update web feature docs to reflect the contact email flow.
- Add coverage for validation, saving, and verification resend behavior.

**Testing**
- Added unit tests for contact email validation, save flow, and verification resend handling.
- Updated feature documentation to match the new profile-edit behavior.
- Not run (not requested).