### PR TITLE
docs: codify branch and PR workflow conventions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## Summary
+
+<!-- 1–3 bullets: what changed and why -->
+
+## Related
+
+<!-- Pick one. Drop this section only when there is no issue. -->
+<!-- Closes #N  — this PR fully resolves the issue -->
+<!-- Fixes #N   — same as Closes, for bugs -->
+<!-- Refs #N    — partial slice; do not auto-close -->
+
+## Test plan
+
+- [ ]
+- [ ]
+
+## Spec / AC
+
+<!-- Link to docs/specs/... when this PR lands feature work. -->
+<!-- Check off only the acceptance criteria this PR implements. -->

--- a/.opencode/commands/pr.md
+++ b/.opencode/commands/pr.md
@@ -1,0 +1,47 @@
+---
+description: Open a PR with issue link and repo template filled in
+---
+
+Open a pull request for the current work. User input: $ARGUMENTS
+
+Follow the PR conventions in @CLAUDE.md (Workflow) and the template in
+@.github/pull_request_template.md.
+
+## Preconditions
+
+1. Run `git status`, `git diff`, and `git log` against the base branch. Confirm we are **not** on `main`.
+2. Prefer that checks already passed: `pnpm lint && pnpm type-check && pnpm -r test`. If the user wants a draft or the suite is slow, note what was skipped.
+3. If the API contract changed, ensure OpenAPI was regenerated.
+
+## Issue number
+
+Resolve the GitHub issue number from, in order:
+
+1. Explicit number in `$ARGUMENTS`
+2. Leading digits in the branch name (`feat/42-…` → `42`)
+3. Commit footers (`Closes #N` / `Refs #N` / `Fixes #N`)
+4. Ask the user if still unknown and an issue is likely
+
+If there is no issue, omit the Related section.
+
+## Link mode
+
+- Default to **`Closes #N`** (or **`Fixes #N`** for pure bugfix branches) when this PR fully resolves the issue.
+- Use **`Refs #N`** when this is a partial slice, or when `$ARGUMENTS` says partial / slice / WIP.
+- Never invent an issue number.
+
+## PR contents
+
+- **Title:** concise, imperative; optional `(#N)` suffix when linked.
+- **Body:** fill the project PR template:
+  - Summary (1–3 bullets from the actual diff)
+  - Related (`Closes` / `Fixes` / `Refs` as decided)
+  - Test plan (concrete steps, not empty checkboxes only)
+  - Spec / AC link when feature work touched `docs/specs/`
+- Push the branch if needed, then create the PR with `gh pr create`.
+- Prefer a ready PR; use `--draft` only if the user asked or CI/tests were skipped.
+
+## Output
+
+Return the PR URL. Reminder: after merge of a feature slice, run
+`docs/specs/prompts/pr-sync.md` against the diff.

--- a/.opencode/commands/start.md
+++ b/.opencode/commands/start.md
@@ -1,0 +1,39 @@
+---
+description: Create a feature/fix branch using repo naming conventions
+---
+
+Start work on a new branch for: $ARGUMENTS
+
+Follow the branch workflow in @CLAUDE.md (Workflow → Branch naming).
+
+## Parse input
+
+Accept freeform text. Extract:
+
+1. **type** — one of `feat`, `fix`, `docs`, `refactor`, `chore`, `ci`, `test`, `perf`. Infer from intent if omitted (`feat` for new behavior, `fix` for bugs).
+2. **issue** — optional GitHub issue number (digits only). Include only if the user gave one or a clear issue reference.
+3. **slug** — short lowercase kebab-case summary of the work.
+
+## Branch name
+
+- With issue: `{type}/{issue}-{slug}`
+- Without: `{type}/{slug}`
+
+Must match:
+
+```
+^(feat|fix|docs|refactor|chore|ci|test|perf)/(?:[0-9]+-)?[a-z0-9]+(?:-[a-z0-9]+)*$
+```
+
+No `#` in the branch name.
+
+## Steps
+
+1. Confirm current branch is clean enough to branch from (prefer up-to-date `main`).
+2. Create and check out the new branch from `main` (fetch/pull if needed).
+3. State the **one-sentence concern** and rough scope budget (files/areas). Ask the user if the concern is ambiguous.
+4. Do **not** implement yet unless the user also asked to implement — stop after the branch exists and scope is named.
+
+## Output
+
+Report: branch name, base, one-sentence concern, and whether an issue will be linked as `Closes` vs `Refs` when the PR is opened.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,9 +177,53 @@ When in doubt, ask the user whether to split rather than expanding the branch.
 
 ## Workflow
 
-Work on a branch, open a PR (CI must pass), merge → auto-deploys to Cloudflare.
+Work on a branch → open a PR → CI must pass → merge → auto-deploys to Cloudflare.
 Don't commit to `main` directly. End commit messages with the Co-Authored-By
 trailer.
