### PR TITLE
Teams-foundation spec + spec-system conventions (backlog, AC checklist)

### DIFF
--- a/.claude/skills/spec-author/SKILL.md
+++ b/.claude/skills/spec-author/SKILL.md
@@ -119,6 +119,7 @@ Before writing the file, verify:
 
 - The spec lives in `docs/specs/features/`
 - Every user story maps to at least one acceptance criterion
+- Each acceptance criterion is **atomic and independently testable** — it becomes a checkbox on the spec's live implementation checklist, checked off (and backed by a test) one at a time as the feature is built (see `docs/specs/SPECS.md`)
 - Every cross-cutting concern has been addressed or explicitly flagged
 - The Telemetry section names the operation(s) and states whether domain events apply
 - If the feature has a web UI, confirm the relevant entry in `docs/web/FEATURES.md` is up to date

--- a/.claude/skills/spec-implement/SKILL.md
+++ b/.claude/skills/spec-implement/SKILL.md
@@ -96,10 +96,24 @@ Present the interpreted impact list to the user and confirm before writing any c
 
 ---
 
+## Slicing a large spec
+
+A spec too large to implement and review in one PR is delivered in **vertical slices**, each its own PR, tracked as GitHub issues (see `docs/specs/SPECS.md`).
+
+- The spec file stays whole — do not split it.
+- Each slice PR implements one coherent group of acceptance criteria and **checks off only those boxes** in the spec (`- [ ]` → `- [x]`), in the same PR.
+- Criteria are grouped by concern, so slices usually own disjoint groups and their checkmarks rarely conflict; if two in-flight slices touch the same group, resolve the checkmark in the later merge.
+- The spec reaches `status: active` only when the final slice checks the last box.
+
+---
+
 ## Completion
 
-When implementation is done:
+When a PR's implementation is done:
 
-- Confirm all acceptance criteria in the spec are satisfied — walk through them one by one
+- Walk through the acceptance criteria this PR set out to satisfy, one by one, and **check off each satisfied box in the spec** (`- [ ]` → `- [x]`), committing that edit in the same PR. Check a box only when its behavior is implemented **and covered by a test** — not merely written.
+- If this PR implements the **whole** spec, confirm every box is checked and advance the spec's `status` to `active`. If it implements only a slice (see above), check off just this slice's criteria and leave `status` unchanged — the spec becomes `active` when the final slice checks the last box.
 - Note any criteria that could not be met and why (flag candidates for the spec)
 - Remind the user to run `/spec-author` (document existing code) if behavior diverged from the spec during implementation
+
+See `docs/specs/SPECS.md` (Spec lifecycle & acceptance criteria) for the canonical convention.

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,6 +53,16 @@ index; the root `README.md` keeps the doc map. When you add a doc, add the link.
 **Prose over cleverness.** Short sentences, concrete examples, real values.
 Assume the reader is competent but new to _this_ project.
 
+**Future work lives in the issue tracker, not the repo.** The codebase reflects
+the app's _current state_ and the _decisions_ behind it (ADRs). Planned, proposed,
+or deferred work — backlog items, follow-ups, tech-debt, "fix this later" notes —
+is tracked as **GitHub issues**, not as in-repo TODO or backlog documents. This
+keeps specs and docs describing what _is_, not what _might be_, and gives future
+work real triage (labels, assignees, close-on-merge). It extends the
+one-home-per-fact method of [ADR-0008](decisions/0008-documentation-method.md).
+The lone exception is `docs/specs/backlog/archive-asset.md`, a parked spec that
+predates this convention and will be migrated.
+
 ## The generated API spec
 
 `docs/reference/openapi.json` is produced from the Zod route specs in

--- a/docs/specs/SPECS.md
+++ b/docs/specs/SPECS.md
@@ -1,4 +1,4 @@
-> **Audience:** everyone · **Purpose:** authoritative map of all feature and cross-cutting specs · **Source of truth:** this file · **Last reviewed:** 2026-07-02
+> **Audience:** everyone · **Purpose:** authoritative map of all feature and cross-cutting specs · **Source of truth:** this file · **Last reviewed:** 2026-07-03
 
 # Spec Index
 
@@ -43,12 +43,18 @@ relevant cross-cutting specs rather than re-describing the behavior.
 | [user-profile.md](./features/user-profile.md)                 | Identity      | active |
 | [email-verification.md](./features/email-verification.md)     | Identity      | active |
 | [telemetry-enrichment.md](./features/telemetry-enrichment.md) | Observability | draft  |
