### PR TITLE
chore(lint): pin no-floating-promises explicitly for apps/api

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,10 @@ app served by a Cloudflare Worker — it currently hosts the marketing home page
   `child_process`, etc. in `apps/api/src/**`. Use WinterCG/Web APIs. (ADR-0006)
 - **No `process.env`** in `apps/api/src/**` — also lint-blocked. Read config
   from the Worker `env` binding (`c.env.*`), typed in `worker.ts`.
+- **No floating promises** in `apps/api/src/**` — Workers silently drops
+  un-awaited promises (dropped work, swallowed errors).
+  `@typescript-eslint/no-floating-promises` is an explicit lint error: `await`,
+  `.catch`, or mark intentionally-detached work with `void`.
 - **D1 (SQLite)** via the `DB` binding. Migrations in `/migrations`, applied
   with `wrangler d1 migrations apply pineapple --local|--remote`.
 - **Cloudflare Queues** are declared in `apps/api/wrangler.jsonc` but `wrangler

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -134,6 +134,18 @@ export default tseslint.config(
     },
   },
 
+  // ── CF Workers: no floating promises ─────────────────────────────────────
+  // Workers silently drops un-awaited promises: work is dropped and errors
+  // are swallowed. recommendedTypeChecked already enables this rule
+  // repo-wide; pin it explicitly for the API so the guarantee survives
+  // future config changes. Intentionally-detached work must use `void`.
+  {
+    files: ["apps/api/src/**/*.ts"],
+    rules: {
+      "@typescript-eslint/no-floating-promises": "error",
+    },
+  },
+
   // ── Non-type-aware linting for JS/CJS config files ───────────────────────
   {
     files: ["**/*.{js,mjs,cjs}"],


### PR DESCRIPTION
## Summary

- Verified `@typescript-eslint/no-floating-promises` is active for `apps/api/src/**` (inherited from `recommendedTypeChecked`) — a deliberate floating promise fails `pnpm lint`
- Pinned the rule explicitly for `apps/api/src/**` with the Workers rationale (un-awaited promises are silently dropped: lost work, swallowed errors), so the guarantee survives future config changes
- Documented the constraint in `CLAUDE.md` under Workers runtime constraints

## Related

Closes #69

## Test plan

- [x] Deliberate floating promise in `apps/api/src` fails `pnpm lint` with `@typescript-eslint/no-floating-promises` (probe added, verified, removed)
- [x] `pnpm lint && pnpm type-check && pnpm -r test` all pass