### PR TITLE
feat(activity): shared-asset access + actor attribution

### DIFF
--- a/apps/api/src/api/schemas/activitySchemas.ts
+++ b/apps/api/src/api/schemas/activitySchemas.ts
@@ -54,12 +54,26 @@ export const ActivityAssetSnapshotSchema = z
   })
   .openapi("ActivityAssetSnapshot");
 
+export const ActivityActorSnapshotSchema = z
+  .object({
+    id: z.string().uuid().openapi({
+      example: "71afbc20-f2e0-4fc8-a989-278437cf792c",
+      description: "Stable acting-user id (never an email or auth-provider identifier)",
+    }),
+    displayName: z.string().openapi({
+      example: "Pat Rivera",
+      description: "Display-name snapshot of the actor at the time of the action",
+    }),
+  })
+  .openapi("ActivityActorSnapshot");
+
 export const ActivityEntrySchema = z
   .object({
     id: z.string().uuid().openapi({ example: "d5b3b826-2d77-494a-b99d-0d9fcf7c47c0" }),
     type: ActivityEntryTypeSchema,
     occurredAt: z.string().datetime().openapi({ example: "2026-06-09T18:25:24.887Z" }),
     asset: ActivityAssetSnapshotSchema,
+    actor: ActivityActorSnapshotSchema,
     title: z.string().optional().openapi({ example: "Changed oil" }),
     performedAt: DateOnlySchema.optional().openapi({ example: "2026-06-09" }),
   })