+| [teams-foundation.md](./features/teams-foundation.md)         | Teams         | draft  |
 
 ## Backlog (parked specs)
 
-Preserved design thinking that is **not** part of any active work. Parked specs live in
-`backlog/` and are excluded from the active feature set above. Reactivate one by moving it into
-`features/` and adding a row to the table above.
+**Backlog and future work now live in GitHub issues, not this repo.** The codebase reflects
+the current state of the app and the decisions behind it (ADRs); planned, proposed, or deferred
+work is tracked as issues. See the convention in [`docs/README.md`](../README.md).
+
+The `backlog/` folder is retained only for the one grandfathered **parked spec** below —
+preserved design thinking that predates this convention. Do **not** add new deferrals here; file
+an issue instead. Reactivate the parked spec by moving it into `features/` and adding a row to
+the table above.
 
 | Spec                                           | Area   | Why parked                                                                                                                                                                     |
 | ---------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |

--- a/docs/specs/SPECS.md
+++ b/docs/specs/SPECS.md
@@ -43,7 +43,7 @@ relevant cross-cutting specs rather than re-describing the behavior.
 | [user-profile.md](./features/user-profile.md)                 | Identity      | active |
 | [email-verification.md](./features/email-verification.md)     | Identity      | active |
 | [telemetry-enrichment.md](./features/telemetry-enrichment.md) | Observability | draft  |
-| [teams-foundation.md](./features/teams-foundation.md)         | Teams         | draft  |
+| [teams-foundation.md](./features/teams-foundation.md)         | Teams         | review |
 
 ## Backlog (parked specs)
 

--- a/docs/specs/SPECS.md
+++ b/docs/specs/SPECS.md
@@ -95,3 +95,22 @@ docs/specs/
 
 **After a PR merges:** run `prompts/pr-sync.md` against the diff to classify
 changes and update the spec if behavior changed.
+
+## Spec lifecycle & acceptance criteria
+
+A spec's **`status`** tracks its lifecycle: `draft` (being written) → `wip` (incomplete, not
+yet ready to implement) → `review` (complete, ready to implement) → `active` (implemented and
+live on `main`); `deprecated` when retired.
+
+The **acceptance-criteria checkboxes are the live implementation checklist.** A box is checked
+(`- [x]`) **only when its behavior is implemented and covered by a test on `main`** — not when
+code is merely written. The spec advances to `active` once every box is checked. This keeps the
+remaining work visible in the spec itself, so anyone (including a cold agent) can resume without
+relying on external notes.
+
+**Large specs are implemented in slices.** When a spec is too big for one PR, split the work
+into vertical slices, each tracked as a GitHub issue (see Backlog). The spec file stays whole;
+each slice PR implements one coherent group of criteria and checks off **only** the boxes it
+lands, including that spec edit in the same PR. Because criteria are grouped by concern, slices
+usually own disjoint groups, so checkmarks rarely conflict. The spec becomes `active` when the
+final slice checks the last box.

--- a/docs/specs/features/teams-foundation.md
+++ b/docs/specs/features/teams-foundation.md
@@ -48,15 +48,6 @@ authoritative in `openapi.json`.
 
 ## Acceptance Criteria
 
-> **Implementation status (live checklist).** These boxes track the build. A box is checked
-> only once its behavior is implemented **and covered by a test** on `main`; the spec's `status`
-> advances to `active` when all are checked. The feature ships in slices, so boxes are checked
-> across several PRs — in order: the **Team creation** and **Reading your team** groups first
-> (team + membership core), then **Sharing & unsharing**, **Member access to shared assets**,
-> **Read-path integration**, and **Permissions extension** (sharing + access). The web surface
-> is tracked separately in [`docs/web/FEATURES.md`](../../web/FEATURES.md). Each PR checks off
-> only the criteria it lands, so any reader can see remaining work at a glance.
-
 **Team creation**
 
 - [ ] An authenticated user who belongs to no team can create a team by providing a **name**; on success they become the team's **owner** and its only member

