### PR TITLE
docs: teams remaining-slices implementation plan (PLAN.md)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -3,28 +3,56 @@
 > **Audience:** agents and humans implementing the teams epic  
 > **Scope:** teams epic only (#62) — not `/verify-email`, #52, API chores #65–70, or #18  
 > **Stacking:** GitHub Stacked PRs via [`gh stack`](https://github.github.com/gh-stack/)  
-> **Last updated:** 2026-07-13
+> **Last updated:** 2026-07-13 (reconciled after `main` merge of PR #75 / #53)
 
 Check a box **only when that item is done on the branch/PR that lands it** (code + tests + any required OpenAPI/spec AC updates). Do not check from intent alone.
 
-**Before implementing any layer:** open the **Spec** path(s) listed for that layer and implement only the AC that layer owns. Mark those AC boxes in the same PR.
+**Before implementing any layer:** open the **Spec** path(s) for that layer, implement only the AC tagged with that layer’s **slice id** (`S3` / `S4` / `S5` / etc.), and check those boxes in the same PR.
+
+---
+
+## Reconciled from `main` (PR #75 — Closes #53)
+
+Landed on `main` after this plan was first written. **Do not redo.**
+
+| Change | Effect on this plan |
+| ------ | ------------------- |
+| Read specs updated for team-shared assets | [#53](https://github.com/snaveevans/pineapple/issues/53) **closed** — drop “optional close #53” work |
+| [teams-foundation.md](docs/specs/features/teams-foundation.md) **Delivery Plan** `S1`…`S5` | Official slice ids; AC tagged per slice. Status: **`in-progress`** (`S1`/`S2` done) |
+| [activity-history.md](docs/specs/features/activity-history.md) Delivery Plan | `S1` base (shipped); **`S2` = #73** (shared activity + actor). Status: **`in-progress`** |
+| [dashboard.md](docs/specs/features/dashboard.md) Delivery Plan | **`S3` = #74** (`sharing` on dashboard); **`S4` = #59** (web badges). Status: **`in-progress`** |
+| [app-search.md](docs/specs/features/app-search.md) Delivery Plan | **`S3` = #74**; **`S4` = #59**. Status: **`in-progress`** |
+| [asset-library.md](docs/specs/features/asset-library.md) Delivery Plan | **`S3` = #59** (web badges; API `sharing` already from teams `S2`). Status: **`in-progress`** |
+| [SPECS.md](docs/specs/SPECS.md) lifecycle | `review` → **`in-progress`** → `active`; every AC has exactly one slice tag |
+| Spec-author / spec-implement skills | Slice tags + Delivery Plan required when authoring/implementing |
+
+### teams-foundation Delivery Plan (source of truth)
+
+| Slice | Scope | Issue | Status |
+| ----- | ----- | ----- | ------ |
+| `S1` | Team + membership core | #57 | **done on main** |
+| `S2` | Asset sharing + access (backend), `sharing` on `GET /api/assets` | #58 | **done on main** |
+| `S3` | Shared-asset activity + actor attribution → criteria in activity-history | #73 | **todo** (Stack B) |
+| `S4` | `sharing` on dashboard + search read models → dashboard `S3` + app-search `S3` | #74 | **todo** (Stack A1) |
+| `S5` | Web sharing badges → asset-library `S3` + dashboard `S4` + app-search `S4` + FEATURES.md | #59 | **todo** (Stack A2) |
 
 ---
 
 ## Task → spec map (source of truth)
 
-| Layer | Issue | Spec(s) to implement against | Status of spec today |
-| ----- | ----- | ---------------------------- | -------------------- |
-| A1 | [#74](https://github.com/snaveevans/pineapple/issues/74) | [dashboard.md](docs/specs/features/dashboard.md) (`sharing` on fleet/queue), [app-search.md](docs/specs/features/app-search.md) (`sharing` on hits), [teams-foundation.md](docs/specs/features/teams-foundation.md) (read-path `sharing` descriptor AC) | draft / draft / review |
-| A2 | [#59](https://github.com/snaveevans/pineapple/issues/59) | [teams-foundation.md](docs/specs/features/teams-foundation.md) (read-path UI intent), [asset-library.md](docs/specs/features/asset-library.md), [dashboard.md](docs/specs/features/dashboard.md), [app-search.md](docs/specs/features/app-search.md), web intent [FEATURES.md](docs/web/FEATURES.md) | review / review / draft / draft |
-| B1 | [#73](https://github.com/snaveevans/pineapple/issues/73) | [activity-history.md](docs/specs/features/activity-history.md) (access + actor + filters), [teams-foundation.md](docs/specs/features/teams-foundation.md) (unchecked activity AC), [ADR-0010](docs/decisions/0010-smart-events-for-durable-consumers.md) | draft / review |
-| C1–C5 | [#60](https://github.com/snaveevans/pineapple/issues/60) | **Author then implement:** [invite-teammate.md](docs/specs/features/invite-teammate.md) _(create in C1)_ · depends on [teams-foundation.md](docs/specs/features/teams-foundation.md), [ADR-0015](docs/decisions/0015-teams-as-opt-in-sharing-scope.md), email [ADR-0012](docs/decisions/0012-transactional-email-via-cloudflare-email-sending.md) | not written yet |
-| D1–D4 | [#61](https://github.com/snaveevans/pineapple/issues/61) | **Author then implement:** [team-management.md](docs/specs/features/team-management.md) _(create in D1)_ · resolves [#56](https://github.com/snaveevans/pineapple/issues/56) · depends on invite-teammate + teams-foundation | not written yet |
-| Decision | [#55](https://github.com/snaveevans/pineapple/issues/55) | [notifications.md](docs/specs/features/notifications.md) (+ teams-foundation deferred flag) | active |
-| Decision | [#56](https://github.com/snaveevans/pineapple/issues/56) | Recorded in **team-management.md** (D1); coded in D2+ | open decision |
-| Epic | [#62](https://github.com/snaveevans/pineapple/issues/62) | [teams-foundation.md](docs/specs/features/teams-foundation.md), [ADR-0015](docs/decisions/0015-teams-as-opt-in-sharing-scope.md), index [SPECS.md](docs/specs/SPECS.md) | review |
+| Layer | Issue | Spec slice(s) | Spec path(s) | Spec status |
+| ----- | ----- | ------------- | ------------ | ----------- |
+| A1 | [#74](https://github.com/snaveevans/pineapple/issues/74) | teams-foundation **`S4`**; dashboard **`S3`**; app-search **`S3`** | [dashboard.md](docs/specs/features/dashboard.md), [app-search.md](docs/specs/features/app-search.md), [teams-foundation.md](docs/specs/features/teams-foundation.md) | in-progress |
+| A2 | [#59](https://github.com/snaveevans/pineapple/issues/59) | teams-foundation **`S5`**; asset-library **`S3`**; dashboard **`S4`**; app-search **`S4`** | same + [asset-library.md](docs/specs/features/asset-library.md) + [FEATURES.md](docs/web/FEATURES.md) | in-progress |
+| B1 | [#73](https://github.com/snaveevans/pineapple/issues/73) | teams-foundation **`S3`**; activity-history **`S2`** | [activity-history.md](docs/specs/features/activity-history.md), [teams-foundation.md](docs/specs/features/teams-foundation.md), [ADR-0010](docs/decisions/0010-smart-events-for-durable-consumers.md) | in-progress |
+| C1–C5 | [#60](https://github.com/snaveevans/pineapple/issues/60) | **Author then implement** invite-teammate (own Delivery Plan) | [invite-teammate.md](docs/specs/features/invite-teammate.md) _(create in C1)_ · [teams-foundation.md](docs/specs/features/teams-foundation.md) · [ADR-0015](docs/decisions/0015-teams-as-opt-in-sharing-scope.md) · [ADR-0012](docs/decisions/0012-transactional-email-via-cloudflare-email-sending.md) | not written |
+| D1–D4 | [#61](https://github.com/snaveevans/pineapple/issues/61) | **Author then implement** team-management (own Delivery Plan; resolves #56) | [team-management.md](docs/specs/features/team-management.md) _(create in D1)_ | not written |
+| Decision | [#55](https://github.com/snaveevans/pineapple/issues/55) | notifications recipient policy | [notifications.md](docs/specs/features/notifications.md) | active |
+| Decision | [#56](https://github.com/snaveevans/pineapple/issues/56) | recorded in team-management Delivery Plan / AC | team-management.md (D1) | open |
+| Epic | [#62](https://github.com/snaveevans/pineapple/issues/62) | umbrella | teams-foundation + ADR-0015 + [SPECS.md](docs/specs/SPECS.md) | — |
+| ~~#53~~ | closed by PR #75 | read-surface spec pass | — | **done** |
 
-**Cross-cutting always in force** (do not re-spec; follow these):
+**Cross-cutting always in force:**
 
 - [authentication.md](docs/specs/cross-cutting/authentication.md)
 - [permissions.md](docs/specs/cross-cutting/permissions.md)
@@ -33,24 +61,26 @@ Check a box **only when that item is done on the branch/PR that lands it** (code
 - [loading-states.md](docs/specs/cross-cutting/loading-states.md)
 - [telemetry.md](docs/specs/cross-cutting/telemetry.md)
 
-**API contract:** generated OpenAPI (`docs/reference/openapi.json`) is authoritative for HTTP shapes once a layer lands; Zod route specs are the edit surface.
+**API contract:** `docs/reference/openapi.json` (edit Zod route specs, then regenerate).
+
+**How to find work in a spec:** open Delivery Plan → find slice id → implement every AC tagged `` `Sn` `` for that slice; leave other tags alone.
 
 ---
 
 ## Reality check
 
-Core product features (dashboard, activity, search, notifications, maintenance, assets, profile) are **already on `main`**. Many unchecked AC boxes in specs are lifecycle drift, not missing code.
+Core product features (dashboard, activity, search, notifications, maintenance, assets, profile) are **already on `main`**. Many older AC boxes remain unchecked pending box reconciliation (noted as Flags in specs) — that is **not** this plan’s scope unless a slice PR owns those boxes.
 
-**Teams epic [#62](https://github.com/snaveevans/pineapple/issues/62)** is the remaining product track.
+**Teams epic [#62](https://github.com/snaveevans/pineapple/issues/62)** remaining product track:
 
 | Done | Remaining |
 | ---- | --------- |
-| #57 team + membership | **#74** sharing descriptor on dashboard + search |
-| #58 asset share/access | **#73** shared activity + actor attribution |
-| Create-team + share UI on maintenance | **#59** list-surface sharing badges |
-| `sharing` on `GET /api/assets` | **#60** invite-teammate (spec + implement) |
-| | **#61** team-management (spec + implement; resolves #56) |
-| | **#55** reminder recipient decision (before multi-member reminders) |
+| #57 / teams `S1` team + membership | **#74** / teams `S4` + dashboard `S3` + search `S3` |
+| #58 / teams `S2` asset share + access | **#73** / teams `S3` + activity-history `S2` |
+| Create-team + share UI on maintenance | **#59** / teams `S5` + library `S3` + dashboard `S4` + search `S4` |
+| #53 read specs reconciled (PR #75) | **#60** invite-teammate |
+| `sharing` on `GET /api/assets` | **#61** team-management (+ #56) |
+| | **#55** reminder recipient decision |
 
 ### Out of scope for this plan
 
@@ -61,35 +91,34 @@ Core product features (dashboard, activity, search, notifications, maintenance, 
 | API hygiene #65–#70 | (no feature spec) |
 | #18 security dashboard | (no feature spec) |
 | Parked archive-asset | [archive-asset.md](docs/specs/backlog/archive-asset.md) |
+| Reconciling stale `S1` AC boxes on already-shipped features | Flags in activity-history / app-search / etc. |
 
 - [ ] _(do not implement under this plan)_ Public `/verify-email` web page
-- [ ] _(do not implement under this plan)_ #52 404-masking for wrong-owner access
+- [ ] _(do not implement under this plan)_ #52 404-masking
 - [ ] _(do not implement under this plan)_ API hygiene #65–#70
 - [ ] _(do not implement under this plan)_ #18 security dashboard
 - [ ] _(do not implement under this plan)_ Parked archive-asset
+- [x] ~~#53 update read specs~~ — **done on main (PR #75)**
 
 ---
 
 ## Dependency graph
 
 ```text
-main
- ├─ Stack A (foundation finish)
- │   ├─ L1  #74  sharing descriptor (dashboard + search API)
- │   │      specs: dashboard.md, app-search.md, teams-foundation.md
- │   └─ L2  #59  web badges
- │          specs: teams-foundation.md + asset-library/dashboard/app-search + FEATURES.md
+main  (includes #57 S1, #58 S2, PR #75 slice-tagged specs)
+ ├─ Stack A (foundation finish — depends on S2)
+ │   ├─ A1  #74  teams S4 = dashboard S3 + app-search S3
+ │   └─ A2  #59  teams S5 = library S3 + dashboard S4 + app-search S4  (needs A1)
  │
- └─ Stack B (parallel with A)
-     └─ L1  #73  shared activity + actor attribution
-            specs: activity-history.md, teams-foundation.md, ADR-0010
+ └─ Stack B (parallel with A — depends on S2 only)
+     └─ B1  #73  teams S3 = activity-history S2
 
-main (after A+B merge) ── Stack C: invite-teammate.md (author → implement)
-main (after C) ────────── Stack D: team-management.md (author → implement; #56)
-                           #55 → notifications.md decision
+main (after A+B) ── Stack C: invite-teammate.md (author → implement)
+main (after C) ──── Stack D: team-management.md (author → implement; #56)
+                     #55 → notifications.md decision
 ```
 
-**Why two parallel stacks for foundation leftovers:** #73 and #74 both only need #58 (done). Stacking #73 under #74 would create a false dependency. Stack A is the real dependent pair (#74 → #59).
+**Why two parallel stacks:** #73 (`S3`) and #74 (`S4`) both depend only on teams `S2` (done). Stack A is the real chain (`S4` → `S5`).
 
 ---
 
@@ -111,158 +140,155 @@ gs init feat/<issue>-<slug>     # bottom layer, off main
 gs add feat/<issue>-<slug>     # next layer, base = previous branch
 # implement → commit
 gs push && gs submit           # push all branches, open PRs with correct bases
-# after review: merge bottom → rest auto-rebase; or merge partial stack when CI is green
 ```
 
 ### Repo conventions (every layer)
 
 - [ ] Branch name: `feat/{issue}-{slug}` (or `docs/{issue}-{slug}` for spec-only)
-- [ ] PR body uses template; `Closes #N` only when this PR fully finishes the issue; else `Refs #N`
-- [ ] PR **Spec / AC** section links the paths below and lists AC boxes checked
-- [ ] Spec AC checkboxes: only mark boxes **this PR** lands, in the same PR
-- [ ] Before open/push readiness: `pnpm lint && pnpm type-check && pnpm -r test`
-- [ ] Regenerate OpenAPI when contract changes: `pnpm --filter @snaveevans/pineapple-api openapi:generate`
-- [ ] One concern per layer (~40 files / ~800 net lines is a **split signal**, not a target)
+- [ ] PR body: `Closes #N` only when this PR fully finishes the issue; else `Refs #N`
+- [ ] PR **Spec / AC** section lists slice ids (`S4`, dashboard `S3`, …) and paths
+- [ ] Check off **only** AC tagged for this slice (and only when tested)
+- [ ] `pnpm lint && pnpm type-check && pnpm -r test` before ready
+- [ ] OpenAPI regen when contract changes
+- [ ] One concern per layer (~40 files / ~800 net lines = split signal)
 - [ ] No drive-by refactors, no API hygiene, no archive work
 
-### Per-PR checklist (copy into each PR work session)
+### Per-PR checklist
 
-- [ ] Opened the **Spec** path(s) for this layer (see Task → spec map)
-- [ ] One-sentence scope named; stop if a second concern appears
+- [ ] Opened Spec Delivery Plan + all AC with this layer’s slice tag(s)
+- [ ] One-sentence scope; stop if a second concern appears
 - [ ] Tests for new behavior
 - [ ] `pnpm lint && pnpm type-check && pnpm -r test`
 - [ ] OpenAPI regen if API changed
-- [ ] Spec AC checkboxes for **this** layer only
-- [ ] PR: Summary / Related / Test plan / Spec (with paths)
-- [ ] Commit messages: Conventional Commits + Co-Authored-By trailer
+- [ ] Spec AC checkboxes for **this slice only**
+- [ ] PR: Summary / Related / Test plan / Spec (paths + slice ids)
+- [ ] Conventional Commits + Co-Authored-By trailer
 
 ---
 
-## Stack A — Read-model badges
+## Stack A — Read-model badges (teams `S4` → `S5`)
 
-### A1 — `feat/74-sharing-descriptor` · Closes #74
+### A1 — `feat/74-sharing-descriptor` · Closes #74 · teams-foundation **`S4`**
 
 | | |
 | --- | --- |
 | **Issue** | [#74](https://github.com/snaveevans/pineapple/issues/74) |
-| **Primary specs** | [docs/specs/features/dashboard.md](docs/specs/features/dashboard.md) · [docs/specs/features/app-search.md](docs/specs/features/app-search.md) |
-| **Foundation AC** | [docs/specs/features/teams-foundation.md](docs/specs/features/teams-foundation.md) — **Read-path integration** (`sharing` descriptor on read models; dashboard + search still incomplete vs library) |
-| **ADR** | [ADR-0009](docs/decisions/0009-computed-fields-belong-in-api-read-models.md) (computed fields in API) · [ADR-0015](docs/decisions/0015-teams-as-opt-in-sharing-scope.md) |
-| **Web intent** | none this layer |
+| **Slice ids** | teams-foundation **`S4`** · dashboard **`S3`** · app-search **`S3`** |
+| **Primary specs** | [dashboard.md](docs/specs/features/dashboard.md) · [app-search.md](docs/specs/features/app-search.md) |
+| **Foundation** | [teams-foundation.md](docs/specs/features/teams-foundation.md) — Delivery Plan `S4` + AC tagged `S4` |
+| **ADR** | [ADR-0009](docs/decisions/0009-computed-fields-belong-in-api-read-models.md) · [ADR-0015](docs/decisions/0015-teams-as-opt-in-sharing-scope.md) |
+| **Web** | none this layer |
 | **Contract** | regenerate `docs/reference/openapi.json` |
 
-**Concern:** Backend only — put computed `sharing` on dashboard + search (same shape as `ListAssets`).
+**Concern:** Backend only — computed `sharing` on dashboard + search (same shape as library).
 
-**Do not:** web UI (#59), activity (#73).
+**Do not:** web UI (#59 / `S5`), activity (#73 / `S3`).
 
 #### Implementation
 
-- [ ] Read AC in `dashboard.md` + `app-search.md` + teams-foundation read-path section before coding
-- [ ] `GetDashboard` attaches `sharing` to fleet/queue representations that surface assets
-- [ ] `SearchAssets` reverses intentional omission of `sharing` on hits
-- [ ] Zod / OpenAPI schemas updated for dashboard + search `sharing`
+- [ ] Read all AC tagged dashboard `S3`, app-search `S3`, teams-foundation `S4`
+- [ ] `GetDashboard` attaches `sharing` where assets surface (fleet/queue)
+- [ ] `SearchAssets` adds `sharing` on hits (reverses intentional omission)
+- [ ] Zod / OpenAPI schemas updated
 - [ ] OpenAPI regenerated and committed
 - [ ] Use-case tests: owned vs shared-with-me vs personal
 - [ ] `pnpm lint && pnpm type-check && pnpm -r test` green
-- [ ] PR opened (stack bottom, base `main`) with `Closes #74` and Spec links above
+- [ ] PR opened (stack bottom, base `main`) with `Closes #74` + slice ids in Spec section
 - [ ] PR merged
 
-#### Spec / docs updates (same PR)
+#### Spec updates (same PR)
 
-- [ ] Check off AC in `dashboard.md` that this PR implements (only tested ones)
-- [ ] Check off AC in `app-search.md` that this PR implements (only tested ones)
-- [ ] Check off teams-foundation read-path AC only if this PR completes remaining descriptor gaps for dashboard/search
-- [ ] No web `FEATURES.md` badge work (that's A2)
+- [ ] Check off teams-foundation AC tagged `` `S4` ``
+- [ ] Check off dashboard AC tagged `` `S3` ``
+- [ ] Check off app-search AC tagged `` `S3` ``
+- [ ] Do **not** touch `S1`/`S2` reconciliation Flags unless tests already cover them
 
 ---
 
-### A2 — `feat/59-sharing-badges` · Closes #59 · base = A1
+### A2 — `feat/59-sharing-badges` · Closes #59 · teams-foundation **`S5`** · base = A1
 
 | | |
 | --- | --- |
 | **Issue** | [#59](https://github.com/snaveevans/pineapple/issues/59) |
-| **Primary specs** | [docs/specs/features/teams-foundation.md](docs/specs/features/teams-foundation.md) (read-path / member visibility UX) |
-| **Surface specs** | [docs/specs/features/asset-library.md](docs/specs/features/asset-library.md) · [docs/specs/features/dashboard.md](docs/specs/features/dashboard.md) · [docs/specs/features/app-search.md](docs/specs/features/app-search.md) |
-| **Web intent** | [docs/web/FEATURES.md](docs/web/FEATURES.md) — library, home/dashboard, search entries |
-| **ADR** | [ADR-0015](docs/decisions/0015-teams-as-opt-in-sharing-scope.md) |
-| **Depends on** | A1 API descriptors for dashboard + search; library already has `sharing` from #58 |
+| **Slice ids** | teams-foundation **`S5`** · asset-library **`S3`** · dashboard **`S4`** · app-search **`S4`** |
+| **Primary specs** | [asset-library.md](docs/specs/features/asset-library.md) · [dashboard.md](docs/specs/features/dashboard.md) · [app-search.md](docs/specs/features/app-search.md) |
+| **Foundation** | [teams-foundation.md](docs/specs/features/teams-foundation.md) — Delivery Plan `S5` (criteria live in sibling specs) |
+| **Web intent** | [docs/web/FEATURES.md](docs/web/FEATURES.md) |
+| **Depends on** | A1 (dashboard/search `sharing`); library API already has `sharing` from teams `S2` |
 
 **Concern:** Web badges only.
 
-**Do not:** backend changes beyond what A1 already provides.
+**Do not:** backend beyond A1.
 
 #### Implementation
 
-- [ ] Read teams-foundation + surface specs + `FEATURES.md` before coding
-- [ ] Asset library cards: “shared with team” / “shared by {owner}” (API already has `sharing`)
-- [ ] Dashboard queue rows consume A1 `sharing` descriptor
-- [ ] Search results consume A1 `sharing` descriptor
-- [ ] UI tests for badge copy and states
-- [ ] `docs/web/FEATURES.md` updated for list badges
+- [ ] Read AC tagged library `S3`, dashboard `S4`, app-search `S4`
+- [ ] Library cards: “shared with team” / “shared by {owner}”
+- [ ] Dashboard queue rows consume A1 `sharing`
+- [ ] Search results consume A1 `sharing`
+- [ ] UI tests for badge copy/states
+- [ ] `docs/web/FEATURES.md` updated
 - [ ] `pnpm lint && pnpm type-check && pnpm -r test` green
-- [ ] PR opened (stacked on A1) with `Closes #59` and Spec links above
+- [ ] PR opened (stacked on A1) with `Closes #59` + slice ids
 - [ ] PR merged (after A1)
 
-#### Spec / docs updates (same PR)
+#### Spec updates (same PR)
 
-- [ ] Check off UI-facing AC this PR implements in the surface specs (if present)
-- [ ] `FEATURES.md` reflects badge behavior on library / dashboard / search
+- [ ] Check off asset-library `` `S3` ``, dashboard `` `S4` ``, app-search `` `S4` `` AC this PR lands
+- [ ] Note teams-foundation `S5` complete when sibling boxes + FEATURES.md are done (plan Scope cell has no local AC tags)
 
 ---
 
-## Stack B — Shared activity (parallel with A)
+## Stack B — Shared activity (parallel) · teams **`S3`**
 
 ### B1 — `feat/73-shared-activity` · Closes #73
 
 | | |
 | --- | --- |
 | **Issue** | [#73](https://github.com/snaveevans/pineapple/issues/73) |
-| **Primary spec** | [docs/specs/features/activity-history.md](docs/specs/features/activity-history.md) — shared-asset access, actor attribution, filters, pagination |
-| **Foundation AC** | [docs/specs/features/teams-foundation.md](docs/specs/features/teams-foundation.md) — **Member access** unchecked rows: activity follows the asset |
-| **ADR** | [ADR-0010](docs/decisions/0010-smart-events-for-durable-consumers.md) (actor display name on durable events) · [ADR-0015](docs/decisions/0015-teams-as-opt-in-sharing-scope.md) |
-| **Web intent** | [docs/web/FEATURES.md](docs/web/FEATURES.md) — History / activity |
-| **Telemetry** | [docs/specs/cross-cutting/telemetry.md](docs/specs/cross-cutting/telemetry.md) — no actor display name in AE |
-| **Contract** | regenerate OpenAPI if activity response shape changes |
+| **Slice ids** | teams-foundation **`S3`** · activity-history **`S2`** |
+| **Primary spec** | [activity-history.md](docs/specs/features/activity-history.md) — Delivery Plan `S2` + all AC tagged `S2` |
+| **Foundation** | [teams-foundation.md](docs/specs/features/teams-foundation.md) — AC tagged `S3` (points at activity-history) |
+| **ADR** | [ADR-0010](docs/decisions/0010-smart-events-for-durable-consumers.md) · [ADR-0015](docs/decisions/0015-teams-as-opt-in-sharing-scope.md) |
+| **Web** | [FEATURES.md](docs/web/FEATURES.md) History |
+| **Telemetry** | [telemetry.md](docs/specs/cross-cutting/telemetry.md) — no actor display name in AE |
 
-**Concern:** Activity feed access + actor attribution (closes last unchecked teams-foundation AC).
+**Concern:** Activity feed access + actor attribution.
 
-If event payload + migration + query + UI exceeds ~800 lines or ~40 files, **split** before opening (same specs apply to every sub-slice):
+If too large, split (same slice tags; use `Refs #73` until final):
 
 | Split | Slice | Spec focus |
 | ----- | ----- | ---------- |
-| B1a | Event payload + projection migration + write path | activity-history + ADR-0010 |
-| B1b | List query + filters + API | activity-history access/filters AC |
-| B1c | Web attribution | activity-history UI + FEATURES.md |
-
-Prefer one PR if it stays tight.
+| B1a | Event payload + projection migration + write path | activity-history `S2` + ADR-0010 |
+| B1b | List query + filters + API | activity-history `S2` access/filters |
+| B1c | Web attribution | activity-history `S2` UI + FEATURES.md |
 
 #### Backend
 
-- [ ] Read `activity-history.md` + teams-foundation activity AC + ADR-0010 before coding
-- [ ] `ListActivity` / activity repo: visible = own activity **OR** activity on assets **currently** shared with caller's team
-- [ ] Evaluate against **current** sharing (unshared asset entries drop out next request)
-- [ ] Shared asset shows **full** history, including entries predating the share
-- [ ] Actor on read model: stable id + display name snapshot (never email/auth ids)
-- [ ] Smart events (ADR-0010): producers supply actor display name; History projection stores snapshot
-- [ ] Migration if activity entries need actor display name column/payload
-- [ ] `availableFilters` computed over accessible set (owned + currently shared)
-- [ ] Telemetry handlers stay thin — **do not** write actor display name to Analytics Engine
-- [ ] OpenAPI regenerated if activity contract changes
-- [ ] Tests: access, filters, actor attribution, unshare drops access, telemetry PII-free
+- [ ] Read every activity-history AC tagged `` `S2` `` + teams-foundation `` `S3` ``
+- [ ] Feed = own activity **OR** activity on assets **currently** shared with caller’s team
+- [ ] Current sharing evaluation; unshare drops entries next request
+- [ ] Shared asset shows **full** history (including pre-share)
+- [ ] Actor on read model: stable id + display name snapshot (no email)
+- [ ] Smart events: actor display name on durable events; projection snapshot
+- [ ] Migration if needed for actor display name
+- [ ] `availableFilters` over accessible set
+- [ ] Telemetry: no actor display name in AE
+- [ ] OpenAPI if response shape changes
+- [ ] Tests: access, filters, actor, unshare, PII-free telemetry
 
 #### Web
 
-- [ ] `AppActivityHistory.tsx` renders shared-asset entries
-- [ ] Per-entry actor attribution (“you” vs teammate display name)
-- [ ] UI tests for shared entries + attribution
-- [ ] `docs/web/FEATURES.md` updated if History behavior changes
+- [ ] `AppActivityHistory.tsx` shared entries + “you” vs teammate name
+- [ ] UI tests
+- [ ] FEATURES.md if History behavior changes
 
 #### Spec / PR
 
-- [ ] Check activity-related AC in `teams-foundation.md` this PR lands
-- [ ] Check activity-history AC this PR lands (only boxes covered by tests)
+- [ ] Check off activity-history `` `S2` `` AC this PR lands
+- [ ] Check off teams-foundation `` `S3` `` AC
 - [ ] `pnpm lint && pnpm type-check && pnpm -r test` green
-- [ ] PR opened with `Closes #73` (or `Refs #73` on intermediate B1a/B1b slices) and Spec links above
+- [ ] PR with `Closes #73` (or `Refs #73` on intermediate splits)
 - [ ] PR(s) merged
 
 ---
@@ -271,207 +297,175 @@ Prefer one PR if it stays tight.
 
 | Spec | Action |
 | ---- | ------ |
-| [teams-foundation.md](docs/specs/features/teams-foundation.md) | All AC checked → status `active` |
-| [SPECS.md](docs/specs/SPECS.md) | Row status → `active` |
-| [activity-history.md](docs/specs/features/activity-history.md) / [dashboard.md](docs/specs/features/dashboard.md) / [app-search.md](docs/specs/features/app-search.md) / [asset-library.md](docs/specs/features/asset-library.md) | Align status/AC with code if still stale |
-| [#53](https://github.com/snaveevans/pineapple/issues/53) | Close if read specs fully describe team-shared assets |
+| [teams-foundation.md](docs/specs/features/teams-foundation.md) | `S3`–`S5` all `[x]` → status **`active`** |
+| [activity-history.md](docs/specs/features/activity-history.md) | `S2` complete; status may stay `in-progress` until `S1` box reconciliation Flags are cleared (out of plan unless owned) |
+| [dashboard.md](docs/specs/features/dashboard.md) / [app-search.md](docs/specs/features/app-search.md) / [asset-library.md](docs/specs/features/asset-library.md) | `S3`/`S4` (as applicable) checked; status → `active` only when **all** boxes including shipped `S1` are reconciled |
+| [SPECS.md](docs/specs/SPECS.md) | Update status column when a spec becomes `active` |
+| Epic #62 | Mark foundation slices done |
 
-- [ ] Stack A1, A2, and B1 (or B1a–c) are on `main`
-- [ ] Remaining teams-foundation AC boxes checked if behavior is tested on `main`
-- [ ] `teams-foundation.md` status → `active`
-- [ ] `SPECS.md` row for teams-foundation reflects `active`
-- [ ] Epic #62 foundation checklist rows updated (③ activity, ④ descriptor, ⑤ web badges)
-- [ ] Optional: close #53 if read specs still say “own assets only” — land any missing wording from the read-surface pass
+- [ ] A1, A2, B1 on `main`
+- [ ] teams-foundation `S3`/`S4`/`S5` AC checked
+- [ ] teams-foundation status → `active` (only if **no** remaining `[ ]`)
+- [ ] SPECS.md updated
+- [ ] Epic #62 foundation rows checked
+- [x] #53 closed (PR #75) — no further action
 
 ---
 
 ## Stack C — Invite teammate (#60)
 
-**Spec-first.** Do not fold team rename/remove/leave into this stack (#61).
+**Spec-first.** Do not fold team rename/remove/leave (#61).
 
 ### C1 — `docs/60-invite-teammate-spec` · Refs #60
 
 | | |
 | --- | --- |
 | **Issue** | [#60](https://github.com/snaveevans/pineapple/issues/60) |
-| **Spec to author** | [docs/specs/features/invite-teammate.md](docs/specs/features/invite-teammate.md) _(does not exist yet — create here)_ |
-| **Skill** | `.agents/skills/spec-author/SKILL.md` |
-| **Depends on / references** | [teams-foundation.md](docs/specs/features/teams-foundation.md) · [ADR-0015](docs/decisions/0015-teams-as-opt-in-sharing-scope.md) · [ADR-0012](docs/decisions/0012-transactional-email-via-cloudflare-email-sending.md) · cross-cutting auth/permissions/validation/telemetry |
-| **Related open decision** | [#55](https://github.com/snaveevans/pineapple/issues/55) → [notifications.md](docs/specs/features/notifications.md) — note as flag; do not invent multi-recipient reminders |
-| **Index** | [docs/specs/SPECS.md](docs/specs/SPECS.md) |
+| **Spec to author** | [docs/specs/features/invite-teammate.md](docs/specs/features/invite-teammate.md) _(create)_ |
+| **Skill** | `.agents/skills/spec-author` / `.claude/skills/spec-author` — include **Delivery Plan + slice tags** (post-PR #75 convention) |
+| **References** | teams-foundation · ADR-0015 · ADR-0012 · cross-cutting specs |
+| **Open decision** | #55 → notifications.md — flag only; no multi-recipient reminders unless decided |
+| **Index** | [SPECS.md](docs/specs/SPECS.md) |
 
-- [ ] Author `docs/specs/features/invite-teammate.md` (spec-author skill)
-- [ ] Cover: invite-by-email, pending/accept/decline, one-team-per-user on accept
-- [ ] Cover: token security, rate limits, email via existing sending port
-- [ ] Note #55 (reminder recipients) as open product flag — do **not** invent multi-recipient reminders unless decided
-- [ ] Index in `docs/specs/SPECS.md`
-- [ ] PR opened with `Refs #60` and link to the new spec path
-- [ ] Spec PR merged / approved as implementable (`status: review`)
+- [ ] Author invite-teammate.md with Delivery Plan (`S1`…) and tagged AC
+- [ ] Cover invite-by-email, pending/accept/decline, one-team-per-user on accept
+- [ ] Cover token security, rate limits, email port
+- [ ] Note #55 as flag
+- [ ] Index in SPECS.md (`review` until first impl slice)
+- [ ] PR `Refs #60` + link to new spec
+- [ ] Spec merged / implementable (`status: review`)
 
-### C2+ — Implementation layers · final layer Closes #60
+### C2+ — Implement against invite-teammate Delivery Plan · final Closes #60
 
-**Implement against:** [docs/specs/features/invite-teammate.md](docs/specs/features/invite-teammate.md) (from C1) only.  
-**Web intent:** update [docs/web/FEATURES.md](docs/web/FEATURES.md) in C5.
+**Spec:** [invite-teammate.md](docs/specs/features/invite-teammate.md) only.  
+**Web:** [FEATURES.md](docs/web/FEATURES.md) in final web slice.
 
-Adjust after C1 review if needed. Suggested vertical slices:
+Suggested layers (rename to match the Delivery Plan once written):
 
 #### C2 — Domain + storage
 
-- [ ] Read invite-teammate AC for domain/persistence before coding
-- [ ] Invitation aggregate / domain model
-- [ ] Tables + migrations
-- [ ] Domain tests
-- [ ] Stacked PR (`Refs #60` unless this alone finishes the issue)
+- [ ] AC for domain/persistence slice
+- [ ] Aggregate + migrations + domain tests
+- [ ] Check off that slice’s tags; `Refs #60`
 
 #### C3 — API
 
-- [ ] Read invite-teammate API/AC section before coding
-- [ ] Create / list / accept / decline endpoints
-- [ ] Auth, validation, conflict rules (at-most-one-team on accept)
-- [ ] OpenAPI regenerated
-- [ ] Use-case + schema tests
-- [ ] Check off API AC this layer lands in invite-teammate.md
-- [ ] Stacked PR (`Refs #60`)
+- [ ] Create/list/accept/decline + OpenAPI + tests
+- [ ] Check off API slice tags; `Refs #60`
 
 #### C4 — Email path
 
-- [ ] Read invite-teammate email/rate-limit AC + ADR-0012 before coding
-- [ ] Invite email send via existing email port
-- [ ] Rate limits / failure behavior per spec
-- [ ] Tests
-- [ ] Check off email AC this layer lands
-- [ ] Stacked PR (`Refs #60`)
+- [ ] Send + rate limits per spec + ADR-0012
+- [ ] Check off email slice tags; `Refs #60`
 
 #### C5 — Web
 
-- [ ] Read invite-teammate UI stories/AC + FEATURES.md before coding
-- [ ] Invite UI on team page
-- [ ] Accept (and decline if in-app) flow
-- [ ] `docs/web/FEATURES.md` updated
-- [ ] UI tests
-- [ ] Check off remaining invite-teammate AC; status → `active` when all done
-- [ ] Final PR with `Closes #60`
+- [ ] Invite UI + accept flow + FEATURES.md + UI tests
+- [ ] Remaining AC → status `active`; `Closes #60`
 - [ ] Stack C fully merged
 
 ---
 
 ## Stack D — Team management (#61)
 
-Depends on multi-member reality from #60.
+Depends on multi-member from #60.
 
 ### D1 — `docs/61-team-management-spec` · Refs #61
 
 | | |
 | --- | --- |
 | **Issue** | [#61](https://github.com/snaveevans/pineapple/issues/61) |
-| **Spec to author** | [docs/specs/features/team-management.md](docs/specs/features/team-management.md) _(does not exist yet — create here)_ |
-| **Skill** | `.agents/skills/spec-author/SKILL.md` |
-| **Must resolve** | [#56](https://github.com/snaveevans/pineapple/issues/56) — shared-asset lifecycle when owner leaves (decision lives **in this spec**) |
-| **Depends on / references** | [invite-teammate.md](docs/specs/features/invite-teammate.md) · [teams-foundation.md](docs/specs/features/teams-foundation.md) · [ADR-0015](docs/decisions/0015-teams-as-opt-in-sharing-scope.md) · [permissions.md](docs/specs/cross-cutting/permissions.md) |
-| **Index** | [docs/specs/SPECS.md](docs/specs/SPECS.md) |
+| **Spec to author** | [docs/specs/features/team-management.md](docs/specs/features/team-management.md) _(create)_ |
+| **Skill** | spec-author — Delivery Plan + slice tags |
+| **Must resolve** | [#56](https://github.com/snaveevans/pineapple/issues/56) in this spec |
+| **References** | invite-teammate · teams-foundation · ADR-0015 · permissions.md |
+| **Index** | SPECS.md |
 
-- [ ] Author `docs/specs/features/team-management.md`
-- [ ] Roles: remove member, leave, transfer ownership, rename, delete team
-- [ ] **Resolve #56 in the spec:** leave/remove owner of shared assets → auto-unshare / reassign / block (pick one, document)
-- [ ] Index in `docs/specs/SPECS.md`
-- [ ] PR opened with `Refs #61` (and note #56 decision) + link to new spec
-- [ ] Spec PR merged / approved as implementable (`status: review`)
+- [ ] Author team-management.md with Delivery Plan + tagged AC
+- [ ] Roles: remove, leave, transfer, rename, delete
+- [ ] **#56 decision** in-spec (auto-unshare / reassign / block)
+- [ ] Index SPECS.md
+- [ ] PR `Refs #61` (+ #56 decision note)
+- [ ] Spec merged (`status: review`)
 
-### D2+ — Implementation layers · final Closes #61 (and #56)
+### D2+ — Implement against team-management Delivery Plan · final Closes #61 (+ #56)
 
-**Implement against:** [docs/specs/features/team-management.md](docs/specs/features/team-management.md) (from D1) only.  
-**Web intent:** update [docs/web/FEATURES.md](docs/web/FEATURES.md) in D4.
+#### D2 — Membership mutations (+ #56 lifecycle)
 
-#### D2 — Membership mutations
+- [ ] Leave/remove + shared-asset lifecycle per #56 AC
+- [ ] Tests + OpenAPI; check slice tags; `Refs #61`
 
-- [ ] Read team-management AC for leave/remove + #56 lifecycle before coding
-- [ ] Remove member / leave team per D1 rules
-- [ ] Shared-asset lifecycle on leave/remove per #56 decision in the spec
-- [ ] Tests + OpenAPI if needed
-- [ ] Check off AC this layer lands
-- [ ] Stacked PR (`Refs #61`)
+#### D3 — Transfer / rename / delete
 
-#### D3 — Ownership transfer / rename / delete
-
-- [ ] Read team-management AC for transfer/rename/delete before coding
-- [ ] Transfer ownership, rename, delete team per D1
-- [ ] Tests + OpenAPI
-- [ ] Check off AC this layer lands
-- [ ] Stacked PR (`Refs #61`)
+- [ ] Per Delivery Plan; tests; `Refs #61`
 
 #### D4 — Web admin UI
 
-- [ ] Read team-management UI AC + FEATURES.md before coding
-- [ ] Team management UI
-- [ ] `docs/web/FEATURES.md` updated
-- [ ] UI tests
-- [ ] Check off remaining team-management AC; status → `active` when all done
-- [ ] Final PR with `Closes #61` (and `Closes #56` if decision fully implemented)
+- [ ] UI + FEATURES.md + tests
+- [ ] All AC → `active`; `Closes #61` and `Closes #56` if fully done
 - [ ] Stack D fully merged
 
 ---
 
-## Decision follow-ups (tracked, not foundation blockers)
+## Decision follow-ups
 
 ### #55 — Reminder recipient for team-shared assets
 
 | | |
 | --- | --- |
 | **Issue** | [#55](https://github.com/snaveevans/pineapple/issues/55) |
-| **Spec to update** | [docs/specs/features/notifications.md](docs/specs/features/notifications.md) |
-| **Context** | Deferred flag in [teams-foundation.md](docs/specs/features/teams-foundation.md); owner-only today |
-| **Related** | invite-teammate (#60) makes multi-member real |
+| **Spec** | [notifications.md](docs/specs/features/notifications.md) |
+| **Context** | teams-foundation Flags / owner-only today |
 
-Decide before multi-member reminders matter in production.
-
-- [ ] Decision recorded (owner only / all members / designated contact)
-- [ ] `notifications.md` (and related) updated if behavior changes
-- [ ] Implementation issue filed or work sliced if not owner-only
-- [ ] Issue #55 closed when decided (and implemented if decision requires code)
+- [ ] Decision recorded
+- [ ] notifications.md updated if behavior changes
+- [ ] Impl issue or slice if not owner-only
+- [ ] #55 closed when decided (+ implemented if needed)
 
 ### #56 — Shared-asset lifecycle when owner leaves
 
 | | |
 | --- | --- |
 | **Issue** | [#56](https://github.com/snaveevans/pineapple/issues/56) |
-| **Spec that owns the decision** | [docs/specs/features/team-management.md](docs/specs/features/team-management.md) (D1) |
-| **Implementation** | Stack D2+ against that AC |
+| **Spec** | team-management.md (D1) |
+| **Code** | Stack D2+ |
 
-- [ ] Decision recorded in team-management spec
-- [ ] Implemented with membership leave/remove
+- [ ] Decision in team-management spec
+- [ ] Implemented with leave/remove
 - [ ] #56 closed
 
-### #52 — 404-masking (out of plan, related)
+### #52 — 404-masking (out of plan)
 
 | | |
 | --- | --- |
 | **Issue** | [#52](https://github.com/snaveevans/pineapple/issues/52) |
-| **Spec** | [docs/specs/cross-cutting/permissions.md](docs/specs/cross-cutting/permissions.md) |
+| **Spec** | [permissions.md](docs/specs/cross-cutting/permissions.md) |
 
-- [ ] _(optional later)_ Standardize wrong-owner access on 404 — **not part of this plan**
-
----
-
-## Execution order (day-to-day)
-
-- [ ] 1. Confirm `gh stack` works on this repo
-- [ ] 2. From clean `main`: **Stack A** (`gs init feat/74-…` → A1 → `gs add feat/59-…` → A2 → `gs push && gs submit`) — specs: dashboard, app-search, teams-foundation, then FEATURES.md
-- [ ] 3. From clean `main` (second worktree OK): **Stack B** (`gs init feat/73-…`) — specs: activity-history, teams-foundation, ADR-0010
-- [ ] 4. Land A then B (or reverse); keep each layer reviewable and CI-green
-- [ ] 5. Foundation complete checklist (teams-foundation → `active`)
-- [ ] 6. **Stack C** — author invite-teammate.md, then implement against it
-- [ ] 7. **Stack D** — author team-management.md (incl. #56), then implement against it
-- [ ] 8. Epic #62 foundation + invite + management checkboxes closed
+- [ ] _(optional later)_ not part of this plan
 
 ---
 
-## Definition of done (this plan)
+## Execution order
 
-- [ ] Stacks A+B merged → [teams-foundation.md](docs/specs/features/teams-foundation.md) fully implemented and `active`
-- [ ] Stack C merged → [invite-teammate.md](docs/specs/features/invite-teammate.md) implemented and `active`
-- [ ] Stack D merged → [team-management.md](docs/specs/features/team-management.md) implemented and `active`; #56 decided and coded
-- [ ] Epic #62 foundation + invite + management checkboxes closed
-- [ ] #55 still a deliberate notifications follow-up unless decided earlier
+- [ ] 1. Confirm `gh stack` on this repo
+- [ ] 2. **Stack A** from `main`: A1 (#74 / `S4`) → A2 (#59 / `S5`)
+- [ ] 3. **Stack B** parallel: B1 (#73 / `S3` = activity-history `S2`)
+- [ ] 4. Land A and B; CI green per layer
+- [ ] 5. Foundation complete (teams-foundation `S3`–`S5` done → `active` if no open boxes)
+- [ ] 6. **Stack C** invite-teammate (spec → impl)
+- [ ] 7. **Stack D** team-management (spec + #56 → impl)
+- [ ] 8. Epic #62 foundation + invite + management closed
+
+---
+
+## Definition of done
+
+- [ ] A+B → teams-foundation `S3`–`S5` done; status `active` when fully checked
+- [ ] C → invite-teammate implemented and `active`
+- [ ] D → team-management implemented and `active`; #56 done
+- [ ] Epic #62 foundation + invite + management closed
+- [ ] #55 deliberate follow-up unless decided earlier
+- [x] #53 read-spec pass done (PR #75)
 
 ---
 
@@ -479,18 +473,19 @@ Decide before multi-member reminders matter in production.
 
 | Risk | Mitigation |
 | ---- | ---------- |
-| `gh stack` preview not enabled | Fall back to manual base-branch PRs (`base: feat/74-…`) with same layering |
-| #73 event/migration size | Pre-split B1a/B1b/B1c if mid-implementation exceeds budget; same specs on each slice |
-| Spec vs code AC drift | Only check boxes this PR tests; open the Task → spec map paths first |
-| Invite without #55 | Keep owner-only reminders until decision; document in invite-teammate.md |
+| `gh stack` preview off | Manual base-branch PRs with same layering |
+| #73 size | Split B1a/b/c; same slice tags |
+| Checking wrong AC | Only tags for this slice; ignore `S1` reconciliation Flags |
+| Spec status stuck `in-progress` | Shipped base slices may still have unchecked boxes (Flags) — don’t block foundation on unrelated reconciliation |
+| Invite without #55 | Owner-only reminders until decision |
 
 ---
 
 ## First action
 
-1. Verify `gh stack` on this repo  
-2. Open **A1 specs**: [dashboard.md](docs/specs/features/dashboard.md), [app-search.md](docs/specs/features/app-search.md), [teams-foundation.md](docs/specs/features/teams-foundation.md)  
+1. Verify `gh stack`  
+2. Open **A1 slice AC**: teams-foundation `S4`, dashboard `S3`, app-search `S3`  
 3. Implement **Stack A Layer 1 (#74)** from `main`  
-4. Check off boxes in this file as each item lands  
+4. Check off boxes here as work lands  
 
-When a PR merges a feature slice, also run `docs/specs/prompts/pr-sync.md` against the diff if behavior changed.
+After each feature PR merges: run `docs/specs/prompts/pr-sync.md` if behavior changed.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,13 +1,17 @@
-# PLAN: Teams remaining slices (stacked PRs)
+# PLAN: Teams remaining slices
 
 > **Audience:** agents and humans implementing the teams epic  
 > **Scope:** teams epic only (#62) — not `/verify-email`, #52, API chores #65–70, or #18  
-> **Stacking:** GitHub Stacked PRs via [`gh stack`](https://github.github.com/gh-stack/)  
+> **Workflow:** one PR per layer, **merged sequentially off `main`** (default). Stacking with `gh stack` is optional — see [Workflow](#workflow).  
 > **Last updated:** 2026-07-13 (reconciled after `main` merge of PR #75 / #53)
 
 Check a box **only when that item is done on the branch/PR that lands it** (code + tests + any required OpenAPI/spec AC updates). Do not check from intent alone.
 
+> **Two checkbox systems — know which is authoritative.** The **spec AC checkboxes** (in `docs/specs/**`) are the real, mergeable deliverable: they live on `main`, ride along in each feature PR, and are what CI and reviewers see. **The checkboxes in _this_ file are an informational tracker only** — PLAN.md is not on `main`, so a feature PR branched off `main` cannot carry edits to it. Never block or gate a PR on updating PLAN.md; update the **spec AC boxes** in the PR, and (optionally) tick PLAN.md separately on whatever branch carries it. If the two ever disagree, the spec wins.
+
 **Before implementing any layer:** open the **Spec** path(s) for that layer, implement only the AC tagged with that layer’s **slice id** (`S3` / `S4` / `S5` / etc.), and check those boxes in the same PR.
+
+> **Issue titles vs. slice ids:** GitHub issue titles use ①–④ numbering that does **not** line up with the `S1`…`S5` slice ids — e.g. both #59 and #73 are titled "teams-foundation ③". Trust the **slice ids** in the Delivery Plans, never the ① numbering in issue titles.
 
 ---
 
@@ -124,22 +128,32 @@ main (after C) ──── Stack D: team-management.md (author → implement; #
 
 ## Prerequisites
 
-- [ ] Confirm GitHub Stacked PRs (private preview) is enabled for this repo
-- [ ] Install CLI: `gh extension install github/gh-stack`
-- [ ] Optional alias: `gh stack alias` (`gs`)
-- [ ] Start work from a clean, up-to-date `main`
-- [ ] Prefer a **worktree per active stack** if working A and B in parallel
+- [ ] **Sync `main` first:** `git fetch origin && git checkout main && git pull`, and branch every layer off the freshly-fetched `origin/main`. A stale local `main` is missing PR #75's Delivery Plans and slice tags; branching from it silently breaks the "find slice → implement tagged AC" flow.
+- [ ] Start each layer from a clean, up-to-date `main`
+- [ ] Prefer a **worktree per active layer** if working A and B in parallel
+- [ ] _(optional, only if you choose to stack)_ `gh extension install github/gh-stack` + `gh stack alias` (`gs`) — see [Workflow](#workflow)
 
 ---
 
-## Stacking workflow (`gh stack`)
+## Workflow
+
+**Default: one PR per layer, merged sequentially off `main`.** This is the recommended path — especially for an agent working unattended, where stacked-branch rebasing is a needless failure mode. The dependency graph is already a clean linear chain. ("Stack A/B/C/D" below names a **logical group of layers**, not a `gh stack` requirement.)
+
+```bash
+git checkout main && git pull                 # always branch off fresh origin/main
+git checkout -b feat/<issue>-<slug>
+# implement → commit (conventional commits + Co-Authored-By) → push → open PR
+# wait for CI green → merge → then start the next dependent layer from main
+```
+
+A layer that **depends on** another (A2 needs A1; A1 and B1 need only `S2`, already on `main`) starts **after its dependency has merged to `main`** — branch the dependent layer off `main`, not off the open PR.
+
+**Optional: `gh stack`** — only if you are a human keeping several layers in flight at once and want them reviewable in parallel before their base merges. Not required, and not recommended for autonomous agents. If it misbehaves, fall back to the sequential default — never hand-edit PR bases to work around it.
 
 ```bash
 gs init feat/<issue>-<slug>     # bottom layer, off main
-# implement → commit (conventional commits + Co-Authored-By)
-gs add feat/<issue>-<slug>     # next layer, base = previous branch
-# implement → commit
-gs push && gs submit           # push all branches, open PRs with correct bases
+gs add feat/<issue>-<slug>      # next layer, base = previous branch
+gs push && gs submit            # push all branches, open PRs with correct bases
 ```
 
 ### Repo conventions (every layer)
@@ -186,14 +200,18 @@ gs push && gs submit           # push all branches, open PRs with correct bases
 
 #### Implementation
 
+> **Not a pure copy — this changes constructor signatures.** The `sharing` descriptor is computed by the shared `toSharingDescriptor` helper in `apps/api/src/application/usecases/assetSharing.ts`, and `ownerDisplayName` is resolved by batch-loading owners via `UserRepository.findByIds` — see `ListAssets.ts` as the model to copy. **`GetDashboard` and `SearchAssets` do not currently inject `UserRepository`**, so this slice must add that dependency to both use cases, wire it at the composition root (`worker.ts`), and update every existing test that constructs them. Budget for that ripple — it is the bulk of the work, not the descriptor itself.
+
 - [ ] Read all AC tagged dashboard `S3`, app-search `S3`, teams-foundation `S4`
-- [ ] `GetDashboard` attaches `sharing` where assets surface (fleet/queue)
-- [ ] `SearchAssets` adds `sharing` on hits (reverses intentional omission)
-- [ ] Zod / OpenAPI schemas updated
+- [ ] Inject `UserRepository` into `GetDashboard` + `SearchAssets`; wire in `worker.ts`; update their existing tests for the new constructor arg
+- [ ] `GetDashboard` attaches `sharing` (via `toSharingDescriptor`) where assets surface (fleet/queue)
+- [ ] `SearchAssets` adds `sharing` on hits (reverses the intentional omission documented in `SearchAssets.ts`)
+- [ ] Reuse `toSharingDescriptor` / `AssetSharingDescriptor` — do not reinvent the shape
+- [ ] Zod / OpenAPI schemas updated (dashboard + search responses reference the shared sharing shape)
 - [ ] OpenAPI regenerated and committed
-- [ ] Use-case tests: owned vs shared-with-me vs personal
+- [ ] Use-case tests: owned vs shared-with-me (with `ownerDisplayName`) vs personal
 - [ ] `pnpm lint && pnpm type-check && pnpm -r test` green
-- [ ] PR opened (stack bottom, base `main`) with `Closes #74` + slice ids in Spec section
+- [ ] PR opened off `main` with `Closes #74` + slice ids in Spec section
 - [ ] PR merged
 
 #### Spec updates (same PR)
@@ -205,7 +223,7 @@ gs push && gs submit           # push all branches, open PRs with correct bases
 
 ---
 
-### A2 — `feat/59-sharing-badges` · Closes #59 · teams-foundation **`S5`** · base = A1
+### A2 — `feat/59-sharing-badges` · Closes #59 · teams-foundation **`S5`** · after A1 merges
 
 | | |
 | --- | --- |
@@ -227,9 +245,10 @@ gs push && gs submit           # push all branches, open PRs with correct bases
 - [ ] Dashboard queue rows consume A1 `sharing`
 - [ ] Search results consume A1 `sharing`
 - [ ] UI tests for badge copy/states
+- [ ] Behaviorally verify badge copy/states in the running app (preview tooling / `/verify` skill) — not unit tests alone
 - [ ] `docs/web/FEATURES.md` updated
 - [ ] `pnpm lint && pnpm type-check && pnpm -r test` green
-- [ ] PR opened (stacked on A1) with `Closes #59` + slice ids
+- [ ] PR opened off `main` (after A1 merged) with `Closes #59` + slice ids
 - [ ] PR merged (after A1)
 
 #### Spec updates (same PR)
@@ -265,22 +284,26 @@ If too large, split (same slice tags; use `Refs #73` until final):
 
 #### Backend
 
+> **Decide the historical backfill up front.** Activity history is a **durable projection** fed by a queue consumer. Adding actor attribution means *new* events carry the actor display name, but **rows already projected before this slice will not**. The "full history including pre-share" AC forces the question: backfill existing projection rows (migration/replay), or tolerate a null/"Unknown" actor on pre-existing entries? Pick one explicitly and record it in the PR — do not discover it mid-write. If backfill is chosen, it is its own migration step (candidate for split **B1a**).
+
 - [ ] Read every activity-history AC tagged `` `S2` `` + teams-foundation `` `S3` ``
+- [ ] **Backfill decision recorded:** replay/migrate historical projection rows for actor attribution, **or** accept null actor on pre-existing entries (with rationale)
 - [ ] Feed = own activity **OR** activity on assets **currently** shared with caller’s team
 - [ ] Current sharing evaluation; unshare drops entries next request
 - [ ] Shared asset shows **full** history (including pre-share)
 - [ ] Actor on read model: stable id + display name snapshot (no email)
 - [ ] Smart events: actor display name on durable events; projection snapshot
-- [ ] Migration if needed for actor display name
+- [ ] Migration if needed for actor display name (and for the backfill, if chosen)
 - [ ] `availableFilters` over accessible set
 - [ ] Telemetry: no actor display name in AE
 - [ ] OpenAPI if response shape changes
-- [ ] Tests: access, filters, actor, unshare, PII-free telemetry
+- [ ] Tests: access, filters, actor, unshare, PII-free telemetry, **pre-slice historical entries**
 
 #### Web
 
 - [ ] `AppActivityHistory.tsx` shared entries + “you” vs teammate name
 - [ ] UI tests
+- [ ] Behaviorally verify "you" vs teammate attribution in the running app (preview tooling / `/verify` skill)
 - [ ] FEATURES.md if History behavior changes
 
 #### Spec / PR
@@ -313,6 +336,13 @@ If too large, split (same slice tags; use `Refs #73` until final):
 ---
 
 ## Stack C — Invite teammate (#60)
+
+> **⛔ Decision gate — resolve before starting C/D.** Stacks C and D are **not turn-key tasks**: each begins by *authoring a spec*, and that spec cannot be finished by an agent alone because it encodes two open **product decisions**:
+>
+> - **#55** — reminder recipient policy for team-shared assets (owner-only vs. all members). Shapes invite/notification behavior.
+> - **#56** — shared-asset lifecycle when an owner leaves the team (auto-unshare / reassign / block). Shapes team-management (D).
+>
+> An agent can *draft* these specs and lay out the options, but a **human must make the #55 and #56 calls** before the specs can reach `status: review` and implementation can begin. Surface both decisions early — do not leave them buried in D1. **Stacks A and B are fully autonomous; C and D are gated on these two calls.**
 
 **Spec-first.** Do not fold team rename/remove/leave (#61).
 
@@ -447,14 +477,15 @@ Depends on multi-member from #60.
 
 ## Execution order
 
-- [ ] 1. Confirm `gh stack` on this repo
-- [ ] 2. **Stack A** from `main`: A1 (#74 / `S4`) → A2 (#59 / `S5`)
-- [ ] 3. **Stack B** parallel: B1 (#73 / `S3` = activity-history `S2`)
+- [ ] 1. **Sync `main`** (`git fetch && git checkout main && git pull`) — do not branch off a stale local `main`
+- [ ] 2. **Stack A** from `main`: A1 (#74 / `S4`), then A2 (#59 / `S5`) after A1 merges
+- [ ] 3. **Stack B** in parallel from `main`: B1 (#73 / `S3` = activity-history `S2`)
 - [ ] 4. Land A and B; CI green per layer
 - [ ] 5. Foundation complete (teams-foundation `S3`–`S5` done → `active` if no open boxes)
-- [ ] 6. **Stack C** invite-teammate (spec → impl)
-- [ ] 7. **Stack D** team-management (spec + #56 → impl)
-- [ ] 8. Epic #62 foundation + invite + management closed
+- [ ] 6. **Decision gate:** get human calls on **#55** (reminder recipient) and **#56** (owner-leaves lifecycle) — C and D cannot finish without them
+- [ ] 7. **Stack C** invite-teammate (spec → impl)
+- [ ] 8. **Stack D** team-management (spec + #56 → impl)
+- [ ] 9. Epic #62 foundation + invite + management closed
 
 ---
 
@@ -473,19 +504,24 @@ Depends on multi-member from #60.
 
 | Risk | Mitigation |
 | ---- | ---------- |
-| `gh stack` preview off | Manual base-branch PRs with same layering |
+| Stacking brittleness for agents | **Sequential PRs off `main` are the default;** `gh stack` optional (see [Workflow](#workflow)) |
+| Stale local `main` | Always `git fetch && pull` before branching — else missing PR #75 Delivery Plans / slice tags |
+| A1 under-scoped as a "copy" | It adds `UserRepository` to `GetDashboard`/`SearchAssets` + worker wiring + test updates (see A1 note) |
+| #73 actor backfill | Decide replay-vs-null for pre-slice projection rows up front (see B1 note); candidate split B1a |
 | #73 size | Split B1a/b/c; same slice tags |
 | Checking wrong AC | Only tags for this slice; ignore `S1` reconciliation Flags |
+| PLAN.md vs spec boxes diverge | Spec AC boxes are authoritative (on `main`); PLAN.md is an informational tracker |
 | Spec status stuck `in-progress` | Shipped base slices may still have unchecked boxes (Flags) — don’t block foundation on unrelated reconciliation |
+| C/D blocked on product calls | Get #55 + #56 decided at the gate before C/D (see Stack C callout) |
 | Invite without #55 | Owner-only reminders until decision |
 
 ---
 
 ## First action
 
-1. Verify `gh stack`  
+1. **Sync `main`** (`git fetch origin && git checkout main && git pull`)  
 2. Open **A1 slice AC**: teams-foundation `S4`, dashboard `S3`, app-search `S3`  
-3. Implement **Stack A Layer 1 (#74)** from `main`  
-4. Check off boxes here as work lands  
+3. Implement **Stack A Layer 1 (#74)** from `main` — mind the `UserRepository` wiring note in A1  
+4. Update the **spec AC boxes** as work lands (PLAN.md boxes are an optional tracker; see the checkbox note up top)  
 
 After each feature PR merges: run `docs/specs/prompts/pr-sync.md` if behavior changed.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,496 @@
+# PLAN: Teams remaining slices (stacked PRs)
+
+> **Audience:** agents and humans implementing the teams epic  
+> **Scope:** teams epic only (#62) — not `/verify-email`, #52, API chores #65–70, or #18  
+> **Stacking:** GitHub Stacked PRs via [`gh stack`](https://github.github.com/gh-stack/)  
+> **Last updated:** 2026-07-13
+
+Check a box **only when that item is done on the branch/PR that lands it** (code + tests + any required OpenAPI/spec AC updates). Do not check from intent alone.
+
+**Before implementing any layer:** open the **Spec** path(s) listed for that layer and implement only the AC that layer owns. Mark those AC boxes in the same PR.
+
+---
+
+## Task → spec map (source of truth)
+
+| Layer | Issue | Spec(s) to implement against | Status of spec today |
+| ----- | ----- | ---------------------------- | -------------------- |
+| A1 | [#74](https://github.com/snaveevans/pineapple/issues/74) | [dashboard.md](docs/specs/features/dashboard.md) (`sharing` on fleet/queue), [app-search.md](docs/specs/features/app-search.md) (`sharing` on hits), [teams-foundation.md](docs/specs/features/teams-foundation.md) (read-path `sharing` descriptor AC) | draft / draft / review |
+| A2 | [#59](https://github.com/snaveevans/pineapple/issues/59) | [teams-foundation.md](docs/specs/features/teams-foundation.md) (read-path UI intent), [asset-library.md](docs/specs/features/asset-library.md), [dashboard.md](docs/specs/features/dashboard.md), [app-search.md](docs/specs/features/app-search.md), web intent [FEATURES.md](docs/web/FEATURES.md) | review / review / draft / draft |
+| B1 | [#73](https://github.com/snaveevans/pineapple/issues/73) | [activity-history.md](docs/specs/features/activity-history.md) (access + actor + filters), [teams-foundation.md](docs/specs/features/teams-foundation.md) (unchecked activity AC), [ADR-0010](docs/decisions/0010-smart-events-for-durable-consumers.md) | draft / review |
+| C1–C5 | [#60](https://github.com/snaveevans/pineapple/issues/60) | **Author then implement:** [invite-teammate.md](docs/specs/features/invite-teammate.md) _(create in C1)_ · depends on [teams-foundation.md](docs/specs/features/teams-foundation.md), [ADR-0015](docs/decisions/0015-teams-as-opt-in-sharing-scope.md), email [ADR-0012](docs/decisions/0012-transactional-email-via-cloudflare-email-sending.md) | not written yet |
+| D1–D4 | [#61](https://github.com/snaveevans/pineapple/issues/61) | **Author then implement:** [team-management.md](docs/specs/features/team-management.md) _(create in D1)_ · resolves [#56](https://github.com/snaveevans/pineapple/issues/56) · depends on invite-teammate + teams-foundation | not written yet |
+| Decision | [#55](https://github.com/snaveevans/pineapple/issues/55) | [notifications.md](docs/specs/features/notifications.md) (+ teams-foundation deferred flag) | active |
+| Decision | [#56](https://github.com/snaveevans/pineapple/issues/56) | Recorded in **team-management.md** (D1); coded in D2+ | open decision |
+| Epic | [#62](https://github.com/snaveevans/pineapple/issues/62) | [teams-foundation.md](docs/specs/features/teams-foundation.md), [ADR-0015](docs/decisions/0015-teams-as-opt-in-sharing-scope.md), index [SPECS.md](docs/specs/SPECS.md) | review |
+
+**Cross-cutting always in force** (do not re-spec; follow these):
+
+- [authentication.md](docs/specs/cross-cutting/authentication.md)
+- [permissions.md](docs/specs/cross-cutting/permissions.md)
+- [validation.md](docs/specs/cross-cutting/validation.md)
+- [error-handling.md](docs/specs/cross-cutting/error-handling.md)
+- [loading-states.md](docs/specs/cross-cutting/loading-states.md)
+- [telemetry.md](docs/specs/cross-cutting/telemetry.md)
+
+**API contract:** generated OpenAPI (`docs/reference/openapi.json`) is authoritative for HTTP shapes once a layer lands; Zod route specs are the edit surface.
+
+---
+
+## Reality check
+
+Core product features (dashboard, activity, search, notifications, maintenance, assets, profile) are **already on `main`**. Many unchecked AC boxes in specs are lifecycle drift, not missing code.
+
+**Teams epic [#62](https://github.com/snaveevans/pineapple/issues/62)** is the remaining product track.
+
+| Done | Remaining |
+| ---- | --------- |
+| #57 team + membership | **#74** sharing descriptor on dashboard + search |
+| #58 asset share/access | **#73** shared activity + actor attribution |
+| Create-team + share UI on maintenance | **#59** list-surface sharing badges |
+| `sharing` on `GET /api/assets` | **#60** invite-teammate (spec + implement) |
+| | **#61** team-management (spec + implement; resolves #56) |
+| | **#55** reminder recipient decision (before multi-member reminders) |
+
+### Out of scope for this plan
+
+| Item | Related spec (if any) |
+| ---- | --------------------- |
+| Public `/verify-email` web page | [email-verification.md](docs/specs/features/email-verification.md) |
+| #52 404-masking | [permissions.md](docs/specs/cross-cutting/permissions.md) Known Issue |
+| API hygiene #65–#70 | (no feature spec) |
+| #18 security dashboard | (no feature spec) |
+| Parked archive-asset | [archive-asset.md](docs/specs/backlog/archive-asset.md) |
+
+- [ ] _(do not implement under this plan)_ Public `/verify-email` web page
+- [ ] _(do not implement under this plan)_ #52 404-masking for wrong-owner access
+- [ ] _(do not implement under this plan)_ API hygiene #65–#70
+- [ ] _(do not implement under this plan)_ #18 security dashboard
+- [ ] _(do not implement under this plan)_ Parked archive-asset
+
+---
+
+## Dependency graph
+
+```text
+main
+ ├─ Stack A (foundation finish)
+ │   ├─ L1  #74  sharing descriptor (dashboard + search API)
+ │   │      specs: dashboard.md, app-search.md, teams-foundation.md
+ │   └─ L2  #59  web badges
+ │          specs: teams-foundation.md + asset-library/dashboard/app-search + FEATURES.md
+ │
+ └─ Stack B (parallel with A)
+     └─ L1  #73  shared activity + actor attribution
+            specs: activity-history.md, teams-foundation.md, ADR-0010
+
+main (after A+B merge) ── Stack C: invite-teammate.md (author → implement)
+main (after C) ────────── Stack D: team-management.md (author → implement; #56)
+                           #55 → notifications.md decision
+```
+
+**Why two parallel stacks for foundation leftovers:** #73 and #74 both only need #58 (done). Stacking #73 under #74 would create a false dependency. Stack A is the real dependent pair (#74 → #59).
+
+---
+
+## Prerequisites
+
+- [ ] Confirm GitHub Stacked PRs (private preview) is enabled for this repo
+- [ ] Install CLI: `gh extension install github/gh-stack`
+- [ ] Optional alias: `gh stack alias` (`gs`)
+- [ ] Start work from a clean, up-to-date `main`
+- [ ] Prefer a **worktree per active stack** if working A and B in parallel
+
+---
+
+## Stacking workflow (`gh stack`)
+
+```bash
+gs init feat/<issue>-<slug>     # bottom layer, off main
+# implement → commit (conventional commits + Co-Authored-By)
+gs add feat/<issue>-<slug>     # next layer, base = previous branch
+# implement → commit
+gs push && gs submit           # push all branches, open PRs with correct bases
+# after review: merge bottom → rest auto-rebase; or merge partial stack when CI is green
+```
+
+### Repo conventions (every layer)
+
+- [ ] Branch name: `feat/{issue}-{slug}` (or `docs/{issue}-{slug}` for spec-only)
+- [ ] PR body uses template; `Closes #N` only when this PR fully finishes the issue; else `Refs #N`
+- [ ] PR **Spec / AC** section links the paths below and lists AC boxes checked
+- [ ] Spec AC checkboxes: only mark boxes **this PR** lands, in the same PR
+- [ ] Before open/push readiness: `pnpm lint && pnpm type-check && pnpm -r test`
+- [ ] Regenerate OpenAPI when contract changes: `pnpm --filter @snaveevans/pineapple-api openapi:generate`
+- [ ] One concern per layer (~40 files / ~800 net lines is a **split signal**, not a target)
+- [ ] No drive-by refactors, no API hygiene, no archive work
+
+### Per-PR checklist (copy into each PR work session)
+
+- [ ] Opened the **Spec** path(s) for this layer (see Task → spec map)
+- [ ] One-sentence scope named; stop if a second concern appears
+- [ ] Tests for new behavior
+- [ ] `pnpm lint && pnpm type-check && pnpm -r test`
+- [ ] OpenAPI regen if API changed
+- [ ] Spec AC checkboxes for **this** layer only
+- [ ] PR: Summary / Related / Test plan / Spec (with paths)
+- [ ] Commit messages: Conventional Commits + Co-Authored-By trailer
+
+---
+
+## Stack A — Read-model badges
+
+### A1 — `feat/74-sharing-descriptor` · Closes #74
+
+| | |
+| --- | --- |
+| **Issue** | [#74](https://github.com/snaveevans/pineapple/issues/74) |
+| **Primary specs** | [docs/specs/features/dashboard.md](docs/specs/features/dashboard.md) · [docs/specs/features/app-search.md](docs/specs/features/app-search.md) |
+| **Foundation AC** | [docs/specs/features/teams-foundation.md](docs/specs/features/teams-foundation.md) — **Read-path integration** (`sharing` descriptor on read models; dashboard + search still incomplete vs library) |
+| **ADR** | [ADR-0009](docs/decisions/0009-computed-fields-belong-in-api-read-models.md) (computed fields in API) · [ADR-0015](docs/decisions/0015-teams-as-opt-in-sharing-scope.md) |
+| **Web intent** | none this layer |
+| **Contract** | regenerate `docs/reference/openapi.json` |
+
+**Concern:** Backend only — put computed `sharing` on dashboard + search (same shape as `ListAssets`).
+
+**Do not:** web UI (#59), activity (#73).
+
+#### Implementation
+
+- [ ] Read AC in `dashboard.md` + `app-search.md` + teams-foundation read-path section before coding
+- [ ] `GetDashboard` attaches `sharing` to fleet/queue representations that surface assets
+- [ ] `SearchAssets` reverses intentional omission of `sharing` on hits
+- [ ] Zod / OpenAPI schemas updated for dashboard + search `sharing`
+- [ ] OpenAPI regenerated and committed
+- [ ] Use-case tests: owned vs shared-with-me vs personal
+- [ ] `pnpm lint && pnpm type-check && pnpm -r test` green
+- [ ] PR opened (stack bottom, base `main`) with `Closes #74` and Spec links above
+- [ ] PR merged
+
+#### Spec / docs updates (same PR)
+
+- [ ] Check off AC in `dashboard.md` that this PR implements (only tested ones)
+- [ ] Check off AC in `app-search.md` that this PR implements (only tested ones)
+- [ ] Check off teams-foundation read-path AC only if this PR completes remaining descriptor gaps for dashboard/search
+- [ ] No web `FEATURES.md` badge work (that's A2)
+
+---
+
+### A2 — `feat/59-sharing-badges` · Closes #59 · base = A1
+
+| | |
+| --- | --- |
+| **Issue** | [#59](https://github.com/snaveevans/pineapple/issues/59) |
+| **Primary specs** | [docs/specs/features/teams-foundation.md](docs/specs/features/teams-foundation.md) (read-path / member visibility UX) |
+| **Surface specs** | [docs/specs/features/asset-library.md](docs/specs/features/asset-library.md) · [docs/specs/features/dashboard.md](docs/specs/features/dashboard.md) · [docs/specs/features/app-search.md](docs/specs/features/app-search.md) |
+| **Web intent** | [docs/web/FEATURES.md](docs/web/FEATURES.md) — library, home/dashboard, search entries |
+| **ADR** | [ADR-0015](docs/decisions/0015-teams-as-opt-in-sharing-scope.md) |
+| **Depends on** | A1 API descriptors for dashboard + search; library already has `sharing` from #58 |
+
+**Concern:** Web badges only.
+
+**Do not:** backend changes beyond what A1 already provides.
+
+#### Implementation
+
+- [ ] Read teams-foundation + surface specs + `FEATURES.md` before coding
+- [ ] Asset library cards: “shared with team” / “shared by {owner}” (API already has `sharing`)
+- [ ] Dashboard queue rows consume A1 `sharing` descriptor
+- [ ] Search results consume A1 `sharing` descriptor
+- [ ] UI tests for badge copy and states
+- [ ] `docs/web/FEATURES.md` updated for list badges
+- [ ] `pnpm lint && pnpm type-check && pnpm -r test` green
+- [ ] PR opened (stacked on A1) with `Closes #59` and Spec links above
+- [ ] PR merged (after A1)
+
+#### Spec / docs updates (same PR)
+
+- [ ] Check off UI-facing AC this PR implements in the surface specs (if present)
+- [ ] `FEATURES.md` reflects badge behavior on library / dashboard / search
+
+---
+
+## Stack B — Shared activity (parallel with A)
+
+### B1 — `feat/73-shared-activity` · Closes #73
+
+| | |
+| --- | --- |
+| **Issue** | [#73](https://github.com/snaveevans/pineapple/issues/73) |
+| **Primary spec** | [docs/specs/features/activity-history.md](docs/specs/features/activity-history.md) — shared-asset access, actor attribution, filters, pagination |
+| **Foundation AC** | [docs/specs/features/teams-foundation.md](docs/specs/features/teams-foundation.md) — **Member access** unchecked rows: activity follows the asset |
+| **ADR** | [ADR-0010](docs/decisions/0010-smart-events-for-durable-consumers.md) (actor display name on durable events) · [ADR-0015](docs/decisions/0015-teams-as-opt-in-sharing-scope.md) |
+| **Web intent** | [docs/web/FEATURES.md](docs/web/FEATURES.md) — History / activity |
+| **Telemetry** | [docs/specs/cross-cutting/telemetry.md](docs/specs/cross-cutting/telemetry.md) — no actor display name in AE |
+| **Contract** | regenerate OpenAPI if activity response shape changes |
+
+**Concern:** Activity feed access + actor attribution (closes last unchecked teams-foundation AC).
+
+If event payload + migration + query + UI exceeds ~800 lines or ~40 files, **split** before opening (same specs apply to every sub-slice):
+
+| Split | Slice | Spec focus |
+| ----- | ----- | ---------- |
+| B1a | Event payload + projection migration + write path | activity-history + ADR-0010 |
+| B1b | List query + filters + API | activity-history access/filters AC |
+| B1c | Web attribution | activity-history UI + FEATURES.md |
+
+Prefer one PR if it stays tight.
+
+#### Backend
+
+- [ ] Read `activity-history.md` + teams-foundation activity AC + ADR-0010 before coding
+- [ ] `ListActivity` / activity repo: visible = own activity **OR** activity on assets **currently** shared with caller's team
+- [ ] Evaluate against **current** sharing (unshared asset entries drop out next request)
+- [ ] Shared asset shows **full** history, including entries predating the share
+- [ ] Actor on read model: stable id + display name snapshot (never email/auth ids)
+- [ ] Smart events (ADR-0010): producers supply actor display name; History projection stores snapshot
+- [ ] Migration if activity entries need actor display name column/payload
+- [ ] `availableFilters` computed over accessible set (owned + currently shared)
+- [ ] Telemetry handlers stay thin — **do not** write actor display name to Analytics Engine
+- [ ] OpenAPI regenerated if activity contract changes
+- [ ] Tests: access, filters, actor attribution, unshare drops access, telemetry PII-free
+
+#### Web
+
+- [ ] `AppActivityHistory.tsx` renders shared-asset entries
+- [ ] Per-entry actor attribution (“you” vs teammate display name)
+- [ ] UI tests for shared entries + attribution
+- [ ] `docs/web/FEATURES.md` updated if History behavior changes
+
+#### Spec / PR
+
+- [ ] Check activity-related AC in `teams-foundation.md` this PR lands
+- [ ] Check activity-history AC this PR lands (only boxes covered by tests)
+- [ ] `pnpm lint && pnpm type-check && pnpm -r test` green
+- [ ] PR opened with `Closes #73` (or `Refs #73` on intermediate B1a/B1b slices) and Spec links above
+- [ ] PR(s) merged
+
+---
+
+## After Stacks A + B — foundation complete
+
+| Spec | Action |
+| ---- | ------ |
+| [teams-foundation.md](docs/specs/features/teams-foundation.md) | All AC checked → status `active` |
+| [SPECS.md](docs/specs/SPECS.md) | Row status → `active` |
+| [activity-history.md](docs/specs/features/activity-history.md) / [dashboard.md](docs/specs/features/dashboard.md) / [app-search.md](docs/specs/features/app-search.md) / [asset-library.md](docs/specs/features/asset-library.md) | Align status/AC with code if still stale |
+| [#53](https://github.com/snaveevans/pineapple/issues/53) | Close if read specs fully describe team-shared assets |
+
+- [ ] Stack A1, A2, and B1 (or B1a–c) are on `main`
+- [ ] Remaining teams-foundation AC boxes checked if behavior is tested on `main`
+- [ ] `teams-foundation.md` status → `active`
+- [ ] `SPECS.md` row for teams-foundation reflects `active`
+- [ ] Epic #62 foundation checklist rows updated (③ activity, ④ descriptor, ⑤ web badges)
+- [ ] Optional: close #53 if read specs still say “own assets only” — land any missing wording from the read-surface pass
+
+---
+
+## Stack C — Invite teammate (#60)
+
+**Spec-first.** Do not fold team rename/remove/leave into this stack (#61).
+
+### C1 — `docs/60-invite-teammate-spec` · Refs #60
+
+| | |
+| --- | --- |
+| **Issue** | [#60](https://github.com/snaveevans/pineapple/issues/60) |
+| **Spec to author** | [docs/specs/features/invite-teammate.md](docs/specs/features/invite-teammate.md) _(does not exist yet — create here)_ |
+| **Skill** | `.agents/skills/spec-author/SKILL.md` |
+| **Depends on / references** | [teams-foundation.md](docs/specs/features/teams-foundation.md) · [ADR-0015](docs/decisions/0015-teams-as-opt-in-sharing-scope.md) · [ADR-0012](docs/decisions/0012-transactional-email-via-cloudflare-email-sending.md) · cross-cutting auth/permissions/validation/telemetry |
+| **Related open decision** | [#55](https://github.com/snaveevans/pineapple/issues/55) → [notifications.md](docs/specs/features/notifications.md) — note as flag; do not invent multi-recipient reminders |
+| **Index** | [docs/specs/SPECS.md](docs/specs/SPECS.md) |
+
+- [ ] Author `docs/specs/features/invite-teammate.md` (spec-author skill)
+- [ ] Cover: invite-by-email, pending/accept/decline, one-team-per-user on accept
+- [ ] Cover: token security, rate limits, email via existing sending port
+- [ ] Note #55 (reminder recipients) as open product flag — do **not** invent multi-recipient reminders unless decided
+- [ ] Index in `docs/specs/SPECS.md`
+- [ ] PR opened with `Refs #60` and link to the new spec path
+- [ ] Spec PR merged / approved as implementable (`status: review`)
+
+### C2+ — Implementation layers · final layer Closes #60
+
+**Implement against:** [docs/specs/features/invite-teammate.md](docs/specs/features/invite-teammate.md) (from C1) only.  
+**Web intent:** update [docs/web/FEATURES.md](docs/web/FEATURES.md) in C5.
+
+Adjust after C1 review if needed. Suggested vertical slices:
+
+#### C2 — Domain + storage
+
+- [ ] Read invite-teammate AC for domain/persistence before coding
+- [ ] Invitation aggregate / domain model
+- [ ] Tables + migrations
+- [ ] Domain tests
+- [ ] Stacked PR (`Refs #60` unless this alone finishes the issue)
+
+#### C3 — API
+
+- [ ] Read invite-teammate API/AC section before coding
+- [ ] Create / list / accept / decline endpoints
+- [ ] Auth, validation, conflict rules (at-most-one-team on accept)
+- [ ] OpenAPI regenerated
+- [ ] Use-case + schema tests
+- [ ] Check off API AC this layer lands in invite-teammate.md
+- [ ] Stacked PR (`Refs #60`)
+
+#### C4 — Email path
+
+- [ ] Read invite-teammate email/rate-limit AC + ADR-0012 before coding
+- [ ] Invite email send via existing email port
+- [ ] Rate limits / failure behavior per spec
+- [ ] Tests
+- [ ] Check off email AC this layer lands
+- [ ] Stacked PR (`Refs #60`)
+
+#### C5 — Web
+
+- [ ] Read invite-teammate UI stories/AC + FEATURES.md before coding
+- [ ] Invite UI on team page
+- [ ] Accept (and decline if in-app) flow
+- [ ] `docs/web/FEATURES.md` updated
+- [ ] UI tests
+- [ ] Check off remaining invite-teammate AC; status → `active` when all done
+- [ ] Final PR with `Closes #60`
+- [ ] Stack C fully merged
+
+---
+
+## Stack D — Team management (#61)
+
+Depends on multi-member reality from #60.
+
+### D1 — `docs/61-team-management-spec` · Refs #61
+
+| | |
+| --- | --- |
+| **Issue** | [#61](https://github.com/snaveevans/pineapple/issues/61) |
+| **Spec to author** | [docs/specs/features/team-management.md](docs/specs/features/team-management.md) _(does not exist yet — create here)_ |
+| **Skill** | `.agents/skills/spec-author/SKILL.md` |
+| **Must resolve** | [#56](https://github.com/snaveevans/pineapple/issues/56) — shared-asset lifecycle when owner leaves (decision lives **in this spec**) |
+| **Depends on / references** | [invite-teammate.md](docs/specs/features/invite-teammate.md) · [teams-foundation.md](docs/specs/features/teams-foundation.md) · [ADR-0015](docs/decisions/0015-teams-as-opt-in-sharing-scope.md) · [permissions.md](docs/specs/cross-cutting/permissions.md) |
+| **Index** | [docs/specs/SPECS.md](docs/specs/SPECS.md) |
+
+- [ ] Author `docs/specs/features/team-management.md`
+- [ ] Roles: remove member, leave, transfer ownership, rename, delete team
+- [ ] **Resolve #56 in the spec:** leave/remove owner of shared assets → auto-unshare / reassign / block (pick one, document)
+- [ ] Index in `docs/specs/SPECS.md`
+- [ ] PR opened with `Refs #61` (and note #56 decision) + link to new spec
+- [ ] Spec PR merged / approved as implementable (`status: review`)
+
+### D2+ — Implementation layers · final Closes #61 (and #56)
+
+**Implement against:** [docs/specs/features/team-management.md](docs/specs/features/team-management.md) (from D1) only.  
+**Web intent:** update [docs/web/FEATURES.md](docs/web/FEATURES.md) in D4.
+
+#### D2 — Membership mutations
+
+- [ ] Read team-management AC for leave/remove + #56 lifecycle before coding
+- [ ] Remove member / leave team per D1 rules
+- [ ] Shared-asset lifecycle on leave/remove per #56 decision in the spec
+- [ ] Tests + OpenAPI if needed
+- [ ] Check off AC this layer lands
+- [ ] Stacked PR (`Refs #61`)
+
+#### D3 — Ownership transfer / rename / delete
+
+- [ ] Read team-management AC for transfer/rename/delete before coding
+- [ ] Transfer ownership, rename, delete team per D1
+- [ ] Tests + OpenAPI
+- [ ] Check off AC this layer lands
+- [ ] Stacked PR (`Refs #61`)
+
+#### D4 — Web admin UI
+
+- [ ] Read team-management UI AC + FEATURES.md before coding
+- [ ] Team management UI
+- [ ] `docs/web/FEATURES.md` updated
+- [ ] UI tests
+- [ ] Check off remaining team-management AC; status → `active` when all done
+- [ ] Final PR with `Closes #61` (and `Closes #56` if decision fully implemented)
+- [ ] Stack D fully merged
+
+---
+
+## Decision follow-ups (tracked, not foundation blockers)
+
+### #55 — Reminder recipient for team-shared assets
+
+| | |
+| --- | --- |
+| **Issue** | [#55](https://github.com/snaveevans/pineapple/issues/55) |
+| **Spec to update** | [docs/specs/features/notifications.md](docs/specs/features/notifications.md) |
+| **Context** | Deferred flag in [teams-foundation.md](docs/specs/features/teams-foundation.md); owner-only today |
+| **Related** | invite-teammate (#60) makes multi-member real |
+
+Decide before multi-member reminders matter in production.
+
+- [ ] Decision recorded (owner only / all members / designated contact)
+- [ ] `notifications.md` (and related) updated if behavior changes
+- [ ] Implementation issue filed or work sliced if not owner-only
+- [ ] Issue #55 closed when decided (and implemented if decision requires code)
+
+### #56 — Shared-asset lifecycle when owner leaves
+
+| | |
+| --- | --- |
+| **Issue** | [#56](https://github.com/snaveevans/pineapple/issues/56) |
+| **Spec that owns the decision** | [docs/specs/features/team-management.md](docs/specs/features/team-management.md) (D1) |
+| **Implementation** | Stack D2+ against that AC |
+
+- [ ] Decision recorded in team-management spec
+- [ ] Implemented with membership leave/remove
+- [ ] #56 closed
+
+### #52 — 404-masking (out of plan, related)
+
+| | |
+| --- | --- |
+| **Issue** | [#52](https://github.com/snaveevans/pineapple/issues/52) |
+| **Spec** | [docs/specs/cross-cutting/permissions.md](docs/specs/cross-cutting/permissions.md) |
+
+- [ ] _(optional later)_ Standardize wrong-owner access on 404 — **not part of this plan**
+
+---
+
+## Execution order (day-to-day)
+
+- [ ] 1. Confirm `gh stack` works on this repo
+- [ ] 2. From clean `main`: **Stack A** (`gs init feat/74-…` → A1 → `gs add feat/59-…` → A2 → `gs push && gs submit`) — specs: dashboard, app-search, teams-foundation, then FEATURES.md
+- [ ] 3. From clean `main` (second worktree OK): **Stack B** (`gs init feat/73-…`) — specs: activity-history, teams-foundation, ADR-0010
+- [ ] 4. Land A then B (or reverse); keep each layer reviewable and CI-green
+- [ ] 5. Foundation complete checklist (teams-foundation → `active`)
+- [ ] 6. **Stack C** — author invite-teammate.md, then implement against it
+- [ ] 7. **Stack D** — author team-management.md (incl. #56), then implement against it
+- [ ] 8. Epic #62 foundation + invite + management checkboxes closed
+
+---
+
+## Definition of done (this plan)
+
+- [ ] Stacks A+B merged → [teams-foundation.md](docs/specs/features/teams-foundation.md) fully implemented and `active`
+- [ ] Stack C merged → [invite-teammate.md](docs/specs/features/invite-teammate.md) implemented and `active`
+- [ ] Stack D merged → [team-management.md](docs/specs/features/team-management.md) implemented and `active`; #56 decided and coded
+- [ ] Epic #62 foundation + invite + management checkboxes closed
+- [ ] #55 still a deliberate notifications follow-up unless decided earlier
+
+---
+
+## Risks / watch-outs
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| `gh stack` preview not enabled | Fall back to manual base-branch PRs (`base: feat/74-…`) with same layering |
+| #73 event/migration size | Pre-split B1a/B1b/B1c if mid-implementation exceeds budget; same specs on each slice |
+| Spec vs code AC drift | Only check boxes this PR tests; open the Task → spec map paths first |
+| Invite without #55 | Keep owner-only reminders until decision; document in invite-teammate.md |
+
+---
+
+## First action
+
+1. Verify `gh stack` on this repo  
+2. Open **A1 specs**: [dashboard.md](docs/specs/features/dashboard.md), [app-search.md](docs/specs/features/app-search.md), [teams-foundation.md](docs/specs/features/teams-foundation.md)  
+3. Implement **Stack A Layer 1 (#74)** from `main`  
+4. Check off boxes in this file as each item lands  
+
+When a PR merges a feature slice, also run `docs/specs/prompts/pr-sync.md` against the diff if behavior changed.


### PR DESCRIPTION
## Summary

- Adds `PLAN.md` — a stacked-slice implementation plan for the remaining **teams / asset-sharing** epic (#62), scoped for an agent or human to pick up, validate, commit, and PR each slice.
- Maps each remaining issue (#73, #74, #59, #60, #61, #55, #56) to its spec Delivery-Plan slice ids (`S3`–`S5`, activity-history `S2`), with per-layer AC, dependency graph, and execution order.
- Hardened for **autonomous execution**: sequential PRs off `main` are the default (`gh stack` optional); spec AC boxes are the authoritative tracker; A1's hidden `UserRepository` wiring, #73's projection backfill decision, and the #55/#56 human decision gate blocking Stacks C/D are all called out explicitly.

## Related

Refs #62

<!-- Planning doc only — resolves no issue on its own; the slice PRs it describes carry the Closes/Refs. -->

## Test plan

- [x] Docs-only change — no code, tests, or API contract affected
- [x] Verified plan claims against the repo: slice-tag ↔ issue mapping matches the specs on `origin/main`; `sharing` is present on `GET /api/assets` but absent from dashboard/search; all referenced issues exist
- [x] Markdown tables well-formed; internal `#workflow` anchor resolves

## Spec / AC

No spec AC checkboxes are owned by this PR — PLAN.md is a planning artifact, not a feature slice. The slice PRs it describes (A1/#74, A2/#59, B1/#73, …) check off their spec AC when they land.