+
+### Branch naming
+
+```
+{type}/{issue}-{slug}   # with a GitHub issue
+{type}/{slug}           # without
+```
+
+- **type:** `feat` | `fix` | `docs` | `refactor` | `chore` | `ci` | `test` | `perf`
+- **issue:** bare digits only (no `#`) — first segment after `type/` when numeric
+- **slug:** lowercase kebab-case, short
+
+Examples: `feat/42-team-invite`, `fix/87-null-session`, `docs/adr-0016`,
+`chore/upgrade-wrangler`.
+
+Regex: `^(feat|fix|docs|refactor|chore|ci|test|perf)/(?:[0-9]+-)?[a-z0-9]+(?:-[a-z0-9]+)*$`
+
+### Issue linking
+
+| Place       | Rule                                                                                                                   |
+| ----------- | ---------------------------------------------------------------------------------------------------------------------- |
+| Branch      | Optional: include the issue number for human signal                                                                    |
+| Commits     | `Closes #N` or `Refs #N` footer when useful                                                                            |
+| **PR body** | **Required** when an issue exists: `Closes #N` / `Fixes #N` if this PR fully resolves it; `Refs #N` for partial slices |
+
+GitHub only auto-closes/links from PR and commit text — not branch names. Use
+`Refs #N` on intermediate slices; `Closes #N` only on the PR that finishes the
+issue.
+
+### Opening a PR
+
+Use the template in `.github/pull_request_template.md`. Before opening:
+
+1. `pnpm lint && pnpm type-check && pnpm -r test`
+2. Regenerate OpenAPI if the contract changed
+3. Confirm one concern (scope discipline above)
+
+Agent shortcuts: `/start` (branch from type + optional issue + slug), `/pr`
+(open PR with issue link filled in).
+
+### After merge
+
+When the PR lands a feature slice, run `docs/specs/prompts/pr-sync.md` against
+the diff to keep the spec honest.
 
 When making a meaningful change to `apps/web` — adding a screen, changing a user
 flow, adding or removing a feature — read `docs/web/FEATURES.md` and update it to

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -1,7 +1,7 @@
 # Getting Started
 
 > **Audience:** contributors & operators · **Purpose:** run, test, and deploy
-> Pineapple · **Source of truth:** this file · **Last reviewed:** 2026-05-29
+> Pineapple · **Source of truth:** this file · **Last reviewed:** 2026-07-10
 
 ## Prerequisites
 
@@ -127,3 +127,31 @@ secrets and fails if `DEV_AUTH_EMAIL` is present.
 Work on a branch → open a PR → CI must pass → merge → auto-deploy. `main` is
 protected (PR required, CI required, you can merge your own PRs). Don't push to
 `main` directly.
+
+### Branch naming
+
+```
+{type}/{issue}-{slug}   # with a GitHub issue
+{type}/{slug}           # without
+```
+
+| Part    | Rules                                                                                            |
+| ------- | ------------------------------------------------------------------------------------------------ |
+| `type`  | `feat`, `fix`, `docs`, `refactor`, `chore`, `ci`, `test`, `perf`                                 |
+| `issue` | Optional. Bare digits (no `#`). Only the first path segment after `type/` when it is all digits. |
+| `slug`  | Lowercase kebab-case, short                                                                      |
+
+Examples: `feat/42-team-invite`, `fix/87-null-session`, `chore/upgrade-wrangler`.
+
+### Issues and PRs
+
+- Prefer a GitHub issue for user-facing features and bugs; chores can skip one.
+- Link the issue in the **PR body** (not only the branch name):
+  - `Closes #42` / `Fixes #42` when this PR fully resolves the issue
+  - `Refs #42` for a partial slice (do not auto-close until the last slice)
+- Fill out `.github/pull_request_template.md` (summary, related issue, test plan,
+  spec/AC when relevant).
+- Commits use Conventional Commits; optional footers `Closes #N` / `Refs #N`.
+
+Before opening a PR: `pnpm lint && pnpm type-check && pnpm -r test` (and
+regenerate OpenAPI if the API contract changed).


### PR DESCRIPTION
## Summary

- Document branch naming (`{type}/{issue}-{slug}`), issue linking (`Closes`/`Refs` in PR body), and PR checklist in `CLAUDE.md` and getting-started
- Add `.github/pull_request_template.md` so every PR prompts for summary, issue link, test plan, and spec/AC
- Add opencode commands `/start` (create branch + name scope) and `/pr` (open PR with template and issue link)

## Test plan

- [x] Branch name matches convention: `docs/branch-pr-workflow`
- [x] Commit uses conventional commits
- [x] After merge, restart opencode and confirm `/start` and `/pr` appear in command list
- [x] Open a follow-up PR later and confirm the GitHub PR template pre-fills

## Spec / AC

N/A — process/docs only.