### PR TITLE
teams-foundation ①: team + membership core (backend)

### DIFF
--- a/.claude/skills/spec-author/SKILL.md
+++ b/.claude/skills/spec-author/SKILL.md
@@ -119,6 +119,7 @@ Before writing the file, verify:
 
 - The spec lives in `docs/specs/features/`
 - Every user story maps to at least one acceptance criterion
+- Each acceptance criterion is **atomic and independently testable** — it becomes a checkbox on the spec's live implementation checklist, checked off (and backed by a test) one at a time as the feature is built (see `docs/specs/SPECS.md`)
 - Every cross-cutting concern has been addressed or explicitly flagged
 - The Telemetry section names the operation(s) and states whether domain events apply
 - If the feature has a web UI, confirm the relevant entry in `docs/web/FEATURES.md` is up to date

--- a/.claude/skills/spec-implement/SKILL.md
+++ b/.claude/skills/spec-implement/SKILL.md
@@ -96,10 +96,24 @@ Present the interpreted impact list to the user and confirm before writing any c
 
 ---
 
+## Slicing a large spec
+
+A spec too large to implement and review in one PR is delivered in **vertical slices**, each its own PR, tracked as GitHub issues (see `docs/specs/SPECS.md`).
+
+- The spec file stays whole — do not split it.
+- Each slice PR implements one coherent group of acceptance criteria and **checks off only those boxes** in the spec (`- [ ]` → `- [x]`), in the same PR.
+- Criteria are grouped by concern, so slices usually own disjoint groups and their checkmarks rarely conflict; if two in-flight slices touch the same group, resolve the checkmark in the later merge.
+- The spec reaches `status: active` only when the final slice checks the last box.
+
+---
+
 ## Completion
 
-When implementation is done:
+When a PR's implementation is done:
 
-- Confirm all acceptance criteria in the spec are satisfied — walk through them one by one
+- Walk through the acceptance criteria this PR set out to satisfy, one by one, and **check off each satisfied box in the spec** (`- [ ]` → `- [x]`), committing that edit in the same PR. Check a box only when its behavior is implemented **and covered by a test** — not merely written.
+- If this PR implements the **whole** spec, confirm every box is checked and advance the spec's `status` to `active`. If it implements only a slice (see above), check off just this slice's criteria and leave `status` unchanged — the spec becomes `active` when the final slice checks the last box.
 - Note any criteria that could not be met and why (flag candidates for the spec)
 - Remind the user to run `/spec-author` (document existing code) if behavior diverged from the spec during implementation
+
+See `docs/specs/SPECS.md` (Spec lifecycle & acceptance criteria) for the canonical convention.

--- a/apps/api/src/api/middleware/technicalTelemetry.test.ts
+++ b/apps/api/src/api/middleware/technicalTelemetry.test.ts
@@ -505,6 +505,40 @@ describe("buildApiRequestTelemetryDataPoint", () => {
       ],
     });
   });
+
+  it.each([
+    ["POST", "/api/teams", "CreateTeam"],
+    ["GET", "/api/teams/me", "GetMyTeam"],
+  ])("maps %s %s to %s", (method, pathname, operation) => {
+    expect(
+      buildApiRequestTelemetryDataPoint({
+        method,
+        pathname,
+        status: 200,
+        durationMs: 1,
+        requestSizeBytes: 0,
+        authenticated: true,
+        country: "US",
+        userId,
+        error: null,
+      }),
+    ).toMatchObject({
+      indexes: [operation],
+      blobs: [
+        operation,
+        pathname,
+        method,
+        "2xx",
+        "200",
+        "success",
+        "none",
+        "true",
+        "v2",
+        "US",
+        userId,
+      ],
+    });
+  });
 });
 
 describe("requestCountry", () => {

--- a/apps/api/src/api/middleware/technicalTelemetry.ts
+++ b/apps/api/src/api/middleware/technicalTelemetry.ts
@@ -220,6 +220,12 @@ function routeTelemetry(method: string, pathname: string): RouteTelemetry {
       routePattern: "/api/assets/{assetId}/maintenance-tasks/{taskId}",
     };
   }
+  if (pathname === "/api/teams" && method === "POST") {
+    return { operation: "CreateTeam", routePattern: "/api/teams" };
+  }
+  if (pathname === "/api/teams/me" && method === "GET") {
+    return { operation: "GetMyTeam", routePattern: "/api/teams/me" };
+  }
   if (pathname === "/health" && method === "GET") {
     return { operation: "Health", routePattern: "/health" };
   }

--- a/apps/api/src/api/openapi.ts
+++ b/apps/api/src/api/openapi.ts
@@ -41,6 +41,11 @@ import {
   NotificationQuerySchema,
   NotificationSchema,
 } from "./schemas/notificationSchemas.ts";
+import {
+  CreateTeamBodySchema,
+  MyTeamResponseSchema,
+  TeamResponseSchema,
+} from "./schemas/teamSchemas.ts";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // OpenAPI route specs (metadata only — no handlers, no infrastructure).
@@ -93,6 +98,10 @@ export const openApiConfig = {
     {
       name: "Notifications",
       description: "Authenticated durable notification inbox and read lifecycle",
+    },
+    {
+      name: "Teams",
+      description: "Create and read the caller's team (ADR-0015 teams foundation)",
     },
   ],
 };
@@ -656,6 +665,59 @@ export const deleteMaintenanceTaskRoute = createRoute({
   },
 });
 