--- a/docs/specs/features/teams-foundation.md
+++ b/docs/specs/features/teams-foundation.md
@@ -1,0 +1,188 @@
+---
+name: teams-foundation
+description: The foundation for teams — creating a team, the membership model, and sharing/unsharing individual assets so members can see and edit them
+metadata:
+  type: feature
+---
+
+# Teams Foundation
+
+**Status:** draft
+**Owner:** [unknown — assign on review]
+**Last Updated:** 2026-07-03
+**Related Specs:** [ADR-0015](../../decisions/0015-teams-as-opt-in-sharing-scope.md), [authentication.md](../cross-cutting/authentication.md), [permissions.md](../cross-cutting/permissions.md), [validation.md](../cross-cutting/validation.md), [error-handling.md](../cross-cutting/error-handling.md), [loading-states.md](../cross-cutting/loading-states.md), [telemetry.md](../cross-cutting/telemetry.md), [asset-library.md](./asset-library.md), [dashboard.md](./dashboard.md), [app-search.md](./app-search.md)
+
+---
+
+## Summary
+
+This feature introduces **teams** as an opt-in sharing scope on top of the existing
+per-user ownership model (see [ADR-0015](../../decisions/0015-teams-as-opt-in-sharing-scope.md)).
+Today every asset is private to the user who created it. This spec lets a user
+**create a team**, and lets an asset's owner **share individual assets to that team**
+so that the team's members can see and help maintain them. Everything a user does not
+explicitly share stays personal and private, exactly as before.
+
+It is deliberately the **foundation** — the sharing mechanism — not the whole team
+experience. It defines what a team is, what membership grants, and how sharing works,
+but it does **not** cover how a second person joins a team (invitations) or how a team
+is administered (removing members, leaving, transferring, renaming, deleting). Those are
+separate specs. Until the invitations spec lands, a team has exactly one member — its
+creator — so sharing is fully functional but not yet observable by a second person. This
+is the intended land-the-mechanism-first sequencing.
+
+This feature has a web UI (a create-team affordance, a per-asset share/unshare control,
+and a "my team" view). UX intent for those screens belongs in
+[`docs/web/FEATURES.md`](../../web/FEATURES.md); the implemented API contract is
+authoritative in `openapi.json`.
+
+## User Stories
+
+- As a **user with no team**, I can **create a team and give it a name** so that **I have a shared space to put assets in**
+- As an **asset owner**, I can **share one of my assets to my team** so that **its members can see and help maintain it**
+- As an **asset owner**, I can **unshare an asset** so that **it becomes private to me again**
+- As a **team member**, I can **see and edit the assets shared with my team** so that **I can help maintain them as if they were my own**
+- As a **team member**, I can **view my team and who belongs to it** so that **I know who I'm sharing with**
+- As a **user already in a team**, I am **prevented from creating a second team** so that **the one-team-per-user rule holds**
+- As a **non-owner member**, I am **prevented from changing an asset's sharing** so that **only the asset's owner controls whether it is shared**
+
+## Acceptance Criteria
+
+**Team creation**
+
+- [ ] An authenticated user who belongs to no team can create a team by providing a **name**; on success they become the team's **owner** and its only member
+- [ ] Creating a team when the requester already belongs to a team (as owner or member) fails with **409 Conflict** and no team is created
+- [ ] The team name is **required**, trimmed, and bounded by a maximum length (see Validation); an invalid name fails with **422** before any team is created
+- [ ] A new team starts with exactly one membership: the creator, with role `owner`
+
+**Reading your team**
+
+- [ ] A member can read their own team, including its name and the list of members with each member's display name and role
+- [ ] A user who belongs to no team gets an explicit "no team" result (not an error), so the client can render a create-team prompt
+
+**Sharing & unsharing (asset-owner only)**
+
+- [ ] The **owner of an asset** can share that asset to the team they belong to; after sharing, the asset is visible and editable to every member of that team
+- [ ] Sharing requires the requester to belong to a team; sharing when the requester has no team fails with a **409 Conflict** (there is nothing to share into)
+- [ ] Only the asset's owner may share or unshare it — a member who does not own the asset attempting to change its sharing fails with **403 Forbidden**
+- [ ] The asset owner can unshare a shared asset, returning it to **personal**; members immediately lose access
+- [ ] Sharing an asset that is already shared to the caller's team is an idempotent success (no duplicate, no error); unsharing an already-personal asset is an idempotent success
+- [ ] "Owner" here means the **asset's** owner (`ownerId`), which may be any team member — not necessarily the team's owner. Any member can share the assets **they** own
+
+**Member access to shared assets (full parity)**
+
+- [ ] A team member can read an asset shared with their team and all of its dependent records (maintenance tasks, maintenance records, activity)
+- [ ] A team member can perform the same **write** actions on a shared asset that its owner can — add, edit, and delete maintenance tasks, and log maintenance records — with the sole exceptions of changing its sharing and deleting the asset itself, which remain asset-owner-only
+- [ ] Access to a shared asset's dependent records **follows the asset**: authorization for maintenance/record/activity operations is determined by whether the requester can access the parent asset (owns it, or is a member of the team it is shared with), replacing the direct `ownerId === requesterId` check on those operations
+- [ ] When an asset is unshared, or a member's access otherwise ends, subsequent requests by that member for the asset or its records behave as if the asset does not exist for them
+
+**Read-path integration**
+
+- [ ] Every list of "the user's assets" — the asset library (`GET /api/assets`), the dashboard, and search — returns both the requester's own assets (personal and shared-by-them) **and** the assets shared to the requester's team by others
+- [ ] Each asset in a read model carries a computed **`sharing`** descriptor (computed server-side per ADR-0009, not derived by the client): its scope (`personal` or `team`) and whether the requester is its owner; for an asset shared **with** the requester by someone else, it also identifies the owner (e.g. owner display name) so the member can see whose asset it is
+- [ ] Per-category counts and any other aggregate read-model figures are computed over the full visible set (owned + shared-with-me), so counts and lists stay consistent
+
+**Permissions extension**
+
+- [ ] The single-resource access rule is extended: a request for an asset (or its children) succeeds if the requester **owns it** _or_ **is a member of the team it is shared with**; otherwise the existing not-owned behavior applies
+- [ ] The collection query is extended to include team-shared assets in addition to owned ones; it must never return an asset that is neither owned by nor shared with the requester
+- [ ] [permissions.md](../cross-cutting/permissions.md) must be updated to document team visibility as an extension of the ownership model (per-user ownership remains the default; team sharing is additive)
+
+## Edge Cases & Error States
+
+| Scenario                                                      | Expected Behavior                                                                              |
+| ------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| Create team while already in a team (owner or member)         | 409 Conflict; no team created                                                                  |
+| Create team with empty/whitespace name                        | 422 Validation error mapped to the name field                                                  |
+| Create team with an over-length name                          | 422 Validation error mapped to the name field                                                  |
+| Read "my team" when the user has no team                      | 200 with an explicit "no team" result; client shows create-team prompt                         |
+| Share an asset the requester does not own                     | 403 Forbidden (owner-only), or 404 if the asset is not visible to the requester at all         |
+| Share an asset when the requester has no team                 | 409 Conflict (nothing to share into)                                                           |
+| Share an asset already shared to the caller's team            | Idempotent success (no duplicate)                                                              |
+| Unshare an asset that is already personal                     | Idempotent success                                                                             |
+| Non-owner member tries to unshare a shared asset              | 403 Forbidden (only the asset owner controls sharing)                                          |
+| Member reads/edits an asset shared with their team            | Succeeds; changes are visible to the owner and other members                                   |
+| Member deletes a maintenance task on a shared asset           | Succeeds (full parity)                                                                         |
+| Member tries to delete the shared asset itself                | Not permitted — asset deletion is asset-owner-only (and asset deletion is not yet implemented) |
+| Request an asset shared to a team the requester is **not** in | Treated as not visible (see Flags: 403-vs-404 inherits the permissions.md known issue)         |
+| Asset is unshared while a member has it open                  | The member's next request behaves as if the asset does not exist for them                      |
+| Unauthenticated request to any endpoint here                  | 401 Unauthorized → client redirects to `/login`                                                |
+
+## API Shape (design target)
+
+The implemented contract is authoritative in `openapi.json` once built; this describes the
+intended design, not a second source of truth. A user belongs to at most one team, so
+sharing endpoints target the caller's team implicitly — no team id is supplied by the caller.
+
+- **`POST /api/teams`** — create a team. Body: `{ "name": string }`. Auth required. Returns the created team: `{ id, name, ownerId, members: [{ userId, name, role }], createdAt }`. Errors: **409** (requester already in a team), **422** (invalid name), **401**.
+- **`GET /api/teams/me`** — the caller's team with members, or an explicit empty result when the caller has no team (e.g. `{ "team": null }` with 200). Auth required. Errors: **401**.
+- **`POST /api/assets/{assetId}/share`** — share the asset to the caller's team. Auth required. Asset-owner only. Idempotent. Errors: **403** (not the asset owner), **404** (asset not visible), **409** (requester has no team), **401**.
+- **`DELETE /api/assets/{assetId}/share`** — return the asset to personal. Auth required. Asset-owner only. Idempotent. Errors: **403**, **404**, **401**.
+- **Read models** — `GET /api/assets`, the dashboard, and search responses expand to include team-shared assets and add the computed `sharing` descriptor per asset (see Acceptance Criteria). This changes the response **shape** of existing endpoints (an added field and a wider result set), not their routes.
+
+## Telemetry
+
+**Request telemetry:** the new endpoints must be added to the operation-name mapping in
+`technicalTelemetry.ts` and to [telemetry.md](../cross-cutting/telemetry.md):
+
+- `POST /api/teams` → `CreateTeam`
+- `GET /api/teams/me` → `GetMyTeam`
+- `POST /api/assets/{assetId}/share` → `ShareAsset`
+- `DELETE /api/assets/{assetId}/share` → `UnshareAsset`
+
+Existing endpoints whose responses change (`GET /api/assets`, dashboard, search) keep their
+current operation names.
+
+**Domain events:** this feature introduces mutations, so it publishes domain events for
+durable consumers (activity/History and future team-aware consumers), following Smart Events
+(ADR-0010) — events carry the descriptive state a durable consumer needs (team name, asset
+name, actor) so no consumer re-reads the source:
+
+- `TeamCreated` — on team creation.
+- `AssetSharedToTeam` — on share; carries asset id + name, team id + name, and actor.
+- `AssetUnsharedFromTeam` — on unshare; same shape.
+
+Each needs a telemetry handler and a dataset (`pineapple_team_domain_events` /
+`pineapple_asset_domain_events`), with the full ordered `blobs[]`/`doubles[]` contract defined
+in [telemetry.md](../cross-cutting/telemetry.md) using the `AssetCreated` table as the pattern.
+Per ADR-0010, telemetry handlers stay thin selective readers: they record ids, roles, and
+counts — **not** member emails or other PII — even though the domain event carries names for
+the History projection. Reads (`GetMyTeam`, the expanded lists) publish no domain events.
+
+## Flags
+
+**DEFERRED — Reminder recipient for shared assets:** Maintenance reminders continue to go to
+the **asset owner** only; team-wide reminder delivery for shared assets is not decided here.
+Decide it in the notifications/invitations work, where the recipient set and notification
+plumbing already live. Owner: engineering.
+
+**OUT OF SCOPE / FUTURE — Shared asset when its owner leaves the team:** A shared asset is
+owned by one user but editable by the whole team. What happens to it when that owner leaves or
+is removed (auto-unshare? reassign ownership? block removal?) is a **team-management** concern
+and is not decided here. Owner: engineering; resolve in the team-management spec.
+
+**REVIEW NEEDED — 403 vs 404 for non-member single-resource access:** Requesting an asset
+shared to a team the requester is not in inherits the unresolved 403-vs-404 question in
+[permissions.md](../cross-cutting/permissions.md#known-issues). This spec follows the current
+canonical behavior (403 for exists-but-forbidden) to match the rest of the app; the app-wide
+switch to 404 is tracked in [#52](https://github.com/snaveevans/pineapple/issues/52), and this
+spec will follow that decision once made.
+
+**REVIEW NEEDED — Existing read specs must note shared assets:** [asset-library.md](./asset-library.md),
+[dashboard.md](./dashboard.md), and [app-search.md](./app-search.md) describe "the user's own
+assets." Once this lands they must be updated to state that team-shared assets also appear and
+carry the `sharing` descriptor. Tracked in [#53](https://github.com/snaveevans/pineapple/issues/53).
+
+**NOT SPECIFIED — Team name maximum length:** The name is required and bounded, but the exact
+limit is not fixed here. `DISPLAY_NAME_MAX_LENGTH` (100) is a reasonable precedent; confirm at
+implementation and encode it in the Zod schema.
+
+## Out of Scope
+
+- **Inviting or adding a second member** — the invitation/accept flow is the separate `invite-teammate` spec. Until it lands, a team has only its creator.
+- **Team administration** — removing members, leaving a team, transferring ownership, renaming or deleting a team belong to the `team-management` spec.
+- **Multiple teams per user / active-team switching** — a user has at most one team; multi-team is a future extension of ADR-0015, not this spec.
+- **Team-wide reminder delivery** — see the deferred flag; reminders stay owner-directed for now.
+- **Migrating existing assets** — none required; the model is additive and existing assets are simply personal until shared.
+- **Sub-asset sharing** — sharing is per-asset; a single maintenance task or record cannot be shared independently of its asset.
+- **Sharing to a team the requester does not belong to** — a user can only share into their own team.

--- a/docs/specs/features/teams-foundation.md
+++ b/docs/specs/features/teams-foundation.md
@@ -48,6 +48,15 @@ authoritative in `openapi.json`.
 
 ## Acceptance Criteria
 
+> **Implementation status (live checklist).** These boxes track the build. A box is checked
+> only once its behavior is implemented **and covered by a test** on `main`; the spec's `status`
+> advances to `active` when all are checked. The feature ships in slices, so boxes are checked
+> across several PRs — in order: the **Team creation** and **Reading your team** groups first
+> (team + membership core), then **Sharing & unsharing**, **Member access to shared assets**,
+> **Read-path integration**, and **Permissions extension** (sharing + access). The web surface
+> is tracked separately in [`docs/web/FEATURES.md`](../../web/FEATURES.md). Each PR checks off
+> only the criteria it lands, so any reader can see remaining work at a glance.
+
 **Team creation**
 
 - [ ] An authenticated user who belongs to no team can create a team by providing a **name**; on success they become the team's **owner** and its only member

--- a/docs/specs/features/teams-foundation.md
+++ b/docs/specs/features/teams-foundation.md
@@ -7,7 +7,7 @@ metadata:
 
 # Teams Foundation
 
-**Status:** draft
+**Status:** review
 **Owner:** [unknown — assign on review]
 **Last Updated:** 2026-07-03
 **Related Specs:** [ADR-0015](../../decisions/0015-teams-as-opt-in-sharing-scope.md), [authentication.md](../cross-cutting/authentication.md), [permissions.md](../cross-cutting/permissions.md), [validation.md](../cross-cutting/validation.md), [error-handling.md](../cross-cutting/error-handling.md), [loading-states.md](../cross-cutting/loading-states.md), [telemetry.md](../cross-cutting/telemetry.md), [asset-library.md](./asset-library.md), [dashboard.md](./dashboard.md), [app-search.md](./app-search.md)
@@ -52,7 +52,7 @@ authoritative in `openapi.json`.
 
 - [ ] An authenticated user who belongs to no team can create a team by providing a **name**; on success they become the team's **owner** and its only member
 - [ ] Creating a team when the requester already belongs to a team (as owner or member) fails with **409 Conflict** and no team is created
-- [ ] The team name is **required**, trimmed, and bounded by a maximum length (see Validation); an invalid name fails with **422** before any team is created
+- [ ] The team name is **required**, trimmed, and at most **100 characters** (matching `DISPLAY_NAME_MAX_LENGTH`); it need not be unique. An invalid name fails with **422** before any team is created
 - [ ] A new team starts with exactly one membership: the creator, with role `owner`
 
 **Reading your team**
@@ -72,7 +72,7 @@ authoritative in `openapi.json`.
 **Member access to shared assets (full parity)**
 
 - [ ] A team member can read an asset shared with their team and all of its dependent records (maintenance tasks, maintenance records, activity)
-- [ ] A team member can perform the same **write** actions on a shared asset that its owner can — add, edit, and delete maintenance tasks, and log maintenance records — with the sole exceptions of changing its sharing and deleting the asset itself, which remain asset-owner-only
+- [ ] A team member can perform the same **write** actions on a shared asset that its owner can — the maintenance actions that exist today: adding and deleting maintenance tasks, and logging maintenance records — with the sole exceptions of changing its sharing and deleting the asset itself, which remain asset-owner-only
 - [ ] Access to a shared asset's dependent records **follows the asset**: authorization for maintenance/record/activity operations is determined by whether the requester can access the parent asset (owns it, or is a member of the team it is shared with), replacing the direct `ownerId === requesterId` check on those operations
 - [ ] When an asset is unshared, or a member's access otherwise ends, subsequent requests by that member for the asset or its records behave as if the asset does not exist for them
 
@@ -154,12 +154,12 @@ the History projection. Reads (`GetMyTeam`, the expanded lists) publish no domai
 **DEFERRED — Reminder recipient for shared assets:** Maintenance reminders continue to go to
 the **asset owner** only; team-wide reminder delivery for shared assets is not decided here.
 Decide it in the notifications/invitations work, where the recipient set and notification
-plumbing already live. Owner: engineering.
+plumbing already live. Tracked in [#55](https://github.com/snaveevans/pineapple/issues/55).
 
 **OUT OF SCOPE / FUTURE — Shared asset when its owner leaves the team:** A shared asset is
 owned by one user but editable by the whole team. What happens to it when that owner leaves or
 is removed (auto-unshare? reassign ownership? block removal?) is a **team-management** concern
-and is not decided here. Owner: engineering; resolve in the team-management spec.
+and is not decided here. Resolve in the team-management spec; tracked in [#56](https://github.com/snaveevans/pineapple/issues/56).
 
 **REVIEW NEEDED — 403 vs 404 for non-member single-resource access:** Requesting an asset
 shared to a team the requester is not in inherits the unresolved 403-vs-404 question in
@@ -172,10 +172,6 @@ spec will follow that decision once made.
 [dashboard.md](./dashboard.md), and [app-search.md](./app-search.md) describe "the user's own
 assets." Once this lands they must be updated to state that team-shared assets also appear and
 carry the `sharing` descriptor. Tracked in [#53](https://github.com/snaveevans/pineapple/issues/53).
-
-**NOT SPECIFIED — Team name maximum length:** The name is required and bounded, but the exact
-limit is not fixed here. `DISPLAY_NAME_MAX_LENGTH` (100) is a reasonable precedent; confirm at
-implementation and encode it in the Zod schema.
 
 ## Out of Scope
 

--- a/docs/specs/templates/feature-spec.template.md
+++ b/docs/specs/templates/feature-spec.template.md
@@ -23,6 +23,10 @@ One paragraph. What this feature does and the user problem it solves. No impleme
 
 ## Acceptance Criteria
 
+<!-- These boxes are the live implementation checklist: check a box (`- [x]`) only when the
+behavior is implemented AND covered by a test on `main`. Large specs ship in slices (tracked as
+GitHub issues); each PR checks off only the criteria it lands. See docs/specs/SPECS.md. -->
+
 - [ ] [Specific, testable behavior]
 - [ ] [Another testable criterion]
 


### PR DESCRIPTION
> Draft PR — planning docs for the teams feature plus two spec-system conventions surfaced along the way. No implementation.

## 1. `teams-foundation` feature spec (new)

The mechanism spec behind [ADR-0015](docs/decisions/0015-teams-as-opt-in-sharing-scope.md) (PR #51). Deliberately the **foundation** — the sharing mechanism, not the whole team experience.

- Create a team; share/unshare an asset (asset-owner only, idempotent); member access with full parity; read-path integration with a computed `sharing` descriptor.
- Cross-cutting worked through; scope locked with the author (mechanism-only, full parity, reminders deferred).
- Status advanced to `review`; open flags resolved or tracked as issues (#52, #53, #55, #56).

## 2. Backlog convention → GitHub issues

The repo reflects the app's current state + decisions (ADRs); future/deferred work is tracked as issues. Documented in `docs/README.md` and the SPECS.md backlog section (extends ADR-0008). `docs/specs/backlog/archive-asset.md` is grandfathered.

## 3. Spec lifecycle & AC-as-live-checklist convention

A spec's acceptance-criteria checkboxes are the **live implementation checklist** — a box is checked only when its behavior is implemented **and covered by a test** on `main`; the spec goes `active` when all boxes are checked. Large specs are built in **slices** (tracked as issues), each PR checking off only the criteria it lands. This is a general convention, documented in:

- `docs/specs/SPECS.md` — new "Spec lifecycle & acceptance criteria" section (canonical).
- `.claude/skills/spec-author` + `.claude/skills/spec-implement` — reference the convention; spec-implement gains a "Slicing a large spec" section.
- `docs/specs/templates/feature-spec.template.md` — pointer comment on the AC section.

(It does **not** live inside any individual spec.)

## Scope

Docs + skills only. No code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)