### PR TITLE
docs: teams-foundation status active after S3–S5

### DIFF
--- a/docs/specs/SPECS.md
+++ b/docs/specs/SPECS.md
@@ -43,7 +43,7 @@ relevant cross-cutting specs rather than re-describing the behavior.
 | [user-profile.md](./features/user-profile.md)                 | Identity      | active      |
 | [email-verification.md](./features/email-verification.md)     | Identity      | active      |
 | [telemetry-enrichment.md](./features/telemetry-enrichment.md) | Observability | draft       |
-| [teams-foundation.md](./features/teams-foundation.md)         | Teams         | in-progress |
+| [teams-foundation.md](./features/teams-foundation.md)         | Teams         | active      |
 
 ## Backlog (parked specs)
 

--- a/docs/specs/features/teams-foundation.md
+++ b/docs/specs/features/teams-foundation.md
@@ -7,7 +7,7 @@ metadata:
 
 # Teams Foundation
 
-**Status:** in-progress
+**Status:** active
 **Owner:** [unknown — assign on review]
 **Last Updated:** 2026-07-13
 **Related Specs:** [ADR-0015](../../decisions/0015-teams-as-opt-in-sharing-scope.md), [authentication.md](../cross-cutting/authentication.md), [permissions.md](../cross-cutting/permissions.md), [validation.md](../cross-cutting/validation.md), [error-handling.md](../cross-cutting/error-handling.md), [loading-states.md](../cross-cutting/loading-states.md), [telemetry.md](../cross-cutting/telemetry.md), [asset-library.md](./asset-library.md), [dashboard.md](./dashboard.md), [app-search.md](./app-search.md)


### PR DESCRIPTION
## Summary

- Set `teams-foundation` status to **active** now that S3–S5 AC are checked on main (via #77, #78, #79)
- Update `SPECS.md` status column to match
- Leave activity-history / dashboard / app-search / asset-library at `in-progress` — they still have S1 reconciliation Flags

## Related

Refs #62

## Test plan

- [x] No open AC boxes remain in teams-foundation.md
- [x] SPECS.md status column matches

## Spec / AC

- [docs/specs/features/teams-foundation.md](docs/specs/features/teams-foundation.md)
- [docs/specs/SPECS.md](docs/specs/SPECS.md)