+export const createTeamRoute = createRoute({
+  method: "post",
+  path: "/api/teams",
+  tags: ["Teams"],
+  summary: "Create a team",
+  description: "Creates a team owned solely by the caller. A user belongs to at most one team.",
+  security: [cookieAuth],
+  request: {
+    body: {
+      required: true,
+      content: { "application/json": { schema: CreateTeamBodySchema } },
+    },
+  },
+  responses: {
+    201: {
+      description: "Team created",
+      content: { "application/json": { schema: TeamResponseSchema } },
+    },
+    401: {
+      description: "Not authenticated",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    409: {
+      description: "The requester already belongs to a team",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    422: {
+      description: "Validation failed",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
+export const getMyTeamRoute = createRoute({
+  method: "get",
+  path: "/api/teams/me",
+  tags: ["Teams"],
+  summary: "Get the caller's team",
+  description:
+    "Returns the caller's team and members, or `{ team: null }` when the caller has no team.",
+  security: [cookieAuth],
+  responses: {
+    200: {
+      description: "The caller's team, or null",
+      content: { "application/json": { schema: MyTeamResponseSchema } },
+    },
+    401: {
+      description: "Not authenticated",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
 /**
  * Register shared OpenAPI components (security schemes) on a registry.
  * Keyed off the registry type (not the app's Env) so it works for both the
@@ -703,6 +765,8 @@ export function getApiDocument() {
   doc.openapi(listNotificationsRoute, stub);
   doc.openapi(markNotificationReadRoute, stub);
   doc.openapi(markAllNotificationsReadRoute, stub);
+  doc.openapi(createTeamRoute, stub);
+  doc.openapi(getMyTeamRoute, stub);
   registerOpenApiComponents(doc.openAPIRegistry);
   return doc.getOpenAPIDocument(openApiConfig);
 }

--- a/apps/api/src/api/schemas/teamSchemas.ts
+++ b/apps/api/src/api/schemas/teamSchemas.ts
@@ -1,0 +1,42 @@
+// Import `z` from @hono/zod-openapi (not "zod") so schemas carry `.openapi()`
+// metadata. This is the single source of truth for both runtime validation
+// AND the generated OpenAPI spec — change a rule here and the docs follow.
+import { z } from "@hono/zod-openapi";
+
+// ── Requests ─────────────────────────────────────────────────────────────────
+
+export const CreateTeamBodySchema = z
+  .object({
+    name: z.string().min(1, "Name is required").openapi({ example: "The Smiths" }),
+  })
+  .openapi("CreateTeamBody");
+
+export type CreateTeamBody = z.infer<typeof CreateTeamBodySchema>;
+
+// ── Responses ──────────────────────────────────────────────────────────────
+
+/** Serialized team member, matching `serializeTeamMember` in worker.ts. */
+export const TeamMemberResponseSchema = z
+  .object({
+    userId: z.string().openapi({ example: "7d914909-c903-41a4-a13a-82cbd0f61851" }),
+    name: z.string().nullable().openapi({ example: "Dale" }),
+    role: z.enum(["owner", "member"]).openapi({ example: "owner" }),
+  })
+  .openapi("TeamMember");
+
+/** Serialized team, matching `serializeTeam` in worker.ts. */
+export const TeamResponseSchema = z
+  .object({
+    id: z.string().openapi({ example: "195d0ef0-47f5-439f-abfd-29f892c9a040" }),
+    name: z.string().openapi({ example: "The Smiths" }),
+    ownerId: z.string().openapi({ example: "7d914909-c903-41a4-a13a-82cbd0f61851" }),
+    members: z.array(TeamMemberResponseSchema),
+    createdAt: z.string().datetime().openapi({ example: "2026-07-10T03:25:24.887Z" }),
+  })
+  .openapi("Team");
+
+export const MyTeamResponseSchema = z
+  .object({
+    team: TeamResponseSchema.nullable(),
+  })
+  .openapi("MyTeamResponse");

--- a/apps/api/src/application/teams/TeamReadModel.ts
+++ b/apps/api/src/application/teams/TeamReadModel.ts
@@ -1,0 +1,37 @@
+import type { TeamId, UserId } from "@snaveevans/pineapple-shared";
+import type { Team, TeamRole } from "../../domain/teams/Team.ts";
+import type { UserRepository } from "../../domain/identity/UserRepository.ts";
+
+export type TeamMemberReadModel = {
+  userId: UserId;
+  name: string | null;
+  role: TeamRole;
+};
+
+export type TeamWithMembers = {
+  id: TeamId;
+  name: string;
+  ownerId: UserId;
+  members: TeamMemberReadModel[];
+  createdAt: Date;
+};
+
+export async function buildTeamReadModel(
+  team: Team,
+  users: UserRepository,
+): Promise<TeamWithMembers> {
+  const members = await Promise.all(
+    team.members.map(async (member): Promise<TeamMemberReadModel> => {
+      const user = await users.findById(member.userId);
+      return { userId: member.userId, name: user?.name ?? null, role: member.role };
+    }),
+  );
+
+  return {
+    id: team.id,
+    name: team.name,
+    ownerId: team.ownerId,
+    members,
+    createdAt: team.createdAt,
+  };
+}

--- a/apps/api/src/application/usecases/CreateTeam.test.ts
+++ b/apps/api/src/application/usecases/CreateTeam.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import { ConflictError, Email, UserId, ValidationError } from "@snaveevans/pineapple-shared";
+import { CreateTeam } from "./CreateTeam.ts";
+import type { EventBus } from "../ports/EventBus.ts";
+import { Team } from "../../domain/teams/Team.ts";
+import type { TeamRepository } from "../../domain/teams/TeamRepository.ts";
+import type { TeamCreated } from "../../domain/teams/events/TeamCreated.ts";
+import type { DomainEvent } from "../../domain/events/DomainEvent.ts";
+import { User } from "../../domain/identity/User.ts";
+import type { UserRepository } from "../../domain/identity/UserRepository.ts";
+
+class RecordingTeamRepository implements TeamRepository {
+  saved: Team | null = null;
+
+  constructor(private readonly existing: Team | null = null) {}
+
+  findById(): Promise<Team | null> {
+    return Promise.resolve(null);
+  }
+
+  findByMemberId(): Promise<Team | null> {
+    return Promise.resolve(this.existing);
+  }
+
+  save(team: Team): Promise<void> {
+    this.saved = team;
+    return Promise.resolve();
+  }
+}
+
+class FakeUserRepository implements UserRepository {
+  constructor(private readonly users: User[]) {}
+
+  findById(id: UserId): Promise<User | null> {
+    return Promise.resolve(this.users.find((user) => user.id === id) ?? null);
+  }
+
+  findByEmail(): Promise<User | null> {
+    return Promise.resolve(null);
+  }
+
+  save(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+class RecordingEventBus implements EventBus {
+  readonly events: DomainEvent[] = [];
+
+  publish(event: DomainEvent): Promise<void> {
+    this.events.push(event);
+    return Promise.resolve();
+  }
+
+  publishAll(events: readonly DomainEvent[]): Promise<void> {
+    for (const event of events) {
+      this.events.push(event);
+    }
+    return Promise.resolve();
+  }
+
+  subscribe(): void {}
+}
+
+describe("CreateTeam", () => {
+  it("creates a team and returns the requester as its sole owner-member", async () => {
+    const requester = User.create(Email.from("dale@example.com"), "Dale");
+    const teams = new RecordingTeamRepository();
+    const users = new FakeUserRepository([requester]);
+    const eventBus = new RecordingEventBus();
+
+    const result = await new CreateTeam(teams, users, eventBus).execute({
+      requesterId: requester.id,
+      name: "The Smiths",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected ok");
+    expect(result.value).toMatchObject({
+      name: "The Smiths",
+      ownerId: requester.id,
+      members: [{ userId: requester.id, name: "Dale", role: "owner" }],
+    });
+    expect(teams.saved).not.toBeNull();
+
+    expect(eventBus.events).toHaveLength(1);
+    const event = eventBus.events[0] as TeamCreated | undefined;
+    expect(event).toMatchObject({
+      type: "TeamCreated",
+      ownerId: requester.id,
+      actorId: requester.id,
+      name: "The Smiths",
+    });
+  });
+
+  it("fails with a conflict when the requester already belongs to a team", async () => {
+    const requester = User.create(Email.from("dale@example.com"));
+    const existingTeam = Team.create({ ownerId: requester.id, name: "Already in one" });
+    existingTeam.pullEvents(); // drain
+
+    const teams = new RecordingTeamRepository(existingTeam);
+    const users = new FakeUserRepository([requester]);
+    const eventBus = new RecordingEventBus();
+
+    const result = await new CreateTeam(teams, users, eventBus).execute({
+      requesterId: requester.id,
+      name: "New Team",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBeInstanceOf(ConflictError);
+    expect(teams.saved).toBeNull();
+    expect(eventBus.events).toHaveLength(0);
+  });
+
+  it("rejects an invalid name without creating a team", async () => {
+    const requester = User.create(Email.from("dale@example.com"));
+    const teams = new RecordingTeamRepository();
+    const users = new FakeUserRepository([requester]);
+    const eventBus = new RecordingEventBus();
+
+    const result = await new CreateTeam(teams, users, eventBus).execute({
+      requesterId: requester.id,
+      name: "   ",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBeInstanceOf(ValidationError);
+    expect(teams.saved).toBeNull();
+    expect(eventBus.events).toHaveLength(0);
+  });
+});

--- a/apps/api/src/application/usecases/CreateTeam.ts
+++ b/apps/api/src/application/usecases/CreateTeam.ts
@@ -1,0 +1,46 @@
+import {
+  type DomainError,
+  DomainError as DomainErrorClass,
+  ConflictError,
+  ok,
+  err,
+  type Result,
+  type UserId,
+} from "@snaveevans/pineapple-shared";
+import { Team } from "../../domain/teams/Team.ts";
+import type { TeamRepository } from "../../domain/teams/TeamRepository.ts";
+import type { UserRepository } from "../../domain/identity/UserRepository.ts";
+import type { EventBus } from "../ports/EventBus.ts";
+import { buildTeamReadModel, type TeamWithMembers } from "../teams/TeamReadModel.ts";
+
+export type CreateTeamCommand = {
+  requesterId: UserId;
+  name: string;
+};
+
+export class CreateTeam {
+  constructor(
+    private readonly teams: TeamRepository,
+    private readonly users: UserRepository,
+    private readonly eventBus: EventBus,
+  ) {}
+
+  async execute(cmd: CreateTeamCommand): Promise<Result<TeamWithMembers, DomainError>> {
+    try {
+      const existing = await this.teams.findByMemberId(cmd.requesterId);
+      if (existing) {
+        return err(new ConflictError("You already belong to a team"));
+      }
+
+      const team = Team.create({ ownerId: cmd.requesterId, name: cmd.name });
+      const events = team.pullEvents();
+      await this.teams.save(team);
+      await this.eventBus.publishAll(events);
+
+      return ok(await buildTeamReadModel(team, this.users));
+    } catch (e) {
+      if (e instanceof DomainErrorClass) return err(e);
+      throw e;
+    }
+  }
+}

--- a/apps/api/src/application/usecases/GetMyTeam.test.ts
+++ b/apps/api/src/application/usecases/GetMyTeam.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { Email, UserId } from "@snaveevans/pineapple-shared";
+import { GetMyTeam } from "./GetMyTeam.ts";
+import { Team } from "../../domain/teams/Team.ts";
+import type { TeamRepository } from "../../domain/teams/TeamRepository.ts";
+import { User } from "../../domain/identity/User.ts";
+import type { UserRepository } from "../../domain/identity/UserRepository.ts";
+
+class FakeTeamRepository implements TeamRepository {
+  constructor(private readonly team: Team | null) {}
+
+  findById(): Promise<Team | null> {
+    return Promise.resolve(this.team);
+  }
+
+  findByMemberId(): Promise<Team | null> {
+    return Promise.resolve(this.team);
+  }
+
+  save(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+class FakeUserRepository implements UserRepository {
+  constructor(private readonly users: User[]) {}
+
+  findById(id: UserId): Promise<User | null> {
+    return Promise.resolve(this.users.find((user) => user.id === id) ?? null);
+  }
+
+  findByEmail(): Promise<User | null> {
+    return Promise.resolve(null);
+  }
+
+  save(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+describe("GetMyTeam", () => {
+  it("returns the caller's team with resolved member names", async () => {
+    const owner = User.create(Email.from("dale@example.com"), "Dale");
+    const team = Team.create({ ownerId: owner.id, name: "The Smiths" });
+    team.pullEvents(); // drain
+
+    const result = await new GetMyTeam(
+      new FakeTeamRepository(team),
+      new FakeUserRepository([owner]),
+    ).execute({ requesterId: owner.id });
+
+    expect(result).toEqual({
+      ok: true,
+      value: {
+        team: {
+          id: team.id,
+          name: "The Smiths",
+          ownerId: owner.id,
+          members: [{ userId: owner.id, name: "Dale", role: "owner" }],
+          createdAt: team.createdAt,
+        },
+      },
+    });
+  });
+
+  it("returns an explicit null team when the requester belongs to no team", async () => {
+    const requesterId = UserId.generate();
+
+    const result = await new GetMyTeam(
+      new FakeTeamRepository(null),
+      new FakeUserRepository([]),
+    ).execute({ requesterId });
+
+    expect(result).toEqual({ ok: true, value: { team: null } });
+  });
+});

--- a/apps/api/src/application/usecases/GetMyTeam.ts
+++ b/apps/api/src/application/usecases/GetMyTeam.ts
@@ -1,0 +1,38 @@
+import {
+  type DomainError,
+  DomainError as DomainErrorClass,
+  ok,
+  err,
+  type Result,
+  type UserId,
+} from "@snaveevans/pineapple-shared";
+import type { TeamRepository } from "../../domain/teams/TeamRepository.ts";
+import type { UserRepository } from "../../domain/identity/UserRepository.ts";
+import { buildTeamReadModel, type TeamWithMembers } from "../teams/TeamReadModel.ts";
+
+export type GetMyTeamQuery = {
+  requesterId: UserId;
+};
+
+export type MyTeamReadModel = {
+  team: TeamWithMembers | null;
+};
+
+export class GetMyTeam {
+  constructor(
+    private readonly teams: TeamRepository,
+    private readonly users: UserRepository,
+  ) {}
+
+  async execute(query: GetMyTeamQuery): Promise<Result<MyTeamReadModel, DomainError>> {
+    try {
+      const team = await this.teams.findByMemberId(query.requesterId);
+      if (!team) return ok({ team: null });
+
+      return ok({ team: await buildTeamReadModel(team, this.users) });
+    } catch (e) {
+      if (e instanceof DomainErrorClass) return err(e);
+      throw e;
+    }
+  }
+}

--- a/apps/api/src/domain/teams/Team.test.ts
+++ b/apps/api/src/domain/teams/Team.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { UserId, ValidationError } from "@snaveevans/pineapple-shared";
+import { Team } from "./Team.ts";
+
+describe("Team", () => {
+  const ownerId = UserId.generate();
+
+  it("creates a team owned by the creator and emits TeamCreated", () => {
+    const team = Team.create({ ownerId, name: "The Smiths" });
+
+    expect(team.name).toBe("The Smiths");
+    expect(team.ownerId).toBe(ownerId);
+    expect(team.members).toEqual([{ userId: ownerId, role: "owner" }]);
+    expect(team.isMember(ownerId)).toBe(true);
+    expect(team.isMember(UserId.generate())).toBe(false);
+
+    const events = team.pullEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0]?.type).toBe("TeamCreated");
+    expect(events[0]).toMatchObject({
+      teamId: team.id,
+      ownerId,
+      actorId: ownerId,
+      name: "The Smiths",
+    });
+
+    // Second pull returns empty — events are drained
+    expect(team.pullEvents()).toHaveLength(0);
+  });
+
+  it("trims whitespace from name", () => {
+    const team = Team.create({ ownerId, name: "  The Smiths  " });
+    expect(team.name).toBe("The Smiths");
+  });
+
+  it("rejects blank name", () => {
+    expect(() => Team.create({ ownerId, name: "   " })).toThrow(ValidationError);
+  });
+
+  it("rejects over-length name", () => {
+    const longName = "a".repeat(101);
+    expect(() => Team.create({ ownerId, name: longName })).toThrow(ValidationError);
+  });
+
+  it("reconstitutes without emitting events", () => {
+    const original = Team.create({ ownerId, name: "The Smiths" });
+    original.pullEvents(); // drain
+
+    const reconstituted = Team.reconstitute({
+      id: original.id,
+      name: original.name,
+      members: [...original.members],
+      createdAt: original.createdAt,
+    });
+
+    expect(reconstituted.pullEvents()).toHaveLength(0);
+    expect(reconstituted.name).toBe("The Smiths");
+    expect(reconstituted.ownerId).toBe(ownerId);
+  });
+});

--- a/apps/api/src/domain/teams/Team.ts
+++ b/apps/api/src/domain/teams/Team.ts
@@ -1,0 +1,82 @@
+import { TeamId, UserId, InvariantError, ValidationError } from "@snaveevans/pineapple-shared";
+import { DISPLAY_NAME_MAX_LENGTH } from "../identity/User.ts";
+import type { DomainEvent } from "../events/DomainEvent.ts";
+import { TeamCreated } from "./events/TeamCreated.ts";
+
+export type TeamRole = "owner" | "member";
+
+export type TeamMember = {
+  userId: UserId;
+  role: TeamRole;
+};
+
+export class Team {
+  private _domainEvents: DomainEvent[] = [];
+  private _members: TeamMember[];
+
+  private constructor(
+    readonly id: TeamId,
+    public name: string,
+    members: TeamMember[],
+    readonly createdAt: Date,
+  ) {
+    this._members = members;
+  }
+
+  get members(): readonly TeamMember[] {
+    return this._members;
+  }
+
+  get ownerId(): UserId {
+    const owner = this._members.find((member) => member.role === "owner");
+    if (!owner) throw new InvariantError("Team has no owner");
+    return owner.userId;
+  }
+
+  isMember(userId: UserId): boolean {
+    return this._members.some((member) => member.userId === userId);
+  }
+
+  static create(props: { ownerId: UserId; name: string }): Team {
+    const name = Team.#validateName(props.name);
+    const team = new Team(
+      TeamId.generate(),
+      name,
+      [{ userId: props.ownerId, role: "owner" }],
+      new Date(),
+    );
+    team._domainEvents.push(
+      TeamCreated({ teamId: team.id, ownerId: props.ownerId, actorId: props.ownerId, name }),
+    );
+    return team;
+  }
+
+  static reconstitute(props: {
+    id: TeamId;
+    name: string;
+    members: TeamMember[];
+    createdAt: Date;
+  }): Team {
+    return new Team(props.id, props.name, props.members, props.createdAt);
+  }
+
+  pullEvents(): DomainEvent[] {
+    const events = [...this._domainEvents];
+    this._domainEvents = [];
+    return events;
+  }
+
+  static #validateName(name: string): string {
+    const trimmed = name?.trim() ?? "";
+    if (trimmed.length === 0) {
+      throw new ValidationError("Team name is required", "name");
+    }
+    if (trimmed.length > DISPLAY_NAME_MAX_LENGTH) {
+      throw new ValidationError(
+        `Team name must be ${DISPLAY_NAME_MAX_LENGTH} characters or fewer`,
+        "name",
+      );
+    }
+    return trimmed;
+  }
+}

--- a/apps/api/src/domain/teams/TeamRepository.ts
+++ b/apps/api/src/domain/teams/TeamRepository.ts
@@ -1,0 +1,8 @@
+import type { TeamId, UserId } from "@snaveevans/pineapple-shared";
+import type { Team } from "./Team.ts";
+
+export interface TeamRepository {
+  findById(id: TeamId): Promise<Team | null>;
+  findByMemberId(userId: UserId): Promise<Team | null>;
+  save(team: Team): Promise<void>;
+}

--- a/apps/api/src/domain/teams/events/TeamCreated.ts
+++ b/apps/api/src/domain/teams/events/TeamCreated.ts
@@ -1,0 +1,24 @@
+import type { TeamId, UserId } from "@snaveevans/pineapple-shared";
+import { createDomainEventMetadata, type DomainEvent } from "../../events/DomainEvent.ts";
+
+export type TeamCreated = DomainEvent & {
+  type: "TeamCreated";
+  teamId: TeamId;
+  ownerId: UserId;
+  actorId: UserId;
+  name: string;
+};
+
+export const TeamCreated = (props: {
+  teamId: TeamId;
+  ownerId: UserId;
+  actorId: UserId;
+  name: string;
+}): TeamCreated => ({
+  ...createDomainEventMetadata(),
+  type: "TeamCreated",
+  teamId: props.teamId,
+  ownerId: props.ownerId,
+  actorId: props.actorId,
+  name: props.name,
+});

--- a/apps/api/src/infrastructure/persistence/D1TeamRepository.test.ts
+++ b/apps/api/src/infrastructure/persistence/D1TeamRepository.test.ts
@@ -1,0 +1,129 @@
+import { TeamId, UserId } from "@snaveevans/pineapple-shared";
+import { describe, expect, it, vi } from "vitest";
+import { Team } from "../../domain/teams/Team.ts";
+import { D1TeamRepository } from "./D1TeamRepository.ts";
+
+type BoundStatement = {
+  query: string;
+  values: unknown[];
+};
+
+function createDatabaseHarness(
+  options: {
+    teamRow?: { id: string; name: string; created_at: string } | null;
+    memberRows?: { team_id: string; user_id: string; role: string; created_at: string }[];
+  } = {},
+) {
+  const statements: BoundStatement[] = [];
+  const batchedStatements: D1PreparedStatement[][] = [];
+
+  const prepare = vi.fn((query: string) => {
+    return {
+      bind: (...values: unknown[]) => {
+        statements.push({ query, values });
+        return {
+          first: vi
+            .fn()
+            .mockResolvedValue(
+              query.includes("FROM teams WHERE id")
+                ? (options.teamRow ?? null)
+                : query.includes("SELECT team_id FROM team_members")
+                  ? options.teamRow
+                    ? { team_id: options.teamRow.id }
+                    : null
+                  : null,
+            ),
+          all: vi.fn().mockResolvedValue({ results: options.memberRows ?? [] }),
+          run: vi.fn().mockResolvedValue({ success: true }),
+        };
+      },
+    } as unknown as D1PreparedStatement;
+  });
+
+  const batch = vi.fn((stmts: D1PreparedStatement[]) => {
+    batchedStatements.push(stmts);
+    return Promise.resolve(stmts.map(() => ({ success: true })));
+  });
+
+  const db = { prepare, batch } as unknown as D1Database;
+
+  return { db, statements, batchedStatements };
+}
+
+describe("D1TeamRepository", () => {
+  it("findById returns null when no team row exists", async () => {
+    const { db } = createDatabaseHarness();
+
+    const team = await new D1TeamRepository(db).findById(TeamId.generate());
+
+    expect(team).toBeNull();
+  });
+
+  it("findById reconstitutes a team with its members", async () => {
+    const teamId = TeamId.generate();
+    const ownerId = UserId.generate();
+    const { db } = createDatabaseHarness({
+      teamRow: { id: teamId, name: "The Smiths", created_at: "2026-01-01T00:00:00.000Z" },
+      memberRows: [
+        {
+          team_id: teamId,
+          user_id: ownerId,
+          role: "owner",
+          created_at: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+    });
+
+    const team = await new D1TeamRepository(db).findById(teamId);
+
+    expect(team?.name).toBe("The Smiths");
+    expect(team?.ownerId).toBe(ownerId);
+    expect(team?.members).toEqual([{ userId: ownerId, role: "owner" }]);
+  });
+
+  it("findByMemberId returns null when the user belongs to no team", async () => {
+    const { db, statements } = createDatabaseHarness();
+
+    const team = await new D1TeamRepository(db).findByMemberId(UserId.generate());
+
+    expect(team).toBeNull();
+    expect(statements[0]?.query).toContain("SELECT team_id FROM team_members WHERE user_id = ?");
+  });
+
+  it("findByMemberId resolves through the membership row to the full team", async () => {
+    const teamId = TeamId.generate();
+    const ownerId = UserId.generate();
+    const { db } = createDatabaseHarness({
+      teamRow: { id: teamId, name: "The Smiths", created_at: "2026-01-01T00:00:00.000Z" },
+      memberRows: [
+        {
+          team_id: teamId,
+          user_id: ownerId,
+          role: "owner",
+          created_at: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+    });
+
+    const team = await new D1TeamRepository(db).findByMemberId(ownerId);
+
+    expect(team?.id).toBe(teamId);
+    expect(team?.name).toBe("The Smiths");
+  });
+
+  it("save batches a team upsert with one team_members upsert per member", async () => {
+    const { db, batchedStatements, statements } = createDatabaseHarness();
+    const ownerId = UserId.generate();
+    const team = Team.create({ ownerId, name: "The Smiths" });
+    team.pullEvents(); // drain
+
+    await new D1TeamRepository(db).save(team);
+
+    expect(batchedStatements).toHaveLength(1);
+    expect(batchedStatements[0]).toHaveLength(2);
+    expect(statements[0]?.query).toContain("INSERT INTO teams");
+    expect(statements[0]?.values).toEqual([team.id, "The Smiths", team.createdAt.toISOString()]);
+    expect(statements[1]?.query).toContain("INSERT INTO team_members");
+    expect(statements[1]?.values).toEqual([team.id, ownerId, "owner", expect.any(String)]);
+  });
+});

--- a/apps/api/src/infrastructure/persistence/D1TeamRepository.ts
+++ b/apps/api/src/infrastructure/persistence/D1TeamRepository.ts
@@ -1,0 +1,86 @@
+import { TeamId, UserId } from "@snaveevans/pineapple-shared";
+import { Team, type TeamMember, type TeamRole } from "../../domain/teams/Team.ts";
+import type { TeamRepository } from "../../domain/teams/TeamRepository.ts";
+
+type TeamRow = {
+  id: string;
+  name: string;
+  created_at: string;
+};
+
+type TeamMemberRow = {
+  team_id: string;
+  user_id: string;
+  role: string;
+  created_at: string;
+};
+
+export class D1TeamRepository implements TeamRepository {
+  constructor(private readonly db: D1Database) {}
+
+  async findById(id: TeamId): Promise<Team | null> {
+    const row = await this.db
+      .prepare("SELECT id, name, created_at FROM teams WHERE id = ?")
+      .bind(id)
+      .first<TeamRow>();
+    if (!row) return null;
+
+    const memberRows = await this.#findMemberRows(row.id);
+    return this.#rowToTeam(row, memberRows);
+  }
+
+  async findByMemberId(userId: UserId): Promise<Team | null> {
+    const memberRow = await this.db
+      .prepare("SELECT team_id FROM team_members WHERE user_id = ?")
+      .bind(userId)
+      .first<{ team_id: string }>();
+    if (!memberRow) return null;
+
+    return this.findById(TeamId.from(memberRow.team_id));
+  }
+
+  async save(team: Team): Promise<void> {
+    const teamStatement = this.db
+      .prepare(
+        `INSERT INTO teams (id, name, created_at)
+         VALUES (?, ?, ?)
+         ON CONFLICT (id) DO UPDATE SET name = excluded.name`,
+      )
+      .bind(team.id, team.name, team.createdAt.toISOString());
+
+    const now = new Date().toISOString();
+    const memberStatements = team.members.map((member) =>
+      this.db
+        .prepare(
+          `INSERT INTO team_members (team_id, user_id, role, created_at)
+           VALUES (?, ?, ?, ?)
+           ON CONFLICT (team_id, user_id) DO UPDATE SET role = excluded.role`,
+        )
+        .bind(team.id, member.userId, member.role, now),
+    );
+
+    await this.db.batch([teamStatement, ...memberStatements]);
+  }
+
+  async #findMemberRows(teamId: string): Promise<TeamMemberRow[]> {
+    const result = await this.db
+      .prepare("SELECT team_id, user_id, role, created_at FROM team_members WHERE team_id = ?")
+      .bind(teamId)
+      .all<TeamMemberRow>();
+    return result.results;
+  }
+
+  #rowToTeam(row: TeamRow, memberRows: TeamMemberRow[]): Team {
+    const members: TeamMember[] = memberRows.map((memberRow) => ({
+      userId: UserId.from(memberRow.user_id),
+      role: memberRow.role as TeamRole,
+    }));
+
+    return Team.reconstitute({
+      id: TeamId.from(row.id),
+      name: row.name,
+      members,
+      createdAt: new Date(row.created_at),
+    });
+  }
+}

--- a/apps/api/src/infrastructure/telemetry/registerDomainTelemetry.ts
+++ b/apps/api/src/infrastructure/telemetry/registerDomainTelemetry.ts
@@ -7,6 +7,7 @@ import { MaintenanceTaskCreatedTelemetryHandler } from "./maintenance/Maintenanc
 import { MaintenanceTaskDeletedTelemetryHandler } from "./maintenance/MaintenanceTaskDeletedTelemetryHandler.ts";
 import { MaintenanceReminderCreatedTelemetryHandler } from "./notification/MaintenanceReminderCreatedTelemetryHandler.ts";
 import { ReminderEmailDispatchedTelemetryHandler } from "./notification/ReminderEmailDispatchedTelemetryHandler.ts";
+import { TeamCreatedTelemetryHandler } from "./team/TeamCreatedTelemetryHandler.ts";
 import { UserNameUpdatedTelemetryHandler } from "./user/UserNameUpdatedTelemetryHandler.ts";
 import { UserOnboardingCompletedTelemetryHandler } from "./user/UserOnboardingCompletedTelemetryHandler.ts";
 import { UserProvisionedTelemetryHandler } from "./user/UserProvisionedTelemetryHandler.ts";
@@ -18,6 +19,7 @@ export function registerDomainTelemetry(deps: {
   maintenanceTaskDomainDataset: AnalyticsEngineDataset;
   notificationDomainDataset: AnalyticsEngineDataset;
   userDomainDataset: AnalyticsEngineDataset;
+  teamDomainDataset: AnalyticsEngineDataset;
 }): void {
   const assetDomainSink = new AnalyticsEngineTelemetrySink(deps.assetDomainDataset);
   deps.eventBus.subscribe(new AssetCreatedTelemetryHandler(assetDomainSink));
@@ -37,9 +39,10 @@ export function registerDomainTelemetry(deps: {
   deps.eventBus.subscribe(new MaintenanceTaskDeletedTelemetryHandler(maintenanceTaskDomainSink));
   deps.eventBus.subscribe(new MaintenanceTaskAdvancedTelemetryHandler(maintenanceTaskDomainSink));
 
-  const notificationDomainSink = new AnalyticsEngineTelemetrySink(
-    deps.notificationDomainDataset,
-  );
+  const notificationDomainSink = new AnalyticsEngineTelemetrySink(deps.notificationDomainDataset);
   deps.eventBus.subscribe(new MaintenanceReminderCreatedTelemetryHandler(notificationDomainSink));
   deps.eventBus.subscribe(new ReminderEmailDispatchedTelemetryHandler(notificationDomainSink));
+
+  const teamDomainSink = new AnalyticsEngineTelemetrySink(deps.teamDomainDataset);
+  deps.eventBus.subscribe(new TeamCreatedTelemetryHandler(teamDomainSink));
 }

--- a/apps/api/src/infrastructure/telemetry/team/TeamCreatedTelemetryHandler.test.ts
+++ b/apps/api/src/infrastructure/telemetry/team/TeamCreatedTelemetryHandler.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { TeamId, UserId } from "@snaveevans/pineapple-shared";
+import { DomainEventId } from "../../../domain/events/DomainEvent.ts";
+import {
+  TeamCreatedTelemetryHandler,
+  mapTeamCreatedTelemetry,
+} from "./TeamCreatedTelemetryHandler.ts";
+import type { TelemetryDataPoint, TelemetrySink } from "../AnalyticsEngineTelemetrySink.ts";
+import type { TeamCreated } from "../../../domain/teams/events/TeamCreated.ts";
+
+describe("TeamCreatedTelemetryHandler", () => {
+  const event: TeamCreated = {
+    id: DomainEventId.generate(),
+    type: "TeamCreated",
+    teamId: TeamId.from("195d0ef0-47f5-439f-abfd-29f892c9a040"),
+    ownerId: UserId.from("7d914909-c903-41a4-a13a-82cbd0f61851"),
+    actorId: UserId.from("7d914909-c903-41a4-a13a-82cbd0f61851"),
+    name: "The Smiths",
+    occurredAt: new Date("2026-07-10T12:00:00.000Z"),
+  };
+
+  it("maps TeamCreated to the documented Analytics Engine field order, excluding the PII-bearing name", () => {
+    expect(mapTeamCreatedTelemetry(event)).toEqual({
+      indexes: [event.ownerId],
+      blobs: [
+        "TeamCreated",
+        "Team",
+        event.teamId,
+        event.ownerId,
+        event.actorId,
+        "CreateTeam",
+        "v1",
+        "success",
+      ],
+      doubles: [1, event.occurredAt.getTime()],
+    });
+  });
+
+  it("writes mapped data points to the sink", () => {
+    const writes: TelemetryDataPoint[] = [];
+    const sink: TelemetrySink = {
+      write: (dataPoint) => {
+        writes.push(dataPoint);
+      },
+    };
+
+    new TeamCreatedTelemetryHandler(sink).handle(event);
+
+    expect(writes).toEqual([mapTeamCreatedTelemetry(event)]);
+  });
+});

--- a/apps/api/src/infrastructure/telemetry/team/TeamCreatedTelemetryHandler.ts
+++ b/apps/api/src/infrastructure/telemetry/team/TeamCreatedTelemetryHandler.ts
@@ -1,0 +1,30 @@
+import type { DomainEventHandler } from "../../../application/ports/EventBus.ts";
+import type { TeamCreated } from "../../../domain/teams/events/TeamCreated.ts";
+import type { TelemetryDataPoint, TelemetrySink } from "../AnalyticsEngineTelemetrySink.ts";
+
+export function mapTeamCreatedTelemetry(event: TeamCreated): TelemetryDataPoint {
+  return {
+    indexes: [event.ownerId],
+    blobs: [
+      event.type,
+      "Team",
+      event.teamId,
+      event.ownerId,
+      event.actorId,
+      "CreateTeam",
+      "v1",
+      "success",
+    ],
+    doubles: [1, event.occurredAt.getTime()],
+  };
+}
+
+export class TeamCreatedTelemetryHandler implements DomainEventHandler<TeamCreated> {
+  readonly eventType = "TeamCreated" as const;
+
+  constructor(private readonly sink: TelemetrySink) {}
+
+  handle(event: TeamCreated): void {
+    this.sink.write(mapTeamCreatedTelemetry(event));
+  }
+}

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -30,6 +30,7 @@ import { D1MaintenanceRecordRepository } from "./infrastructure/persistence/D1Ma
 import { D1MaintenanceTaskRepository } from "./infrastructure/persistence/D1MaintenanceTaskRepository.ts";
 import { D1NotificationRepository } from "./infrastructure/persistence/D1NotificationRepository.ts";
 import { D1ReminderSweepStore } from "./infrastructure/persistence/D1ReminderSweepStore.ts";
+import { D1TeamRepository } from "./infrastructure/persistence/D1TeamRepository.ts";
 import { D1ActivityLogRepository } from "./infrastructure/activity/D1ActivityLogRepository.ts";
 import { D1ActivityOutboxRepository } from "./infrastructure/activity/D1ActivityOutboxRepository.ts";
 import { handleActivityQueueBatch } from "./infrastructure/activity/ActivityQueueConsumer.ts";
@@ -76,6 +77,9 @@ import { ListNotifications } from "./application/usecases/ListNotifications.ts";
 import { MarkNotificationRead } from "./application/usecases/MarkNotificationRead.ts";
 import { MarkAllNotificationsRead } from "./application/usecases/MarkAllNotificationsRead.ts";
 import { SweepMaintenanceReminders } from "./application/usecases/SweepMaintenanceReminders.ts";
+import { CreateTeam } from "./application/usecases/CreateTeam.ts";
+import { GetMyTeam } from "./application/usecases/GetMyTeam.ts";
+import type { TeamWithMembers } from "./application/teams/TeamReadModel.ts";
 import { D1VerificationTokenRepository } from "./infrastructure/persistence/D1VerificationTokenRepository.ts";
 import { D1VerificationSendLog } from "./infrastructure/persistence/D1VerificationSendLog.ts";
 import { SystemClock } from "./infrastructure/time/SystemClock.ts";
@@ -112,6 +116,8 @@ import {
   searchAssetsRoute,
   updateUserProfileRoute,
   registerOpenApiComponents,
+  createTeamRoute,
+  getMyTeamRoute,
 } from "./api/openapi.ts";
 import openApiSpec from "../../../docs/reference/openapi.json";
 import type { AssetResponseSchema } from "./api/schemas/assetSchemas.ts";
@@ -124,6 +130,7 @@ import type {
   NotificationSchema,
 } from "./api/schemas/notificationSchemas.ts";
 import type { UserProfileResponseSchema } from "./api/schemas/userProfileSchemas.ts";
+import type { MyTeamResponseSchema, TeamResponseSchema } from "./api/schemas/teamSchemas.ts";
 import type { MaintenanceTask } from "./domain/maintenance/MaintenanceTask.ts";
 import { deriveTaskStatus } from "./domain/maintenance/TaskUrgency.ts";
 import type { z } from "@hono/zod-openapi";
@@ -135,6 +142,7 @@ type Bindings = AuthEnv & {
   MAINTENANCE_TASK_DOMAIN_TELEMETRY: AnalyticsEngineDataset;
   NOTIFICATION_DOMAIN_TELEMETRY: AnalyticsEngineDataset;
   USER_DOMAIN_TELEMETRY: AnalyticsEngineDataset;
+  TEAM_DOMAIN_TELEMETRY: AnalyticsEngineDataset;
   API_REQUEST_TELEMETRY: AnalyticsEngineDataset;
   ACTIVITY_HISTORY_QUEUE: Queue<ActivityEventMessage>;
   NOTIFICATION_EVENTS_QUEUE: Queue<NotificationEventMessage>;
@@ -254,6 +262,20 @@ function serializeMaintenanceTask(
     status: deriveTaskStatus(task.nextDue, todayUtc, sevenDaysOut),
     daysDue: calendarDaysBetween(todayUtc, task.nextDue),
     createdAt: task.createdAt.toISOString(),
+  };
+}
+
+function serializeTeam(team: TeamWithMembers): z.infer<typeof TeamResponseSchema> {
+  return {
+    id: team.id,
+    name: team.name,
+    ownerId: team.ownerId,
+    members: team.members.map((member) => ({
+      userId: member.userId,
+      name: member.name,
+      role: member.role,
+    })),
+    createdAt: team.createdAt.toISOString(),
   };
 }
 
@@ -416,6 +438,7 @@ function buildDomainEventBus(env: Bindings): EventBus {
     maintenanceTaskDomainDataset: env.MAINTENANCE_TASK_DOMAIN_TELEMETRY,
     notificationDomainDataset: env.NOTIFICATION_DOMAIN_TELEMETRY,
     userDomainDataset: env.USER_DOMAIN_TELEMETRY,
+    teamDomainDataset: env.TEAM_DOMAIN_TELEMETRY,
   });
   return eventBus;
 }
@@ -605,6 +628,35 @@ app.openapi(searchAssetsRoute, async (c) => {
   });
   if (!result.ok) throw result.error;
   return c.json({ results: result.value }, 200);
+});
+
+// ── Team endpoints ───────────────────────────────────────────────────────────
+
+app.openapi(createTeamRoute, async (c) => {
+  const user = c.get("user");
+  const { name } = c.req.valid("json");
+  const result = await new CreateTeam(
+    new D1TeamRepository(c.env.DB),
+    new D1UserRepository(c.env.DB),
+    c.get("eventBus"),
+  ).execute({ requesterId: user.id, name });
+  if (!result.ok) throw result.error;
+  return c.json(serializeTeam(result.value), 201);
+});
+
+app.openapi(getMyTeamRoute, async (c) => {
+  const user = c.get("user");
+  const result = await new GetMyTeam(
+    new D1TeamRepository(c.env.DB),
+    new D1UserRepository(c.env.DB),
+  ).execute({ requesterId: user.id });
+  if (!result.ok) throw result.error;
+  return c.json(
+    {
+      team: result.value.team ? serializeTeam(result.value.team) : null,
+    } satisfies z.infer<typeof MyTeamResponseSchema>,
+    200,
+  );
 });
 
 // ── Maintenance record endpoints ────────────────────────────────────────────

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -73,6 +73,10 @@ binding = "NOTIFICATION_DOMAIN_TELEMETRY"
 dataset = "pineapple_notification_domain_events"
 
 [[analytics_engine_datasets]]
+binding = "TEAM_DOMAIN_TELEMETRY"
+dataset = "pineapple_team_domain_events"
+
+[[analytics_engine_datasets]]
 binding = "API_REQUEST_TELEMETRY"
 dataset = "pineapple_api_request_events"
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,6 +53,16 @@ index; the root `README.md` keeps the doc map. When you add a doc, add the link.
 **Prose over cleverness.** Short sentences, concrete examples, real values.
 Assume the reader is competent but new to _this_ project.
 
+**Future work lives in the issue tracker, not the repo.** The codebase reflects
+the app's _current state_ and the _decisions_ behind it (ADRs). Planned, proposed,
+or deferred work — backlog items, follow-ups, tech-debt, "fix this later" notes —
+is tracked as **GitHub issues**, not as in-repo TODO or backlog documents. This
+keeps specs and docs describing what _is_, not what _might be_, and gives future
+work real triage (labels, assignees, close-on-merge). It extends the
+one-home-per-fact method of [ADR-0008](decisions/0008-documentation-method.md).
+The lone exception is `docs/specs/backlog/archive-asset.md`, a parked spec that
+predates this convention and will be migrated.
+
 ## The generated API spec
 
 `docs/reference/openapi.json` is produced from the Zod route specs in

--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -43,6 +43,10 @@
     {
       "name": "Notifications",
       "description": "Authenticated durable notification inbox and read lifecycle"
+    },
+    {
+      "name": "Teams",
+      "description": "Create and read the caller's team (ADR-0015 teams foundation)"
     }
   ],
   "components": {
@@ -1252,6 +1256,99 @@
         },
         "required": [
           "unreadCount"
+        ]
+      },
+      "TeamMember": {
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": "string",
+            "example": "7d914909-c903-41a4-a13a-82cbd0f61851"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true,
+            "example": "Dale"
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "owner",
+              "member"
+            ],
+            "example": "owner"
+          }
+        },
+        "required": [
+          "userId",
+          "name",
+          "role"
+        ]
+      },
+      "Team": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "example": "195d0ef0-47f5-439f-abfd-29f892c9a040"
+          },
+          "name": {
+            "type": "string",
+            "example": "The Smiths"
+          },
+          "ownerId": {
+            "type": "string",
+            "example": "7d914909-c903-41a4-a13a-82cbd0f61851"
+          },
+          "members": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TeamMember"
+            }
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2026-07-10T03:25:24.887Z"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "ownerId",
+          "members",
+          "createdAt"
+        ]
+      },
+      "CreateTeamBody": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "example": "The Smiths"
+          }
+        },
+        "required": [
+          "name"
+        ]
+      },
+      "MyTeamResponse": {
+        "type": "object",
+        "properties": {
+          "team": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Team"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          }
+        },
+        "required": [
+          "team"
         ]
       }
     },
@@ -2476,6 +2573,108 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/MarkAllNotificationsReadResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/teams": {
+      "post": {
+        "tags": [
+          "Teams"
+        ],
+        "summary": "Create a team",
+        "description": "Creates a team owned solely by the caller. A user belongs to at most one team.",
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateTeamBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Team created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Team"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The requester already belongs to a team",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/teams/me": {
+      "get": {
+        "tags": [
+          "Teams"
+        ],
+        "summary": "Get the caller's team",
+        "description": "Returns the caller's team and members, or `{ team: null }` when the caller has no team.",
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The caller's team, or null",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MyTeamResponse"
                 }
               }
             }

--- a/docs/specs/SPECS.md
+++ b/docs/specs/SPECS.md
@@ -1,4 +1,4 @@
-> **Audience:** everyone · **Purpose:** authoritative map of all feature and cross-cutting specs · **Source of truth:** this file · **Last reviewed:** 2026-07-02
+> **Audience:** everyone · **Purpose:** authoritative map of all feature and cross-cutting specs · **Source of truth:** this file · **Last reviewed:** 2026-07-03
 
 # Spec Index
 
@@ -43,12 +43,18 @@ relevant cross-cutting specs rather than re-describing the behavior.
 | [user-profile.md](./features/user-profile.md)                 | Identity      | active |
 | [email-verification.md](./features/email-verification.md)     | Identity      | active |
 | [telemetry-enrichment.md](./features/telemetry-enrichment.md) | Observability | draft  |
+| [teams-foundation.md](./features/teams-foundation.md)         | Teams         | draft  |
 
 ## Backlog (parked specs)
 
-Preserved design thinking that is **not** part of any active work. Parked specs live in
-`backlog/` and are excluded from the active feature set above. Reactivate one by moving it into
-`features/` and adding a row to the table above.
+**Backlog and future work now live in GitHub issues, not this repo.** The codebase reflects
+the current state of the app and the decisions behind it (ADRs); planned, proposed, or deferred
+work is tracked as issues. See the convention in [`docs/README.md`](../README.md).
+
+The `backlog/` folder is retained only for the one grandfathered **parked spec** below —
+preserved design thinking that predates this convention. Do **not** add new deferrals here; file
+an issue instead. Reactivate the parked spec by moving it into `features/` and adding a row to
+the table above.
 
 | Spec                                           | Area   | Why parked                                                                                                                                                                     |
 | ---------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |

--- a/docs/specs/SPECS.md
+++ b/docs/specs/SPECS.md
@@ -43,7 +43,7 @@ relevant cross-cutting specs rather than re-describing the behavior.
 | [user-profile.md](./features/user-profile.md)                 | Identity      | active |
 | [email-verification.md](./features/email-verification.md)     | Identity      | active |
 | [telemetry-enrichment.md](./features/telemetry-enrichment.md) | Observability | draft  |
-| [teams-foundation.md](./features/teams-foundation.md)         | Teams         | draft  |
+| [teams-foundation.md](./features/teams-foundation.md)         | Teams         | review |
 
 ## Backlog (parked specs)
 

--- a/docs/specs/SPECS.md
+++ b/docs/specs/SPECS.md
@@ -95,3 +95,22 @@ docs/specs/
 
 **After a PR merges:** run `prompts/pr-sync.md` against the diff to classify
 changes and update the spec if behavior changed.
+
+## Spec lifecycle & acceptance criteria
+
+A spec's **`status`** tracks its lifecycle: `draft` (being written) → `wip` (incomplete, not
+yet ready to implement) → `review` (complete, ready to implement) → `active` (implemented and
+live on `main`); `deprecated` when retired.
+
+The **acceptance-criteria checkboxes are the live implementation checklist.** A box is checked
+(`- [x]`) **only when its behavior is implemented and covered by a test on `main`** — not when
+code is merely written. The spec advances to `active` once every box is checked. This keeps the
+remaining work visible in the spec itself, so anyone (including a cold agent) can resume without
+relying on external notes.
+
+**Large specs are implemented in slices.** When a spec is too big for one PR, split the work
+into vertical slices, each tracked as a GitHub issue (see Backlog). The spec file stays whole;
+each slice PR implements one coherent group of criteria and checks off **only** the boxes it
+lands, including that spec edit in the same PR. Because criteria are grouped by concern, slices
+usually own disjoint groups, so checkmarks rarely conflict. The spec becomes `active` when the
+final slice checks the last box.

--- a/docs/specs/cross-cutting/telemetry.md
+++ b/docs/specs/cross-cutting/telemetry.md
@@ -21,10 +21,10 @@ Telemetry is split into two independent systems: request-level telemetry (every 
 
 ### Two Systems
 
-| System       | Dataset                         | Trigger                             | Capture point                        |
-| ------------ | ------------------------------- | ----------------------------------- | ------------------------------------ |
-| API Request  | `pineapple_api_request_events`  | Every HTTP request                  | `createTechnicalTelemetryMiddleware` |
-| Domain Event | Per-domain datasets (asset, user, maintenance, notification) | Domain event published to event bus | Per-event telemetry handler          |
+| System       | Dataset                                                            | Trigger                             | Capture point                        |
+| ------------ | ------------------------------------------------------------------ | ----------------------------------- | ------------------------------------ |
+| API Request  | `pineapple_api_request_events`                                     | Every HTTP request                  | `createTechnicalTelemetryMiddleware` |
+| Domain Event | Per-domain datasets (asset, user, maintenance, notification, team) | Domain event published to event bus | Per-event telemetry handler          |
 
 The two systems are complementary, not interchangeable. API request telemetry answers operational questions (latency, error rates, traffic). Domain event telemetry answers business questions (what entities were created, by whom, with what attributes).
 
@@ -81,6 +81,24 @@ Both systems write to Cloudflare Analytics Engine using the same envelope:
 | `doubles[1]` | `event_time_ms`    | Event timestamp (ms since epoch)                                               |
 | `doubles[2]` | `asset_model_year` | Model year for vehicles; `0` for other asset types                             |
 
+**Domain event data point — `TeamCreated`** (dataset: `pineapple_team_domain_events`, index: `owner_id`):
+
+| Field        | Name              | Value                                                                          |
+| ------------ | ----------------- | ------------------------------------------------------------------------------ |
+| `indexes[0]` | —                 | `owner_id` (the creator; partition key for per-owner queries)                  |
+| `blobs[0]`   | `event_type`      | `"TeamCreated"`                                                                |
+| `blobs[1]`   | `aggregate_type`  | `"Team"`                                                                       |
+| `blobs[2]`   | `team_id`         | Team UUID                                                                      |
+| `blobs[3]`   | `owner_id`        | Owner UUID (the team's sole member at creation)                                |
+| `blobs[4]`   | `actor_id`        | UUID of the user who performed the action — currently always equals `owner_id` |
+| `blobs[5]`   | `source_use_case` | `"CreateTeam"`                                                                 |
+| `blobs[6]`   | `schema_version`  | `"v1"`                                                                         |
+| `blobs[7]`   | `result`          | `"success"`                                                                    |
+| `doubles[0]` | `count`           | Always `1`                                                                     |
+| `doubles[1]` | `event_time_ms`   | Event timestamp (ms since epoch)                                               |
+
+The team's user-supplied `name` is intentionally excluded from blobs (PII — see Anti-Patterns).
+
 **Domain event data point — `MaintenanceRecordCreated`** (dataset: `pineapple_maintenance_domain_events`, index: `owner_id`):
 
 | Field        | Name                    | Value                                                   |
@@ -113,34 +131,35 @@ These limits apply to every data point written and must be respected when design
 
 ### Planned Datasets
 
-| Dataset                               | Binding                        | Purpose                                 |
-| ------------------------------------- | ------------------------------ | --------------------------------------- |
-| `pineapple_asset_domain_events`       | `ASSET_DOMAIN_TELEMETRY`       | Asset lifecycle events — implemented    |
-| `pineapple_api_request_events`        | `API_REQUEST_TELEMETRY`        | HTTP request telemetry — implemented    |
-| `pineapple_user_domain_events`        | `USER_DOMAIN_TELEMETRY`        | User lifecycle events — planned         |
-| `pineapple_maintenance_domain_events` | `MAINTENANCE_DOMAIN_TELEMETRY` | Maintenance record events — implemented |
+| Dataset                                | Binding                         | Purpose                                                       |
+| -------------------------------------- | ------------------------------- | ------------------------------------------------------------- |
+| `pineapple_asset_domain_events`        | `ASSET_DOMAIN_TELEMETRY`        | Asset lifecycle events — implemented                          |
+| `pineapple_api_request_events`         | `API_REQUEST_TELEMETRY`         | HTTP request telemetry — implemented                          |
+| `pineapple_user_domain_events`         | `USER_DOMAIN_TELEMETRY`         | User lifecycle events — planned                               |
+| `pineapple_maintenance_domain_events`  | `MAINTENANCE_DOMAIN_TELEMETRY`  | Maintenance record events — implemented                       |
 | `pineapple_notification_domain_events` | `NOTIFICATION_DOMAIN_TELEMETRY` | Notification reminder and email delivery events — implemented |
+| `pineapple_team_domain_events`         | `TEAM_DOMAIN_TELEMETRY`         | Team lifecycle events — implemented                           |
 
 ### Notification Domain Event Data Points
 
 **`MaintenanceReminderCreated`** (dataset: `pineapple_notification_domain_events`, index:
 `owner_id`):
 
-| Field        | Name                  | Value                                           |
-| ------------ | --------------------- | ----------------------------------------------- |
-| `indexes[0]` | —                     | `owner_id`                                      |
-| `blobs[0]`   | `event_type`          | `"MaintenanceReminderCreated"`                  |
-| `blobs[1]`   | `aggregate_type`      | `"Notification"`                                |
-| `blobs[2]`   | `notification_id`     | Notification UUID                               |
-| `blobs[3]`   | `notification_type`   | `"maintenance_due_soon"`                        |
-| `blobs[4]`   | `maintenance_task_id` | Task UUID                                       |
-| `blobs[5]`   | `asset_id`            | Asset UUID                                      |
-| `blobs[6]`   | `owner_id`            | Owner UUID                                      |
-| `blobs[7]`   | `actor_id`            | `"system"`                                      |
-| `blobs[8]`   | `schema_version`      | `"v1"`                                          |
-| `blobs[9]`   | `result`              | `"success"`                                     |
-| `doubles[0]` | `count`               | Always `1`                                      |
-| `doubles[1]` | `event_time_ms`       | Event timestamp (ms since epoch)                |
+| Field        | Name                  | Value                                             |
+| ------------ | --------------------- | ------------------------------------------------- |
+| `indexes[0]` | —                     | `owner_id`                                        |
+| `blobs[0]`   | `event_type`          | `"MaintenanceReminderCreated"`                    |
+| `blobs[1]`   | `aggregate_type`      | `"Notification"`                                  |
+| `blobs[2]`   | `notification_id`     | Notification UUID                                 |
+| `blobs[3]`   | `notification_type`   | `"maintenance_due_soon"`                          |
+| `blobs[4]`   | `maintenance_task_id` | Task UUID                                         |
+| `blobs[5]`   | `asset_id`            | Asset UUID                                        |
+| `blobs[6]`   | `owner_id`            | Owner UUID                                        |
+| `blobs[7]`   | `actor_id`            | `"system"`                                        |
+| `blobs[8]`   | `schema_version`      | `"v1"`                                            |
+| `blobs[9]`   | `result`              | `"success"`                                       |
+| `doubles[0]` | `count`               | Always `1`                                        |
+| `doubles[1]` | `event_time_ms`       | Event timestamp (ms since epoch)                  |
 | `doubles[2]` | `lead_days`           | Whole calendar days between creation and due date |
 
 **`ReminderEmailDispatched`** (dataset: `pineapple_notification_domain_events`, index:
@@ -164,37 +183,39 @@ These limits apply to every data point written and must be respected when design
 
 Every API route maps to a named operation used as the `indexes[0]` value in request telemetry. The current mapping:
 
-| Route                                                     | Operation                 |
-| --------------------------------------------------------- | ------------------------- |
-| `POST /api/auth/sign-in/social`                           | `SignIn`                  |
-| `GET /api/auth/callback/google`                           | `OAuthCallback`           |
-| `GET /api/auth/get-session`                               | `SessionCheck`            |
-| `POST /api/auth/sign-out`                                 | `SignOut`                 |
-| `/api/auth/*` (other)                                     | `Auth`                    |
-| `POST /api/assets`                                        | `CreateAsset`             |
-| `GET /api/assets`                                         | `ListAssets`              |
-| `GET /api/assets/{id}`                                    | `GetAsset`                |
-| `GET /api/activity`                                       | `ListActivity`            |
-| `GET /api/dashboard`                                      | `GetDashboard`            |
-| `GET /api/search`                                         | `SearchAssets`            |
-| `GET /api/users/me`                                       | `GetUserProfile`          |
-| `PATCH /api/users/me`                                     | `UpdateUserProfile`       |
-| `PUT /api/users/me/notification-email`                    | `SetNotificationEmail`    |
-| `DELETE /api/users/me/notification-email`                 | `RemoveNotificationEmail` |
+| Route                                                     | Operation                  |
+| --------------------------------------------------------- | -------------------------- |
+| `POST /api/auth/sign-in/social`                           | `SignIn`                   |
+| `GET /api/auth/callback/google`                           | `OAuthCallback`            |
+| `GET /api/auth/get-session`                               | `SessionCheck`             |
+| `POST /api/auth/sign-out`                                 | `SignOut`                  |
+| `/api/auth/*` (other)                                     | `Auth`                     |
+| `POST /api/assets`                                        | `CreateAsset`              |
+| `GET /api/assets`                                         | `ListAssets`               |
+| `GET /api/assets/{id}`                                    | `GetAsset`                 |
+| `GET /api/activity`                                       | `ListActivity`             |
+| `GET /api/dashboard`                                      | `GetDashboard`             |
+| `GET /api/search`                                         | `SearchAssets`             |
+| `GET /api/users/me`                                       | `GetUserProfile`           |
+| `PATCH /api/users/me`                                     | `UpdateUserProfile`        |
+| `PUT /api/users/me/notification-email`                    | `SetNotificationEmail`     |
+| `DELETE /api/users/me/notification-email`                 | `RemoveNotificationEmail`  |
 | `POST /api/users/me/notification-email/verification`      | `RequestEmailVerification` |
 | `POST /api/verify-email`                                  | `ConfirmEmailVerification` |
-| `GET /api/notifications`                                  | `ListNotifications`       |
-| `POST /api/notifications/{notificationId}/read`            | `MarkNotificationRead`    |
-| `POST /api/notifications/read-all`                         | `MarkAllNotificationsRead` |
-| `POST /api/assets/{assetId}/maintenance-records`          | `CreateMaintenanceRecord` |
-| `GET /api/assets/{assetId}/maintenance-records`           | `ListMaintenanceRecords`  |
-| `POST /api/assets/{assetId}/maintenance-tasks`            | `CreateMaintenanceTask`   |
-| `GET /api/assets/{assetId}/maintenance-tasks`             | `ListMaintenanceTasks`    |
-| `DELETE /api/assets/{assetId}/maintenance-tasks/{taskId}` | `DeleteMaintenanceTask`   |
-| `GET /health`                                             | `Health`                  |
-| `GET /openapi.json`                                       | `OpenApiDocument`         |
-| `GET /reference`                                          | `ApiReference`            |
-| (anything else)                                           | `Unknown`                 |
+| `GET /api/notifications`                                  | `ListNotifications`        |
+| `POST /api/notifications/{notificationId}/read`           | `MarkNotificationRead`     |
+| `POST /api/notifications/read-all`                        | `MarkAllNotificationsRead` |
+| `POST /api/assets/{assetId}/maintenance-records`          | `CreateMaintenanceRecord`  |
+| `GET /api/assets/{assetId}/maintenance-records`           | `ListMaintenanceRecords`   |
+| `POST /api/assets/{assetId}/maintenance-tasks`            | `CreateMaintenanceTask`    |
+| `GET /api/assets/{assetId}/maintenance-tasks`             | `ListMaintenanceTasks`     |
+| `DELETE /api/assets/{assetId}/maintenance-tasks/{taskId}` | `DeleteMaintenanceTask`    |
+| `POST /api/teams`                                         | `CreateTeam`               |
+| `GET /api/teams/me`                                       | `GetMyTeam`                |
+| `GET /health`                                             | `Health`                   |
+| `GET /openapi.json`                                       | `OpenApiDocument`          |
+| `GET /reference`                                          | `ApiReference`             |
+| (anything else)                                           | `Unknown`                  |
 
 ### Failure Policy
 

--- a/docs/specs/features/teams-foundation.md
+++ b/docs/specs/features/teams-foundation.md
@@ -48,15 +48,6 @@ authoritative in `openapi.json`.
 
 ## Acceptance Criteria
 
-> **Implementation status (live checklist).** These boxes track the build. A box is checked
-> only once its behavior is implemented **and covered by a test** on `main`; the spec's `status`
-> advances to `active` when all are checked. The feature ships in slices, so boxes are checked
-> across several PRs — in order: the **Team creation** and **Reading your team** groups first
-> (team + membership core), then **Sharing & unsharing**, **Member access to shared assets**,
-> **Read-path integration**, and **Permissions extension** (sharing + access). The web surface
-> is tracked separately in [`docs/web/FEATURES.md`](../../web/FEATURES.md). Each PR checks off
-> only the criteria it lands, so any reader can see remaining work at a glance.
-
 **Team creation**
 
 - [ ] An authenticated user who belongs to no team can create a team by providing a **name**; on success they become the team's **owner** and its only member

--- a/docs/specs/features/teams-foundation.md
+++ b/docs/specs/features/teams-foundation.md
@@ -1,0 +1,188 @@
+---
+name: teams-foundation
+description: The foundation for teams — creating a team, the membership model, and sharing/unsharing individual assets so members can see and edit them
+metadata:
+  type: feature
+---
+
+# Teams Foundation
+
+**Status:** draft
+**Owner:** [unknown — assign on review]
+**Last Updated:** 2026-07-03
+**Related Specs:** [ADR-0015](../../decisions/0015-teams-as-opt-in-sharing-scope.md), [authentication.md](../cross-cutting/authentication.md), [permissions.md](../cross-cutting/permissions.md), [validation.md](../cross-cutting/validation.md), [error-handling.md](../cross-cutting/error-handling.md), [loading-states.md](../cross-cutting/loading-states.md), [telemetry.md](../cross-cutting/telemetry.md), [asset-library.md](./asset-library.md), [dashboard.md](./dashboard.md), [app-search.md](./app-search.md)
+
+---
+
+## Summary
+
+This feature introduces **teams** as an opt-in sharing scope on top of the existing
+per-user ownership model (see [ADR-0015](../../decisions/0015-teams-as-opt-in-sharing-scope.md)).
+Today every asset is private to the user who created it. This spec lets a user
+**create a team**, and lets an asset's owner **share individual assets to that team**
+so that the team's members can see and help maintain them. Everything a user does not
+explicitly share stays personal and private, exactly as before.
+
+It is deliberately the **foundation** — the sharing mechanism — not the whole team
+experience. It defines what a team is, what membership grants, and how sharing works,
+but it does **not** cover how a second person joins a team (invitations) or how a team
+is administered (removing members, leaving, transferring, renaming, deleting). Those are
+separate specs. Until the invitations spec lands, a team has exactly one member — its
+creator — so sharing is fully functional but not yet observable by a second person. This
+is the intended land-the-mechanism-first sequencing.
+
+This feature has a web UI (a create-team affordance, a per-asset share/unshare control,
+and a "my team" view). UX intent for those screens belongs in
+[`docs/web/FEATURES.md`](../../web/FEATURES.md); the implemented API contract is
+authoritative in `openapi.json`.
+
+## User Stories
+
+- As a **user with no team**, I can **create a team and give it a name** so that **I have a shared space to put assets in**
+- As an **asset owner**, I can **share one of my assets to my team** so that **its members can see and help maintain it**
+- As an **asset owner**, I can **unshare an asset** so that **it becomes private to me again**
+- As a **team member**, I can **see and edit the assets shared with my team** so that **I can help maintain them as if they were my own**
+- As a **team member**, I can **view my team and who belongs to it** so that **I know who I'm sharing with**
+- As a **user already in a team**, I am **prevented from creating a second team** so that **the one-team-per-user rule holds**
+- As a **non-owner member**, I am **prevented from changing an asset's sharing** so that **only the asset's owner controls whether it is shared**
+
+## Acceptance Criteria
+
+**Team creation**
+
+- [ ] An authenticated user who belongs to no team can create a team by providing a **name**; on success they become the team's **owner** and its only member
+- [ ] Creating a team when the requester already belongs to a team (as owner or member) fails with **409 Conflict** and no team is created
+- [ ] The team name is **required**, trimmed, and bounded by a maximum length (see Validation); an invalid name fails with **422** before any team is created
+- [ ] A new team starts with exactly one membership: the creator, with role `owner`
+
+**Reading your team**
+
+- [ ] A member can read their own team, including its name and the list of members with each member's display name and role
+- [ ] A user who belongs to no team gets an explicit "no team" result (not an error), so the client can render a create-team prompt
+
+**Sharing & unsharing (asset-owner only)**
+
+- [ ] The **owner of an asset** can share that asset to the team they belong to; after sharing, the asset is visible and editable to every member of that team
+- [ ] Sharing requires the requester to belong to a team; sharing when the requester has no team fails with a **409 Conflict** (there is nothing to share into)
+- [ ] Only the asset's owner may share or unshare it — a member who does not own the asset attempting to change its sharing fails with **403 Forbidden**
+- [ ] The asset owner can unshare a shared asset, returning it to **personal**; members immediately lose access
+- [ ] Sharing an asset that is already shared to the caller's team is an idempotent success (no duplicate, no error); unsharing an already-personal asset is an idempotent success
+- [ ] "Owner" here means the **asset's** owner (`ownerId`), which may be any team member — not necessarily the team's owner. Any member can share the assets **they** own
+
+**Member access to shared assets (full parity)**
+
+- [ ] A team member can read an asset shared with their team and all of its dependent records (maintenance tasks, maintenance records, activity)
+- [ ] A team member can perform the same **write** actions on a shared asset that its owner can — add, edit, and delete maintenance tasks, and log maintenance records — with the sole exceptions of changing its sharing and deleting the asset itself, which remain asset-owner-only
+- [ ] Access to a shared asset's dependent records **follows the asset**: authorization for maintenance/record/activity operations is determined by whether the requester can access the parent asset (owns it, or is a member of the team it is shared with), replacing the direct `ownerId === requesterId` check on those operations
+- [ ] When an asset is unshared, or a member's access otherwise ends, subsequent requests by that member for the asset or its records behave as if the asset does not exist for them
+
+**Read-path integration**
+
+- [ ] Every list of "the user's assets" — the asset library (`GET /api/assets`), the dashboard, and search — returns both the requester's own assets (personal and shared-by-them) **and** the assets shared to the requester's team by others
+- [ ] Each asset in a read model carries a computed **`sharing`** descriptor (computed server-side per ADR-0009, not derived by the client): its scope (`personal` or `team`) and whether the requester is its owner; for an asset shared **with** the requester by someone else, it also identifies the owner (e.g. owner display name) so the member can see whose asset it is
+- [ ] Per-category counts and any other aggregate read-model figures are computed over the full visible set (owned + shared-with-me), so counts and lists stay consistent
+
+**Permissions extension**
+
+- [ ] The single-resource access rule is extended: a request for an asset (or its children) succeeds if the requester **owns it** _or_ **is a member of the team it is shared with**; otherwise the existing not-owned behavior applies
+- [ ] The collection query is extended to include team-shared assets in addition to owned ones; it must never return an asset that is neither owned by nor shared with the requester
+- [ ] [permissions.md](../cross-cutting/permissions.md) must be updated to document team visibility as an extension of the ownership model (per-user ownership remains the default; team sharing is additive)
+
+## Edge Cases & Error States
+
+| Scenario                                                      | Expected Behavior                                                                              |
+| ------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| Create team while already in a team (owner or member)         | 409 Conflict; no team created                                                                  |
+| Create team with empty/whitespace name                        | 422 Validation error mapped to the name field                                                  |
+| Create team with an over-length name                          | 422 Validation error mapped to the name field                                                  |
+| Read "my team" when the user has no team                      | 200 with an explicit "no team" result; client shows create-team prompt                         |
+| Share an asset the requester does not own                     | 403 Forbidden (owner-only), or 404 if the asset is not visible to the requester at all         |
+| Share an asset when the requester has no team                 | 409 Conflict (nothing to share into)                                                           |
+| Share an asset already shared to the caller's team            | Idempotent success (no duplicate)                                                              |
+| Unshare an asset that is already personal                     | Idempotent success                                                                             |
+| Non-owner member tries to unshare a shared asset              | 403 Forbidden (only the asset owner controls sharing)                                          |
+| Member reads/edits an asset shared with their team            | Succeeds; changes are visible to the owner and other members                                   |
+| Member deletes a maintenance task on a shared asset           | Succeeds (full parity)                                                                         |
+| Member tries to delete the shared asset itself                | Not permitted — asset deletion is asset-owner-only (and asset deletion is not yet implemented) |
+| Request an asset shared to a team the requester is **not** in | Treated as not visible (see Flags: 403-vs-404 inherits the permissions.md known issue)         |
+| Asset is unshared while a member has it open                  | The member's next request behaves as if the asset does not exist for them                      |
+| Unauthenticated request to any endpoint here                  | 401 Unauthorized → client redirects to `/login`                                                |
+
+## API Shape (design target)
+
+The implemented contract is authoritative in `openapi.json` once built; this describes the
+intended design, not a second source of truth. A user belongs to at most one team, so
+sharing endpoints target the caller's team implicitly — no team id is supplied by the caller.
+
+- **`POST /api/teams`** — create a team. Body: `{ "name": string }`. Auth required. Returns the created team: `{ id, name, ownerId, members: [{ userId, name, role }], createdAt }`. Errors: **409** (requester already in a team), **422** (invalid name), **401**.
+- **`GET /api/teams/me`** — the caller's team with members, or an explicit empty result when the caller has no team (e.g. `{ "team": null }` with 200). Auth required. Errors: **401**.
+- **`POST /api/assets/{assetId}/share`** — share the asset to the caller's team. Auth required. Asset-owner only. Idempotent. Errors: **403** (not the asset owner), **404** (asset not visible), **409** (requester has no team), **401**.
+- **`DELETE /api/assets/{assetId}/share`** — return the asset to personal. Auth required. Asset-owner only. Idempotent. Errors: **403**, **404**, **401**.
+- **Read models** — `GET /api/assets`, the dashboard, and search responses expand to include team-shared assets and add the computed `sharing` descriptor per asset (see Acceptance Criteria). This changes the response **shape** of existing endpoints (an added field and a wider result set), not their routes.
+
+## Telemetry
+
+**Request telemetry:** the new endpoints must be added to the operation-name mapping in
+`technicalTelemetry.ts` and to [telemetry.md](../cross-cutting/telemetry.md):
+
+- `POST /api/teams` → `CreateTeam`
+- `GET /api/teams/me` → `GetMyTeam`
+- `POST /api/assets/{assetId}/share` → `ShareAsset`
+- `DELETE /api/assets/{assetId}/share` → `UnshareAsset`
+
+Existing endpoints whose responses change (`GET /api/assets`, dashboard, search) keep their
+current operation names.
+
+**Domain events:** this feature introduces mutations, so it publishes domain events for
+durable consumers (activity/History and future team-aware consumers), following Smart Events
+(ADR-0010) — events carry the descriptive state a durable consumer needs (team name, asset
+name, actor) so no consumer re-reads the source:
+
+- `TeamCreated` — on team creation.
+- `AssetSharedToTeam` — on share; carries asset id + name, team id + name, and actor.
+- `AssetUnsharedFromTeam` — on unshare; same shape.
+
+Each needs a telemetry handler and a dataset (`pineapple_team_domain_events` /
+`pineapple_asset_domain_events`), with the full ordered `blobs[]`/`doubles[]` contract defined
+in [telemetry.md](../cross-cutting/telemetry.md) using the `AssetCreated` table as the pattern.
+Per ADR-0010, telemetry handlers stay thin selective readers: they record ids, roles, and
+counts — **not** member emails or other PII — even though the domain event carries names for
+the History projection. Reads (`GetMyTeam`, the expanded lists) publish no domain events.
+
+## Flags
+
+**DEFERRED — Reminder recipient for shared assets:** Maintenance reminders continue to go to
+the **asset owner** only; team-wide reminder delivery for shared assets is not decided here.
+Decide it in the notifications/invitations work, where the recipient set and notification
+plumbing already live. Owner: engineering.
+
+**OUT OF SCOPE / FUTURE — Shared asset when its owner leaves the team:** A shared asset is
+owned by one user but editable by the whole team. What happens to it when that owner leaves or
+is removed (auto-unshare? reassign ownership? block removal?) is a **team-management** concern
+and is not decided here. Owner: engineering; resolve in the team-management spec.
+
+**REVIEW NEEDED — 403 vs 404 for non-member single-resource access:** Requesting an asset
+shared to a team the requester is not in inherits the unresolved 403-vs-404 question in
+[permissions.md](../cross-cutting/permissions.md#known-issues). This spec follows the current
+canonical behavior (403 for exists-but-forbidden) to match the rest of the app; the app-wide
+switch to 404 is tracked in [#52](https://github.com/snaveevans/pineapple/issues/52), and this
+spec will follow that decision once made.
+
+**REVIEW NEEDED — Existing read specs must note shared assets:** [asset-library.md](./asset-library.md),
+[dashboard.md](./dashboard.md), and [app-search.md](./app-search.md) describe "the user's own
+assets." Once this lands they must be updated to state that team-shared assets also appear and
+carry the `sharing` descriptor. Tracked in [#53](https://github.com/snaveevans/pineapple/issues/53).
+
+**NOT SPECIFIED — Team name maximum length:** The name is required and bounded, but the exact
+limit is not fixed here. `DISPLAY_NAME_MAX_LENGTH` (100) is a reasonable precedent; confirm at
+implementation and encode it in the Zod schema.
+
+## Out of Scope
+
+- **Inviting or adding a second member** — the invitation/accept flow is the separate `invite-teammate` spec. Until it lands, a team has only its creator.
+- **Team administration** — removing members, leaving a team, transferring ownership, renaming or deleting a team belong to the `team-management` spec.
+- **Multiple teams per user / active-team switching** — a user has at most one team; multi-team is a future extension of ADR-0015, not this spec.
+- **Team-wide reminder delivery** — see the deferred flag; reminders stay owner-directed for now.
+- **Migrating existing assets** — none required; the model is additive and existing assets are simply personal until shared.
+- **Sub-asset sharing** — sharing is per-asset; a single maintenance task or record cannot be shared independently of its asset.
+- **Sharing to a team the requester does not belong to** — a user can only share into their own team.

--- a/docs/specs/features/teams-foundation.md
+++ b/docs/specs/features/teams-foundation.md
@@ -48,6 +48,15 @@ authoritative in `openapi.json`.
 
 ## Acceptance Criteria
 
+> **Implementation status (live checklist).** These boxes track the build. A box is checked
+> only once its behavior is implemented **and covered by a test** on `main`; the spec's `status`
+> advances to `active` when all are checked. The feature ships in slices, so boxes are checked
+> across several PRs — in order: the **Team creation** and **Reading your team** groups first
+> (team + membership core), then **Sharing & unsharing**, **Member access to shared assets**,
+> **Read-path integration**, and **Permissions extension** (sharing + access). The web surface
+> is tracked separately in [`docs/web/FEATURES.md`](../../web/FEATURES.md). Each PR checks off
+> only the criteria it lands, so any reader can see remaining work at a glance.
+
 **Team creation**
 
 - [ ] An authenticated user who belongs to no team can create a team by providing a **name**; on success they become the team's **owner** and its only member

--- a/docs/specs/features/teams-foundation.md
+++ b/docs/specs/features/teams-foundation.md
@@ -50,15 +50,15 @@ authoritative in `openapi.json`.
 
 **Team creation**
 
-- [ ] An authenticated user who belongs to no team can create a team by providing a **name**; on success they become the team's **owner** and its only member
-- [ ] Creating a team when the requester already belongs to a team (as owner or member) fails with **409 Conflict** and no team is created
-- [ ] The team name is **required**, trimmed, and at most **100 characters** (matching `DISPLAY_NAME_MAX_LENGTH`); it need not be unique. An invalid name fails with **422** before any team is created
-- [ ] A new team starts with exactly one membership: the creator, with role `owner`
+- [x] An authenticated user who belongs to no team can create a team by providing a **name**; on success they become the team's **owner** and its only member
+- [x] Creating a team when the requester already belongs to a team (as owner or member) fails with **409 Conflict** and no team is created
+- [x] The team name is **required**, trimmed, and at most **100 characters** (matching `DISPLAY_NAME_MAX_LENGTH`); it need not be unique. An invalid name fails with **422** before any team is created
+- [x] A new team starts with exactly one membership: the creator, with role `owner`
 
 **Reading your team**
 
-- [ ] A member can read their own team, including its name and the list of members with each member's display name and role
-- [ ] A user who belongs to no team gets an explicit "no team" result (not an error), so the client can render a create-team prompt
+- [x] A member can read their own team, including its name and the list of members with each member's display name and role
+- [x] A user who belongs to no team gets an explicit "no team" result (not an error), so the client can render a create-team prompt
 
 **Sharing & unsharing (asset-owner only)**
 

--- a/docs/specs/features/teams-foundation.md
+++ b/docs/specs/features/teams-foundation.md
@@ -7,7 +7,7 @@ metadata:
 
 # Teams Foundation
 
-**Status:** draft
+**Status:** review
 **Owner:** [unknown — assign on review]
 **Last Updated:** 2026-07-03
 **Related Specs:** [ADR-0015](../../decisions/0015-teams-as-opt-in-sharing-scope.md), [authentication.md](../cross-cutting/authentication.md), [permissions.md](../cross-cutting/permissions.md), [validation.md](../cross-cutting/validation.md), [error-handling.md](../cross-cutting/error-handling.md), [loading-states.md](../cross-cutting/loading-states.md), [telemetry.md](../cross-cutting/telemetry.md), [asset-library.md](./asset-library.md), [dashboard.md](./dashboard.md), [app-search.md](./app-search.md)
@@ -52,7 +52,7 @@ authoritative in `openapi.json`.
 
 - [ ] An authenticated user who belongs to no team can create a team by providing a **name**; on success they become the team's **owner** and its only member
 - [ ] Creating a team when the requester already belongs to a team (as owner or member) fails with **409 Conflict** and no team is created
-- [ ] The team name is **required**, trimmed, and bounded by a maximum length (see Validation); an invalid name fails with **422** before any team is created
+- [ ] The team name is **required**, trimmed, and at most **100 characters** (matching `DISPLAY_NAME_MAX_LENGTH`); it need not be unique. An invalid name fails with **422** before any team is created
 - [ ] A new team starts with exactly one membership: the creator, with role `owner`
 
 **Reading your team**
@@ -72,7 +72,7 @@ authoritative in `openapi.json`.
 **Member access to shared assets (full parity)**
 
 - [ ] A team member can read an asset shared with their team and all of its dependent records (maintenance tasks, maintenance records, activity)
-- [ ] A team member can perform the same **write** actions on a shared asset that its owner can — add, edit, and delete maintenance tasks, and log maintenance records — with the sole exceptions of changing its sharing and deleting the asset itself, which remain asset-owner-only
+- [ ] A team member can perform the same **write** actions on a shared asset that its owner can — the maintenance actions that exist today: adding and deleting maintenance tasks, and logging maintenance records — with the sole exceptions of changing its sharing and deleting the asset itself, which remain asset-owner-only
 - [ ] Access to a shared asset's dependent records **follows the asset**: authorization for maintenance/record/activity operations is determined by whether the requester can access the parent asset (owns it, or is a member of the team it is shared with), replacing the direct `ownerId === requesterId` check on those operations
 - [ ] When an asset is unshared, or a member's access otherwise ends, subsequent requests by that member for the asset or its records behave as if the asset does not exist for them
 
@@ -154,12 +154,12 @@ the History projection. Reads (`GetMyTeam`, the expanded lists) publish no domai
 **DEFERRED — Reminder recipient for shared assets:** Maintenance reminders continue to go to
 the **asset owner** only; team-wide reminder delivery for shared assets is not decided here.
 Decide it in the notifications/invitations work, where the recipient set and notification
-plumbing already live. Owner: engineering.
+plumbing already live. Tracked in [#55](https://github.com/snaveevans/pineapple/issues/55).
 
 **OUT OF SCOPE / FUTURE — Shared asset when its owner leaves the team:** A shared asset is
 owned by one user but editable by the whole team. What happens to it when that owner leaves or
 is removed (auto-unshare? reassign ownership? block removal?) is a **team-management** concern
-and is not decided here. Owner: engineering; resolve in the team-management spec.
+and is not decided here. Resolve in the team-management spec; tracked in [#56](https://github.com/snaveevans/pineapple/issues/56).
 
 **REVIEW NEEDED — 403 vs 404 for non-member single-resource access:** Requesting an asset
 shared to a team the requester is not in inherits the unresolved 403-vs-404 question in
@@ -172,10 +172,6 @@ spec will follow that decision once made.
 [dashboard.md](./dashboard.md), and [app-search.md](./app-search.md) describe "the user's own
 assets." Once this lands they must be updated to state that team-shared assets also appear and
 carry the `sharing` descriptor. Tracked in [#53](https://github.com/snaveevans/pineapple/issues/53).
-
-**NOT SPECIFIED — Team name maximum length:** The name is required and bounded, but the exact
-limit is not fixed here. `DISPLAY_NAME_MAX_LENGTH` (100) is a reasonable precedent; confirm at
-implementation and encode it in the Zod schema.
 
 ## Out of Scope
 

--- a/docs/specs/templates/feature-spec.template.md
+++ b/docs/specs/templates/feature-spec.template.md
@@ -23,6 +23,10 @@ One paragraph. What this feature does and the user problem it solves. No impleme
 
 ## Acceptance Criteria
 
+<!-- These boxes are the live implementation checklist: check a box (`- [x]`) only when the
+behavior is implemented AND covered by a test on `main`. Large specs ship in slices (tracked as
+GitHub issues); each PR checks off only the criteria it lands. See docs/specs/SPECS.md. -->
+
 - [ ] [Specific, testable behavior]
 - [ ] [Another testable criterion]
 

--- a/migrations/0013_teams.sql
+++ b/migrations/0013_teams.sql
@@ -1,0 +1,17 @@
+-- Teams foundation (ADR-0015): a team is a named group a user opts into.
+-- A user belongs to at most one team, enforced here via UNIQUE(user_id) —
+-- membership rows are never shared across teams.
+
+CREATE TABLE IF NOT EXISTS teams (
+  id         TEXT NOT NULL PRIMARY KEY,
+  name       TEXT NOT NULL,
+  created_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS team_members (
+  team_id    TEXT NOT NULL REFERENCES teams(id),
+  user_id    TEXT NOT NULL UNIQUE REFERENCES users(id),
+  role       TEXT NOT NULL CHECK (role IN ('owner', 'member')),
+  created_at TEXT NOT NULL,
+  PRIMARY KEY (team_id, user_id)
+);

--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -3,6 +3,7 @@ export { ActivityEntryId } from "./types/ActivityEntryId.ts";
 export { MaintenanceRecordId } from "./types/MaintenanceRecordId.ts";
 export { MaintenanceTaskId } from "./types/MaintenanceTaskId.ts";
 export { UserId } from "./types/UserId.ts";
+export { TeamId } from "./types/TeamId.ts";
 export { Email } from "./types/Email.ts";
 export { NotificationId } from "./types/NotificationId.ts";
 export { ScheduledReminderId } from "./types/ScheduledReminderId.ts";

--- a/packages/shared/types/TeamId.ts
+++ b/packages/shared/types/TeamId.ts
@@ -1,0 +1,6 @@
+export type TeamId = string & { readonly _brand: "TeamId" };
+
+export const TeamId = {
+  generate: (): TeamId => crypto.randomUUID() as TeamId,
+  from: (raw: string): TeamId => raw as TeamId,
+};


### PR DESCRIPTION
## Summary
- Implements the first vertical slice of `docs/specs/features/teams-foundation.md` (ADR-0015): team creation and reading your own team, backend only.
- New `Team` aggregate + `team`/`team_members` tables (migration `0013_teams.sql`); a user belongs to at most one team, enforced via `UNIQUE(user_id)`.
- `POST /api/teams` — create a team you own (409 if already in one, 422 on invalid/over-length name).
- `GET /api/teams/me` — read your team + members, or an explicit `{ team: null }` when you have none.
- `TeamCreated` domain event + telemetry handler (dataset `pineapple_team_domain_events`), PII-free per ADR-0010 (team name excluded from blobs).
- Checks off the "Team creation" and "Reading your team" AC groups in the spec; spec `status` stays `review` until slices ② and ③ land.

## Not in this PR
Asset sharing/unsharing, the permissions extension, and the web UI are separate slices: [#58](https://github.com/snaveevans/pineapple/issues/58) and [#59](https://github.com/snaveevans/pineapple/issues/59).

Closes #57.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm type-check`
- [x] `pnpm -r test` (all packages)
- [x] `pnpm --filter @snaveevans/pineapple-api openapi:generate` — no diff beyond the new routes, committed
- [x] `wrangler d1 migrations apply pineapple --local` applies `0013_teams.sql` cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)