@@ -88,6 +102,10 @@ export const ActivityAvailableFiltersSchema = z
 
 export const ActivityResponseSchema = z
   .object({
+    viewerUserId: z.string().uuid().openapi({
+      example: "7d914909-c903-41a4-a13a-82cbd0f61851",
+      description: "Caller's domain user id for attributing 'you' vs teammate in the client",
+    }),
     entries: z.array(ActivityEntrySchema),
     availableFilters: ActivityAvailableFiltersSchema,
     nextCursor: z.string().nullable().openapi({ example: null }),

--- a/apps/api/src/domain/activity/ActivityEntry.ts
+++ b/apps/api/src/domain/activity/ActivityEntry.ts
@@ -1,4 +1,4 @@
-import type { ActivityEntryId, AssetId } from "@snaveevans/pineapple-shared";
+import type { ActivityEntryId, AssetId, UserId } from "@snaveevans/pineapple-shared";
 import type { AssetType } from "../asset/AssetType.ts";
 
 export const ACTIVITY_ENTRY_TYPES = [
@@ -17,11 +17,18 @@ export type ActivityAssetSnapshot = {
   type: AssetType;
 };
 
+/** Stable actor attribution; display name is a projection snapshot (never email). */
+export type ActivityActorSnapshot = {
+  id: UserId;
+  displayName: string;
+};
+
 export type ActivityEntry = {
   id: ActivityEntryId;
   type: ActivityEntryType;
   occurredAt: Date;
   asset: ActivityAssetSnapshot;
+  actor: ActivityActorSnapshot;
   title?: string;
   performedAt?: string;
 };
@@ -42,6 +49,8 @@ export type ActivityAvailableFilters = {
 };
 
 export type ActivityReadModel = {
+  /** Caller's domain user id — lets the client mark "you" vs teammate without a second lookup. */
+  viewerUserId: UserId;
   entries: ActivityEntry[];
   availableFilters: ActivityAvailableFilters;
   nextCursor: string | null;

--- a/apps/api/src/infrastructure/activity/ActivityEventMessage.ts
+++ b/apps/api/src/infrastructure/activity/ActivityEventMessage.ts
@@ -34,6 +34,13 @@ type ActivityEventCommon<
   assetId: string;
   ownerId: string;
   actorId: string;
+  /**
+   * Display-name snapshot for the acting user (ADR-0010). Optional on the wire so
+   * in-flight queue payloads from before this field remain valid; the outbox insert
+   * enriches it from `users` before enqueue, and the projection falls back to
+   * "Unknown" when absent.
+   */
+  actorDisplayName?: string;
   assetName: string;
   assetType: AssetType;
   activityEntryType: EntryType;
@@ -218,6 +225,7 @@ function hasCommonFields(value: Record<string, unknown>): boolean {
     isString(value.assetId) &&
     isString(value.ownerId) &&
     isString(value.actorId) &&
+    (value.actorDisplayName === undefined || isString(value.actorDisplayName)) &&
     isString(value.assetName) &&
     isAssetType(value.assetType) &&
     isActivityEntryTypeOrNull(value.activityEntryType)

--- a/apps/api/src/infrastructure/activity/D1ActivityLogRepository.test.ts
+++ b/apps/api/src/infrastructure/activity/D1ActivityLogRepository.test.ts
@@ -35,6 +35,7 @@ function baseEvent(overrides: Partial<ActivityEventMessage> = {}): ActivityEvent
     assetId: AssetId.from("195d0ef0-47f5-439f-abfd-29f892c9a040"),
     ownerId: UserId.from("7d914909-c903-41a4-a13a-82cbd0f61851"),
     actorId: UserId.from("71afbc20-f2e0-4fc8-a989-278437cf792c"),
+    actorDisplayName: "Pat Rivera",
     assetName: "Truck",
     assetType: "vehicle",
     activityEntryType: "task_completed",
@@ -66,6 +67,7 @@ describe("D1ActivityLogRepository", () => {
       event.id,
       event.ownerId,
       event.actorId,
+      "Pat Rivera",
       "task_completed",
       event.occurredAt,
       event.assetId,
@@ -75,6 +77,17 @@ describe("D1ActivityLogRepository", () => {
       event.performedAt,
       expect.any(String),
     ]);
+  });
+
+  it("snapshots Unknown when actorDisplayName is missing on a pre-slice event", async () => {
+    const { db, statements } = createDatabaseHarness();
+    const withName = baseEvent();
+    const { actorDisplayName: _omit, ...withoutName } = withName;
+    void _omit;
+
+    await new D1ActivityLogRepository(db).recordEvent(withoutName);
+
+    expect(statements[0]?.values[4]).toBe("Unknown");
   });
 
   it("does not create a maintenance_logged entry for a record collapsed into a task completion", async () => {
@@ -112,6 +125,7 @@ describe("D1ActivityLogRepository", () => {
       event.id,
       event.ownerId,
       event.actorId,
+      "Pat Rivera",
       "maintenance_logged",
       event.occurredAt,
       event.assetId,
@@ -136,8 +150,9 @@ describe("D1ActivityLogRepository", () => {
 
   it("skips aggregate filter scans on cursor pages", async () => {
     const { db, prepare } = createDatabaseHarness();
+    const ownerId = UserId.from("7d914909-c903-41a4-a13a-82cbd0f61851");
     const result = await new D1ActivityLogRepository(db).list({
-      ownerId: UserId.from("7d914909-c903-41a4-a13a-82cbd0f61851"),
+      ownerId,
       limit: 25,
       cursor: encodeCursor({
         v: 1,
@@ -147,6 +162,19 @@ describe("D1ActivityLogRepository", () => {
     });
 
     expect(prepare).toHaveBeenCalledTimes(1);
+    expect(result.viewerUserId).toBe(ownerId);
     expect(result.availableFilters).toEqual({ types: [], assets: [] });
+  });
+
+  it("lists with a current-sharing visibility predicate (owned or team-shared assets)", async () => {
+    const { db, statements } = createDatabaseHarness();
+    const ownerId = UserId.from("7d914909-c903-41a4-a13a-82cbd0f61851");
+
+    await new D1ActivityLogRepository(db).list({ ownerId, limit: 25 });
+
+    const listQuery = statements.find((s) => s.query.includes("FROM activity_entries"));
+    expect(listQuery?.query).toContain("team_members");
+    expect(listQuery?.query).toContain("shared_team_id");
+    expect(listQuery?.values.slice(0, 2)).toEqual([ownerId, ownerId]);
   });
 });

--- a/apps/api/src/infrastructure/activity/D1ActivityLogRepository.ts
+++ b/apps/api/src/infrastructure/activity/D1ActivityLogRepository.ts
@@ -21,6 +21,8 @@ type ActivityEntryRow = {
   asset_id: string;
   asset_name: string;
   asset_type: string;
+  actor_id: string;
+  actor_display_name: string | null;
   title: string | null;
   performed_at: string | null;
 };
@@ -49,7 +51,23 @@ type CursorPayload = DecodedCursor & {
 };
 
 const SELECT_COLUMNS =
-  "id, type, occurred_at, asset_id, asset_name, asset_type, title, performed_at";
+  "id, type, occurred_at, asset_id, asset_name, asset_type, actor_id, actor_display_name, title, performed_at";
+
+/**
+ * Visibility: caller's own assets (owner_id) OR assets currently shared with a
+ * team the caller belongs to. Evaluated against current sharing state so unshare
+ * drops entries on the next request.
+ */
+const ACCESSIBLE_ENTRY_SQL = `(
+  owner_id = ?
+  OR asset_id IN (
+    SELECT a.id
+    FROM assets a
+    INNER JOIN team_members tm ON tm.team_id = a.shared_team_id
+    WHERE tm.user_id = ?
+      AND a.shared_team_id IS NOT NULL
+  )
+)`;
 
 export class D1ActivityLogRepository implements ActivityLogRepository {
   constructor(private readonly db: D1Database) {}
@@ -65,6 +83,7 @@ export class D1ActivityLogRepository implements ActivityLogRepository {
     const last = visibleEntries.at(-1);
 
     return {
+      viewerUserId: query.ownerId,
       entries: visibleEntries,
       availableFilters,
       nextCursor: hasMore && last ? encodeCursor(last, query) : null,
@@ -82,12 +101,17 @@ export class D1ActivityLogRepository implements ActivityLogRepository {
     const entry = entryFromEvent(event);
     if (entry === null) return null;
 
+    const actorDisplayName =
+      event.actorDisplayName?.trim() && event.actorDisplayName.trim().length > 0
+        ? event.actorDisplayName.trim()
+        : "Unknown";
+
     return this.db
       .prepare(
         `INSERT INTO activity_entries
-           (id, source_event_id, owner_id, actor_id, type, occurred_at,
+           (id, source_event_id, owner_id, actor_id, actor_display_name, type, occurred_at,
             asset_id, asset_name, asset_type, title, performed_at, created_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
          ON CONFLICT(source_event_id) DO NOTHING`,
       )
       .bind(
@@ -95,6 +119,7 @@ export class D1ActivityLogRepository implements ActivityLogRepository {
         event.id,
         event.ownerId,
         event.actorId,
+        actorDisplayName,
         entry.type,
         entry.occurredAt,
         entry.assetId,
@@ -110,8 +135,8 @@ export class D1ActivityLogRepository implements ActivityLogRepository {
     query: ActivityLogQuery,
     cursor: DecodedCursor | null,
   ): Promise<ActivityEntryRow[]> {
-    const conditions = ["owner_id = ?"];
-    const values: (string | number)[] = [query.ownerId];
+    const conditions = [ACCESSIBLE_ENTRY_SQL];
+    const values: (string | number)[] = [query.ownerId, query.ownerId];
 
     if (query.type !== undefined) {
       conditions.push("type = ?");
@@ -155,10 +180,10 @@ export class D1ActivityLogRepository implements ActivityLogRepository {
       .prepare(
         `SELECT type, COUNT(*) AS count
          FROM activity_entries
-         WHERE owner_id = ?
+         WHERE ${ACCESSIBLE_ENTRY_SQL}
          GROUP BY type`,
       )
-      .bind(ownerId)
+      .bind(ownerId, ownerId)
       .all<ActivityTypeFacetRow>();
 
     const byType = new Map(result.results.map((row) => [row.type, row.count]));
@@ -179,12 +204,12 @@ export class D1ActivityLogRepository implements ActivityLogRepository {
                   COUNT(*) OVER (PARTITION BY asset_id) AS count,
                   ROW_NUMBER() OVER (PARTITION BY asset_id ORDER BY occurred_at DESC, id DESC) AS rn
            FROM activity_entries
-           WHERE owner_id = ?
+           WHERE ${ACCESSIBLE_ENTRY_SQL}
          )
          WHERE rn = 1
          ORDER BY asset_name COLLATE NOCASE ASC, asset_id ASC`,
       )
-      .bind(ownerId)
+      .bind(ownerId, ownerId)
       .all<ActivityAssetFacetRow>();
 
     return result.results.map((row) => ({
@@ -243,6 +268,7 @@ function entryFromEvent(event: ActivityEventMessage): {
 }
 
 function rowToEntry(row: ActivityEntryRow): ActivityEntry {
+  const displayName = row.actor_display_name?.trim();
   return {
     id: ActivityEntryId.from(row.id),
     type: row.type as ActivityEntryType,
@@ -251,6 +277,10 @@ function rowToEntry(row: ActivityEntryRow): ActivityEntry {
       id: AssetId.from(row.asset_id),
       name: row.asset_name,
       type: row.asset_type as AssetType,
+    },
+    actor: {
+      id: UserId.from(row.actor_id),
+      displayName: displayName && displayName.length > 0 ? displayName : "Unknown",
     },
     ...(row.title !== null ? { title: row.title } : {}),
     ...(row.performed_at !== null ? { performedAt: row.performed_at } : {}),

--- a/apps/api/src/infrastructure/activity/D1ActivityOutboxRepository.test.ts
+++ b/apps/api/src/infrastructure/activity/D1ActivityOutboxRepository.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
+import { AssetCreated } from "../../domain/asset/events/AssetCreated.ts";
+import { AssetId, UserId } from "@snaveevans/pineapple-shared";
 import type { ActivityEventMessage } from "./ActivityEventMessage.ts";
-import { D1ActivityOutboxRepository } from "./D1ActivityOutboxRepository.ts";
+import {
+  D1ActivityOutboxRepository,
+  prepareActivityOutboxInsert,
+} from "./D1ActivityOutboxRepository.ts";
 
 const activityMessage: ActivityEventMessage = {
   id: "e2d3cf94-3779-43ea-b595-dac35dcba45a",
@@ -31,6 +36,26 @@ function createDatabaseHarness(
   const db = { prepare, batch } as unknown as D1Database & { batch: typeof batch };
   return { db, batch, statements };
 }
+
+describe("prepareActivityOutboxInsert", () => {
+  it("enriches actorDisplayName from users when writing the outbox payload", () => {
+    const { db, statements } = createDatabaseHarness();
+    const event = AssetCreated({
+      assetId: AssetId.from("195d0ef0-47f5-439f-abfd-29f892c9a040"),
+      ownerId: UserId.from("7d914909-c903-41a4-a13a-82cbd0f61851"),
+      actorId: UserId.from("71afbc20-f2e0-4fc8-a989-278437cf792c"),
+      assetName: "Truck",
+      assetType: "vehicle",
+    });
+
+    const statement = prepareActivityOutboxInsert(db, event);
+    expect(statement).not.toBeNull();
+    expect(statements[0]?.query).toContain("json_set");
+    expect(statements[0]?.query).toContain("actorDisplayName");
+    expect(statements[0]?.query).toContain("FROM users");
+    expect(statements[0]?.values).toContain(event.actorId);
+  });
+});
 
 describe("D1ActivityOutboxRepository", () => {
   it("atomically claims pending rows before sending them", async () => {

--- a/apps/api/src/infrastructure/activity/D1ActivityOutboxRepository.ts
+++ b/apps/api/src/infrastructure/activity/D1ActivityOutboxRepository.ts
@@ -21,13 +21,26 @@ export function prepareActivityOutboxInsert(
   if (message === null) return null;
 
   const now = new Date().toISOString();
+  // Enrich actorDisplayName from users at outbox write so the durable queue
+  // payload (and projection) carry a name snapshot without a projection re-read.
   return db
     .prepare(
       `INSERT OR IGNORE INTO activity_event_outbox
          (id, consumer, event_type, payload, status, attempts, created_at, updated_at)
-       VALUES (?, ?, ?, ?, 'pending', 0, ?, ?)`,
+       SELECT ?, ?, ?,
+              json_set(?, '$.actorDisplayName',
+                       COALESCE((SELECT name FROM users WHERE id = ?), 'Unknown')),
+              'pending', 0, ?, ?`,
     )
-    .bind(message.id, ACTIVITY_HISTORY_CONSUMER, message.type, JSON.stringify(message), now, now);
+    .bind(
+      message.id,
+      ACTIVITY_HISTORY_CONSUMER,
+      message.type,
+      JSON.stringify(message),
+      message.actorId,
+      now,
+      now,
+    );
 }
 
 export class D1ActivityOutboxRepository {

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -286,6 +286,10 @@ function serializeActivityEntry(entry: ActivityEntry): z.infer<typeof ActivityEn
     type: entry.type,
     occurredAt: entry.occurredAt.toISOString(),
     asset: entry.asset,
+    actor: {
+      id: entry.actor.id,
+      displayName: entry.actor.displayName,
+    },
     ...(entry.title !== undefined ? { title: entry.title } : {}),
     ...(entry.performedAt !== undefined ? { performedAt: entry.performedAt } : {}),
   };
@@ -474,6 +478,7 @@ app.openapi(getActivityRoute, async (c) => {
   if (!result.ok) throw result.error;
   return c.json(
     {
+      viewerUserId: result.value.viewerUserId,
       entries: result.value.entries.map(serializeActivityEntry),
       availableFilters: result.value.availableFilters,
       nextCursor: result.value.nextCursor,

--- a/apps/web/src/api/activity.ts
+++ b/apps/web/src/api/activity.ts
@@ -14,11 +14,17 @@ export type ActivityAssetSnapshot = {
   type: AssetType;
 };
 
+export type ActivityActorSnapshot = {
+  id: string;
+  displayName: string;
+};
+
 export type ActivityEntry = {
   id: string;
   type: ActivityEntryType;
   occurredAt: string;
   asset: ActivityAssetSnapshot;
+  actor: ActivityActorSnapshot;
   title?: string;
   performedAt?: string;
 };
@@ -39,6 +45,7 @@ export type ActivityAvailableFilters = {
 };
 
 export type ActivityResponse = {
+  viewerUserId: string;
   entries: ActivityEntry[];
   availableFilters: ActivityAvailableFilters;
   nextCursor: string | null;

--- a/apps/web/src/app/AppActivityHistory.test.tsx
+++ b/apps/web/src/app/AppActivityHistory.test.tsx
@@ -45,6 +45,9 @@ let root: Root | null = null;
 let container: HTMLDivElement | null = null;
 let activityQueryResult: unknown;
 
+const viewerUserId = "7d914909-c903-41a4-a13a-82cbd0f61851";
+const teammateUserId = "71afbc20-f2e0-4fc8-a989-278437cf792c";
+
 const entries: ActivityEntry[] = [
   {
     id: "f60feab8-48df-4947-ae58-6ef7257531da",
@@ -55,6 +58,7 @@ const entries: ActivityEntry[] = [
       name: "Sprinter Van",
       type: "vehicle",
     },
+    actor: { id: viewerUserId, displayName: "Dale" },
     title: "Cabin filter",
   },
   {
@@ -66,6 +70,7 @@ const entries: ActivityEntry[] = [
       name: "Generac Generator",
       type: "equipment",
     },
+    actor: { id: teammateUserId, displayName: "Pat Rivera" },
     title: "Oil change",
     performedAt: "2026-06-30",
   },
@@ -73,6 +78,7 @@ const entries: ActivityEntry[] = [
 
 function activityPage(): ActivityResponse {
   return {
+    viewerUserId,
     entries,
     availableFilters: {
       types: [
@@ -168,5 +174,12 @@ describe("AppActivityHistory", () => {
 
     expect(document.querySelector('[data-asset-icon="vehicle:van"]')).not.toBeNull();
     expect(document.querySelector('[data-asset-icon="equipment:bolt"]')).not.toBeNull();
+  });
+
+  it("attributes entries as you vs teammate display name", async () => {
+    await renderHistory();
+
+    expect(document.body.textContent).toContain("by you");
+    expect(document.body.textContent).toContain("by Pat Rivera");
   });
 });

--- a/apps/web/src/app/AppActivityHistory.tsx
+++ b/apps/web/src/app/AppActivityHistory.tsx
@@ -15,6 +15,7 @@ import { Icon, type IconName } from "../design/Icon.tsx";
 import { HFAssetIcon } from "../design/hf.tsx";
 import { paths } from "../routes.ts";
 import { HFBottomNav, HFTopBar } from "./AppChrome.tsx";
+import { activityActorLabel } from "./activityPresentation.ts";
 import { assetTypeLabel } from "./assetPresentation.ts";
 import { dateKey, formatMonthDay, formatShortDate, ymdToUTC } from "./dateFormat.ts";
 
@@ -373,10 +374,19 @@ function PerformedFact({ entry, color }: { entry: ActivityEntry; color: string }
   );
 }
 
-function ActivityEventCard({ entry, now }: { entry: ActivityEntry; now: Date }) {
+function ActivityEventCard({
+  entry,
+  now,
+  viewerUserId,
+}: {
+  entry: ActivityEntry;
+  now: Date;
+  viewerUserId: string;
+}) {
   const config = TYPE_CONFIG[entry.type];
   const occurredAt = new Date(entry.occurredAt);
   const title = entry.title ?? "Untitled activity";
+  const actorLabel = activityActorLabel(entry.actor, viewerUserId);
 
   let headline: ReactNode;
   let detail: ReactNode = null;
@@ -450,6 +460,9 @@ function ActivityEventCard({ entry, now }: { entry: ActivityEntry; now: Date }) 
               {config.verb}
             </span>
             {headline}
+            <span className="hh-actor" title={actorLabel === "You" ? "You" : actorLabel}>
+              {actorLabel === "You" ? "by you" : `by ${actorLabel}`}
+            </span>
           </div>
           <div className="hh-time">
             <span className="hh-time-rel">{relativeLabel(entry.occurredAt, now)}</span>
@@ -463,7 +476,15 @@ function ActivityEventCard({ entry, now }: { entry: ActivityEntry; now: Date }) 
   );
 }
 
-function ActivityTimeline({ groups, now }: { groups: ActivityGroup[]; now: Date }) {
+function ActivityTimeline({
+  groups,
+  now,
+  viewerUserId,
+}: {
+  groups: ActivityGroup[];
+  now: Date;
+  viewerUserId: string;
+}) {
   return (
     <div className="hh-timeline">
       {groups.map((group) => (
@@ -479,7 +500,12 @@ function ActivityTimeline({ groups, now }: { groups: ActivityGroup[]; now: Date 
             </span>
           </div>
           {group.entries.map((entry) => (
-            <ActivityEventCard key={entry.id} entry={entry} now={now} />
+            <ActivityEventCard
+              key={entry.id}
+              entry={entry}
+              now={now}
+              viewerUserId={viewerUserId}
+            />
           ))}
         </section>
       ))}
@@ -671,10 +697,11 @@ export function AppActivityHistory() {
       />
     );
   } else {
+    const viewerUserId = firstPage?.viewerUserId ?? "";
     body = (
       <div className="hh-grid">
         <div>
-          <ActivityTimeline groups={groups} now={now} />
+          <ActivityTimeline groups={groups} now={now} viewerUserId={viewerUserId} />
           <div className="hh-loadmore">
             {activityQuery.hasNextPage ? (
               <button

--- a/apps/web/src/app/activityPresentation.test.ts
+++ b/apps/web/src/app/activityPresentation.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { activityActorLabel } from "./activityPresentation";
+
+describe("activityActorLabel", () => {
+  const viewerId = "7d914909-c903-41a4-a13a-82cbd0f61851";
+  const teammateId = "71afbc20-f2e0-4fc8-a989-278437cf792c";
+
+  it("labels the viewer's own actions as You", () => {
+    expect(activityActorLabel({ id: viewerId, displayName: "Dale" }, viewerId)).toBe("You");
+  });
+
+  it("labels teammate actions with their display-name snapshot", () => {
+    expect(activityActorLabel({ id: teammateId, displayName: "Pat Rivera" }, viewerId)).toBe(
+      "Pat Rivera",
+    );
+  });
+
+  it("falls back to Unknown when the snapshot is blank", () => {
+    expect(activityActorLabel({ id: teammateId, displayName: "  " }, viewerId)).toBe("Unknown");
+  });
+});

--- a/apps/web/src/app/activityPresentation.ts
+++ b/apps/web/src/app/activityPresentation.ts
@@ -1,0 +1,11 @@
+import type { ActivityActorSnapshot } from "../api/activity";
+
+/**
+ * Attribution label for an activity entry actor.
+ * "You" when the actor is the viewer; otherwise the snapshotted display name.
+ */
+export function activityActorLabel(actor: ActivityActorSnapshot, viewerUserId: string): string {
+  if (actor.id === viewerUserId) return "You";
+  const name = actor.displayName.trim();
+  return name.length > 0 ? name : "Unknown";
+}

--- a/apps/web/src/app/styles/activity-history.css
+++ b/apps/web/src/app/styles/activity-history.css
@@ -276,6 +276,15 @@
   font-weight: 600;
 }
 
+.hh-actor {
+  display: block;
+  margin-top: 2px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--hf-ink-soft);
+  letter-spacing: -0.005em;
+}
+
 .hh-time {
   flex-shrink: 0;
   text-align: right;

--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -919,6 +919,26 @@
           "type"
         ]
       },
+      "ActivityActorSnapshot": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Stable acting-user id (never an email or auth-provider identifier)",
+            "example": "71afbc20-f2e0-4fc8-a989-278437cf792c"
+          },
+          "displayName": {
+            "type": "string",
+            "description": "Display-name snapshot of the actor at the time of the action",
+            "example": "Pat Rivera"
+          }
+        },
+        "required": [
+          "id",
+          "displayName"
+        ]
+      },
       "ActivityEntry": {
         "type": "object",
         "properties": {
@@ -946,6 +966,9 @@
           "asset": {
             "$ref": "#/components/schemas/ActivityAssetSnapshot"
           },
+          "actor": {
+            "$ref": "#/components/schemas/ActivityActorSnapshot"
+          },
           "title": {
             "type": "string",
             "example": "Changed oil"
@@ -961,7 +984,8 @@
           "id",
           "type",
           "occurredAt",
-          "asset"
+          "asset",
+          "actor"
         ]
       },
       "ActivityTypeFilter": {
@@ -1030,6 +1054,12 @@
       "ActivityResponse": {
         "type": "object",
         "properties": {
+          "viewerUserId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Caller's domain user id for attributing 'you' vs teammate in the client",
+            "example": "7d914909-c903-41a4-a13a-82cbd0f61851"
+          },
           "entries": {
             "type": "array",
             "items": {
@@ -1046,6 +1076,7 @@
           }
         },
         "required": [
+          "viewerUserId",
           "entries",
           "availableFilters",
           "nextCursor"

--- a/docs/specs/features/activity-history.md
+++ b/docs/specs/features/activity-history.md
@@ -174,7 +174,7 @@ _Each criterion below carries exactly one slice tag (`S1` or `S2`) from the Deli
 - [ ] `S1` The initial response returns the caller's activity in a single read model
       containing: the page of entries, the available filters with counts, and a
       pagination cursor
-- [ ] `S2` The feed returns activity for every asset the caller can currently access:
+- [x] `S2` The feed returns activity for every asset the caller can currently access:
       entries for assets the caller **owns**, plus entries for assets **currently
       shared with the caller's team** ([teams-foundation.md](./teams-foundation.md)).
       An entry is returned if and only if the caller can access its asset at request
@@ -187,9 +187,9 @@ _Each criterion below carries exactly one slice tag (`S1` or `S2`) from the Deli
       `maintenance_logged`, `task_completed`, `task_scheduled`, `task_deleted`),
       `occurredAt`, and an asset snapshot (`id`, `name`, `type`) sufficient to render
       the row without an additional lookup
-- [ ] `S2` Each entry additionally carries an **actor** attribution (a stable acting-user
+- [x] `S2` Each entry additionally carries an **actor** attribution (a stable acting-user
       id and a display name) identifying who performed the action
-- [ ] `S2` The actor attribution lets the client mark an entry as the caller's own versus
+- [x] `S2` The actor attribution lets the client mark an entry as the caller's own versus
       a teammate's (e.g. render "you" when the actor is the caller, otherwise the
       actor's display name); it exposes a display name and a stable id only — never
       the actor's email or auth-provider identifiers
@@ -203,7 +203,7 @@ _Each criterion below carries exactly one slice tag (`S1` or `S2`) from the Deli
       `maintenance_logged` entry
 - [ ] `S1` Entries for deleted tasks and archived assets are still returned and fully
       renderable from their snapshot
-- [ ] `S2` For a shared asset, the caller sees its **entire** activity history — including
+- [x] `S2` For a shared asset, the caller sees its **entire** activity history — including
       entries recorded before the asset was shared or before the caller joined the team
       — matching how a shared asset's maintenance records follow the asset. Sharing
       grants access to the asset's history; it does not slice the history by date
@@ -221,7 +221,7 @@ _Each criterion below carries exactly one slice tag (`S1` or `S2`) from the Deli
 - [ ] `S1` Filter facet counts are computed over the caller's **complete** history, not
       the currently filtered view, so the user can pivot between filters (the same
       principle as the library's category counts in [asset-library.md](./asset-library.md))
-- [ ] `S2` The `availableFilters` facets and their counts span the caller's **accessible**
+- [x] `S2` The `availableFilters` facets and their counts span the caller's **accessible**
       history, the same visibility rule as the feed: assets currently shared with the
       caller's team appear in the asset facet alongside owned assets, and an unshared
       asset's contribution drops out of the facets on the next request

--- a/docs/specs/features/teams-foundation.md
+++ b/docs/specs/features/teams-foundation.md
@@ -76,7 +76,7 @@ _Each criterion carries exactly one slice tag (`S1`…`S5`) from the [Delivery P
 - [x] `S2` A team member can read an asset shared with their team and its **maintenance tasks and records** (the activity feed is `S3`, below)
 - [x] `S2` A team member can perform the same **write** actions on a shared asset that its owner can — the maintenance actions that exist today: adding and deleting maintenance tasks, and logging maintenance records — with the sole exceptions of changing its sharing and deleting the asset itself, which remain asset-owner-only
 - [x] `S2` Access to a shared asset's dependent records **follows the asset**: authorization for maintenance task and record operations is determined by whether the requester can access the parent asset (owns it, or is a member of the team it is shared with), replacing the direct `ownerId === requesterId` check on those operations
-- [ ] `S3` Access to the **activity feed** for shared assets follows the asset the same way — specified in [activity-history.md](./activity-history.md) (team visibility of shared-asset activity, with actor attribution)
+- [x] `S3` Access to the **activity feed** for shared assets follows the asset the same way — specified in [activity-history.md](./activity-history.md) (team visibility of shared-asset activity, with actor attribution)
 - [x] `S2` When an asset is unshared, or a member's access otherwise ends, subsequent requests by that member for the asset or its records behave as if the asset does not exist for them
 
 **Read-path integration**

--- a/docs/web/FEATURES.md
+++ b/docs/web/FEATURES.md
@@ -225,13 +225,13 @@ For the API contract behind each feature, see the linked spec in `docs/specs/fea
 ## Activity History
 
 **Route:** `/app/history`
-**Goal:** Let the user review a durable, cross-asset timeline of actions they have taken across their fleet.
+**Goal:** Let the user review a durable, cross-asset timeline of actions they have taken across their fleet (owned assets and assets currently shared with their team).
 
 **Key states:**
 
 - Loading: fetches `GET /api/activity` before rendering the feed
 - Empty account history: explains that future asset, maintenance, and task actions will appear
-- Populated: reverse-chronological timeline grouped by action day, with an all-time activity breakdown rail; each entry shows action type, title/name, asset snapshot, relative time, and absolute time
+- Populated: reverse-chronological timeline grouped by action day, with an all-time activity breakdown rail; each entry shows action type, title/name, asset snapshot, actor attribution ("by you" / teammate name), relative time, and absolute time
 - Filtered: type chips and a single asset selector refetch the server-side filtered feed
 - Search: inline search narrows the currently loaded history entries by title or asset name only; it does not query the API or search unloaded pages
 - Filtered empty: active filters/search remain visible and can be cleared
@@ -241,9 +241,11 @@ For the API contract behind each feature, see the linked spec in `docs/specs/fea
 **Non-obvious behavior:**
 
 - The first API page returns the activity page, available filters, counts, and cursor in one read model; cursor pages preserve those first-page filters while loading older entries
+- The feed spans owned assets and assets currently shared with the caller's team; unshare drops those entries on the next fetch
+- Actor attribution uses `viewerUserId` plus each entry's `actor` snapshot — "by you" when the actor is the viewer, otherwise the teammate's display name (never email)
 - The client does not filter a preloaded history locally for type or asset filters
 - The History search field is intentionally labeled as loaded-history search and only narrows fetched pages client-side
-- Filter counts come from the caller's complete history, not the current filtered view
+- Filter counts come from the caller's accessible history, not the current filtered view
 - Deleted tasks and archived/renamed assets still render from the event snapshot
 - Completing a scheduled task by logging work appears as one `task_completed` row, not as both completed and logged rows
 - 401 response redirects to `/login`

--- a/migrations/0015_activity_actor_display_name.sql
+++ b/migrations/0015_activity_actor_display_name.sql
@@ -1,0 +1,11 @@
+-- Snapshot actor display names on activity entries (activity-history S2 / ADR-0010).
+-- Pre-existing rows are backfilled from the users table so historical entries remain
+-- attributable after this slice; missing names fall back to "Unknown".
+ALTER TABLE activity_entries ADD COLUMN actor_display_name TEXT;
+
+UPDATE activity_entries
+SET actor_display_name = COALESCE(
+  (SELECT name FROM users WHERE users.id = activity_entries.actor_id),
+  'Unknown'
+)
+WHERE actor_display_name IS NULL;


### PR DESCRIPTION
## Summary

- Activity feed visibility is **owned assets OR assets currently shared with the caller's team** (unshare drops entries on the next request; full history including pre-share when shared)
- Each entry exposes **actor** `{ id, displayName }` (no email); response includes `viewerUserId` so the client can render "by you" vs teammate name
- Durable events/outbox payloads are enriched with `actorDisplayName` (ADR-0010); projection stores the snapshot
- **Historical backfill:** migration `0015_activity_actor_display_name.sql` adds `actor_display_name` and backfills from `users.name` (fallback `"Unknown"`)
- Telemetry continues to write only `actorId` — no actor display names in Analytics Engine
- Web History shows actor attribution; FEATURES.md + activity-history `S2` / teams-foundation `S3` AC checked

## Related

Closes #73

## Test plan

- [x] Repository projects actor display name; Unknown for pre-slice payloads
- [x] List SQL uses team-sharing visibility predicate for entries + facets
- [x] Outbox insert enriches `actorDisplayName` from `users`
- [x] Web attribution tests: "by you" / "by Pat Rivera"
- [x] `pnpm lint && pnpm type-check && pnpm -r test`
- [x] OpenAPI regenerated

## Spec / AC

- [docs/specs/features/activity-history.md](docs/specs/features/activity-history.md) — `S2`
- [docs/specs/features/teams-foundation.md](docs/specs/features/teams-foundation.md) — `S3`
- [docs/web/FEATURES.md](docs/web/FEATURES.md)

## Historical actor policy

**Backfill chosen:** existing projection rows get `actor_display_name` from the current `users.name` at migration time (or `"Unknown"` if the user has no name). New events carry a name snapshot on the durable payload.