### PR TITLE
feat: asset sharing and team-based access (teams-foundation ②)

### DIFF
--- a/apps/api/src/api/middleware/technicalTelemetry.ts
+++ b/apps/api/src/api/middleware/technicalTelemetry.ts
@@ -190,6 +190,12 @@ function routeTelemetry(method: string, pathname: string): RouteTelemetry {
   if (/^\/api\/assets\/[^/]+$/.test(pathname) && method === "GET") {
     return { operation: "GetAsset", routePattern: "/api/assets/{id}" };
   }
+  if (/^\/api\/assets\/[^/]+\/share$/.test(pathname) && method === "POST") {
+    return { operation: "ShareAsset", routePattern: "/api/assets/{assetId}/share" };
+  }
+  if (/^\/api\/assets\/[^/]+\/share$/.test(pathname) && method === "DELETE") {
+    return { operation: "UnshareAsset", routePattern: "/api/assets/{assetId}/share" };
+  }
   if (/^\/api\/assets\/[^/]+\/maintenance-records$/.test(pathname) && method === "POST") {
     return {
       operation: "CreateMaintenanceRecord",

--- a/apps/api/src/api/openapi.ts
+++ b/apps/api/src/api/openapi.ts
@@ -3,6 +3,7 @@ import {
   AssetIdParamSchema,
   AssetListResponseSchema,
   AssetResponseSchema,
+  AssetShareParamSchema,
   CreateAssetBodySchema,
   CreatedAssetResponseSchema,
   ErrorResponseSchema,
@@ -155,11 +156,12 @@ export const listAssetsRoute = createRoute({
   path: "/api/assets",
   tags: ["Assets"],
   summary: "List my assets",
-  description: "Returns the caller's active (non-archived) assets and their counts by category.",
+  description:
+    "Returns the caller's active (non-archived) assets — owned and shared with their team — and category counts over that set. Each asset includes a computed `sharing` descriptor.",
   security: [cookieAuth],
   responses: {
     200: {
-      description: "The caller's assets",
+      description: "The caller's visible assets",
       content: { "application/json": { schema: AssetListResponseSchema } },
     },
     401: {
@@ -174,6 +176,8 @@ export const getAssetRoute = createRoute({
   path: "/api/assets/{id}",
   tags: ["Assets"],
   summary: "Get an asset by id",
+  description:
+    "Returns an asset the caller owns or that is shared with their team, including a computed `sharing` descriptor.",
   security: [cookieAuth],
   request: { params: AssetIdParamSchema },
   responses: {
@@ -186,7 +190,7 @@ export const getAssetRoute = createRoute({
       content: { "application/json": { schema: ErrorResponseSchema } },
     },
     403: {
-      description: "The asset belongs to another user",
+      description: "The asset is not visible to the caller",
       content: { "application/json": { schema: ErrorResponseSchema } },
     },
     404: {
@@ -201,7 +205,8 @@ export const searchAssetsRoute = createRoute({
   path: "/api/search",
   tags: ["Assets"],
   summary: "Search my assets",
-  description: "Returns up to 20 active assets owned by the caller that match the free-text query.",
+  description:
+    "Returns up to 20 active assets visible to the caller (owned or shared with their team) that match the free-text query.",
   security: [cookieAuth],
   request: { query: SearchAssetsQuerySchema },
   responses: {
@@ -665,6 +670,67 @@ export const deleteMaintenanceTaskRoute = createRoute({
   },
 });
 
+export const shareAssetRoute = createRoute({
+  method: "post",
+  path: "/api/assets/{assetId}/share",
+  tags: ["Assets"],
+  summary: "Share an asset to my team",
+  description:
+    "Shares the asset to the caller's team. Asset-owner only. Idempotent when already shared to that team.",
+  security: [cookieAuth],
+  request: { params: AssetShareParamSchema },
+  responses: {
+    200: {
+      description: "Asset shared (or already shared)",
+      content: { "application/json": { schema: AssetResponseSchema } },
+    },
+    401: {
+      description: "Not authenticated",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    403: {
+      description: "Caller is not the asset owner",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    404: {
+      description: "No such asset",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    409: {
+      description: "Caller does not belong to a team",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
+export const unshareAssetRoute = createRoute({
+  method: "delete",
+  path: "/api/assets/{assetId}/share",
+  tags: ["Assets"],
+  summary: "Unshare an asset",
+  description: "Returns the asset to personal. Asset-owner only. Idempotent when already personal.",
+  security: [cookieAuth],
+  request: { params: AssetShareParamSchema },
+  responses: {
+    200: {
+      description: "Asset unshared (or already personal)",
+      content: { "application/json": { schema: AssetResponseSchema } },
+    },
+    401: {
+      description: "Not authenticated",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    403: {
+      description: "Caller is not the asset owner",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    404: {
+      description: "No such asset",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
 export const createTeamRoute = createRoute({
   method: "post",
   path: "/api/teams",
@@ -768,6 +834,8 @@ export function getApiDocument() {
   doc.openapi(markAllNotificationsReadRoute, stub);
   doc.openapi(createTeamRoute, stub);
   doc.openapi(getMyTeamRoute, stub);
+  doc.openapi(shareAssetRoute, stub);
+  doc.openapi(unshareAssetRoute, stub);
   registerOpenApiComponents(doc.openAPIRegistry);
   return doc.getOpenAPIDocument(openApiConfig);
 }

--- a/apps/api/src/api/schemas/assetSchemas.ts
+++ b/apps/api/src/api/schemas/assetSchemas.ts
@@ -82,6 +82,14 @@ export const AssetIdParamSchema = z.object({
 
 // ── Responses ──────────────────────────────────────────────────────────────
 
+export const AssetSharingSchema = z
+  .object({
+    scope: z.enum(["personal", "team"]).openapi({ example: "personal" }),
+    isOwner: z.boolean().openapi({ example: true }),
+    ownerDisplayName: z.string().optional().openapi({ example: "Dale" }),
+  })
+  .openapi("AssetSharing");
+
 /** Serialized asset, matching `serializeAsset` in worker.ts. */
 export const AssetResponseSchema = z
   .object({
@@ -92,8 +100,16 @@ export const AssetResponseSchema = z
     archivedAt: z.string().datetime().nullable().openapi({ example: null }),
     createdAt: z.string().datetime().openapi({ example: "2026-05-29T03:25:24.887Z" }),
     updatedAt: z.string().datetime().openapi({ example: "2026-05-29T03:25:24.887Z" }),
+    sharing: AssetSharingSchema,
   })
   .openapi("Asset");
+
+export const AssetShareParamSchema = z.object({
+  assetId: z.string().openapi({
+    param: { name: "assetId", in: "path" },
+    example: "195d0ef0-47f5-439f-abfd-29f892c9a040",
+  }),
+});
 
 const AssetCategoryCountSchema = z.number().int().nonnegative().openapi({ example: 1 });
 const AssetCategoryCountProperties = Object.fromEntries(

--- a/apps/api/src/application/usecases/CreateAsset.test.ts
+++ b/apps/api/src/application/usecases/CreateAsset.test.ts
@@ -14,10 +14,6 @@ class RecordingAssetRepository implements AssetRepository {
     return Promise.resolve(null);
   }
 
-  findByOwner(): Promise<Asset[]> {
-    return Promise.resolve([]);
-  }
-
   findVisibleTo(): Promise<Asset[]> {
     return Promise.resolve([]);
   }

--- a/apps/api/src/application/usecases/CreateAsset.test.ts
+++ b/apps/api/src/application/usecases/CreateAsset.test.ts
@@ -18,6 +18,10 @@ class RecordingAssetRepository implements AssetRepository {
     return Promise.resolve([]);
   }
 
+  findVisibleTo(): Promise<Asset[]> {
+    return Promise.resolve([]);
+  }
+
   save(asset: Asset): Promise<void> {
     this.saved = asset;
     return Promise.resolve();

--- a/apps/api/src/application/usecases/CreateMaintenanceRecord.test.ts
+++ b/apps/api/src/application/usecases/CreateMaintenanceRecord.test.ts
@@ -10,6 +10,8 @@ import {
 } from "@snaveevans/pineapple-shared";
 import { Asset } from "../../domain/asset/Asset.ts";
 import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
+import type { Team } from "../../domain/team/Team.ts";
+import type { TeamRepository } from "../../domain/team/TeamRepository.ts";
 import type { DomainEvent } from "../../domain/events/DomainEvent.ts";
 import type { MaintenanceRecord } from "../../domain/maintenance/MaintenanceRecord.ts";
 import { MaintenanceTask } from "../../domain/maintenance/MaintenanceTask.ts";
@@ -30,6 +32,23 @@ class AssetRepositoryFake implements AssetRepository {
     return Promise.resolve([]);
   }
 
+  findVisibleTo(): Promise<Asset[]> {
+    return Promise.resolve([]);
+  }
+
+  save(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+class TeamRepositoryFake implements TeamRepository {
+  constructor(private readonly team: Team | null = null) {}
+  findByMember(): Promise<Team | null> {
+    return Promise.resolve(this.team);
+  }
+  findById(): Promise<Team | null> {
+    return Promise.resolve(this.team);
+  }
   save(): Promise<void> {
     return Promise.resolve();
   }
@@ -58,7 +77,7 @@ class MaintenanceTaskRepositoryFake implements MaintenanceTaskRepository {
   findByAsset(): Promise<MaintenanceTask[]> {
     return Promise.resolve([]);
   }
-  findByOwnerForActiveAssets(): Promise<MaintenanceTask[]> {
+  findForVisibleActiveAssets(): Promise<MaintenanceTask[]> {
     return Promise.resolve([]);
   }
   findById(): Promise<MaintenanceTask | null> {
@@ -109,6 +128,7 @@ describe("CreateMaintenanceRecord", () => {
 
     const result = await new CreateMaintenanceRecord(
       new AssetRepositoryFake(asset),
+      new TeamRepositoryFake(),
       records,
       new MaintenanceTaskRepositoryFake(),
       events,
@@ -164,6 +184,7 @@ describe("CreateMaintenanceRecord", () => {
     const asset = assetFor();
     const result = await new CreateMaintenanceRecord(
       new AssetRepositoryFake(asset),
+      new TeamRepositoryFake(),
       new MaintenanceRecordWriterFake(),
       new MaintenanceTaskRepositoryFake(),
       new EventBusFake(),
@@ -187,6 +208,7 @@ describe("CreateMaintenanceRecord", () => {
     const records = new MaintenanceRecordWriterFake();
     const result = await new CreateMaintenanceRecord(
       new AssetRepositoryFake(asset),
+      new TeamRepositoryFake(),
       records,
       new MaintenanceTaskRepositoryFake(),
       new EventBusFake(),
@@ -208,6 +230,7 @@ describe("CreateMaintenanceRecord", () => {
     const asset = assetFor();
     const result = await new CreateMaintenanceRecord(
       new AssetRepositoryFake(asset),
+      new TeamRepositoryFake(),
       new MaintenanceRecordWriterFake(),
       new MaintenanceTaskRepositoryFake(),
       new EventBusFake(),
@@ -229,6 +252,7 @@ describe("CreateMaintenanceRecord", () => {
   function executeWithAsset(asset: Asset | null, requesterId: UserId) {
     return new CreateMaintenanceRecord(
       new AssetRepositoryFake(asset),
+      new TeamRepositoryFake(),
       new MaintenanceRecordWriterFake(),
       new MaintenanceTaskRepositoryFake(),
       new EventBusFake(),
@@ -283,6 +307,7 @@ describe("CreateMaintenanceRecord", () => {
 
       const result = await new CreateMaintenanceRecord(
         new AssetRepositoryFake(asset),
+        new TeamRepositoryFake(),
         records,
         tasks,
         events,
@@ -342,6 +367,7 @@ describe("CreateMaintenanceRecord", () => {
 
       const result = await new CreateMaintenanceRecord(
         new AssetRepositoryFake(asset),
+        new TeamRepositoryFake(),
         records,
         new MaintenanceTaskRepositoryFake(task),
         events,
@@ -389,6 +415,7 @@ describe("CreateMaintenanceRecord", () => {
 
       const result = await new CreateMaintenanceRecord(
         new AssetRepositoryFake(asset),
+        new TeamRepositoryFake(),
         records,
         tasks,
         events,
@@ -439,6 +466,7 @@ describe("CreateMaintenanceRecord", () => {
 
       const result = await new CreateMaintenanceRecord(
         new AssetRepositoryFake(asset),
+        new TeamRepositoryFake(),
         records,
         tasks,
         events,
@@ -467,6 +495,7 @@ describe("CreateMaintenanceRecord", () => {
       const asset = assetFor();
       const result = await new CreateMaintenanceRecord(
         new AssetRepositoryFake(asset),
+        new TeamRepositoryFake(),
         new MaintenanceRecordWriterFake(),
         new MaintenanceTaskRepositoryFake(null),
         new EventBusFake(),
@@ -483,11 +512,13 @@ describe("CreateMaintenanceRecord", () => {
       if (!result.ok) expect(result.error).toBeInstanceOf(NotFoundError);
     });
 
-    it("returns not found when taskId belongs to another user's task", async () => {
+    it("allows a task on an accessible asset even when task.ownerId differs from requester", async () => {
+      // Access follows the asset; child ownerId is attribution, not the access gate.
       const asset = assetFor();
       const task = makeTask({ assetId: asset.id, ownerId: UserId.generate() });
       const result = await new CreateMaintenanceRecord(
         new AssetRepositoryFake(asset),
+        new TeamRepositoryFake(),
         new MaintenanceRecordWriterFake(),
         new MaintenanceTaskRepositoryFake(task),
         new EventBusFake(),
@@ -500,8 +531,7 @@ describe("CreateMaintenanceRecord", () => {
         taskId: task.id,
       });
 
-      expect(result.ok).toBe(false);
-      if (!result.ok) expect(result.error).toBeInstanceOf(NotFoundError);
+      expect(result.ok).toBe(true);
     });
 
     it("returns validation error when taskId belongs to a different asset", async () => {
@@ -509,6 +539,7 @@ describe("CreateMaintenanceRecord", () => {
       const task = makeTask({ assetId: AssetId.generate(), ownerId });
       const result = await new CreateMaintenanceRecord(
         new AssetRepositoryFake(asset),
+        new TeamRepositoryFake(),
         new MaintenanceRecordWriterFake(),
         new MaintenanceTaskRepositoryFake(task),
         new EventBusFake(),

--- a/apps/api/src/application/usecases/CreateMaintenanceRecord.test.ts
+++ b/apps/api/src/application/usecases/CreateMaintenanceRecord.test.ts
@@ -10,7 +10,8 @@ import {
 } from "@snaveevans/pineapple-shared";
 import { Asset } from "../../domain/asset/Asset.ts";
 import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
-import type { Team } from "../../domain/team/Team.ts";
+import { createMembership } from "../../domain/team/Membership.ts";
+import { Team } from "../../domain/team/Team.ts";
 import type { TeamRepository } from "../../domain/team/TeamRepository.ts";
 import type { DomainEvent } from "../../domain/events/DomainEvent.ts";
 import type { MaintenanceRecord } from "../../domain/maintenance/MaintenanceRecord.ts";
@@ -26,10 +27,6 @@ class AssetRepositoryFake implements AssetRepository {
 
   findById(): Promise<Asset | null> {
     return Promise.resolve(this.asset);
-  }
-
-  findByOwner(): Promise<Asset[]> {
-    return Promise.resolve([]);
   }
 
   findVisibleTo(): Promise<Asset[]> {
@@ -169,6 +166,54 @@ describe("CreateMaintenanceRecord", () => {
     const result = await executeWithAsset(assetFor(UserId.generate()), ownerId);
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.error).toBeInstanceOf(ForbiddenError);
+  });
+
+  it("allows a non-owner team member to log a record on a shared asset", async () => {
+    const memberId = UserId.generate();
+    const asset = assetFor(ownerId);
+    asset.pullEvents();
+    const team = Team.create({ ownerId, name: "Field Ops" });
+    team.pullEvents();
+    asset.shareToTeam({ teamId: team.id, teamName: team.name, actorId: ownerId });
+    asset.pullEvents();
+    const memberTeam = Team.reconstitute({
+      id: team.id,
+      ownerId: team.ownerId,
+      name: team.name,
+      createdAt: team.createdAt,
+      members: [
+        ...team.members,
+        createMembership({ userId: memberId, role: "member", joinedAt: new Date() }),
+      ],
+    });
+    const records = new MaintenanceRecordWriterFake();
+    const events = new EventBusFake();
+
+    const result = await new CreateMaintenanceRecord(
+      new AssetRepositoryFake(asset),
+      new TeamRepositoryFake(memberTeam),
+      records,
+      new MaintenanceTaskRepositoryFake(),
+      events,
+      dates,
+    ).execute({
+      assetId: asset.id,
+      requesterId: memberId,
+      title: "Member logged oil",
+      performedAt: "2026-06-09",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.ownerId).toBe(ownerId);
+    expect(events.events).toEqual([
+      expect.objectContaining({
+        type: "MaintenanceRecordCreated",
+        ownerId,
+        actorId: memberId,
+        title: "Member logged oil",
+      }),
+    ]);
   });
 
   it("returns conflict for an archived asset", async () => {

--- a/apps/api/src/application/usecases/CreateMaintenanceRecord.ts
+++ b/apps/api/src/application/usecases/CreateMaintenanceRecord.ts
@@ -16,9 +16,11 @@ import {
 import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
 import { MaintenanceRecord } from "../../domain/maintenance/MaintenanceRecord.ts";
 import type { MaintenanceTaskRepository } from "../../domain/maintenance/MaintenanceTaskRepository.ts";
+import type { TeamRepository } from "../../domain/team/TeamRepository.ts";
 import type { EventBus } from "../ports/EventBus.ts";
 import type { MaintenanceRecordWriter } from "../ports/MaintenanceRecordWriter.ts";
 import type { UtcDateProvider } from "../ports/UtcDateProvider.ts";
+import { canAccessAsset } from "./assetAccess.ts";
 
 export type CreateMaintenanceRecordCommand = {
   assetId: AssetId;
@@ -32,6 +34,7 @@ export type CreateMaintenanceRecordCommand = {
 export class CreateMaintenanceRecord {
   constructor(
     private readonly assets: AssetRepository,
+    private readonly teams: TeamRepository,
     private readonly records: MaintenanceRecordWriter,
     private readonly tasks: MaintenanceTaskRepository,
     private readonly eventBus: EventBus,
@@ -44,7 +47,7 @@ export class CreateMaintenanceRecord {
     try {
       const asset = await this.assets.findById(command.assetId);
       if (!asset) return err(new NotFoundError("Asset not found"));
-      if (asset.ownerId !== command.requesterId) {
+      if (!(await canAccessAsset(asset, command.requesterId, this.teams))) {
         return err(new ForbiddenError("Access denied"));
       }
       if (asset.archivedAt !== null) {
@@ -54,7 +57,7 @@ export class CreateMaintenanceRecord {
       let task = null;
       if (command.taskId !== undefined) {
         task = await this.tasks.findById(command.taskId);
-        if (!task || task.ownerId !== command.requesterId) {
+        if (!task) {
           return err(new NotFoundError("Maintenance task not found"));
         }
         if (task.assetId !== command.assetId) {

--- a/apps/api/src/application/usecases/CreateMaintenanceTask.test.ts
+++ b/apps/api/src/application/usecases/CreateMaintenanceTask.test.ts
@@ -9,6 +9,8 @@ import {
 } from "@snaveevans/pineapple-shared";
 import { Asset } from "../../domain/asset/Asset.ts";
 import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
+import type { Team } from "../../domain/team/Team.ts";
+import type { TeamRepository } from "../../domain/team/TeamRepository.ts";
 import type { DomainEvent } from "../../domain/events/DomainEvent.ts";
 import type { MaintenanceTask } from "../../domain/maintenance/MaintenanceTask.ts";
 import type { MaintenanceTaskRepository } from "../../domain/maintenance/MaintenanceTaskRepository.ts";
@@ -24,6 +26,23 @@ class AssetRepositoryFake implements AssetRepository {
   findByOwner(): Promise<Asset[]> {
     return Promise.resolve([]);
   }
+
+  findVisibleTo(): Promise<Asset[]> {
+    return Promise.resolve([]);
+  }
+  save(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+class TeamRepositoryFake implements TeamRepository {
+  constructor(private readonly team: Team | null = null) {}
+  findByMember(): Promise<Team | null> {
+    return Promise.resolve(this.team);
+  }
+  findById(): Promise<Team | null> {
+    return Promise.resolve(this.team);
+  }
   save(): Promise<void> {
     return Promise.resolve();
   }
@@ -34,7 +53,7 @@ class MaintenanceTaskRepositoryFake implements MaintenanceTaskRepository {
   findByAsset(): Promise<MaintenanceTask[]> {
     return Promise.resolve([]);
   }
-  findByOwnerForActiveAssets(): Promise<MaintenanceTask[]> {
+  findForVisibleActiveAssets(): Promise<MaintenanceTask[]> {
     return Promise.resolve([]);
   }
   findById(): Promise<MaintenanceTask | null> {
@@ -81,6 +100,7 @@ describe("CreateMaintenanceTask", () => {
     const events = new EventBusFake();
     const result = await new CreateMaintenanceTask(
       new AssetRepositoryFake(a),
+      new TeamRepositoryFake(),
       tasks,
       events,
       dates,
@@ -124,6 +144,7 @@ describe("CreateMaintenanceTask", () => {
     const tasks = new MaintenanceTaskRepositoryFake();
     const result = await new CreateMaintenanceTask(
       new AssetRepositoryFake(null),
+      new TeamRepositoryFake(),
       tasks,
       new EventBusFake(),
       dates,
@@ -150,6 +171,7 @@ describe("CreateMaintenanceTask", () => {
     const tasks = new MaintenanceTaskRepositoryFake();
     const result = await new CreateMaintenanceTask(
       new AssetRepositoryFake(a),
+      new TeamRepositoryFake(),
       tasks,
       new EventBusFake(),
       dates,

--- a/apps/api/src/application/usecases/CreateMaintenanceTask.test.ts
+++ b/apps/api/src/application/usecases/CreateMaintenanceTask.test.ts
@@ -23,9 +23,6 @@ class AssetRepositoryFake implements AssetRepository {
   findById(): Promise<Asset | null> {
     return Promise.resolve(this.asset);
   }
-  findByOwner(): Promise<Asset[]> {
-    return Promise.resolve([]);
-  }
 
   findVisibleTo(): Promise<Asset[]> {
     return Promise.resolve([]);

--- a/apps/api/src/application/usecases/CreateMaintenanceTask.test.ts
+++ b/apps/api/src/application/usecases/CreateMaintenanceTask.test.ts
@@ -9,7 +9,8 @@ import {
 } from "@snaveevans/pineapple-shared";
 import { Asset } from "../../domain/asset/Asset.ts";
 import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
-import type { Team } from "../../domain/team/Team.ts";
+import { createMembership } from "../../domain/team/Membership.ts";
+import { Team } from "../../domain/team/Team.ts";
 import type { TeamRepository } from "../../domain/team/TeamRepository.ts";
 import type { DomainEvent } from "../../domain/events/DomainEvent.ts";
 import type { MaintenanceTask } from "../../domain/maintenance/MaintenanceTask.ts";
@@ -160,6 +161,54 @@ describe("CreateMaintenanceTask", () => {
     const { result } = await execute({ requesterId: UserId.generate() });
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.error).toBeInstanceOf(ForbiddenError);
+  });
+
+  it("allows a non-owner team member to create a task on a shared asset", async () => {
+    const memberId = UserId.generate();
+    const a = asset(ownerId);
+    a.pullEvents();
+    const team = Team.create({ ownerId, name: "Field Ops" });
+    team.pullEvents();
+    a.shareToTeam({ teamId: team.id, teamName: team.name, actorId: ownerId });
+    a.pullEvents();
+    const memberTeam = Team.reconstitute({
+      id: team.id,
+      ownerId: team.ownerId,
+      name: team.name,
+      createdAt: team.createdAt,
+      members: [
+        ...team.members,
+        createMembership({ userId: memberId, role: "member", joinedAt: new Date() }),
+      ],
+    });
+    const tasks = new MaintenanceTaskRepositoryFake();
+    const events = new EventBusFake();
+
+    const result = await new CreateMaintenanceTask(
+      new AssetRepositoryFake(a),
+      new TeamRepositoryFake(memberTeam),
+      tasks,
+      events,
+      dates,
+    ).execute({
+      assetId: a.id,
+      requesterId: memberId,
+      title: "Member scheduled oil",
+      intervalValue: 3,
+      intervalUnit: "month",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.ownerId).toBe(ownerId);
+    expect(events.events).toEqual([
+      expect.objectContaining({
+        type: "MaintenanceTaskCreated",
+        ownerId,
+        actorId: memberId,
+        title: "Member scheduled oil",
+      }),
+    ]);
   });
 
   it("returns conflict for an archived asset", async () => {

--- a/apps/api/src/application/usecases/CreateMaintenanceTask.ts
+++ b/apps/api/src/application/usecases/CreateMaintenanceTask.ts
@@ -14,8 +14,10 @@ import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
 import { MaintenanceTask } from "../../domain/maintenance/MaintenanceTask.ts";
 import type { MaintenanceTaskRepository } from "../../domain/maintenance/MaintenanceTaskRepository.ts";
 import type { IntervalUnit } from "../../domain/maintenance/IntervalUnit.ts";
+import type { TeamRepository } from "../../domain/team/TeamRepository.ts";
 import type { EventBus } from "../ports/EventBus.ts";
 import type { UtcDateProvider } from "../ports/UtcDateProvider.ts";
+import { canAccessAsset } from "./assetAccess.ts";
 
 export type CreateMaintenanceTaskCommand = {
   assetId: AssetId;
@@ -29,6 +31,7 @@ export type CreateMaintenanceTaskCommand = {
 export class CreateMaintenanceTask {
   constructor(
     private readonly assets: AssetRepository,
+    private readonly teams: TeamRepository,
     private readonly tasks: MaintenanceTaskRepository,
     private readonly eventBus: EventBus,
     private readonly dates: UtcDateProvider,
@@ -40,7 +43,7 @@ export class CreateMaintenanceTask {
     try {
       const asset = await this.assets.findById(command.assetId);
       if (!asset) return err(new NotFoundError("Asset not found"));
-      if (asset.ownerId !== command.requesterId) {
+      if (!(await canAccessAsset(asset, command.requesterId, this.teams))) {
         return err(new ForbiddenError("Access denied"));
       }
       if (asset.archivedAt !== null) {

--- a/apps/api/src/application/usecases/DeleteMaintenanceTask.test.ts
+++ b/apps/api/src/application/usecases/DeleteMaintenanceTask.test.ts
@@ -57,10 +57,6 @@ class AssetRepositoryFake implements AssetRepository {
     return Promise.resolve(this.asset);
   }
 
-  findByOwner(): Promise<Asset[]> {
-    return Promise.resolve([]);
-  }
-
   findVisibleTo(): Promise<Asset[]> {
     return Promise.resolve([]);
   }

--- a/apps/api/src/application/usecases/DeleteMaintenanceTask.test.ts
+++ b/apps/api/src/application/usecases/DeleteMaintenanceTask.test.ts
@@ -9,7 +9,8 @@ import {
 import type { DomainEvent } from "../../domain/events/DomainEvent.ts";
 import { Asset } from "../../domain/asset/Asset.ts";
 import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
-import type { Team } from "../../domain/team/Team.ts";
+import { createMembership } from "../../domain/team/Membership.ts";
+import { Team } from "../../domain/team/Team.ts";
 import type { TeamRepository } from "../../domain/team/TeamRepository.ts";
 import { MaintenanceTask } from "../../domain/maintenance/MaintenanceTask.ts";
 import type { MaintenanceTaskRepository } from "../../domain/maintenance/MaintenanceTaskRepository.ts";
@@ -179,6 +180,55 @@ describe("DeleteMaintenanceTask", () => {
     });
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.error).toBeInstanceOf(ForbiddenError);
+  });
+
+  it("allows a non-owner team member to delete a task on a shared asset", async () => {
+    const memberId = UserId.generate();
+    const team = Team.create({ ownerId, name: "Field Ops" });
+    team.pullEvents();
+    const sharedAsset = Asset.reconstitute({
+      id: assetId,
+      ownerId,
+      name: asset.name,
+      metadata: asset.metadata,
+      archivedAt: null,
+      createdAt: asset.createdAt,
+      updatedAt: asset.updatedAt,
+      sharedTeamId: team.id,
+    });
+    const memberTeam = Team.reconstitute({
+      id: team.id,
+      ownerId: team.ownerId,
+      name: team.name,
+      createdAt: team.createdAt,
+      members: [
+        ...team.members,
+        createMembership({ userId: memberId, role: "member", joinedAt: new Date() }),
+      ],
+    });
+    const task = makeTask();
+    const repo = new MaintenanceTaskRepositoryFake(task);
+    const events = new EventBusFake();
+
+    const result = await new DeleteMaintenanceTask(
+      new AssetRepositoryFake(sharedAsset),
+      new TeamRepositoryFake(memberTeam),
+      repo,
+      events,
+    ).execute({
+      taskId: task.id,
+      assetId,
+      requesterId: memberId,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(repo.deleted).toBe(task.id);
+    expect(events.events).toEqual([
+      expect.objectContaining({
+        type: "MaintenanceTaskDeleted",
+        actorId: memberId,
+      }),
+    ]);
   });
 
   it("returns not found when task belongs to a different asset", async () => {

--- a/apps/api/src/application/usecases/DeleteMaintenanceTask.test.ts
+++ b/apps/api/src/application/usecases/DeleteMaintenanceTask.test.ts
@@ -9,10 +9,25 @@ import {
 import type { DomainEvent } from "../../domain/events/DomainEvent.ts";
 import { Asset } from "../../domain/asset/Asset.ts";
 import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
+import type { Team } from "../../domain/team/Team.ts";
+import type { TeamRepository } from "../../domain/team/TeamRepository.ts";
 import { MaintenanceTask } from "../../domain/maintenance/MaintenanceTask.ts";
 import type { MaintenanceTaskRepository } from "../../domain/maintenance/MaintenanceTaskRepository.ts";
 import type { EventBus } from "../ports/EventBus.ts";
 import { DeleteMaintenanceTask } from "./DeleteMaintenanceTask.ts";
+
+class TeamRepositoryFake implements TeamRepository {
+  constructor(private readonly team: Team | null = null) {}
+  findByMember(): Promise<Team | null> {
+    return Promise.resolve(this.team);
+  }
+  findById(): Promise<Team | null> {
+    return Promise.resolve(this.team);
+  }
+  save(): Promise<void> {
+    return Promise.resolve();
+  }
+}
 
 class MaintenanceTaskRepositoryFake implements MaintenanceTaskRepository {
   deleted: MaintenanceTaskId | null = null;
@@ -20,7 +35,7 @@ class MaintenanceTaskRepositoryFake implements MaintenanceTaskRepository {
   findByAsset(): Promise<MaintenanceTask[]> {
     return Promise.resolve([]);
   }
-  findByOwnerForActiveAssets(): Promise<MaintenanceTask[]> {
+  findForVisibleActiveAssets(): Promise<MaintenanceTask[]> {
     return Promise.resolve([]);
   }
   findById(): Promise<MaintenanceTask | null> {
@@ -43,6 +58,10 @@ class AssetRepositoryFake implements AssetRepository {
   }
 
   findByOwner(): Promise<Asset[]> {
+    return Promise.resolve([]);
+  }
+
+  findVisibleTo(): Promise<Asset[]> {
     return Promise.resolve([]);
   }
 
@@ -97,6 +116,7 @@ describe("DeleteMaintenanceTask", () => {
     const events = new EventBusFake();
     const result = await new DeleteMaintenanceTask(
       new AssetRepositoryFake(asset),
+      new TeamRepositoryFake(),
       repo,
       events,
     ).execute({
@@ -121,6 +141,7 @@ describe("DeleteMaintenanceTask", () => {
     const repo = new MaintenanceTaskRepositoryFake(null);
     const result = await new DeleteMaintenanceTask(
       new AssetRepositoryFake(asset),
+      new TeamRepositoryFake(),
       repo,
       new EventBusFake(),
     ).execute({
@@ -132,16 +153,32 @@ describe("DeleteMaintenanceTask", () => {
     if (!result.ok) expect(result.error).toBeInstanceOf(NotFoundError);
   });
 
-  it("returns forbidden for another owner's task", async () => {
-    const task = makeTask(UserId.generate());
-    const repo = new MaintenanceTaskRepositoryFake(task);
+  it("returns forbidden when the requester cannot access the parent asset", async () => {
+    const task = makeTask();
+    const otherAsset = Asset.create({
+      ownerId: UserId.generate(),
+      name: "Other truck",
+      metadata: { kind: "vehicle", make: "Ford", model: "F-150", year: 2020 },
+    });
+    const otherTask = MaintenanceTask.reconstitute({
+      id: task.id,
+      assetId: otherAsset.id,
+      ownerId: otherAsset.ownerId,
+      title: task.title,
+      intervalValue: task.intervalValue,
+      intervalUnit: task.intervalUnit,
+      lastCompletedDate: task.lastCompletedDate,
+      nextDue: task.nextDue,
+      createdAt: task.createdAt,
+    });
     const result = await new DeleteMaintenanceTask(
-      new AssetRepositoryFake(asset),
-      repo,
+      new AssetRepositoryFake(otherAsset),
+      new TeamRepositoryFake(),
+      new MaintenanceTaskRepositoryFake(otherTask),
       new EventBusFake(),
     ).execute({
-      taskId: task.id,
-      assetId,
+      taskId: otherTask.id,
+      assetId: otherAsset.id,
       requesterId: ownerId,
     });
     expect(result.ok).toBe(false);
@@ -153,6 +190,7 @@ describe("DeleteMaintenanceTask", () => {
     const repo = new MaintenanceTaskRepositoryFake(task);
     const result = await new DeleteMaintenanceTask(
       new AssetRepositoryFake(asset),
+      new TeamRepositoryFake(),
       repo,
       new EventBusFake(),
     ).execute({

--- a/apps/api/src/application/usecases/DeleteMaintenanceTask.ts
+++ b/apps/api/src/application/usecases/DeleteMaintenanceTask.ts
@@ -12,7 +12,9 @@ import {
 } from "@snaveevans/pineapple-shared";
 import type { MaintenanceTaskRepository } from "../../domain/maintenance/MaintenanceTaskRepository.ts";
 import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
+import type { TeamRepository } from "../../domain/team/TeamRepository.ts";
 import type { EventBus } from "../ports/EventBus.ts";
+import { canAccessAsset } from "./assetAccess.ts";
 
 export type DeleteMaintenanceTaskCommand = {
   taskId: MaintenanceTaskId;
@@ -23,6 +25,7 @@ export type DeleteMaintenanceTaskCommand = {
 export class DeleteMaintenanceTask {
   constructor(
     private readonly assets: AssetRepository,
+    private readonly teams: TeamRepository,
     private readonly tasks: MaintenanceTaskRepository,
     private readonly eventBus: EventBus,
   ) {}
@@ -31,15 +34,15 @@ export class DeleteMaintenanceTask {
     try {
       const task = await this.tasks.findById(command.taskId);
       if (!task) return err(new NotFoundError("Maintenance task not found"));
-      if (task.ownerId !== command.requesterId) {
-        return err(new ForbiddenError("Access denied"));
-      }
       if (task.assetId !== command.assetId) {
         return err(new NotFoundError("Maintenance task not found"));
       }
 
       const asset = await this.assets.findById(task.assetId);
       if (!asset) return err(new NotFoundError("Asset not found"));
+      if (!(await canAccessAsset(asset, command.requesterId, this.teams))) {
+        return err(new ForbiddenError("Access denied"));
+      }
 
       task.remove(command.requesterId, { assetName: asset.name, assetType: asset.type });
       const events = task.pullEvents();

--- a/apps/api/src/application/usecases/GetAsset.ts
+++ b/apps/api/src/application/usecases/GetAsset.ts
@@ -11,21 +11,46 @@ import {
 } from "@snaveevans/pineapple-shared";
 import type { Asset } from "../../domain/asset/Asset.ts";
 import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
+import type { TeamRepository } from "../../domain/team/TeamRepository.ts";
+import type { UserRepository } from "../../domain/identity/UserRepository.ts";
+import { canAccessAsset } from "./assetAccess.ts";
+import { toSharingDescriptor, type AssetSharingDescriptor } from "./assetSharing.ts";
 
 export type GetAssetQuery = {
   assetId: AssetId;
   requesterId: UserId;
 };
 
-export class GetAsset {
-  constructor(private readonly assets: AssetRepository) {}
+export type AssetReadModel = {
+  asset: Asset;
+  sharing: AssetSharingDescriptor;
+};
 
-  async execute(query: GetAssetQuery): Promise<Result<Asset, DomainError>> {
+export class GetAsset {
+  constructor(
+    private readonly assets: AssetRepository,
+    private readonly teams: TeamRepository,
+    private readonly users: UserRepository,
+  ) {}
+
+  async execute(query: GetAssetQuery): Promise<Result<AssetReadModel, DomainError>> {
     try {
       const asset = await this.assets.findById(query.assetId);
       if (!asset) return err(new NotFoundError("Asset not found"));
-      if (asset.ownerId !== query.requesterId) return err(new ForbiddenError("Access denied"));
-      return ok(asset);
+      if (!(await canAccessAsset(asset, query.requesterId, this.teams))) {
+        return err(new ForbiddenError("Access denied"));
+      }
+
+      let ownerDisplayName: string | null = null;
+      if (asset.ownerId !== query.requesterId) {
+        const owners = await this.users.findByIds([asset.ownerId]);
+        ownerDisplayName = owners[0]?.name ?? "Unknown";
+      }
+
+      return ok({
+        asset,
+        sharing: toSharingDescriptor(asset, query.requesterId, ownerDisplayName),
+      });
     } catch (e) {
       if (e instanceof DomainErrorClass) return err(e);
       throw e;

--- a/apps/api/src/application/usecases/GetDashboard.test.ts
+++ b/apps/api/src/application/usecases/GetDashboard.test.ts
@@ -22,6 +22,10 @@ class AssetRepositoryFake implements AssetRepository {
   findByOwner(): Promise<Asset[]> {
     return Promise.resolve(this.assets);
   }
+
+  findVisibleTo(): Promise<Asset[]> {
+    return Promise.resolve(this.assets);
+  }
   save(): Promise<void> {
     return Promise.resolve();
   }
@@ -32,7 +36,7 @@ class MaintenanceTaskRepositoryFake implements MaintenanceTaskRepository {
   findByAsset(): Promise<MaintenanceTask[]> {
     return Promise.resolve([]);
   }
-  findByOwnerForActiveAssets(): Promise<MaintenanceTask[]> {
+  findForVisibleActiveAssets(): Promise<MaintenanceTask[]> {
     return Promise.resolve(this.tasks);
   }
   findById(): Promise<MaintenanceTask | null> {
@@ -233,7 +237,7 @@ describe("GetDashboard", () => {
     });
     const result = await new GetDashboard(
       new AssetRepositoryFake([active, archived]),
-      // findByOwnerForActiveAssets omits archived-asset tasks; see D1MaintenanceTaskRepository.test.ts
+      // findForVisibleActiveAssets omits archived-asset tasks; see D1MaintenanceTaskRepository.test.ts
       new MaintenanceTaskRepositoryFake([
         task(active.id, { title: "Oil change", nextDue: "2026-06-20" }),
       ]),

--- a/apps/api/src/application/usecases/GetDashboard.test.ts
+++ b/apps/api/src/application/usecases/GetDashboard.test.ts
@@ -19,9 +19,6 @@ class AssetRepositoryFake implements AssetRepository {
   findById(): Promise<Asset | null> {
     return Promise.resolve(null);
   }
-  findByOwner(): Promise<Asset[]> {
-    return Promise.resolve(this.assets);
-  }
 
   findVisibleTo(): Promise<Asset[]> {
     return Promise.resolve(this.assets);

--- a/apps/api/src/application/usecases/GetDashboard.ts
+++ b/apps/api/src/application/usecases/GetDashboard.ts
@@ -92,8 +92,8 @@ export class GetDashboard {
     try {
       const todayUtc = this.dates.today();
       const [allAssets, tasks] = await Promise.all([
-        this.assets.findByOwner(query.ownerId),
-        this.tasks.findByOwnerForActiveAssets(query.ownerId),
+        this.assets.findVisibleTo(query.ownerId),
+        this.tasks.findForVisibleActiveAssets(query.ownerId),
       ]);
 
       const activeAssets = allAssets.filter((asset) => asset.archivedAt === null);

--- a/apps/api/src/application/usecases/ListAssets.test.ts
+++ b/apps/api/src/application/usecases/ListAssets.test.ts
@@ -15,10 +15,6 @@ class AssetRepositoryFake implements AssetRepository {
     return Promise.resolve(null);
   }
 
-  findByOwner(ownerId: UserId): Promise<Asset[]> {
-    return Promise.resolve(this.assets.filter((asset) => asset.ownerId === ownerId));
-  }
-
   findVisibleTo(userId: UserId): Promise<Asset[]> {
     this.requestedUserId = userId;
     return Promise.resolve(this.assets.filter((asset) => asset.ownerId === userId));

--- a/apps/api/src/application/usecases/ListAssets.test.ts
+++ b/apps/api/src/application/usecases/ListAssets.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from "vitest";
 import { AssetId, UserId } from "@snaveevans/pineapple-shared";
 import { Asset } from "../../domain/asset/Asset.ts";
 import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
+import { User } from "../../domain/identity/User.ts";
+import type { UserRepository } from "../../domain/identity/UserRepository.ts";
 import { ListAssets } from "./ListAssets.ts";
 
 class AssetRepositoryFake implements AssetRepository {
-  requestedOwnerId: UserId | null = null;
+  requestedUserId: UserId | null = null;
 
   constructor(private readonly assets: Asset[]) {}
 
@@ -14,8 +16,30 @@ class AssetRepositoryFake implements AssetRepository {
   }
 
   findByOwner(ownerId: UserId): Promise<Asset[]> {
-    this.requestedOwnerId = ownerId;
     return Promise.resolve(this.assets.filter((asset) => asset.ownerId === ownerId));
+  }
+
+  findVisibleTo(userId: UserId): Promise<Asset[]> {
+    this.requestedUserId = userId;
+    return Promise.resolve(this.assets.filter((asset) => asset.ownerId === userId));
+  }
+
+  save(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+class UserRepositoryFake implements UserRepository {
+  findById(): Promise<User | null> {
+    return Promise.resolve(null);
+  }
+
+  findByIds(): Promise<User[]> {
+    return Promise.resolve([]);
+  }
+
+  findByEmail(): Promise<User | null> {
+    return Promise.resolve(null);
   }
 
   save(): Promise<void> {
@@ -73,16 +97,16 @@ describe("ListAssets", () => {
       otherOwnerAsset,
     ]);
 
-    const result = await new ListAssets(repository).execute({ ownerId });
-
-    expect(result).toEqual({
-      ok: true,
-      value: {
-        assets: [vehicle, equipment, property],
-        counts: { all: 3, vehicle: 1, equipment: 1, property: 1 },
-      },
+    const result = await new ListAssets(repository, new UserRepositoryFake()).execute({
+      requesterId: ownerId,
     });
-    expect(repository.requestedOwnerId).toBe(ownerId);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.assets.map((item) => item.asset)).toEqual([vehicle, equipment, property]);
+    expect(result.value.assets.every((item) => item.sharing.isOwner)).toBe(true);
+    expect(result.value.counts).toEqual({ all: 3, vehicle: 1, equipment: 1, property: 1 });
+    expect(repository.requestedUserId).toBe(ownerId);
   });
 
   it("returns zero counts when the owner has no active assets", async () => {
@@ -96,7 +120,10 @@ describe("ListAssets", () => {
       updatedAt: new Date("2026-06-01T00:00:00.000Z"),
     });
 
-    const result = await new ListAssets(new AssetRepositoryFake([archived])).execute({ ownerId });
+    const result = await new ListAssets(
+      new AssetRepositoryFake([archived]),
+      new UserRepositoryFake(),
+    ).execute({ requesterId: ownerId });
 
     expect(result).toEqual({
       ok: true,

--- a/apps/api/src/application/usecases/ListAssets.ts
+++ b/apps/api/src/application/usecases/ListAssets.ts
@@ -10,25 +10,58 @@ import {
 } from "@snaveevans/pineapple-shared";
 import type { Asset } from "../../domain/asset/Asset.ts";
 import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
+import type { UserRepository } from "../../domain/identity/UserRepository.ts";
+import { toSharingDescriptor, type AssetSharingDescriptor } from "./assetSharing.ts";
 
 export type ListAssetsQuery = {
-  ownerId: UserId;
+  requesterId: UserId;
+};
+
+export type ListedAsset = {
+  asset: Asset;
+  sharing: AssetSharingDescriptor;
 };
 
 export type AssetListReadModel = {
-  assets: Asset[];
+  assets: ListedAsset[];
   counts: AssetCategoryCounts;
 };
 
 export class ListAssets {
-  constructor(private readonly assets: AssetRepository) {}
+  constructor(
+    private readonly assets: AssetRepository,
+    private readonly users: UserRepository,
+  ) {}
 
   async execute(query: ListAssetsQuery): Promise<Result<AssetListReadModel, DomainError>> {
     try {
-      const assets = (await this.assets.findByOwner(query.ownerId)).filter(
+      const assets = (await this.assets.findVisibleTo(query.requesterId)).filter(
         (asset) => asset.archivedAt === null,
       );
-      return ok({ assets, counts: buildAssetCategoryCounts(assets) });
+
+      const otherOwnerIds = [
+        ...new Set(
+          assets
+            .filter((asset) => asset.ownerId !== query.requesterId)
+            .map((asset) => asset.ownerId),
+        ),
+      ];
+      const owners = otherOwnerIds.length > 0 ? await this.users.findByIds(otherOwnerIds) : [];
+      const ownerNames = new Map(owners.map((user) => [user.id, user.name ?? "Unknown"]));
+
+      const listed: ListedAsset[] = assets.map((asset) => ({
+        asset,
+        sharing: toSharingDescriptor(
+          asset,
+          query.requesterId,
+          asset.ownerId === query.requesterId ? null : (ownerNames.get(asset.ownerId) ?? "Unknown"),
+        ),
+      }));
+
+      return ok({
+        assets: listed,
+        counts: buildAssetCategoryCounts(assets),
+      });
     } catch (e) {
       if (e instanceof DomainErrorClass) return err(e);
       throw e;

--- a/apps/api/src/application/usecases/ListMaintenanceRecords.test.ts
+++ b/apps/api/src/application/usecases/ListMaintenanceRecords.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import { ForbiddenError, NotFoundError, UserId } from "@snaveevans/pineapple-shared";
 import { Asset } from "../../domain/asset/Asset.ts";
 import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
+import type { Team } from "../../domain/team/Team.ts";
+import type { TeamRepository } from "../../domain/team/TeamRepository.ts";
 import { MaintenanceRecord } from "../../domain/maintenance/MaintenanceRecord.ts";
 import type { MaintenanceRecordRepository } from "../../domain/maintenance/MaintenanceRecordRepository.ts";
 import { ListMaintenanceRecords } from "./ListMaintenanceRecords.ts";
@@ -17,6 +19,23 @@ class AssetRepositoryFake implements AssetRepository {
     return Promise.resolve([]);
   }
 
+  findVisibleTo(): Promise<Asset[]> {
+    return Promise.resolve([]);
+  }
+
+  save(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+class TeamRepositoryFake implements TeamRepository {
+  constructor(private readonly team: Team | null = null) {}
+  findByMember(): Promise<Team | null> {
+    return Promise.resolve(this.team);
+  }
+  findById(): Promise<Team | null> {
+    return Promise.resolve(this.team);
+  }
   save(): Promise<void> {
     return Promise.resolve();
   }
@@ -51,6 +70,7 @@ describe("ListMaintenanceRecords", () => {
 
     const result = await new ListMaintenanceRecords(
       new AssetRepositoryFake(asset),
+      new TeamRepositoryFake(),
       records,
     ).execute({ assetId: asset.id, requesterId: ownerId });
 
@@ -63,6 +83,7 @@ describe("ListMaintenanceRecords", () => {
     const assetId = assetFor().id;
     const result = await new ListMaintenanceRecords(
       new AssetRepositoryFake(null),
+      new TeamRepositoryFake(),
       new MaintenanceRecordRepositoryFake([]),
     ).execute({ assetId, requesterId: ownerId });
 
@@ -76,6 +97,7 @@ describe("ListMaintenanceRecords", () => {
 
     const result = await new ListMaintenanceRecords(
       new AssetRepositoryFake(asset),
+      new TeamRepositoryFake(),
       new MaintenanceRecordRepositoryFake([]),
     ).execute({ assetId: asset.id, requesterId: UserId.generate() });
 

--- a/apps/api/src/application/usecases/ListMaintenanceRecords.test.ts
+++ b/apps/api/src/application/usecases/ListMaintenanceRecords.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from "vitest";
 import { ForbiddenError, NotFoundError, UserId } from "@snaveevans/pineapple-shared";
 import { Asset } from "../../domain/asset/Asset.ts";
 import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
-import type { Team } from "../../domain/team/Team.ts";
+import { createMembership } from "../../domain/team/Membership.ts";
+import { Team } from "../../domain/team/Team.ts";
 import type { TeamRepository } from "../../domain/team/TeamRepository.ts";
 import { MaintenanceRecord } from "../../domain/maintenance/MaintenanceRecord.ts";
 import type { MaintenanceRecordRepository } from "../../domain/maintenance/MaintenanceRecordRepository.ts";
@@ -99,6 +100,39 @@ describe("ListMaintenanceRecords", () => {
 
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.error).toBeInstanceOf(ForbiddenError);
+  });
+
+  it("allows a non-owner team member to list records on a shared asset", async () => {
+    const memberId = UserId.generate();
+    const asset = assetFor();
+    asset.pullEvents();
+    const team = Team.create({ ownerId, name: "Field Ops" });
+    team.pullEvents();
+    asset.shareToTeam({ teamId: team.id, teamName: team.name, actorId: ownerId });
+    asset.pullEvents();
+    const memberTeam = Team.reconstitute({
+      id: team.id,
+      ownerId: team.ownerId,
+      name: team.name,
+      createdAt: team.createdAt,
+      members: [
+        ...team.members,
+        createMembership({ userId: memberId, role: "member", joinedAt: new Date() }),
+      ],
+    });
+    const history = [record(asset, "2026-06-01", "2026-06-02T00:00:00.000Z")];
+    const records = new MaintenanceRecordRepositoryFake(history);
+
+    const result = await new ListMaintenanceRecords(
+      new AssetRepositoryFake(asset),
+      new TeamRepositoryFake(memberTeam),
+      records,
+    ).execute({ assetId: asset.id, requesterId: memberId });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toEqual(history);
+    // Records are stored under the asset owner; access follows the asset.
+    expect(records.requestedOwnerId).toBe(ownerId);
   });
 
   function assetFor(): Asset {

--- a/apps/api/src/application/usecases/ListMaintenanceRecords.test.ts
+++ b/apps/api/src/application/usecases/ListMaintenanceRecords.test.ts
@@ -15,10 +15,6 @@ class AssetRepositoryFake implements AssetRepository {
     return Promise.resolve(this.asset);
   }
 
-  findByOwner(): Promise<Asset[]> {
-    return Promise.resolve([]);
-  }
-
   findVisibleTo(): Promise<Asset[]> {
     return Promise.resolve([]);
   }

--- a/apps/api/src/application/usecases/ListMaintenanceRecords.ts
+++ b/apps/api/src/application/usecases/ListMaintenanceRecords.ts
@@ -12,6 +12,8 @@ import {
 import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
 import type { MaintenanceRecord } from "../../domain/maintenance/MaintenanceRecord.ts";
 import type { MaintenanceRecordRepository } from "../../domain/maintenance/MaintenanceRecordRepository.ts";
+import type { TeamRepository } from "../../domain/team/TeamRepository.ts";
+import { canAccessAsset } from "./assetAccess.ts";
 
 export type ListMaintenanceRecordsQuery = {
   assetId: AssetId;
@@ -21,6 +23,7 @@ export type ListMaintenanceRecordsQuery = {
 export class ListMaintenanceRecords {
   constructor(
     private readonly assets: AssetRepository,
+    private readonly teams: TeamRepository,
     private readonly records: MaintenanceRecordRepository,
   ) {}
 
@@ -30,11 +33,12 @@ export class ListMaintenanceRecords {
     try {
       const asset = await this.assets.findById(query.assetId);
       if (!asset) return err(new NotFoundError("Asset not found"));
-      if (asset.ownerId !== query.requesterId) {
+      if (!(await canAccessAsset(asset, query.requesterId, this.teams))) {
         return err(new ForbiddenError("Access denied"));
       }
 
-      const records = await this.records.findByAsset(asset.id, query.requesterId);
+      // Access follows the asset; records are stored under the asset owner.
+      const records = await this.records.findByAsset(asset.id, asset.ownerId);
       return ok(records);
     } catch (error) {
       if (error instanceof DomainErrorClass) return err(error);

--- a/apps/api/src/application/usecases/ListMaintenanceTasks.test.ts
+++ b/apps/api/src/application/usecases/ListMaintenanceTasks.test.ts
@@ -8,7 +8,8 @@ import {
 } from "@snaveevans/pineapple-shared";
 import { Asset } from "../../domain/asset/Asset.ts";
 import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
-import type { Team } from "../../domain/team/Team.ts";
+import { createMembership } from "../../domain/team/Membership.ts";
+import { Team } from "../../domain/team/Team.ts";
 import type { TeamRepository } from "../../domain/team/TeamRepository.ts";
 import { MaintenanceTask } from "../../domain/maintenance/MaintenanceTask.ts";
 import type { MaintenanceTaskRepository } from "../../domain/maintenance/MaintenanceTaskRepository.ts";
@@ -18,9 +19,6 @@ class AssetRepositoryFake implements AssetRepository {
   constructor(private readonly asset: Asset | null) {}
   findById(): Promise<Asset | null> {
     return Promise.resolve(this.asset);
-  }
-  findByOwner(): Promise<Asset[]> {
-    return Promise.resolve([]);
   }
 
   findVisibleTo(): Promise<Asset[]> {
@@ -130,5 +128,34 @@ describe("ListMaintenanceTasks", () => {
 
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.error).toBeInstanceOf(ForbiddenError);
+  });
+
+  it("allows a non-owner team member to list tasks on a shared asset", async () => {
+    const memberId = UserId.generate();
+    const a = asset(ownerId);
+    const team = Team.create({ ownerId, name: "Field Ops" });
+    team.pullEvents();
+    a.shareToTeam({ teamId: team.id, teamName: team.name, actorId: ownerId });
+    a.pullEvents();
+    const memberTeam = Team.reconstitute({
+      id: team.id,
+      ownerId: team.ownerId,
+      name: team.name,
+      createdAt: team.createdAt,
+      members: [
+        ...team.members,
+        createMembership({ userId: memberId, role: "member", joinedAt: new Date() }),
+      ],
+    });
+    const task = makeTask(a.id);
+
+    const result = await new ListMaintenanceTasks(
+      new AssetRepositoryFake(a),
+      new TeamRepositoryFake(memberTeam),
+      new MaintenanceTaskRepositoryFake([task]),
+    ).execute({ assetId: a.id, requesterId: memberId });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toEqual([task]);
   });
 });

--- a/apps/api/src/application/usecases/ListMaintenanceTasks.test.ts
+++ b/apps/api/src/application/usecases/ListMaintenanceTasks.test.ts
@@ -8,6 +8,8 @@ import {
 } from "@snaveevans/pineapple-shared";
 import { Asset } from "../../domain/asset/Asset.ts";
 import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
+import type { Team } from "../../domain/team/Team.ts";
+import type { TeamRepository } from "../../domain/team/TeamRepository.ts";
 import { MaintenanceTask } from "../../domain/maintenance/MaintenanceTask.ts";
 import type { MaintenanceTaskRepository } from "../../domain/maintenance/MaintenanceTaskRepository.ts";
 import { ListMaintenanceTasks } from "./ListMaintenanceTasks.ts";
@@ -20,6 +22,23 @@ class AssetRepositoryFake implements AssetRepository {
   findByOwner(): Promise<Asset[]> {
     return Promise.resolve([]);
   }
+
+  findVisibleTo(): Promise<Asset[]> {
+    return Promise.resolve([]);
+  }
+  save(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+class TeamRepositoryFake implements TeamRepository {
+  constructor(private readonly team: Team | null = null) {}
+  findByMember(): Promise<Team | null> {
+    return Promise.resolve(this.team);
+  }
+  findById(): Promise<Team | null> {
+    return Promise.resolve(this.team);
+  }
   save(): Promise<void> {
     return Promise.resolve();
   }
@@ -30,7 +49,7 @@ class MaintenanceTaskRepositoryFake implements MaintenanceTaskRepository {
   findByAsset(): Promise<MaintenanceTask[]> {
     return Promise.resolve(this.tasks);
   }
-  findByOwnerForActiveAssets(): Promise<MaintenanceTask[]> {
+  findForVisibleActiveAssets(): Promise<MaintenanceTask[]> {
     return Promise.resolve([]);
   }
   findById(): Promise<MaintenanceTask | null> {
@@ -70,6 +89,7 @@ describe("ListMaintenanceTasks", () => {
     const task = makeTask(a.id);
     const result = await new ListMaintenanceTasks(
       new AssetRepositoryFake(a),
+      new TeamRepositoryFake(),
       new MaintenanceTaskRepositoryFake([task]),
     ).execute({ assetId: a.id, requesterId: ownerId });
 
@@ -81,6 +101,7 @@ describe("ListMaintenanceTasks", () => {
     const a = asset();
     const result = await new ListMaintenanceTasks(
       new AssetRepositoryFake(a),
+      new TeamRepositoryFake(),
       new MaintenanceTaskRepositoryFake([]),
     ).execute({ assetId: a.id, requesterId: ownerId });
 
@@ -91,6 +112,7 @@ describe("ListMaintenanceTasks", () => {
   it("returns not found when the asset does not exist", async () => {
     const result = await new ListMaintenanceTasks(
       new AssetRepositoryFake(null),
+      new TeamRepositoryFake(),
       new MaintenanceTaskRepositoryFake(),
     ).execute({ assetId: AssetId.generate(), requesterId: ownerId });
 
@@ -102,6 +124,7 @@ describe("ListMaintenanceTasks", () => {
     const a = asset(UserId.generate());
     const result = await new ListMaintenanceTasks(
       new AssetRepositoryFake(a),
+      new TeamRepositoryFake(),
       new MaintenanceTaskRepositoryFake(),
     ).execute({ assetId: a.id, requesterId: ownerId });
 

--- a/apps/api/src/application/usecases/ListMaintenanceTasks.ts
+++ b/apps/api/src/application/usecases/ListMaintenanceTasks.ts
@@ -12,6 +12,8 @@ import {
 import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
 import type { MaintenanceTask } from "../../domain/maintenance/MaintenanceTask.ts";
 import type { MaintenanceTaskRepository } from "../../domain/maintenance/MaintenanceTaskRepository.ts";
+import type { TeamRepository } from "../../domain/team/TeamRepository.ts";
+import { canAccessAsset } from "./assetAccess.ts";
 
 export type ListMaintenanceTasksQuery = {
   assetId: AssetId;
@@ -21,6 +23,7 @@ export type ListMaintenanceTasksQuery = {
 export class ListMaintenanceTasks {
   constructor(
     private readonly assets: AssetRepository,
+    private readonly teams: TeamRepository,
     private readonly tasks: MaintenanceTaskRepository,
   ) {}
 
@@ -28,7 +31,7 @@ export class ListMaintenanceTasks {
     try {
       const asset = await this.assets.findById(query.assetId);
       if (!asset) return err(new NotFoundError("Asset not found"));
-      if (asset.ownerId !== query.requesterId) {
+      if (!(await canAccessAsset(asset, query.requesterId, this.teams))) {
         return err(new ForbiddenError("Access denied"));
       }
 

--- a/apps/api/src/application/usecases/SearchAssets.test.ts
+++ b/apps/api/src/application/usecases/SearchAssets.test.ts
@@ -14,10 +14,6 @@ class AssetRepositoryFake implements AssetRepository {
     return Promise.resolve(null);
   }
 
-  findByOwner(ownerId: UserId): Promise<Asset[]> {
-    return Promise.resolve(this.assets.filter((asset) => asset.ownerId === ownerId));
-  }
-
   findVisibleTo(userId: UserId): Promise<Asset[]> {
     this.requestedUserId = userId;
     return Promise.resolve(this.assets.filter((asset) => asset.ownerId === userId));

--- a/apps/api/src/application/usecases/SearchAssets.test.ts
+++ b/apps/api/src/application/usecases/SearchAssets.test.ts
@@ -6,7 +6,7 @@ import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
 import { SearchAssets } from "./SearchAssets.ts";
 
 class AssetRepositoryFake implements AssetRepository {
-  requestedOwnerId: UserId | null = null;
+  requestedUserId: UserId | null = null;
 
   constructor(private readonly assets: Asset[]) {}
 
@@ -15,8 +15,12 @@ class AssetRepositoryFake implements AssetRepository {
   }
 
   findByOwner(ownerId: UserId): Promise<Asset[]> {
-    this.requestedOwnerId = ownerId;
     return Promise.resolve(this.assets.filter((asset) => asset.ownerId === ownerId));
+  }
+
+  findVisibleTo(userId: UserId): Promise<Asset[]> {
+    this.requestedUserId = userId;
+    return Promise.resolve(this.assets.filter((asset) => asset.ownerId === userId));
   }
 
   save(): Promise<void> {
@@ -48,7 +52,7 @@ function asset(props: {
 
 async function search(assets: Asset[], q: string) {
   const repository = new AssetRepositoryFake(assets);
-  const result = await new SearchAssets(repository).execute({ ownerId, q });
+  const result = await new SearchAssets(repository).execute({ requesterId: ownerId, q });
   expect(result.ok).toBe(true);
   if (!result.ok) throw result.error;
   return { repository, results: result.value };
@@ -76,7 +80,7 @@ describe("SearchAssets", () => {
 
     const { repository, results } = await search([active, archived, anotherOwner], "ram");
 
-    expect(repository.requestedOwnerId).toBe(ownerId);
+    expect(repository.requestedUserId).toBe(ownerId);
     expect(results.map((result) => result.id)).toEqual([active.id]);
   });
 

--- a/apps/api/src/application/usecases/SearchAssets.ts
+++ b/apps/api/src/application/usecases/SearchAssets.ts
@@ -18,6 +18,11 @@ export type SearchAssetsQuery = {
   q: string;
 };
 
+/**
+ * Compact search hit. Intentionally omits the full asset `sharing` descriptor —
+ * list/get carry that; search stays a lightweight name/type/summary match list
+ * over the same visible set (owned + team-shared).
+ */
 export type SearchAssetResult = {
   id: string;
   name: string;

--- a/apps/api/src/application/usecases/SearchAssets.ts
+++ b/apps/api/src/application/usecases/SearchAssets.ts
@@ -14,7 +14,7 @@ import type { AssetType } from "../../domain/asset/AssetType.ts";
 const MAX_SEARCH_RESULTS = 20;
 
 export type SearchAssetsQuery = {
-  ownerId: UserId;
+  requesterId: UserId;
   q: string;
 };
 
@@ -33,7 +33,7 @@ export class SearchAssets {
       const terms = searchTerms(query.q);
       if (terms.length === 0) return ok([]);
 
-      const assets = await this.assets.findByOwner(query.ownerId);
+      const assets = await this.assets.findVisibleTo(query.requesterId);
       const results = assets
         .filter((asset) => asset.archivedAt === null)
         .filter((asset) => matchesAllTerms(asset, terms))

--- a/apps/api/src/application/usecases/ShareAsset.test.ts
+++ b/apps/api/src/application/usecases/ShareAsset.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "vitest";
+import {
+  AssetId,
+  ConflictError,
+  ForbiddenError,
+  NotFoundError,
+  UserId,
+} from "@snaveevans/pineapple-shared";
+import { Asset } from "../../domain/asset/Asset.ts";
+import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
+import type { DomainEvent } from "../../domain/events/DomainEvent.ts";
+import { createMembership } from "../../domain/team/Membership.ts";
+import { Team } from "../../domain/team/Team.ts";
+import type { TeamRepository } from "../../domain/team/TeamRepository.ts";
+import type { EventBus } from "../ports/EventBus.ts";
+import { ShareAsset } from "./ShareAsset.ts";
+
+class FakeAssetRepository implements AssetRepository {
+  saved: Asset | null = null;
+  savedEvents: readonly DomainEvent[] = [];
+
+  constructor(private asset: Asset | null) {}
+
+  findById(): Promise<Asset | null> {
+    return Promise.resolve(this.asset);
+  }
+
+  findByOwner(): Promise<Asset[]> {
+    return Promise.resolve([]);
+  }
+
+  findVisibleTo(): Promise<Asset[]> {
+    return Promise.resolve([]);
+  }
+
+  save(asset: Asset, events: readonly DomainEvent[] = []): Promise<void> {
+    this.saved = asset;
+    this.savedEvents = events;
+    return Promise.resolve();
+  }
+}
+
+class FakeTeamRepository implements TeamRepository {
+  constructor(private team: Team | null) {}
+
+  findByMember(): Promise<Team | null> {
+    return Promise.resolve(this.team);
+  }
+
+  findById(): Promise<Team | null> {
+    return Promise.resolve(this.team);
+  }
+
+  save(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+class RecordingEventBus implements EventBus {
+  readonly events: DomainEvent[] = [];
+
+  publish(event: DomainEvent): Promise<void> {
+    this.events.push(event);
+    return Promise.resolve();
+  }
+
+  publishAll(events: readonly DomainEvent[]): Promise<void> {
+    for (const event of events) this.events.push(event);
+    return Promise.resolve();
+  }
+
+  subscribe(): void {}
+}
+
+function makeAsset(ownerId: UserId): Asset {
+  const asset = Asset.create({
+    ownerId,
+    name: "Truck",
+    metadata: { kind: "vehicle", make: "Ram", model: "2500", year: 2016 },
+  });
+  asset.pullEvents();
+  return asset;
+}
+
+describe("ShareAsset", () => {
+  const ownerId = UserId.generate();
+  const otherId = UserId.generate();
+
+  it("shares the asset to the owner's team and publishes AssetSharedToTeam", async () => {
+    const asset = makeAsset(ownerId);
+    const team = Team.create({ ownerId, name: "Field Ops" });
+    team.pullEvents();
+    const assets = new FakeAssetRepository(asset);
+    const eventBus = new RecordingEventBus();
+
+    const result = await new ShareAsset(assets, new FakeTeamRepository(team), eventBus).execute({
+      assetId: asset.id,
+      requesterId: ownerId,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.sharedTeamId).toBe(team.id);
+    expect(eventBus.events).toHaveLength(1);
+    expect(eventBus.events[0]?.type).toBe("AssetSharedToTeam");
+    expect(assets.savedEvents).toHaveLength(1);
+  });
+
+  it("is idempotent when already shared to the caller's team", async () => {
+    const asset = makeAsset(ownerId);
+    const team = Team.create({ ownerId, name: "Field Ops" });
+    team.pullEvents();
+    asset.shareToTeam({ teamId: team.id, teamName: team.name, actorId: ownerId });
+    asset.pullEvents();
+    const eventBus = new RecordingEventBus();
+
+    const result = await new ShareAsset(
+      new FakeAssetRepository(asset),
+      new FakeTeamRepository(team),
+      eventBus,
+    ).execute({ assetId: asset.id, requesterId: ownerId });
+
+    expect(result.ok).toBe(true);
+    expect(eventBus.events).toHaveLength(0);
+  });
+
+  it("returns 409 when the owner has no team", async () => {
+    const asset = makeAsset(ownerId);
+    const result = await new ShareAsset(
+      new FakeAssetRepository(asset),
+      new FakeTeamRepository(null),
+      new RecordingEventBus(),
+    ).execute({ assetId: asset.id, requesterId: ownerId });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBeInstanceOf(ConflictError);
+  });
+
+  it("returns 403 when a non-owner tries to share", async () => {
+    const asset = makeAsset(ownerId);
+    const team = Team.create({ ownerId, name: "Field Ops" });
+    team.pullEvents();
+    // Simulate other user as member of same team (would need membership API; use reconstitute)
+    const memberTeam = Team.reconstitute({
+      id: team.id,
+      ownerId: team.ownerId,
+      name: team.name,
+      createdAt: team.createdAt,
+      members: [
+        ...team.members,
+        createMembership({ userId: otherId, role: "member", joinedAt: new Date() }),
+      ],
+    });
+    asset.shareToTeam({ teamId: team.id, teamName: team.name, actorId: ownerId });
+    asset.pullEvents();
+
+    const result = await new ShareAsset(
+      new FakeAssetRepository(asset),
+      new FakeTeamRepository(memberTeam),
+      new RecordingEventBus(),
+    ).execute({ assetId: asset.id, requesterId: otherId });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBeInstanceOf(ForbiddenError);
+  });
+
+  it("returns 404 when the asset does not exist", async () => {
+    const result = await new ShareAsset(
+      new FakeAssetRepository(null),
+      new FakeTeamRepository(null),
+      new RecordingEventBus(),
+    ).execute({ assetId: AssetId.generate(), requesterId: ownerId });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBeInstanceOf(NotFoundError);
+  });
+
+  it("returns 403 when a stranger tries to share someone else's personal asset", async () => {
+    const asset = makeAsset(ownerId);
+    const result = await new ShareAsset(
+      new FakeAssetRepository(asset),
+      new FakeTeamRepository(Team.create({ ownerId: otherId, name: "Other" })),
+      new RecordingEventBus(),
+    ).execute({ assetId: asset.id, requesterId: otherId });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBeInstanceOf(ForbiddenError);
+  });
+});

--- a/apps/api/src/application/usecases/ShareAsset.test.ts
+++ b/apps/api/src/application/usecases/ShareAsset.test.ts
@@ -25,10 +25,6 @@ class FakeAssetRepository implements AssetRepository {
     return Promise.resolve(this.asset);
   }
 
-  findByOwner(): Promise<Asset[]> {
-    return Promise.resolve([]);
-  }
-
   findVisibleTo(): Promise<Asset[]> {
     return Promise.resolve([]);
   }

--- a/apps/api/src/application/usecases/ShareAsset.ts
+++ b/apps/api/src/application/usecases/ShareAsset.ts
@@ -1,0 +1,61 @@
+import {
+  type AssetId,
+  ConflictError,
+  type DomainError,
+  DomainError as DomainErrorClass,
+  ForbiddenError,
+  NotFoundError,
+  ok,
+  err,
+  type Result,
+  type UserId,
+} from "@snaveevans/pineapple-shared";
+import type { Asset } from "../../domain/asset/Asset.ts";
+import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
+import type { TeamRepository } from "../../domain/team/TeamRepository.ts";
+import type { EventBus } from "../ports/EventBus.ts";
+import { canAccessAsset } from "./assetAccess.ts";
+
+export type ShareAssetCommand = {
+  assetId: AssetId;
+  requesterId: UserId;
+};
+
+export class ShareAsset {
+  constructor(
+    private readonly assets: AssetRepository,
+    private readonly teams: TeamRepository,
+    private readonly eventBus: EventBus,
+  ) {}
+
+  async execute(cmd: ShareAssetCommand): Promise<Result<Asset, DomainError>> {
+    try {
+      const asset = await this.assets.findById(cmd.assetId);
+      if (!asset) return err(new NotFoundError("Asset not found"));
+
+      if (asset.ownerId !== cmd.requesterId) {
+        const visible = await canAccessAsset(asset, cmd.requesterId, this.teams);
+        if (!visible) return err(new ForbiddenError("Access denied"));
+        return err(new ForbiddenError("Only the asset owner can change sharing"));
+      }
+
+      const team = await this.teams.findByMember(cmd.requesterId);
+      if (!team) return err(new ConflictError("User does not belong to a team"));
+
+      asset.shareToTeam({
+        teamId: team.id,
+        teamName: team.name,
+        actorId: cmd.requesterId,
+      });
+      const events = asset.pullEvents();
+      await this.assets.save(asset, events);
+      if (events.length > 0) {
+        await this.eventBus.publishAll(events);
+      }
+      return ok(asset);
+    } catch (e) {
+      if (e instanceof DomainErrorClass) return err(e);
+      throw e;
+    }
+  }
+}

--- a/apps/api/src/application/usecases/UnshareAsset.test.ts
+++ b/apps/api/src/application/usecases/UnshareAsset.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+import { ForbiddenError, NotFoundError, UserId } from "@snaveevans/pineapple-shared";
+import { Asset } from "../../domain/asset/Asset.ts";
+import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
+import type { DomainEvent } from "../../domain/events/DomainEvent.ts";
+import { createMembership } from "../../domain/team/Membership.ts";
+import { Team } from "../../domain/team/Team.ts";
+import type { TeamRepository } from "../../domain/team/TeamRepository.ts";
+import type { EventBus } from "../ports/EventBus.ts";
+import { UnshareAsset } from "./UnshareAsset.ts";
+
+class FakeAssetRepository implements AssetRepository {
+  constructor(private asset: Asset | null) {}
+
+  findById(): Promise<Asset | null> {
+    return Promise.resolve(this.asset);
+  }
+
+  findByOwner(): Promise<Asset[]> {
+    return Promise.resolve([]);
+  }
+
+  findVisibleTo(): Promise<Asset[]> {
+    return Promise.resolve([]);
+  }
+
+  save(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+class FakeTeamRepository implements TeamRepository {
+  constructor(private team: Team | null) {}
+
+  findByMember(): Promise<Team | null> {
+    return Promise.resolve(this.team);
+  }
+
+  findById(): Promise<Team | null> {
+    return Promise.resolve(this.team);
+  }
+
+  save(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+class RecordingEventBus implements EventBus {
+  readonly events: DomainEvent[] = [];
+
+  publish(event: DomainEvent): Promise<void> {
+    this.events.push(event);
+    return Promise.resolve();
+  }
+
+  publishAll(events: readonly DomainEvent[]): Promise<void> {
+    for (const event of events) this.events.push(event);
+    return Promise.resolve();
+  }
+
+  subscribe(): void {}
+}
+
+function makeAsset(ownerId: UserId): Asset {
+  const asset = Asset.create({
+    ownerId,
+    name: "Truck",
+    metadata: { kind: "vehicle", make: "Ram", model: "2500", year: 2016 },
+  });
+  asset.pullEvents();
+  return asset;
+}
+
+describe("UnshareAsset", () => {
+  const ownerId = UserId.generate();
+  const otherId = UserId.generate();
+
+  it("unshares a shared asset and publishes AssetUnsharedFromTeam", async () => {
+    const asset = makeAsset(ownerId);
+    const team = Team.create({ ownerId, name: "Field Ops" });
+    team.pullEvents();
+    asset.shareToTeam({ teamId: team.id, teamName: team.name, actorId: ownerId });
+    asset.pullEvents();
+    const eventBus = new RecordingEventBus();
+
+    const result = await new UnshareAsset(
+      new FakeAssetRepository(asset),
+      new FakeTeamRepository(team),
+      eventBus,
+    ).execute({ assetId: asset.id, requesterId: ownerId });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.sharedTeamId).toBeNull();
+    expect(eventBus.events).toHaveLength(1);
+    expect(eventBus.events[0]?.type).toBe("AssetUnsharedFromTeam");
+  });
+
+  it("is idempotent when the asset is already personal", async () => {
+    const asset = makeAsset(ownerId);
+    const eventBus = new RecordingEventBus();
+
+    const result = await new UnshareAsset(
+      new FakeAssetRepository(asset),
+      new FakeTeamRepository(null),
+      eventBus,
+    ).execute({ assetId: asset.id, requesterId: ownerId });
+
+    expect(result.ok).toBe(true);
+    expect(eventBus.events).toHaveLength(0);
+  });
+
+  it("returns 403 when a non-owner tries to unshare", async () => {
+    const asset = makeAsset(ownerId);
+    const team = Team.create({ ownerId, name: "Field Ops" });
+    team.pullEvents();
+    asset.shareToTeam({ teamId: team.id, teamName: team.name, actorId: ownerId });
+    asset.pullEvents();
+    const memberTeam = Team.reconstitute({
+      id: team.id,
+      ownerId: team.ownerId,
+      name: team.name,
+      createdAt: team.createdAt,
+      members: [
+        ...team.members,
+        createMembership({ userId: otherId, role: "member", joinedAt: new Date() }),
+      ],
+    });
+
+    const result = await new UnshareAsset(
+      new FakeAssetRepository(asset),
+      new FakeTeamRepository(memberTeam),
+      new RecordingEventBus(),
+    ).execute({ assetId: asset.id, requesterId: otherId });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBeInstanceOf(ForbiddenError);
+  });
+
+  it("returns 404 when the asset does not exist", async () => {
+    const result = await new UnshareAsset(
+      new FakeAssetRepository(null),
+      new FakeTeamRepository(null),
+      new RecordingEventBus(),
+    ).execute({
+      assetId: makeAsset(ownerId).id,
+      requesterId: ownerId,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBeInstanceOf(NotFoundError);
+  });
+});

--- a/apps/api/src/application/usecases/UnshareAsset.test.ts
+++ b/apps/api/src/application/usecases/UnshareAsset.test.ts
@@ -16,10 +16,6 @@ class FakeAssetRepository implements AssetRepository {
     return Promise.resolve(this.asset);
   }
 
-  findByOwner(): Promise<Asset[]> {
-    return Promise.resolve([]);
-  }
-
   findVisibleTo(): Promise<Asset[]> {
     return Promise.resolve([]);
   }

--- a/apps/api/src/application/usecases/UnshareAsset.ts
+++ b/apps/api/src/application/usecases/UnshareAsset.ts
@@ -1,0 +1,65 @@
+import {
+  type AssetId,
+  type DomainError,
+  DomainError as DomainErrorClass,
+  ForbiddenError,
+  NotFoundError,
+  ok,
+  err,
+  type Result,
+  type UserId,
+} from "@snaveevans/pineapple-shared";
+import type { Asset } from "../../domain/asset/Asset.ts";
+import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
+import type { TeamRepository } from "../../domain/team/TeamRepository.ts";
+import type { EventBus } from "../ports/EventBus.ts";
+import { canAccessAsset } from "./assetAccess.ts";
+
+export type UnshareAssetCommand = {
+  assetId: AssetId;
+  requesterId: UserId;
+};
+
+export class UnshareAsset {
+  constructor(
+    private readonly assets: AssetRepository,
+    private readonly teams: TeamRepository,
+    private readonly eventBus: EventBus,
+  ) {}
+
+  async execute(cmd: UnshareAssetCommand): Promise<Result<Asset, DomainError>> {
+    try {
+      const asset = await this.assets.findById(cmd.assetId);
+      if (!asset) return err(new NotFoundError("Asset not found"));
+
+      if (asset.ownerId !== cmd.requesterId) {
+        const visible = await canAccessAsset(asset, cmd.requesterId, this.teams);
+        if (!visible) return err(new ForbiddenError("Access denied"));
+        return err(new ForbiddenError("Only the asset owner can change sharing"));
+      }
+
+      if (asset.sharedTeamId === null) {
+        return ok(asset);
+      }
+
+      const team = await this.teams.findById(asset.sharedTeamId);
+      const teamId = asset.sharedTeamId;
+      const teamName = team?.name ?? "Unknown team";
+
+      asset.unshare({
+        actorId: cmd.requesterId,
+        teamId,
+        teamName,
+      });
+      const events = asset.pullEvents();
+      await this.assets.save(asset, events);
+      if (events.length > 0) {
+        await this.eventBus.publishAll(events);
+      }
+      return ok(asset);
+    } catch (e) {
+      if (e instanceof DomainErrorClass) return err(e);
+      throw e;
+    }
+  }
+}

--- a/apps/api/src/application/usecases/assetAccess.test.ts
+++ b/apps/api/src/application/usecases/assetAccess.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { UserId } from "@snaveevans/pineapple-shared";
+import { Asset } from "../../domain/asset/Asset.ts";
+import { createMembership } from "../../domain/team/Membership.ts";
+import { Team } from "../../domain/team/Team.ts";
+import type { TeamRepository } from "../../domain/team/TeamRepository.ts";
+import { canAccessAsset } from "./assetAccess.ts";
+
+class TeamRepositoryFake implements TeamRepository {
+  constructor(private readonly team: Team | null) {}
+  findByMember(): Promise<Team | null> {
+    return Promise.resolve(this.team);
+  }
+  findById(): Promise<Team | null> {
+    return Promise.resolve(this.team);
+  }
+  save(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+function makeAsset(ownerId: UserId): Asset {
+  const asset = Asset.create({
+    ownerId,
+    name: "Truck",
+    metadata: { kind: "vehicle", make: "Ram", model: "2500", year: 2016 },
+  });
+  asset.pullEvents();
+  return asset;
+}
+
+describe("canAccessAsset", () => {
+  const ownerId = UserId.generate();
+  const memberId = UserId.generate();
+  const strangerId = UserId.generate();
+
+  it("allows the asset owner", async () => {
+    const asset = makeAsset(ownerId);
+    await expect(canAccessAsset(asset, ownerId, new TeamRepositoryFake(null))).resolves.toBe(true);
+  });
+
+  it("denies a non-owner when the asset is personal", async () => {
+    const asset = makeAsset(ownerId);
+    await expect(canAccessAsset(asset, memberId, new TeamRepositoryFake(null))).resolves.toBe(
+      false,
+    );
+  });
+
+  it("allows a team member when the asset is shared to their team", async () => {
+    const asset = makeAsset(ownerId);
+    const team = Team.create({ ownerId, name: "Field Ops" });
+    team.pullEvents();
+    const memberTeam = Team.reconstitute({
+      id: team.id,
+      ownerId: team.ownerId,
+      name: team.name,
+      createdAt: team.createdAt,
+      members: [
+        ...team.members,
+        createMembership({ userId: memberId, role: "member", joinedAt: new Date() }),
+      ],
+    });
+    asset.shareToTeam({ teamId: team.id, teamName: team.name, actorId: ownerId });
+    asset.pullEvents();
+
+    await expect(canAccessAsset(asset, memberId, new TeamRepositoryFake(memberTeam))).resolves.toBe(
+      true,
+    );
+  });
+
+  it("denies a stranger when the asset is shared to another team", async () => {
+    const asset = makeAsset(ownerId);
+    const team = Team.create({ ownerId, name: "Field Ops" });
+    team.pullEvents();
+    asset.shareToTeam({ teamId: team.id, teamName: team.name, actorId: ownerId });
+    asset.pullEvents();
+    const otherTeam = Team.create({ ownerId: strangerId, name: "Other" });
+    otherTeam.pullEvents();
+
+    await expect(
+      canAccessAsset(asset, strangerId, new TeamRepositoryFake(otherTeam)),
+    ).resolves.toBe(false);
+  });
+});

--- a/apps/api/src/application/usecases/assetAccess.ts
+++ b/apps/api/src/application/usecases/assetAccess.ts
@@ -1,0 +1,18 @@
+import type { UserId } from "@snaveevans/pineapple-shared";
+import type { Asset } from "../../domain/asset/Asset.ts";
+import type { TeamRepository } from "../../domain/team/TeamRepository.ts";
+
+/**
+ * Whether the requester can see/edit the asset: they own it, or they belong
+ * to the team it is shared with. Access to dependent records follows the asset.
+ */
+export async function canAccessAsset(
+  asset: Asset,
+  requesterId: UserId,
+  teams: TeamRepository,
+): Promise<boolean> {
+  if (asset.ownerId === requesterId) return true;
+  if (asset.sharedTeamId === null) return false;
+  const team = await teams.findByMember(requesterId);
+  return team !== null && team.id === asset.sharedTeamId;
+}

--- a/apps/api/src/application/usecases/assetSharing.ts
+++ b/apps/api/src/application/usecases/assetSharing.ts
@@ -1,0 +1,21 @@
+import type { UserId } from "@snaveevans/pineapple-shared";
+import type { Asset } from "../../domain/asset/Asset.ts";
+
+export type AssetSharingDescriptor = {
+  scope: "personal" | "team";
+  isOwner: boolean;
+  ownerDisplayName?: string;
+};
+
+export function toSharingDescriptor(
+  asset: Asset,
+  requesterId: UserId,
+  ownerDisplayName: string | null,
+): AssetSharingDescriptor {
+  const isOwner = asset.ownerId === requesterId;
+  const scope = asset.sharedTeamId === null ? "personal" : "team";
+  if (isOwner || ownerDisplayName === null) {
+    return { scope, isOwner };
+  }
+  return { scope, isOwner, ownerDisplayName };
+}

--- a/apps/api/src/domain/asset/Asset.test.ts
+++ b/apps/api/src/domain/asset/Asset.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { UserId, ValidationError } from "@snaveevans/pineapple-shared";
+import { TeamId, UserId, ValidationError } from "@snaveevans/pineapple-shared";
 import { Asset } from "./Asset";
 
 describe("Asset", () => {
@@ -12,6 +12,8 @@ describe("Asset", () => {
     expect(asset.name).toBe("My Truck");
     expect(asset.type).toBe("vehicle");
     expect(asset.ownerId).toBe(ownerId);
+    expect(asset.sharedTeamId).toBeNull();
+    expect(asset.isShared).toBe(false);
 
     const events = asset.pullEvents();
     expect(events).toHaveLength(1);
@@ -66,9 +68,82 @@ describe("Asset", () => {
       archivedAt: null,
       createdAt: original.createdAt,
       updatedAt: original.updatedAt,
+      sharedTeamId: null,
     });
 
     expect(reconstituted.pullEvents()).toHaveLength(0);
     expect(reconstituted.name).toBe("Truck");
+    expect(reconstituted.sharedTeamId).toBeNull();
+  });
+
+  it("shares to a team and emits AssetSharedToTeam", () => {
+    const asset = Asset.create({ ownerId, name: "Truck", metadata: validVehicle });
+    asset.pullEvents();
+    const teamId = TeamId.generate();
+
+    asset.shareToTeam({ teamId, teamName: "Field Ops", actorId: ownerId });
+
+    expect(asset.sharedTeamId).toBe(teamId);
+    expect(asset.isShared).toBe(true);
+    const events = asset.pullEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: "AssetSharedToTeam",
+      assetId: asset.id,
+      ownerId,
+      actorId: ownerId,
+      assetName: "Truck",
+      teamId,
+      teamName: "Field Ops",
+    });
+  });
+
+  it("shareToTeam is idempotent for the same team", () => {
+    const asset = Asset.create({ ownerId, name: "Truck", metadata: validVehicle });
+    asset.pullEvents();
+    const teamId = TeamId.generate();
+
+    asset.shareToTeam({ teamId, teamName: "Field Ops", actorId: ownerId });
+    asset.pullEvents();
+    asset.shareToTeam({ teamId, teamName: "Field Ops", actorId: ownerId });
+
+    expect(asset.sharedTeamId).toBe(teamId);
+    expect(asset.pullEvents()).toHaveLength(0);
+  });
+
+  it("unshares and emits AssetUnsharedFromTeam", () => {
+    const asset = Asset.create({ ownerId, name: "Truck", metadata: validVehicle });
+    asset.pullEvents();
+    const teamId = TeamId.generate();
+    asset.shareToTeam({ teamId, teamName: "Field Ops", actorId: ownerId });
+    asset.pullEvents();
+
+    asset.unshare({ actorId: ownerId, teamId, teamName: "Field Ops" });
+
+    expect(asset.sharedTeamId).toBeNull();
+    expect(asset.isShared).toBe(false);
+    const events = asset.pullEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: "AssetUnsharedFromTeam",
+      assetId: asset.id,
+      teamId,
+      teamName: "Field Ops",
+      assetName: "Truck",
+    });
+  });
+
+  it("unshare is idempotent when already personal", () => {
+    const asset = Asset.create({ ownerId, name: "Truck", metadata: validVehicle });
+    asset.pullEvents();
+
+    asset.unshare({
+      actorId: ownerId,
+      teamId: TeamId.generate(),
+      teamName: "Field Ops",
+    });
+
+    expect(asset.sharedTeamId).toBeNull();
+    expect(asset.pullEvents()).toHaveLength(0);
   });
 });

--- a/apps/api/src/domain/asset/Asset.ts
+++ b/apps/api/src/domain/asset/Asset.ts
@@ -1,8 +1,10 @@
-import { AssetId, UserId, ValidationError } from "@snaveevans/pineapple-shared";
+import { AssetId, TeamId, UserId, ValidationError } from "@snaveevans/pineapple-shared";
 import { validateMetadata, type AssetMetadata } from "./AssetMetadata.ts";
 import type { AssetType } from "./AssetType.ts";
 import type { DomainEvent } from "../events/DomainEvent.ts";
 import { AssetCreated } from "./events/AssetCreated.ts";
+import { AssetSharedToTeam } from "./events/AssetSharedToTeam.ts";
+import { AssetUnsharedFromTeam } from "./events/AssetUnsharedFromTeam.ts";
 
 export class Asset {
   private _domainEvents: DomainEvent[] = [];
@@ -15,10 +17,19 @@ export class Asset {
     public archivedAt: Date | null,
     readonly createdAt: Date,
     public updatedAt: Date,
+    private _sharedTeamId: TeamId | null,
   ) {}
 
   get type(): AssetType {
     return this.metadata.kind;
+  }
+
+  get sharedTeamId(): TeamId | null {
+    return this._sharedTeamId;
+  }
+
+  get isShared(): boolean {
+    return this._sharedTeamId !== null;
   }
 
   static create(props: { ownerId: UserId; name: string; metadata: AssetMetadata }): Asset {
@@ -36,6 +47,7 @@ export class Asset {
       null,
       now,
       now,
+      null,
     );
     asset._domainEvents.push(
       AssetCreated({
@@ -58,6 +70,7 @@ export class Asset {
     archivedAt: Date | null;
     createdAt: Date;
     updatedAt: Date;
+    sharedTeamId?: TeamId | null;
   }): Asset {
     return new Asset(
       props.id,
@@ -67,6 +80,7 @@ export class Asset {
       props.archivedAt,
       props.createdAt,
       props.updatedAt,
+      props.sharedTeamId ?? null,
     );
   }
 
@@ -74,6 +88,48 @@ export class Asset {
     if (!name?.trim()) throw new ValidationError("Name required", "name");
     this.name = name.trim();
     this.updatedAt = new Date();
+  }
+
+  /**
+   * Share this asset to a team. Idempotent when already shared to the same team
+   * (no event). Cross-aggregate fields (teamName) are supplied by the application layer.
+   */
+  shareToTeam(props: { teamId: TeamId; teamName: string; actorId: UserId }): void {
+    if (this._sharedTeamId === props.teamId) return;
+
+    this._sharedTeamId = props.teamId;
+    this.updatedAt = new Date();
+    this._domainEvents.push(
+      AssetSharedToTeam({
+        assetId: this.id,
+        ownerId: this.ownerId,
+        actorId: props.actorId,
+        assetName: this.name,
+        teamId: props.teamId,
+        teamName: props.teamName,
+      }),
+    );
+  }
+
+  /**
+   * Return this asset to personal. Idempotent when already personal (no event).
+   * teamName is supplied by the application layer for the durable event.
+   */
+  unshare(props: { actorId: UserId; teamId: TeamId; teamName: string }): void {
+    if (this._sharedTeamId === null) return;
+
+    this._sharedTeamId = null;
+    this.updatedAt = new Date();
+    this._domainEvents.push(
+      AssetUnsharedFromTeam({
+        assetId: this.id,
+        ownerId: this.ownerId,
+        actorId: props.actorId,
+        assetName: this.name,
+        teamId: props.teamId,
+        teamName: props.teamName,
+      }),
+    );
   }
 
   pullEvents(): DomainEvent[] {

--- a/apps/api/src/domain/asset/Asset.ts
+++ b/apps/api/src/domain/asset/Asset.ts
@@ -93,6 +93,12 @@ export class Asset {
   /**
    * Share this asset to a team. Idempotent when already shared to the same team
    * (no event). Cross-aggregate fields (teamName) are supplied by the application layer.
+   *
+   * If already shared to a *different* team, this overwrites `sharedTeamId` and emits
+   * only `AssetSharedToTeam` — not `AssetUnsharedFromTeam` for the outgoing team.
+   * Unreachable today (one team per user; share always targets the caller's team),
+   * but when multi-team / team-switching lands, emit an unshare for the prior team
+   * so durable consumers keep a complete audit trail (ADR-0010).
    */
   shareToTeam(props: { teamId: TeamId; teamName: string; actorId: UserId }): void {
     if (this._sharedTeamId === props.teamId) return;

--- a/apps/api/src/domain/asset/AssetRepository.ts
+++ b/apps/api/src/domain/asset/AssetRepository.ts
@@ -5,5 +5,7 @@ import type { Asset } from "./Asset.ts";
 export interface AssetRepository {
   findById(id: AssetId): Promise<Asset | null>;
   findByOwner(ownerId: UserId): Promise<Asset[]>;
+  /** Assets the user owns plus assets shared to a team they belong to. */
+  findVisibleTo(userId: UserId): Promise<Asset[]>;
   save(asset: Asset, events?: readonly DomainEvent[]): Promise<void>;
 }

--- a/apps/api/src/domain/asset/AssetRepository.ts
+++ b/apps/api/src/domain/asset/AssetRepository.ts
@@ -4,7 +4,6 @@ import type { Asset } from "./Asset.ts";
 
 export interface AssetRepository {
   findById(id: AssetId): Promise<Asset | null>;
-  findByOwner(ownerId: UserId): Promise<Asset[]>;
   /** Assets the user owns plus assets shared to a team they belong to. */
   findVisibleTo(userId: UserId): Promise<Asset[]>;
   save(asset: Asset, events?: readonly DomainEvent[]): Promise<void>;

--- a/apps/api/src/domain/asset/events/AssetSharedToTeam.ts
+++ b/apps/api/src/domain/asset/events/AssetSharedToTeam.ts
@@ -1,0 +1,30 @@
+import type { AssetId, TeamId, UserId } from "@snaveevans/pineapple-shared";
+import { createDomainEventMetadata, type DomainEvent } from "../../events/DomainEvent.ts";
+
+export type AssetSharedToTeam = DomainEvent & {
+  type: "AssetSharedToTeam";
+  assetId: AssetId;
+  ownerId: UserId;
+  actorId: UserId;
+  assetName: string;
+  teamId: TeamId;
+  teamName: string;
+};
+
+export const AssetSharedToTeam = (props: {
+  assetId: AssetId;
+  ownerId: UserId;
+  actorId: UserId;
+  assetName: string;
+  teamId: TeamId;
+  teamName: string;
+}): AssetSharedToTeam => ({
+  ...createDomainEventMetadata(),
+  type: "AssetSharedToTeam",
+  assetId: props.assetId,
+  ownerId: props.ownerId,
+  actorId: props.actorId,
+  assetName: props.assetName,
+  teamId: props.teamId,
+  teamName: props.teamName,
+});

--- a/apps/api/src/domain/asset/events/AssetUnsharedFromTeam.ts
+++ b/apps/api/src/domain/asset/events/AssetUnsharedFromTeam.ts
@@ -1,0 +1,30 @@
+import type { AssetId, TeamId, UserId } from "@snaveevans/pineapple-shared";
+import { createDomainEventMetadata, type DomainEvent } from "../../events/DomainEvent.ts";
+
+export type AssetUnsharedFromTeam = DomainEvent & {
+  type: "AssetUnsharedFromTeam";
+  assetId: AssetId;
+  ownerId: UserId;
+  actorId: UserId;
+  assetName: string;
+  teamId: TeamId;
+  teamName: string;
+};
+
+export const AssetUnsharedFromTeam = (props: {
+  assetId: AssetId;
+  ownerId: UserId;
+  actorId: UserId;
+  assetName: string;
+  teamId: TeamId;
+  teamName: string;
+}): AssetUnsharedFromTeam => ({
+  ...createDomainEventMetadata(),
+  type: "AssetUnsharedFromTeam",
+  assetId: props.assetId,
+  ownerId: props.ownerId,
+  actorId: props.actorId,
+  assetName: props.assetName,
+  teamId: props.teamId,
+  teamName: props.teamName,
+});

--- a/apps/api/src/domain/maintenance/MaintenanceTaskRepository.ts
+++ b/apps/api/src/domain/maintenance/MaintenanceTaskRepository.ts
@@ -5,8 +5,11 @@ import type { MaintenanceTask } from "./MaintenanceTask.ts";
 export interface MaintenanceTaskRepository {
   /** Returns tasks ordered by nextDue ASC. Ownership is verified at the use-case layer. */
   findByAsset(assetId: AssetId): Promise<MaintenanceTask[]>;
-  /** Returns tasks for active assets owned by the caller, ordered by nextDue ASC then createdAt ASC. */
-  findByOwnerForActiveAssets(ownerId: UserId): Promise<MaintenanceTask[]>;
+  /**
+   * Tasks on active assets the caller can see (owns or shared to their team),
+   * ordered by nextDue ASC then createdAt ASC.
+   */
+  findForVisibleActiveAssets(userId: UserId): Promise<MaintenanceTask[]>;
   findById(id: MaintenanceTaskId): Promise<MaintenanceTask | null>;
   save(task: MaintenanceTask, events?: readonly DomainEvent[]): Promise<void>;
   /** Nulls task_id on linked maintenance_records, then deletes the task. */

--- a/apps/api/src/infrastructure/persistence/D1AssetRepository.test.ts
+++ b/apps/api/src/infrastructure/persistence/D1AssetRepository.test.ts
@@ -1,0 +1,43 @@
+import { UserId } from "@snaveevans/pineapple-shared";
+import { describe, expect, it, vi } from "vitest";
+import { D1AssetRepository } from "./D1AssetRepository.ts";
+
+type BoundStatement = {
+  query: string;
+  values: unknown[];
+};
+
+function createDatabaseHarness() {
+  const statements: BoundStatement[] = [];
+  const prepare = vi.fn((query: string) => {
+    return {
+      bind: (...values: unknown[]) => {
+        statements.push({ query, values });
+        return {
+          all: vi.fn().mockResolvedValue({ results: [] }),
+          first: vi.fn().mockResolvedValue(null),
+          run: vi.fn().mockResolvedValue(undefined),
+        };
+      },
+    } as unknown as D1PreparedStatement;
+  });
+  const db = { prepare } as unknown as D1Database;
+
+  return { db, statements };
+}
+
+describe("D1AssetRepository", () => {
+  it("findVisibleTo includes owned assets and team-shared assets via membership subquery", async () => {
+    const { db, statements } = createDatabaseHarness();
+    const userId = UserId.generate();
+
+    await new D1AssetRepository(db).findVisibleTo(userId);
+
+    expect(statements).toHaveLength(1);
+    const query = statements[0]?.query ?? "";
+    expect(query).toContain("owner_id = ?");
+    expect(query).toContain("shared_team_id IN");
+    expect(query).toContain("SELECT team_id FROM team_members WHERE user_id = ?");
+    expect(statements[0]?.values).toEqual([userId, userId]);
+  });
+});

--- a/apps/api/src/infrastructure/persistence/D1AssetRepository.ts
+++ b/apps/api/src/infrastructure/persistence/D1AssetRepository.ts
@@ -1,4 +1,4 @@
-import { AssetId, UserId } from "@snaveevans/pineapple-shared";
+import { AssetId, TeamId, UserId } from "@snaveevans/pineapple-shared";
 import { Asset } from "../../domain/asset/Asset.ts";
 import type { AssetMetadata } from "../../domain/asset/AssetMetadata.ts";
 import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
@@ -14,16 +14,18 @@ type AssetRow = {
   archived_at: string | null;
   created_at: string;
   updated_at: string;
+  shared_team_id: string | null;
 };
+
+const SELECT_COLUMNS =
+  "id, owner_id, name, type, metadata, archived_at, created_at, updated_at, shared_team_id";
 
 export class D1AssetRepository implements AssetRepository {
   constructor(private readonly db: D1Database) {}
 
   async findById(id: AssetId): Promise<Asset | null> {
     const row = await this.db
-      .prepare(
-        "SELECT id, owner_id, name, type, metadata, archived_at, created_at, updated_at FROM assets WHERE id = ?",
-      )
+      .prepare(`SELECT ${SELECT_COLUMNS} FROM assets WHERE id = ?`)
       .bind(id)
       .first<AssetRow>();
     return row ? this.#rowToAsset(row) : null;
@@ -31,10 +33,23 @@ export class D1AssetRepository implements AssetRepository {
 
   async findByOwner(ownerId: UserId): Promise<Asset[]> {
     const result = await this.db
-      .prepare(
-        "SELECT id, owner_id, name, type, metadata, archived_at, created_at, updated_at FROM assets WHERE owner_id = ?",
-      )
+      .prepare(`SELECT ${SELECT_COLUMNS} FROM assets WHERE owner_id = ?`)
       .bind(ownerId)
+      .all<AssetRow>();
+    return result.results.map((row) => this.#rowToAsset(row));
+  }
+
+  async findVisibleTo(userId: UserId): Promise<Asset[]> {
+    const result = await this.db
+      .prepare(
+        `SELECT ${SELECT_COLUMNS}
+         FROM assets
+         WHERE owner_id = ?
+            OR shared_team_id IN (
+                 SELECT team_id FROM team_members WHERE user_id = ?
+               )`,
+      )
+      .bind(userId, userId)
       .all<AssetRow>();
     return result.results.map((row) => this.#rowToAsset(row));
   }
@@ -42,13 +57,14 @@ export class D1AssetRepository implements AssetRepository {
   async save(asset: Asset, events: readonly DomainEvent[] = []): Promise<void> {
     const assetStatement = this.db
       .prepare(
-        `INSERT INTO assets (id, owner_id, name, type, metadata, archived_at, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        `INSERT INTO assets (id, owner_id, name, type, metadata, archived_at, created_at, updated_at, shared_team_id)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
          ON CONFLICT (id) DO UPDATE SET
-           name        = excluded.name,
-           metadata    = excluded.metadata,
-           archived_at = excluded.archived_at,
-           updated_at  = excluded.updated_at`,
+           name           = excluded.name,
+           metadata       = excluded.metadata,
+           archived_at    = excluded.archived_at,
+           updated_at     = excluded.updated_at,
+           shared_team_id = excluded.shared_team_id`,
       )
       .bind(
         asset.id,
@@ -59,6 +75,7 @@ export class D1AssetRepository implements AssetRepository {
         asset.archivedAt?.toISOString() ?? null,
         asset.createdAt.toISOString(),
         asset.updatedAt.toISOString(),
+        asset.sharedTeamId,
       );
 
     const outboxStatements = events
@@ -82,6 +99,7 @@ export class D1AssetRepository implements AssetRepository {
       archivedAt: row.archived_at ? new Date(row.archived_at) : null,
       createdAt: new Date(row.created_at),
       updatedAt: new Date(row.updated_at),
+      sharedTeamId: row.shared_team_id ? TeamId.from(row.shared_team_id) : null,
     });
   }
 }

--- a/apps/api/src/infrastructure/persistence/D1AssetRepository.ts
+++ b/apps/api/src/infrastructure/persistence/D1AssetRepository.ts
@@ -31,14 +31,6 @@ export class D1AssetRepository implements AssetRepository {
     return row ? this.#rowToAsset(row) : null;
   }
 
-  async findByOwner(ownerId: UserId): Promise<Asset[]> {
-    const result = await this.db
-      .prepare(`SELECT ${SELECT_COLUMNS} FROM assets WHERE owner_id = ?`)
-      .bind(ownerId)
-      .all<AssetRow>();
-    return result.results.map((row) => this.#rowToAsset(row));
-  }
-
   async findVisibleTo(userId: UserId): Promise<Asset[]> {
     const result = await this.db
       .prepare(

--- a/apps/api/src/infrastructure/persistence/D1MaintenanceTaskRepository.test.ts
+++ b/apps/api/src/infrastructure/persistence/D1MaintenanceTaskRepository.test.ts
@@ -25,16 +25,17 @@ function createDatabaseHarness() {
 }
 
 describe("D1MaintenanceTaskRepository", () => {
-  it("findByOwnerForActiveAssets joins active assets and excludes archived rows", async () => {
+  it("findForVisibleActiveAssets joins active assets including team-shared", async () => {
     const { db, statements } = createDatabaseHarness();
     const ownerId = UserId.generate();
 
-    await new D1MaintenanceTaskRepository(db).findByOwnerForActiveAssets(ownerId);
+    await new D1MaintenanceTaskRepository(db).findForVisibleActiveAssets(ownerId);
 
     expect(statements).toHaveLength(1);
     const query = statements[0]?.query ?? "";
     expect(query).toContain("INNER JOIN assets a ON a.id = t.asset_id");
     expect(query).toContain("a.archived_at IS NULL");
-    expect(statements[0]?.values).toEqual([ownerId]);
+    expect(query).toContain("shared_team_id");
+    expect(statements[0]?.values).toEqual([ownerId, ownerId]);
   });
 });

--- a/apps/api/src/infrastructure/persistence/D1MaintenanceTaskRepository.ts
+++ b/apps/api/src/infrastructure/persistence/D1MaintenanceTaskRepository.ts
@@ -65,17 +65,23 @@ export class D1MaintenanceTaskRepository implements MaintenanceTaskRepository {
     return result.results.map((row) => this.#rowToTask(row));
   }
 
-  async findByOwnerForActiveAssets(ownerId: UserId): Promise<MaintenanceTask[]> {
+  async findForVisibleActiveAssets(userId: UserId): Promise<MaintenanceTask[]> {
     const result = await this.db
       .prepare(
         `SELECT t.id, t.asset_id, t.owner_id, t.title, t.interval_value, t.interval_unit,
                 t.last_completed_date, t.next_due, t.created_at
          FROM maintenance_tasks t
          INNER JOIN assets a ON a.id = t.asset_id
-         WHERE t.owner_id = ? AND a.archived_at IS NULL
+         WHERE a.archived_at IS NULL
+           AND (
+             a.owner_id = ?
+             OR a.shared_team_id IN (
+                  SELECT team_id FROM team_members WHERE user_id = ?
+                )
+           )
          ORDER BY t.next_due ASC, t.created_at ASC`,
       )
-      .bind(ownerId)
+      .bind(userId, userId)
       .all<MaintenanceTaskRow>();
     return result.results.map((row) => this.#rowToTask(row));
   }

--- a/apps/api/src/infrastructure/telemetry/asset/AssetSharedToTeamTelemetryHandler.test.ts
+++ b/apps/api/src/infrastructure/telemetry/asset/AssetSharedToTeamTelemetryHandler.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from "vitest";
+import { AssetId, TeamId, UserId } from "@snaveevans/pineapple-shared";
+import { AssetSharedToTeam } from "../../../domain/asset/events/AssetSharedToTeam.ts";
+import {
+  AssetSharedToTeamTelemetryHandler,
+  mapAssetSharedToTeamTelemetry,
+} from "./AssetSharedToTeamTelemetryHandler.ts";
+
+describe("AssetSharedToTeamTelemetryHandler", () => {
+  it("maps ids and roles without PII names", () => {
+    const event = AssetSharedToTeam({
+      assetId: AssetId.generate(),
+      ownerId: UserId.generate(),
+      actorId: UserId.generate(),
+      assetName: "Secret Truck Name",
+      teamId: TeamId.generate(),
+      teamName: "Secret Team Name",
+    });
+
+    const point = mapAssetSharedToTeamTelemetry(event);
+
+    expect(point.indexes).toEqual([event.ownerId]);
+    expect(point.blobs).toEqual([
+      "AssetSharedToTeam",
+      "Asset",
+      event.assetId,
+      event.ownerId,
+      event.teamId,
+      event.actorId,
+      "ShareAsset",
+      "v1",
+      "success",
+    ]);
+    expect(point.blobs.join(" ")).not.toContain("Secret");
+    expect(point.doubles).toEqual([1, event.occurredAt.getTime()]);
+  });
+
+  it("writes through the sink", () => {
+    const write = vi.fn();
+    const handler = new AssetSharedToTeamTelemetryHandler({ write });
+    const event = AssetSharedToTeam({
+      assetId: AssetId.generate(),
+      ownerId: UserId.generate(),
+      actorId: UserId.generate(),
+      assetName: "Truck",
+      teamId: TeamId.generate(),
+      teamName: "Ops",
+    });
+
+    handler.handle(event);
+
+    expect(write).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/api/src/infrastructure/telemetry/asset/AssetSharedToTeamTelemetryHandler.ts
+++ b/apps/api/src/infrastructure/telemetry/asset/AssetSharedToTeamTelemetryHandler.ts
@@ -1,0 +1,31 @@
+import type { DomainEventHandler } from "../../../application/ports/EventBus.ts";
+import type { AssetSharedToTeam } from "../../../domain/asset/events/AssetSharedToTeam.ts";
+import type { TelemetryDataPoint, TelemetrySink } from "../AnalyticsEngineTelemetrySink.ts";
+
+export function mapAssetSharedToTeamTelemetry(event: AssetSharedToTeam): TelemetryDataPoint {
+  return {
+    indexes: [event.ownerId],
+    blobs: [
+      event.type,
+      "Asset",
+      event.assetId,
+      event.ownerId,
+      event.teamId,
+      event.actorId,
+      "ShareAsset",
+      "v1",
+      "success",
+    ],
+    doubles: [1, event.occurredAt.getTime()],
+  };
+}
+
+export class AssetSharedToTeamTelemetryHandler implements DomainEventHandler<AssetSharedToTeam> {
+  readonly eventType = "AssetSharedToTeam" as const;
+
+  constructor(private readonly sink: TelemetrySink) {}
+
+  handle(event: AssetSharedToTeam): void {
+    this.sink.write(mapAssetSharedToTeamTelemetry(event));
+  }
+}

--- a/apps/api/src/infrastructure/telemetry/asset/AssetUnsharedFromTeamTelemetryHandler.test.ts
+++ b/apps/api/src/infrastructure/telemetry/asset/AssetUnsharedFromTeamTelemetryHandler.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+import { AssetId, TeamId, UserId } from "@snaveevans/pineapple-shared";
+import { AssetUnsharedFromTeam } from "../../../domain/asset/events/AssetUnsharedFromTeam.ts";
+import {
+  AssetUnsharedFromTeamTelemetryHandler,
+  mapAssetUnsharedFromTeamTelemetry,
+} from "./AssetUnsharedFromTeamTelemetryHandler.ts";
+
+describe("AssetUnsharedFromTeamTelemetryHandler", () => {
+  it("maps ids and roles without PII names", () => {
+    const event = AssetUnsharedFromTeam({
+      assetId: AssetId.generate(),
+      ownerId: UserId.generate(),
+      actorId: UserId.generate(),
+      assetName: "Secret Truck Name",
+      teamId: TeamId.generate(),
+      teamName: "Secret Team Name",
+    });
+
+    const point = mapAssetUnsharedFromTeamTelemetry(event);
+
+    expect(point.indexes).toEqual([event.ownerId]);
+    expect(point.blobs).toEqual([
+      "AssetUnsharedFromTeam",
+      "Asset",
+      event.assetId,
+      event.ownerId,
+      event.teamId,
+      event.actorId,
+      "UnshareAsset",
+      "v1",
+      "success",
+    ]);
+    expect(point.blobs.join(" ")).not.toContain("Secret");
+  });
+
+  it("writes through the sink", () => {
+    const write = vi.fn();
+    const handler = new AssetUnsharedFromTeamTelemetryHandler({ write });
+    const event = AssetUnsharedFromTeam({
+      assetId: AssetId.generate(),
+      ownerId: UserId.generate(),
+      actorId: UserId.generate(),
+      assetName: "Truck",
+      teamId: TeamId.generate(),
+      teamName: "Ops",
+    });
+
+    handler.handle(event);
+
+    expect(write).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/api/src/infrastructure/telemetry/asset/AssetUnsharedFromTeamTelemetryHandler.ts
+++ b/apps/api/src/infrastructure/telemetry/asset/AssetUnsharedFromTeamTelemetryHandler.ts
@@ -1,0 +1,33 @@
+import type { DomainEventHandler } from "../../../application/ports/EventBus.ts";
+import type { AssetUnsharedFromTeam } from "../../../domain/asset/events/AssetUnsharedFromTeam.ts";
+import type { TelemetryDataPoint, TelemetrySink } from "../AnalyticsEngineTelemetrySink.ts";
+
+export function mapAssetUnsharedFromTeamTelemetry(
+  event: AssetUnsharedFromTeam,
+): TelemetryDataPoint {
+  return {
+    indexes: [event.ownerId],
+    blobs: [
+      event.type,
+      "Asset",
+      event.assetId,
+      event.ownerId,
+      event.teamId,
+      event.actorId,
+      "UnshareAsset",
+      "v1",
+      "success",
+    ],
+    doubles: [1, event.occurredAt.getTime()],
+  };
+}
+
+export class AssetUnsharedFromTeamTelemetryHandler implements DomainEventHandler<AssetUnsharedFromTeam> {
+  readonly eventType = "AssetUnsharedFromTeam" as const;
+
+  constructor(private readonly sink: TelemetrySink) {}
+
+  handle(event: AssetUnsharedFromTeam): void {
+    this.sink.write(mapAssetUnsharedFromTeamTelemetry(event));
+  }
+}

--- a/apps/api/src/infrastructure/telemetry/registerDomainTelemetry.ts
+++ b/apps/api/src/infrastructure/telemetry/registerDomainTelemetry.ts
@@ -1,6 +1,8 @@
 import type { EventBus } from "../../application/ports/EventBus.ts";
 import { AnalyticsEngineTelemetrySink } from "./AnalyticsEngineTelemetrySink.ts";
 import { AssetCreatedTelemetryHandler } from "./asset/AssetCreatedTelemetryHandler.ts";
+import { AssetSharedToTeamTelemetryHandler } from "./asset/AssetSharedToTeamTelemetryHandler.ts";
+import { AssetUnsharedFromTeamTelemetryHandler } from "./asset/AssetUnsharedFromTeamTelemetryHandler.ts";
 import { MaintenanceRecordCreatedTelemetryHandler } from "./maintenance/MaintenanceRecordCreatedTelemetryHandler.ts";
 import { MaintenanceTaskAdvancedTelemetryHandler } from "./maintenance/MaintenanceTaskAdvancedTelemetryHandler.ts";
 import { MaintenanceTaskCreatedTelemetryHandler } from "./maintenance/MaintenanceTaskCreatedTelemetryHandler.ts";
@@ -23,6 +25,8 @@ export function registerDomainTelemetry(deps: {
 }): void {
   const assetDomainSink = new AnalyticsEngineTelemetrySink(deps.assetDomainDataset);
   deps.eventBus.subscribe(new AssetCreatedTelemetryHandler(assetDomainSink));
+  deps.eventBus.subscribe(new AssetSharedToTeamTelemetryHandler(assetDomainSink));
+  deps.eventBus.subscribe(new AssetUnsharedFromTeamTelemetryHandler(assetDomainSink));
 
   const userDomainSink = new AnalyticsEngineTelemetrySink(deps.userDomainDataset);
   deps.eventBus.subscribe(new UserProvisionedTelemetryHandler(userDomainSink));

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -81,6 +81,7 @@ import { CreateTeam } from "./application/usecases/CreateTeam.ts";
 import { GetMyTeam } from "./application/usecases/GetMyTeam.ts";
 import { ShareAsset } from "./application/usecases/ShareAsset.ts";
 import { UnshareAsset } from "./application/usecases/UnshareAsset.ts";
+import { toSharingDescriptor } from "./application/usecases/assetSharing.ts";
 import type { AssetSharingDescriptor } from "./application/usecases/assetSharing.ts";
 import { D1VerificationTokenRepository } from "./infrastructure/persistence/D1VerificationTokenRepository.ts";
 import { D1VerificationSendLog } from "./infrastructure/persistence/D1VerificationSendLog.ts";
@@ -677,10 +678,7 @@ app.openapi(shareAssetRoute, async (c) => {
   });
   if (!result.ok) throw result.error;
   return c.json(
-    serializeAsset(result.value, {
-      scope: result.value.sharedTeamId === null ? "personal" : "team",
-      isOwner: true,
-    }),
+    serializeAsset(result.value, toSharingDescriptor(result.value, user.id, null)),
     200,
   );
 });
@@ -698,10 +696,7 @@ app.openapi(unshareAssetRoute, async (c) => {
   });
   if (!result.ok) throw result.error;
   return c.json(
-    serializeAsset(result.value, {
-      scope: result.value.sharedTeamId === null ? "personal" : "team",
-      isOwner: true,
-    }),
+    serializeAsset(result.value, toSharingDescriptor(result.value, user.id, null)),
     200,
   );
 });

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -79,6 +79,9 @@ import { MarkAllNotificationsRead } from "./application/usecases/MarkAllNotifica
 import { SweepMaintenanceReminders } from "./application/usecases/SweepMaintenanceReminders.ts";
 import { CreateTeam } from "./application/usecases/CreateTeam.ts";
 import { GetMyTeam } from "./application/usecases/GetMyTeam.ts";
+import { ShareAsset } from "./application/usecases/ShareAsset.ts";
+import { UnshareAsset } from "./application/usecases/UnshareAsset.ts";
+import type { AssetSharingDescriptor } from "./application/usecases/assetSharing.ts";
 import { D1VerificationTokenRepository } from "./infrastructure/persistence/D1VerificationTokenRepository.ts";
 import { D1VerificationSendLog } from "./infrastructure/persistence/D1VerificationSendLog.ts";
 import { SystemClock } from "./infrastructure/time/SystemClock.ts";
@@ -116,6 +119,8 @@ import {
   updateUserProfileRoute,
   createTeamRoute,
   getMyTeamRoute,
+  shareAssetRoute,
+  unshareAssetRoute,
   registerOpenApiComponents,
 } from "./api/openapi.ts";
 import openApiSpec from "../../../docs/reference/openapi.json";
@@ -219,7 +224,10 @@ app.use(
 
 // ── Serializers ────────────────────────────────────────────────────────────
 
-function serializeAsset(asset: Asset): z.infer<typeof AssetResponseSchema> {
+function serializeAsset(
+  asset: Asset,
+  sharing: AssetSharingDescriptor,
+): z.infer<typeof AssetResponseSchema> {
   return {
     id: asset.id,
     name: asset.name,
@@ -228,6 +236,13 @@ function serializeAsset(asset: Asset): z.infer<typeof AssetResponseSchema> {
     archivedAt: asset.archivedAt?.toISOString() ?? null,
     createdAt: asset.createdAt.toISOString(),
     updatedAt: asset.updatedAt.toISOString(),
+    sharing: {
+      scope: sharing.scope,
+      isOwner: sharing.isOwner,
+      ...(sharing.ownerDisplayName !== undefined
+        ? { ownerDisplayName: sharing.ownerDisplayName }
+        : {}),
+    },
   };
 }
 
@@ -607,13 +622,16 @@ app.openapi(createAssetRoute, async (c) => {
 
 app.openapi(listAssetsRoute, async (c) => {
   const user = c.get("user");
-  const result = await new ListAssets(new D1AssetRepository(c.env.DB)).execute({
-    ownerId: user.id,
+  const result = await new ListAssets(
+    new D1AssetRepository(c.env.DB),
+    new D1UserRepository(c.env.DB),
+  ).execute({
+    requesterId: user.id,
   });
   if (!result.ok) throw result.error;
   return c.json(
     {
-      assets: result.value.assets.map(serializeAsset),
+      assets: result.value.assets.map((item) => serializeAsset(item.asset, item.sharing)),
       counts: result.value.counts,
     },
     200,
@@ -623,23 +641,69 @@ app.openapi(listAssetsRoute, async (c) => {
 app.openapi(getAssetRoute, async (c) => {
   const user = c.get("user");
   const { id } = c.req.valid("param");
-  const result = await new GetAsset(new D1AssetRepository(c.env.DB)).execute({
+  const result = await new GetAsset(
+    new D1AssetRepository(c.env.DB),
+    new D1TeamRepository(c.env.DB),
+    new D1UserRepository(c.env.DB),
+  ).execute({
     assetId: AssetId.from(id),
     requesterId: user.id,
   });
   if (!result.ok) throw result.error;
-  return c.json(serializeAsset(result.value), 200);
+  return c.json(serializeAsset(result.value.asset, result.value.sharing), 200);
 });
 
 app.openapi(searchAssetsRoute, async (c) => {
   const user = c.get("user");
   const { q } = c.req.valid("query");
   const result = await new SearchAssets(new D1AssetRepository(c.env.DB)).execute({
-    ownerId: user.id,
+    requesterId: user.id,
     q,
   });
   if (!result.ok) throw result.error;
   return c.json({ results: result.value }, 200);
+});
+
+app.openapi(shareAssetRoute, async (c) => {
+  const user = c.get("user");
+  const { assetId } = c.req.valid("param");
+  const result = await new ShareAsset(
+    new D1AssetRepository(c.env.DB),
+    new D1TeamRepository(c.env.DB),
+    c.get("eventBus"),
+  ).execute({
+    assetId: AssetId.from(assetId),
+    requesterId: user.id,
+  });
+  if (!result.ok) throw result.error;
+  return c.json(
+    serializeAsset(result.value, {
+      scope: result.value.sharedTeamId === null ? "personal" : "team",
+      isOwner: true,
+    }),
+    200,
+  );
+});
+
+app.openapi(unshareAssetRoute, async (c) => {
+  const user = c.get("user");
+  const { assetId } = c.req.valid("param");
+  const result = await new UnshareAsset(
+    new D1AssetRepository(c.env.DB),
+    new D1TeamRepository(c.env.DB),
+    c.get("eventBus"),
+  ).execute({
+    assetId: AssetId.from(assetId),
+    requesterId: user.id,
+  });
+  if (!result.ok) throw result.error;
+  return c.json(
+    serializeAsset(result.value, {
+      scope: result.value.sharedTeamId === null ? "personal" : "team",
+      isOwner: true,
+    }),
+    200,
+  );
 });
 
 // ── Maintenance record endpoints ────────────────────────────────────────────
@@ -650,6 +714,7 @@ app.openapi(createMaintenanceRecordRoute, async (c) => {
   const { title, performedAt, notes, taskId } = c.req.valid("json");
   const result = await new CreateMaintenanceRecord(
     new D1AssetRepository(c.env.DB),
+    new D1TeamRepository(c.env.DB),
     new D1MaintenanceRecordRepository(c.env.DB),
     new D1MaintenanceTaskRepository(c.env.DB),
     c.get("eventBus"),
@@ -671,6 +736,7 @@ app.openapi(listMaintenanceRecordsRoute, async (c) => {
   const { assetId } = c.req.valid("param");
   const result = await new ListMaintenanceRecords(
     new D1AssetRepository(c.env.DB),
+    new D1TeamRepository(c.env.DB),
     new D1MaintenanceRecordRepository(c.env.DB),
   ).execute({
     assetId: AssetId.from(assetId),
@@ -688,6 +754,7 @@ app.openapi(createMaintenanceTaskRoute, async (c) => {
   const { title, intervalValue, intervalUnit, lastCompletedDate } = c.req.valid("json");
   const result = await new CreateMaintenanceTask(
     new D1AssetRepository(c.env.DB),
+    new D1TeamRepository(c.env.DB),
     new D1MaintenanceTaskRepository(c.env.DB),
     c.get("eventBus"),
     new SystemUtcDateProvider(),
@@ -710,6 +777,7 @@ app.openapi(listMaintenanceTasksRoute, async (c) => {
   const todayUtc = new SystemUtcDateProvider().today();
   const result = await new ListMaintenanceTasks(
     new D1AssetRepository(c.env.DB),
+    new D1TeamRepository(c.env.DB),
     new D1MaintenanceTaskRepository(c.env.DB),
   ).execute({
     assetId: AssetId.from(assetId),
@@ -727,6 +795,7 @@ app.openapi(deleteMaintenanceTaskRoute, async (c) => {
   const { assetId, taskId } = c.req.valid("param");
   const result = await new DeleteMaintenanceTask(
     new D1AssetRepository(c.env.DB),
+    new D1TeamRepository(c.env.DB),
     new D1MaintenanceTaskRepository(c.env.DB),
     c.get("eventBus"),
   ).execute({

--- a/apps/web/src/api/assets.ts
+++ b/apps/web/src/api/assets.ts
@@ -32,6 +32,12 @@ export type EquipmentMetadata = {
 
 export type AssetMetadata = VehicleMetadata | PropertyMetadata | EquipmentMetadata;
 
+export type AssetSharing = {
+  scope: "personal" | "team";
+  isOwner: boolean;
+  ownerDisplayName?: string;
+};
+
 export type AssetResponse = {
   id: string;
   name: string;
@@ -40,6 +46,7 @@ export type AssetResponse = {
   archivedAt: string | null;
   createdAt: string;
   updatedAt: string;
+  sharing: AssetSharing;
 };
 
 export type AssetListResponse = {
@@ -73,4 +80,12 @@ export function createAsset(body: CreateAssetBody): Promise<CreatedAssetResponse
     headers: { "content-type": "application/json" },
     body: JSON.stringify(body),
   });
+}
+
+export function shareAsset(assetId: string): Promise<AssetResponse> {
+  return apiRequest<AssetResponse>(`/api/assets/${assetId}/share`, { method: "POST" });
+}
+
+export function unshareAsset(assetId: string): Promise<AssetResponse> {
+  return apiRequest<AssetResponse>(`/api/assets/${assetId}/share`, { method: "DELETE" });
 }

--- a/apps/web/src/app/AppMaintenanceRecords.tsx
+++ b/apps/web/src/app/AppMaintenanceRecords.tsx
@@ -2,8 +2,16 @@ import { useEffect, useRef, useState, useMemo } from "react";
 import { Link, useNavigate, useParams } from "react-router";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { ApiError } from "../api/client.ts";
-import { getAsset, assetQueryKey } from "../api/assets.ts";
+import {
+  getAsset,
+  shareAsset,
+  unshareAsset,
+  assetQueryKey,
+  assetsQueryKey,
+  type AssetSharing,
+} from "../api/assets.ts";
 import { dashboardQueryKey, getDashboard } from "../api/dashboard.ts";
+import { getMyTeam, teamQueryKey } from "../api/teams.ts";
 import {
   listMaintenanceRecords,
   createMaintenanceRecord,
@@ -847,6 +855,129 @@ function MRForm({ asset, assetId, variant, onClose, onSaved, tasks = [], presele
   );
 }
 
+// ─── share sheet ─────────────────────────────────────────────────────────────
+
+function MRShareSheet({
+  assetName,
+  sharing,
+  teamName,
+  memberCount,
+  teamLoading,
+  noTeam,
+  busy,
+  error,
+  variant,
+  onClose,
+  onShare,
+  onUnshare,
+}: {
+  assetName: string;
+  sharing: AssetSharing;
+  teamName: string | null;
+  memberCount: number;
+  teamLoading: boolean;
+  noTeam: boolean;
+  busy: boolean;
+  error: string | null;
+  variant: "drawer" | "sheet";
+  onClose: () => void;
+  onShare: () => void;
+  onUnshare: () => void;
+}) {
+  const isShared = sharing.scope === "team";
+  const displayTeam = teamName ?? "your team";
+  const memberLabel = memberCount === 1 ? "1 member" : `${memberCount} members`;
+
+  return (
+    <div className={`mr-form mr-form-${variant}`} role="dialog" aria-labelledby="mr-share-title">
+      {variant === "sheet" && <div className="mr-sheet-grab" />}
+      <div className="mr-form-head">
+        <div>
+          <div className="mr-shr-head-title" id="mr-share-title">
+            {isShared ? "Shared with your team" : "Share to your team"}
+          </div>
+          <div className="mr-shr-head-sub">{assetName}</div>
+        </div>
+        <button type="button" className="mr-form-close" onClick={onClose} aria-label="Close">
+          <Icon name="x" size={15} stroke={2.2} />
+        </button>
+      </div>
+      <div className="mr-form-body mr-shr-body">
+        <div className="mr-shr-tile">
+          <Icon name="users" size={24} stroke={1.6} />
+        </div>
+        {teamLoading ? (
+          <div className="mr-shr-sub">Loading team…</div>
+        ) : noTeam ? (
+          <>
+            <div className="mr-shr-sub">
+              You need a team before you can share this asset. Create one, then come back here.
+            </div>
+            <div className="mr-shr-error">
+              <Link to={paths.team}>Create a team</Link>
+            </div>
+          </>
+        ) : (
+          <>
+            {!isShared && (
+              <div className="mr-shr-sub">
+                Members of your team will be able to see this asset and log maintenance on it. Only
+                you can unshare it.
+              </div>
+            )}
+            <div className="mr-shr-team-row">
+              <div className="mr-shr-team-mark">
+                <Icon name="users" size={17} stroke={1.7} />
+              </div>
+              <div>
+                <div className="mr-shr-team-name">{displayTeam}</div>
+                <div className="mr-shr-team-sub">{memberLabel}</div>
+              </div>
+            </div>
+            {isShared && (
+              <div className="mr-shr-owner-note">
+                <Icon name="info" size={14} color="var(--hf-ink-faint)" style={{ flexShrink: 0, marginTop: 1 }} />
+                Unsharing removes access immediately for every team member.
+              </div>
+            )}
+            {error && (
+              <div className="mr-shr-error" role="alert">
+                {error}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+      <div className="mr-form-actions">
+        {noTeam ? (
+          <button type="button" className="mr-btn mr-btn-primary" style={{ width: "100%" }} onClick={onClose}>
+            Close
+          </button>
+        ) : isShared ? (
+          <button
+            type="button"
+            className="mr-shr-unshare-btn"
+            onClick={onUnshare}
+            disabled={busy || teamLoading}
+          >
+            {busy ? "Unsharing…" : "Unshare"}
+          </button>
+        ) : (
+          <button
+            type="button"
+            className="mr-btn mr-btn-primary"
+            style={{ width: "100%" }}
+            onClick={onShare}
+            disabled={busy || teamLoading || noTeam}
+          >
+            {busy ? "Sharing…" : `Share with ${displayTeam}`}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
 // ─── page ────────────────────────────────────────────────────────────────────
 
 export function AppMaintenanceRecords() {
@@ -874,6 +1005,8 @@ export function AppMaintenanceRecords() {
   const [formOpen, setFormOpen] = useState(false);
   const [logFromTaskId, setLogFromTaskId] = useState<string | null>(null);
   const [taskFormOpen, setTaskFormOpen] = useState(false);
+  const [shareOpen, setShareOpen] = useState(false);
+  const [shareError, setShareError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<"overview" | "maintenance">("overview");
   const [density, setDensity] = useState<"timeline" | "table">("timeline");
   const [taskDeleteError, setTaskDeleteError] = useState<string | null>(null);
@@ -911,7 +1044,52 @@ export function AppMaintenanceRecords() {
     select: (data) => data.todayUtc,
   });
 
+  const teamQuery = useQuery({
+    queryKey: teamQueryKey,
+    queryFn: getMyTeam,
+    enabled: shareOpen,
+    staleTime: 30_000,
+  });
+
   const taskFormTodayUtc = dashboardTodayQuery.data ?? todayDateOnly();
+
+  const shareMutation = useMutation({
+    mutationFn: () => shareAsset(assetId),
+    onSuccess: (updated) => {
+      queryClient.setQueryData(assetQueryKey(assetId), updated);
+      void queryClient.invalidateQueries({ queryKey: assetsQueryKey });
+      setShareError(null);
+      setShareOpen(false);
+    },
+    onError: (err) => {
+      if (err instanceof ApiError && err.status === 409) {
+        setShareError("You need a team before you can share this asset.");
+        return;
+      }
+      if (err instanceof ApiError && err.status === 401) {
+        void navigate(paths.login(), { replace: true });
+        return;
+      }
+      setShareError(err instanceof Error ? err.message : "Could not share this asset.");
+    },
+  });
+
+  const unshareMutation = useMutation({
+    mutationFn: () => unshareAsset(assetId),
+    onSuccess: (updated) => {
+      queryClient.setQueryData(assetQueryKey(assetId), updated);
+      void queryClient.invalidateQueries({ queryKey: assetsQueryKey });
+      setShareError(null);
+      setShareOpen(false);
+    },
+    onError: (err) => {
+      if (err instanceof ApiError && err.status === 401) {
+        void navigate(paths.login(), { replace: true });
+        return;
+      }
+      setShareError(err instanceof Error ? err.message : "Could not unshare this asset.");
+    },
+  });
 
   // Redirect on 401
   useEffect(() => {
@@ -923,6 +1101,7 @@ export function AppMaintenanceRecords() {
   }, [assetQuery.error, recordsQuery.error, tasksQuery.error, navigate]);
 
   const asset = assetQuery.data ? toAssetPresentation(assetQuery.data) : null;
+  const sharing = assetQuery.data?.sharing ?? null;
 
   const sorted = useMemo(
     () => sortRecords(recordsQuery.data?.maintenanceRecords ?? []),
@@ -1091,7 +1270,18 @@ export function AppMaintenanceRecords() {
     !assetQuery.isError &&
     (activeTab === "maintenance" ? (recordsQuery.isSuccess && sorted.length > 0) : true) &&
     !taskFormOpen &&
-    !formOpen;
+    !formOpen &&
+    !shareOpen;
+
+  const openShareSheet = () => {
+    setShareError(null);
+    setShareOpen(true);
+  };
+
+  const shareBusy = shareMutation.isPending || unshareMutation.isPending;
+  const team = teamQuery.data?.team ?? null;
+  const noTeam = teamQuery.isSuccess && team === null;
+  const ownerFirstName = sharing?.ownerDisplayName?.split(/\s+/)[0] ?? "the owner";
 
   return (
     <div ref={rootRef} className="hf mr-root" data-density={effectiveDensity}>
@@ -1117,15 +1307,49 @@ export function AppMaintenanceRecords() {
                   <span className="mr-dot" />
                   <span>{asset.summary}</span>
                 </div>
+                {sharing && sharing.scope === "team" && (
+                  sharing.isOwner ? (
+                    <button
+                      type="button"
+                      className="mr-share-badge is-owner"
+                      onClick={openShareSheet}
+                      title="Manage sharing"
+                    >
+                      <Icon name="users" size={11} stroke={2.2} />
+                      <span>Shared with team</span>
+                    </button>
+                  ) : (
+                    <span
+                      className="mr-share-badge is-member"
+                      title={`Shared by ${sharing.ownerDisplayName ?? "a teammate"}`}
+                    >
+                      <Icon name="users" size={11} stroke={2.2} />
+                      <span>Shared by {sharing.ownerDisplayName ?? "a teammate"}</span>
+                    </span>
+                  )
+                )}
               </div>
-              {!recordsQuery.isPending && (
-                <button
-                  className="mr-btn mr-btn-primary mr-hero-add"
-                  onClick={() => openLogForm()}
-                >
-                  <Icon name="plus" size={16} stroke={2.2} />Log maintenance
-                </button>
-              )}
+              <div className="mr-hero-actions">
+                {sharing?.isOwner && (
+                  <button
+                    type="button"
+                    className={`mr-share-btn${sharing.scope === "team" ? " is-active" : ""}`}
+                    onClick={openShareSheet}
+                    title={sharing.scope === "team" ? "Manage sharing" : "Share to team"}
+                    aria-label={sharing.scope === "team" ? "Manage sharing" : "Share to team"}
+                  >
+                    <Icon name="users" size={16} stroke={1.8} />
+                  </button>
+                )}
+                {!recordsQuery.isPending && (
+                  <button
+                    className="mr-btn mr-btn-primary mr-hero-add"
+                    onClick={() => openLogForm()}
+                  >
+                    <Icon name="plus" size={16} stroke={2.2} />Log maintenance
+                  </button>
+                )}
+              </div>
             </div>
           ) : assetQuery.isPending ? (
             <div className="mr-hero">
@@ -1187,9 +1411,41 @@ export function AppMaintenanceRecords() {
               onRetry={() => void assetQuery.refetch()}
             />
           ) : activeTab === "overview" ? (
-            overviewBlock
+            <>
+              {sharing && !sharing.isOwner && sharing.scope === "team" && (
+                <div className="mr-shr-strip">
+                  <Icon
+                    name="users"
+                    size={14}
+                    color="var(--hf-ink-faint)"
+                    style={{ flexShrink: 0, marginTop: 1 }}
+                  />
+                  <span>
+                    Shared by {sharing.ownerDisplayName ?? "a teammate"} — you can view and log
+                    maintenance here. Only {ownerFirstName} can unshare it.
+                  </span>
+                </div>
+              )}
+              {overviewBlock}
+            </>
           ) : (
-            histBlock
+            <>
+              {sharing && !sharing.isOwner && sharing.scope === "team" && (
+                <div className="mr-shr-strip">
+                  <Icon
+                    name="users"
+                    size={14}
+                    color="var(--hf-ink-faint)"
+                    style={{ flexShrink: 0, marginTop: 1 }}
+                  />
+                  <span>
+                    Shared by {sharing.ownerDisplayName ?? "a teammate"} — you can view and log
+                    maintenance here. Only {ownerFirstName} can unshare it.
+                  </span>
+                </div>
+              )}
+              {histBlock}
+            </>
           )}
         </div>
       </main>
@@ -1234,6 +1490,35 @@ export function AppMaintenanceRecords() {
               variant={overlayVariant}
               onClose={() => setTaskFormOpen(false)}
               onCreated={handleTaskCreated}
+            />
+          </div>
+        </div>
+      )}
+
+      {shareOpen && asset && sharing && (
+        <div className={`mr-overlay mr-overlay-${overlayVariant}`}>
+          <div
+            className="mr-scrim"
+            onClick={() => {
+              if (!shareBusy) setShareOpen(false);
+            }}
+          />
+          <div className={`mr-overlay-panel-${overlayVariant}`}>
+            <MRShareSheet
+              assetName={asset.name}
+              sharing={sharing}
+              teamName={team?.name ?? null}
+              memberCount={team?.members.length ?? 0}
+              teamLoading={teamQuery.isPending}
+              noTeam={noTeam}
+              busy={shareBusy}
+              error={shareError}
+              variant={overlayVariant}
+              onClose={() => {
+                if (!shareBusy) setShareOpen(false);
+              }}
+              onShare={() => shareMutation.mutate()}
+              onUnshare={() => unshareMutation.mutate()}
             />
           </div>
         </div>

--- a/apps/web/src/app/assetPresentation.test.ts
+++ b/apps/web/src/app/assetPresentation.test.ts
@@ -7,6 +7,7 @@ const BASE_ASSET = {
   archivedAt: null,
   createdAt: "2026-05-29T03:25:24.887Z",
   updatedAt: "2026-05-29T03:25:24.887Z",
+  sharing: { scope: "personal" as const, isOwner: true },
 } as const;
 
 describe("shortenAssetId", () => {

--- a/apps/web/src/design/Icon.tsx
+++ b/apps/web/src/design/Icon.tsx
@@ -38,7 +38,8 @@ export type IconName =
   | "info"
   | "image"
   | "lock"
-  | "mail";
+  | "mail"
+  | "users";
 
 export interface IconProps {
   name: IconName;
@@ -221,6 +222,14 @@ const PATHS: Record<IconName, ReactNode> = {
     <>
       <rect x="3" y="5" width="18" height="14" rx="2" />
       <path d="M3 6.5 12 13l9-6.5" />
+    </>
+  ),
+  users: (
+    <>
+      <path d="M17 21v-2a4 4 0 0 0-4-4H7a4 4 0 0 0-4 4v2" />
+      <circle cx="10" cy="7" r="4" />
+      <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
+      <path d="M16 3.2a4 4 0 0 1 0 7.6" />
     </>
   ),
 };

--- a/apps/web/src/design/styles/mr.css
+++ b/apps/web/src/design/styles/mr.css
@@ -88,6 +88,88 @@
 .mr-hero-meta .hf-mono { font-family: var(--hf-mono); font-size: 12px; color: var(--hf-ink); }
 .mr-dot { width: 3px; height: 3px; border-radius: 50%; background: var(--hf-ink-faint); }
 .mr-hero-add { align-self: flex-start; flex-shrink: 0; }
+.mr-hero-actions {
+  display: flex; align-items: flex-start; gap: 8px; flex-shrink: 0; align-self: flex-start;
+}
+
+/* ============ sharing (hero badge + action + sheet) ============ */
+.mr-share-badge {
+  margin-top: 8px; display: inline-flex; align-items: center; gap: 5px;
+  padding: 3px 9px 3px 7px; border-radius: 999px; border: 1px solid transparent;
+  font-size: 11px; font-weight: 600; letter-spacing: -0.005em;
+  max-width: 100%; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  font-family: var(--hf-sans); background: none;
+}
+.mr-share-badge span { overflow: hidden; text-overflow: ellipsis; }
+.mr-share-badge.is-owner {
+  background: var(--hf-brand-bg); color: var(--hf-brand-2);
+  border-color: oklch(88% 0.04 150);
+  cursor: pointer;
+}
+.mr-share-badge.is-member {
+  background: var(--hf-surface-2); color: var(--hf-ink-soft); border-color: var(--hf-line);
+}
+.mr-share-btn {
+  flex-shrink: 0; width: 38px; height: 38px; border-radius: 10px;
+  border: 1px solid var(--hf-line); background: var(--hf-surface);
+  color: var(--hf-ink-soft); display: flex; align-items: center; justify-content: center;
+}
+.mr-share-btn:hover { color: var(--hf-ink); border-color: var(--hf-ink-faint); }
+.mr-share-btn.is-active {
+  background: var(--hf-brand-bg); border-color: oklch(88% 0.04 150); color: var(--hf-brand-2);
+}
+.mr-share-btn:disabled { opacity: 0.55; cursor: not-allowed; }
+
+.mr-shr-strip {
+  display: flex; align-items: flex-start; gap: 9px;
+  margin-bottom: 14px; padding: 10px 12px;
+  background: var(--hf-surface-2); border: 1px solid var(--hf-line);
+  border-radius: var(--hf-r-sm, 10px);
+  font-size: 12px; color: var(--hf-ink-soft); line-height: 1.5;
+}
+
+.mr-shr-tile {
+  width: 52px; height: 52px; border-radius: 14px;
+  background: var(--hf-brand-bg); color: var(--hf-brand-2);
+  display: flex; align-items: center; justify-content: center;
+  margin: 2px auto 0;
+}
+.mr-shr-sub {
+  font-size: 13px; color: var(--hf-ink-soft); text-align: center; line-height: 1.5; padding: 0 6px;
+}
+.mr-shr-team-row {
+  display: flex; align-items: center; gap: 11px;
+  padding: 12px 13px; border: 1px solid var(--hf-line); border-radius: var(--hf-r, 12px);
+  background: var(--hf-surface-2);
+}
+.mr-shr-team-mark {
+  width: 36px; height: 36px; border-radius: 10px;
+  background: var(--hf-surface); border: 1px solid var(--hf-line); color: var(--hf-brand-2);
+  display: flex; align-items: center; justify-content: center; flex-shrink: 0;
+}
+.mr-shr-team-name { font-size: 13.5px; font-weight: 600; color: var(--hf-ink); }
+.mr-shr-team-sub { font-size: 11.5px; color: var(--hf-ink-faint); margin-top: 1px; }
+.mr-shr-owner-note {
+  display: flex; gap: 8px; padding: 10px 12px;
+  background: var(--hf-surface-2); border-radius: var(--hf-r-sm, 10px);
+  font-size: 12px; color: var(--hf-ink-soft); line-height: 1.5;
+}
+.mr-shr-unshare-btn {
+  width: 100%; padding: 13px; border-radius: 12px;
+  background: var(--hf-surface); border: 1.5px solid var(--hf-bad); color: var(--hf-bad);
+  font-size: 14.5px; font-weight: 600;
+}
+.mr-shr-unshare-btn:hover { background: color-mix(in oklch, var(--hf-bad) 8%, var(--hf-surface)); }
+.mr-shr-unshare-btn:disabled { opacity: 0.55; cursor: not-allowed; }
+.mr-shr-body {
+  display: flex; flex-direction: column; gap: 14px; padding: 8px 4px 4px;
+}
+.mr-shr-head-title { font-size: 17px; font-weight: 700; color: var(--hf-ink); letter-spacing: -0.02em; }
+.mr-shr-head-sub { font-size: 12.5px; color: var(--hf-ink-soft); margin-top: 2px; }
+.mr-shr-error {
+  font-size: 12.5px; color: var(--hf-bad); line-height: 1.4; text-align: center;
+}
+.mr-shr-error a { color: var(--hf-bad); font-weight: 600; text-decoration: underline; }
 
 /* ============ tabs ============ */
 .mr-tabs { display: flex; gap: 4px; border-bottom: 1px solid var(--hf-line); margin-top: 2px; }

--- a/docs/reference/data-model.md
+++ b/docs/reference/data-model.md
@@ -9,11 +9,13 @@ User 1 ──< owns >── * Asset 1 ──< has >── * MaintenanceRecord
                    └──< appears in >── * ActivityEntry
 ```
 
-A **User** owns many **Assets**. An asset always belongs to exactly one user,
-and a user only ever sees their own assets.
+A **User** owns many **Assets**. An asset always belongs to exactly one user.
+Assets may be **shared** to a team the owner belongs to; team members can then
+see and edit those assets. Unshared assets remain personal.
 
 An **Asset** has zero or more **Maintenance Records**. Each record belongs to
-exactly one asset and inherits access through that asset's owner.
+exactly one asset and inherits access through that asset (ownership or team
+sharing).
 
 An **Activity Entry** is an append-only projection of a tracked domain event.
 It belongs to the same owner as the source action and stores the asset snapshot
@@ -54,6 +56,9 @@ Field shapes and validation rules live in the [OpenAPI spec](openapi.json)
 
 - **`ownerId`** — the owning `UserId`; set on creation and immutable. Not
   exposed in the API response.
+- **`sharedTeamId`** — optional `TeamId`; null means personal. Set only by the
+  asset owner via share/unshare. Not exposed raw in the API; clients receive a
+  computed `sharing` descriptor instead.
 - **`type`** mirrors `metadata.kind` — there is no asset whose `type`
   disagrees with its metadata. Both are immutable after creation.
 
@@ -139,6 +144,8 @@ Aggregates raise events when something significant happens. Today:
 | `MaintenanceReminderCreated` | a due-soon reminder is created                    | event id, notification/task/asset/owner ids, notification type, system actor, and lead-days conclusion                                              |
 | `ReminderEmailDispatched`    | an aggregated reminder email decision is recorded | event id, email batch id, owner id, result, suppress reason, and covered notification count; no email address or reminder copy                      |
 | `TeamCreated`                | a team is created                                 | event id, team/owner/actor, and team name                                                                                                           |
+| `AssetSharedToTeam`          | an asset is shared to a team                      | event id, asset/owner/actor, asset name, team id + name                                                                                             |
+| `AssetUnsharedFromTeam`      | an asset is returned to personal                  | event id, asset/owner/actor, asset name, team id + name (of the team it left)                                                                       |
 
 Events are published after persistence through the in-memory event bus for
 telemetry. Tracked activity events are also written to an outbox in the same D1

--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -258,6 +258,31 @@
           "metadata"
         ]
       },
+      "AssetSharing": {
+        "type": "object",
+        "properties": {
+          "scope": {
+            "type": "string",
+            "enum": [
+              "personal",
+              "team"
+            ],
+            "example": "personal"
+          },
+          "isOwner": {
+            "type": "boolean",
+            "example": true
+          },
+          "ownerDisplayName": {
+            "type": "string",
+            "example": "Dale"
+          }
+        },
+        "required": [
+          "scope",
+          "isOwner"
+        ]
+      },
       "Asset": {
         "type": "object",
         "properties": {
@@ -296,6 +321,9 @@
             "type": "string",
             "format": "date-time",
             "example": "2026-05-29T03:25:24.887Z"
+          },
+          "sharing": {
+            "$ref": "#/components/schemas/AssetSharing"
           }
         },
         "required": [
@@ -305,7 +333,8 @@
           "metadata",
           "archivedAt",
           "createdAt",
-          "updatedAt"
+          "updatedAt",
+          "sharing"
         ]
       },
       "AssetCategoryCounts": {
@@ -1441,7 +1470,7 @@
           "Assets"
         ],
         "summary": "List my assets",
-        "description": "Returns the caller's active (non-archived) assets and their counts by category.",
+        "description": "Returns the caller's active (non-archived) assets — owned and shared with their team — and category counts over that set. Each asset includes a computed `sharing` descriptor.",
         "security": [
           {
             "cookieAuth": []
@@ -1449,7 +1478,7 @@
         ],
         "responses": {
           "200": {
-            "description": "The caller's assets",
+            "description": "The caller's visible assets",
             "content": {
               "application/json": {
                 "schema": {
@@ -1477,6 +1506,7 @@
           "Assets"
         ],
         "summary": "Get an asset by id",
+        "description": "Returns an asset the caller owns or that is shared with their team, including a computed `sharing` descriptor.",
         "security": [
           {
             "cookieAuth": []
@@ -1515,7 +1545,7 @@
             }
           },
           "403": {
-            "description": "The asset belongs to another user",
+            "description": "The asset is not visible to the caller",
             "content": {
               "application/json": {
                 "schema": {
@@ -1543,7 +1573,7 @@
           "Assets"
         ],
         "summary": "Search my assets",
-        "description": "Returns up to 20 active assets owned by the caller that match the free-text query.",
+        "description": "Returns up to 20 active assets visible to the caller (owned or shared with their team) that match the free-text query.",
         "security": [
           {
             "cookieAuth": []
@@ -2687,6 +2717,148 @@
           },
           "401": {
             "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/assets/{assetId}/share": {
+      "post": {
+        "tags": [
+          "Assets"
+        ],
+        "summary": "Share an asset to my team",
+        "description": "Shares the asset to the caller's team. Asset-owner only. Idempotent when already shared to that team.",
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "example": "195d0ef0-47f5-439f-abfd-29f892c9a040"
+            },
+            "required": true,
+            "name": "assetId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Asset shared (or already shared)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Asset"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller is not the asset owner",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No such asset",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Caller does not belong to a team",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Assets"
+        ],
+        "summary": "Unshare an asset",
+        "description": "Returns the asset to personal. Asset-owner only. Idempotent when already personal.",
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "example": "195d0ef0-47f5-439f-abfd-29f892c9a040"
+            },
+            "required": true,
+            "name": "assetId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Asset unshared (or already personal)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Asset"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller is not the asset owner",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No such asset",
             "content": {
               "application/json": {
                 "schema": {

--- a/docs/specs/cross-cutting/permissions.md
+++ b/docs/specs/cross-cutting/permissions.md
@@ -2,7 +2,7 @@
 audience: all contributors
 purpose: canonical ownership and access model for feature specs
 source: this file
-date: 2026-06-02
+date: 2026-07-11
 ---
 
 # Permissions & Ownership — Cross-Cutting Spec
@@ -15,45 +15,110 @@ date: 2026-06-02
 
 ## Summary
 
-The access model is single-tenant by user: every domain entity is owned by the `User` who created it. No roles, groups, or ACL exist. Ownership is enforced in two layers — at the repository query for collections, and at the use case for single-resource access.
+The access model is **per-user ownership by default**, with an optional **team sharing**
+extension (see [ADR-0015](../../decisions/0015-teams-as-opt-in-sharing-scope.md) and
+[teams-foundation](../features/teams-foundation.md)). Every owned entity has an
+`ownerId` set at creation. Assets may additionally be shared to the owner's team,
+which grants every team member read and write access to that asset and its
+dependents. Personal (unshared) assets remain visible only to their owner.
+
+---
 
 ## Canonical Behavior
 
-**Ownership assignment:** On creation, the authenticated `User.id` is stored as `ownerId` on the entity. This is set by the use case using the `requesterId` passed from the route handler; it is never accepted from the API caller.
+**Ownership assignment:** On creation, the authenticated `User.id` is stored as
+`ownerId` on the entity. This is set by the use case using the `requesterId`
+passed from the route handler; it is never accepted from the API caller.
 
-**Collection access:** Repository queries always filter by `ownerId = requesterId`. An entity belonging to another user is invisible — it does not appear in lists and its existence is not revealed.
+**Team sharing (assets):** An asset is personal by default (`sharedTeamId` null).
+Only the **asset owner** may share it to the team they belong to, or unshare it
+back to personal. Team members may use a shared asset but cannot change its
+sharing. Sharing is opt-in and per-asset — there is no automatic team tenancy.
 
-**Single-resource access:** Use cases fetch by ID, then explicitly check `entity.ownerId !== requesterId`. Current behavior:
+**Collection access:** Repository queries return entities the requester can see:
 
-- Entity exists, belongs to requester → proceed
-- Entity exists, belongs to another user → `err(new ForbiddenError(...))` → 403
+- **Owned:** `ownerId = requesterId`
+- **Team-shared assets:** `sharedTeamId` is a team the requester belongs to
+
+An entity that is neither owned nor team-shared is invisible — it does not appear
+in lists and its existence is not revealed via collections.
+
+**Single-resource access:** Use cases fetch by ID, then check access:
+
+- Entity exists, requester **owns** it → proceed
+- Entity exists, requester is a **member of the team it is shared with** → proceed
+  (assets and dependents that follow the asset)
+- Entity exists, requester has no access → `err(new ForbiddenError(...))` → 403
 - Entity does not exist → `err(new NotFoundError(...))` → 404
 
-Note: the 403 vs 404 response for wrong-owner access has not been explicitly decided. See Known Issues.
+**Dependents follow the asset:** Authorization for maintenance tasks, maintenance
+records, and other child operations is determined by whether the requester can
+access the **parent asset** (owns it or is a member of the team it is shared
+with), not by a direct `ownerId === requesterId` check on the child. Child rows
+still store `ownerId` as the asset owner for attribution; access does not require
+the requester to match that field.
+
+**Sharing mutations are asset-owner-only:** Share and unshare require
+`asset.ownerId === requesterId`. A team member who can see a shared asset but
+does not own it receives 403 when attempting to change sharing.
+
+Note: the 403 vs 404 response for exists-but-forbidden access has not been
+explicitly decided. See Known Issues. This app currently returns 403.
+
+---
 
 ## Feature Integration Contract
 
 Every feature spec must document:
 
-- Whether the feature creates an owned entity, and confirm that `ownerId` is derived from the session `requesterId`, not the request body.
-- Whether the feature reads a single owned entity, and confirm that the post-fetch ownership check is present.
-- Whether the feature lists entities, and confirm that the repository query filters by `ownerId`.
-- If the feature involves sharing, delegation, or multi-user access, it must explicitly note that the current model does not support this and describe the required extension.
+- Whether the feature creates an owned entity, and confirm that `ownerId` is
+  derived from the session `requesterId`, not the request body.
+- Whether the feature reads a single owned entity, and confirm that the post-fetch
+  access check is present (own **or** team-shared, as applicable).
+- Whether the feature lists entities, and confirm that the repository query
+  returns only visible entities (owned + team-shared where applicable).
+- If the feature involves further sharing, delegation, or multi-user access
+  beyond team-shared assets, it must explicitly note the extension required.
+
+---
 
 ## Exceptions
 
 | Feature | Deviation | Reason |
 | ------- | --------- | ------ |
 
+---
+
 ## Anti-Patterns
 
-- **Accepting `ownerId` from the request body:** Callers must never supply their own owner. The use case always derives it from the authenticated session.
-- **Listing without an ownership filter:** Querying all entities without filtering by `ownerId` leaks cross-user data.
-- **Returning 404 for forbidden single-resource access:** The canonical behavior is 403 for existence-but-forbidden. Returning 404 instead loses information and must be documented as an explicit exception if ever justified.
+- **Accepting `ownerId` from the request body:** Callers must never supply their
+  own owner. The use case always derives it from the authenticated session.
+- **Listing without a visibility filter:** Querying all entities without filtering
+  by ownership (and team sharing where applicable) leaks cross-user data.
+- **Checking only `ownerId` on asset dependents:** After team sharing, maintenance
+  and similar operations must use the asset-access check, not
+  `child.ownerId === requesterId` alone.
+- **Letting non-owners change sharing:** Only the asset owner may share or unshare.
+- **Returning 404 for forbidden single-resource access:** The canonical behavior is
+  403 for existence-but-forbidden. Returning 404 instead loses information and
+  must be documented as an explicit exception if ever justified.
+
+---
 
 ## Known Issues
 
-- **403 vs 404 on wrong-owner single-resource access has not been decided.** The current code returns 403, which reveals that the entity exists but the requester cannot access it. An alternative is to return 404 unconditionally to avoid leaking existence. **Planned:** make a deliberate call, document the rationale here, and update the Canonical Behavior section accordingly.
-- **Different enforcement mechanisms for collections vs single resources.** Collections filter at the repo-query level; single resources check post-fetch at the use-case level. Both enforce the same invariant but in different places — a new repository method could accidentally skip the ownership filter without a compile-time signal. **Planned:** consider making `ownerId` a non-optional parameter on all repo read methods so the constraint is impossible to omit.
-- **Mutation ownership pattern not established.** Update and delete are not yet implemented. When added, they should follow the single-resource pattern (fetch → ownership check → mutate). This spec should be updated when the first mutation is added.
-- **Archived resource visibility is inconsistent.** Collection queries filter out archived assets, but single-resource access by ID does not exclude archived entities. Whether an archived but owned asset should be readable via direct ID lookup has not been decided. **Planned:** define the access policy for archived resources and apply it consistently across both collection and single-resource access.
+- **403 vs 404 on wrong-owner single-resource access has not been decided.** The
+  current code returns 403, which reveals that the entity exists but the
+  requester cannot access it. An alternative is to return 404 unconditionally to
+  avoid leaking existence. **Planned:** make a deliberate call, document the
+  rationale here, and update the Canonical Behavior section accordingly. Tracked
+  in [#52](https://github.com/snaveevans/pineapple/issues/52).
+- **Different enforcement mechanisms for collections vs single resources.**
+  Collections filter at the repo-query level; single resources check post-fetch
+  at the use-case level. Both enforce the same invariant but in different places.
+- **Asset deletion is not yet implemented.** When added, it should remain
+  asset-owner-only (team members may edit shared assets but not delete them).
+- **Archived resource visibility is inconsistent.** Collection queries filter out
+  archived assets, but single-resource access by ID does not exclude archived
+  entities. **Planned:** define the access policy for archived resources and
+  apply it consistently.

--- a/docs/specs/cross-cutting/telemetry.md
+++ b/docs/specs/cross-cutting/telemetry.md
@@ -116,6 +116,27 @@ Both systems write to Cloudflare Analytics Engine using the same envelope:
 | `doubles[0]` | `count`           | Always `1`                                                                 |
 | `doubles[1]` | `event_time_ms`   | Event timestamp (ms since epoch)                                           |
 
+**Domain event data point — `AssetSharedToTeam`** (dataset: `pineapple_asset_domain_events`,
+index: `owner_id`). Telemetry records ids only — not asset or team names (ADR-0010):
+
+| Field        | Name              | Value                            |
+| ------------ | ----------------- | -------------------------------- |
+| `indexes[0]` | —                 | `owner_id`                       |
+| `blobs[0]`   | `event_type`      | `"AssetSharedToTeam"`            |
+| `blobs[1]`   | `aggregate_type`  | `"Asset"`                        |
+| `blobs[2]`   | `asset_id`        | Asset UUID                       |
+| `blobs[3]`   | `owner_id`        | Owner UUID                       |
+| `blobs[4]`   | `team_id`         | Team UUID                        |
+| `blobs[5]`   | `actor_id`        | Actor UUID                       |
+| `blobs[6]`   | `source_use_case` | `"ShareAsset"`                   |
+| `blobs[7]`   | `schema_version`  | `"v1"`                           |
+| `blobs[8]`   | `result`          | `"success"`                      |
+| `doubles[0]` | `count`           | Always `1`                       |
+| `doubles[1]` | `event_time_ms`   | Event timestamp (ms since epoch) |
+
+**Domain event data point — `AssetUnsharedFromTeam`** (dataset: `pineapple_asset_domain_events`,
+index: `owner_id`). Same shape as share; `source_use_case` is `"UnshareAsset"`.
+
 ### Analytics Engine Constraints
 
 These limits apply to every data point written and must be respected when designing new event schemas:
@@ -211,6 +232,8 @@ Every API route maps to a named operation used as the `indexes[0]` value in requ
 | `DELETE /api/assets/{assetId}/maintenance-tasks/{taskId}` | `DeleteMaintenanceTask`    |
 | `POST /api/teams`                                         | `CreateTeam`               |
 | `GET /api/teams/me`                                       | `GetMyTeam`                |
+| `POST /api/assets/{assetId}/share`                        | `ShareAsset`               |
+| `DELETE /api/assets/{assetId}/share`                      | `UnshareAsset`             |
 | `GET /health`                                             | `Health`                   |
 | `GET /openapi.json`                                       | `OpenApiDocument`          |
 | `GET /reference`                                          | `ApiReference`             |

--- a/docs/specs/features/teams-foundation.md
+++ b/docs/specs/features/teams-foundation.md
@@ -62,31 +62,32 @@ authoritative in `openapi.json`.
 
 **Sharing & unsharing (asset-owner only)**
 
-- [ ] The **owner of an asset** can share that asset to the team they belong to; after sharing, the asset is visible and editable to every member of that team
-- [ ] Sharing requires the requester to belong to a team; sharing when the requester has no team fails with a **409 Conflict** (there is nothing to share into)
-- [ ] Only the asset's owner may share or unshare it — a member who does not own the asset attempting to change its sharing fails with **403 Forbidden**
-- [ ] The asset owner can unshare a shared asset, returning it to **personal**; members immediately lose access
-- [ ] Sharing an asset that is already shared to the caller's team is an idempotent success (no duplicate, no error); unsharing an already-personal asset is an idempotent success
-- [ ] "Owner" here means the **asset's** owner (`ownerId`), which may be any team member — not necessarily the team's owner. Any member can share the assets **they** own
+- [x] The **owner of an asset** can share that asset to the team they belong to; after sharing, the asset is visible and editable to every member of that team
+- [x] Sharing requires the requester to belong to a team; sharing when the requester has no team fails with a **409 Conflict** (there is nothing to share into)
+- [x] Only the asset's owner may share or unshare it — a member who does not own the asset attempting to change its sharing fails with **403 Forbidden**
+- [x] The asset owner can unshare a shared asset, returning it to **personal**; members immediately lose access
+- [x] Sharing an asset that is already shared to the caller's team is an idempotent success (no duplicate, no error); unsharing an already-personal asset is an idempotent success
+- [x] "Owner" here means the **asset's** owner (`ownerId`), which may be any team member — not necessarily the team's owner. Any member can share the assets **they** own
 
 **Member access to shared assets (full parity)**
 
 - [ ] A team member can read an asset shared with their team and all of its dependent records (maintenance tasks, maintenance records, activity)
-- [ ] A team member can perform the same **write** actions on a shared asset that its owner can — the maintenance actions that exist today: adding and deleting maintenance tasks, and logging maintenance records — with the sole exceptions of changing its sharing and deleting the asset itself, which remain asset-owner-only
-- [ ] Access to a shared asset's dependent records **follows the asset**: authorization for maintenance/record/activity operations is determined by whether the requester can access the parent asset (owns it, or is a member of the team it is shared with), replacing the direct `ownerId === requesterId` check on those operations
-- [ ] When an asset is unshared, or a member's access otherwise ends, subsequent requests by that member for the asset or its records behave as if the asset does not exist for them
+<!-- maintenance tasks/records: done; activity feed still owner-scoped — follow-up -->
+- [x] A team member can perform the same **write** actions on a shared asset that its owner can — the maintenance actions that exist today: adding and deleting maintenance tasks, and logging maintenance records — with the sole exceptions of changing its sharing and deleting the asset itself, which remain asset-owner-only
+- [x] Access to a shared asset's dependent records **follows the asset**: authorization for maintenance/record/activity operations is determined by whether the requester can access the parent asset (owns it, or is a member of the team it is shared with), replacing the direct `ownerId === requesterId` check on those operations
+- [x] When an asset is unshared, or a member's access otherwise ends, subsequent requests by that member for the asset or its records behave as if the asset does not exist for them
 
 **Read-path integration**
 
-- [ ] Every list of "the user's assets" — the asset library (`GET /api/assets`), the dashboard, and search — returns both the requester's own assets (personal and shared-by-them) **and** the assets shared to the requester's team by others
-- [ ] Each asset in a read model carries a computed **`sharing`** descriptor (computed server-side per ADR-0009, not derived by the client): its scope (`personal` or `team`) and whether the requester is its owner; for an asset shared **with** the requester by someone else, it also identifies the owner (e.g. owner display name) so the member can see whose asset it is
-- [ ] Per-category counts and any other aggregate read-model figures are computed over the full visible set (owned + shared-with-me), so counts and lists stay consistent
+- [x] Every list of "the user's assets" — the asset library (`GET /api/assets`), the dashboard, and search — returns both the requester's own assets (personal and shared-by-them) **and** the assets shared to the requester's team by others
+- [x] Each asset in a read model carries a computed **`sharing`** descriptor (computed server-side per ADR-0009, not derived by the client): its scope (`personal` or `team`) and whether the requester is its owner; for an asset shared **with** the requester by someone else, it also identifies the owner (e.g. owner display name) so the member can see whose asset it is
+- [x] Per-category counts and any other aggregate read-model figures are computed over the full visible set (owned + shared-with-me), so counts and lists stay consistent
 
 **Permissions extension**
 
-- [ ] The single-resource access rule is extended: a request for an asset (or its children) succeeds if the requester **owns it** _or_ **is a member of the team it is shared with**; otherwise the existing not-owned behavior applies
-- [ ] The collection query is extended to include team-shared assets in addition to owned ones; it must never return an asset that is neither owned by nor shared with the requester
-- [ ] [permissions.md](../cross-cutting/permissions.md) must be updated to document team visibility as an extension of the ownership model (per-user ownership remains the default; team sharing is additive)
+- [x] The single-resource access rule is extended: a request for an asset (or its children) succeeds if the requester **owns it** _or_ **is a member of the team it is shared with**; otherwise the existing not-owned behavior applies
+- [x] The collection query is extended to include team-shared assets in addition to owned ones; it must never return an asset that is neither owned by nor shared with the requester
+- [x] [permissions.md](../cross-cutting/permissions.md) must be updated to document team visibility as an extension of the ownership model (per-user ownership remains the default; team sharing is additive)
 
 ## Edge Cases & Error States
 

--- a/docs/specs/features/teams-foundation.md
+++ b/docs/specs/features/teams-foundation.md
@@ -74,7 +74,8 @@ authoritative in `openapi.json`.
 - [ ] A team member can read an asset shared with their team and all of its dependent records (maintenance tasks, maintenance records, activity)
 <!-- maintenance tasks/records: done; activity feed still owner-scoped — follow-up -->
 - [x] A team member can perform the same **write** actions on a shared asset that its owner can — the maintenance actions that exist today: adding and deleting maintenance tasks, and logging maintenance records — with the sole exceptions of changing its sharing and deleting the asset itself, which remain asset-owner-only
-- [x] Access to a shared asset's dependent records **follows the asset**: authorization for maintenance/record/activity operations is determined by whether the requester can access the parent asset (owns it, or is a member of the team it is shared with), replacing the direct `ownerId === requesterId` check on those operations
+- [x] Access to a shared asset's dependent records **follows the asset**: authorization for maintenance task and record operations is determined by whether the requester can access the parent asset (owns it, or is a member of the team it is shared with), replacing the direct `ownerId === requesterId` check on those operations
+- [ ] Access to the **activity feed** for shared assets follows the asset the same way (still owner-scoped today — follow-up)
 - [x] When an asset is unshared, or a member's access otherwise ends, subsequent requests by that member for the asset or its records behave as if the asset does not exist for them
 
 **Read-path integration**

--- a/docs/web/FEATURES.md
+++ b/docs/web/FEATURES.md
@@ -271,7 +271,7 @@ For the API contract behind each feature, see the linked spec in `docs/specs/fea
 ## Asset Maintenance Records & Tasks
 
 **Route:** `/app/assets/:id/maintenance`
-**Goal:** Let the user view and log maintenance history for a specific asset, and manage upcoming maintenance tasks for it.
+**Goal:** Let the user view and log maintenance history for a specific asset, manage upcoming maintenance tasks, and (if they own the asset) share or unshare it with their team.
 
 **Key states:**
 
@@ -283,14 +283,19 @@ For the API contract behind each feature, see the linked spec in `docs/specs/fea
 - Create record form: inline or modal; validates date and description; submits to API
 - Create task form: inline; validates title and due date
 - Delete task: confirmation before removal
+- Share (owner only): sheet/drawer to share the asset to the caller's team or unshare it back to personal
+- Shared-by-teammate (member view): badge + strip explaining who shared it; no share control
+- No team when sharing: sheet explains a team is required and links to `/app/team`
 
 **Non-obvious behavior:**
 
 - Records and tasks are fetched independently; one can load before the other
 - Dates are stored as ISO strings (YYYY-MM-DD) and displayed as human-readable relative dates ("3 days ago", "yesterday")
 - 401 on any fetch redirects to `/login`
+- Sharing uses the asset's server-computed `sharing` descriptor (`scope`, `isOwner`, optional `ownerDisplayName`); only the asset owner can change sharing
+- Share/unshare are idempotent on the API; the sheet closes on success and refreshes the asset query
 
-**Spec:** [`docs/specs/features/maintenance-record.md`](../specs/features/maintenance-record.md), [`docs/specs/features/maintenance-task.md`](../specs/features/maintenance-task.md)
+**Spec:** [`docs/specs/features/maintenance-record.md`](../specs/features/maintenance-record.md), [`docs/specs/features/maintenance-task.md`](../specs/features/maintenance-task.md), [`docs/specs/features/teams-foundation.md`](../specs/features/teams-foundation.md)
 
 ---
 

--- a/migrations/0014_asset_sharing.sql
+++ b/migrations/0014_asset_sharing.sql
@@ -1,5 +1,8 @@
 -- Opt-in team sharing on assets (ADR-0015 / teams-foundation).
 -- NULL = personal; non-null = shared to that team.
+-- No ON DELETE: team deletion / leave-team are not implemented yet. When they
+-- land, decide whether shared assets auto-unshare or block team removal so
+-- rows are not left pointing at a team the owner no longer belongs to.
 ALTER TABLE assets ADD COLUMN shared_team_id TEXT REFERENCES teams(id);
 
 CREATE INDEX IF NOT EXISTS idx_assets_shared_team_id ON assets(shared_team_id);

--- a/migrations/0014_asset_sharing.sql
+++ b/migrations/0014_asset_sharing.sql
@@ -1,0 +1,5 @@
+-- Opt-in team sharing on assets (ADR-0015 / teams-foundation).
+-- NULL = personal; non-null = shared to that team.
+ALTER TABLE assets ADD COLUMN shared_team_id TEXT REFERENCES teams(id);
+
+CREATE INDEX IF NOT EXISTS idx_assets_shared_team_id ON assets(shared_team_id);


### PR DESCRIPTION
## Summary

- Add `POST`/`DELETE /api/assets/{assetId}/share` (asset-owner only, idempotent) with `shared_team_id` migration and Smart Events (`AssetSharedToTeam` / `AssetUnsharedFromTeam` + telemetry).
- Extend single-resource and collection access: visible if requester owns the asset **or** is a member of the team it is shared with; maintenance use cases follow the asset.
- Add computed `sharing` descriptor on asset read models; expand list/search/dashboard over the full visible set; rewrite `permissions.md`.
- **Web:** share/unshare UI on the asset maintenance page (design handoff) — owner share button + badge, share sheet/drawer, member “shared by” strip, no-team link to `/app/team`.

## Related

Closes #58

## Test plan

- [x] `pnpm lint && pnpm type-check && pnpm -r test`
- [x] Local D1 migration `0014_asset_sharing` applied
- [x] Local API: share without team → 409; share/unshare/idempotent; list/get/search/dashboard; maintenance on shared asset
- [x] Chrome DevTools: DEV_AUTH onboarding → dashboard/assets/team; browser share cycle; Scalar docs show share routes
- [x] Chrome DevTools: maintenance page share sheet → Share with Field Ops → badge; Unshare → personal again

## Spec / AC

[teams-foundation.md](docs/specs/features/teams-foundation.md) — sharing, member access (except activity feed), read-path, permissions extension checked off.

**Web:** [`docs/web/FEATURES.md`](docs/web/FEATURES.md) — asset maintenance share/unshare states documented.

**Deferred:** activity history feed still owner-scoped (noted on remaining AC).