### PR TITLE
ci(api): mutation testing gate for domain + application

### DIFF
--- a/.github/scripts/mutation-decide.sh
+++ b/.github/scripts/mutation-decide.sh
@@ -6,10 +6,18 @@
 #   mutation-decide.sh always
 #   mutation-decide.sh pr <base_sha> <head_sha>
 #
+# Env:
+#   MUTATION_REPO_DIR — git working tree for pr mode (default: repo root of this script)
+#
 # Fail closed: if the PR diff cannot be computed, prints run=true.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+if [ -n "${MUTATION_REPO_DIR:-}" ]; then
+  REPO_DIR="$MUTATION_REPO_DIR"
+else
+  REPO_DIR="$ROOT"
+fi
 SCOPE_SCRIPT="$ROOT/.github/scripts/mutation-scope.sh"
 
 mode="${1:-}"
@@ -26,7 +34,7 @@ case "$mode" in
       echo "Reason: missing base/head SHAs — fail closed, running mutation suite" >&2
       exit 0
     fi
-    if ! files="$(git -C "$ROOT" diff --name-only "$base"..."$head")"; then
+    if ! files="$(git -C "$REPO_DIR" diff --name-only "$base"..."$head")"; then
       echo "run=true"
       echo "Reason: git diff failed — fail closed, running mutation suite" >&2
       exit 0

--- a/.github/scripts/mutation-decide.sh
+++ b/.github/scripts/mutation-decide.sh
@@ -39,7 +39,13 @@ case "$mode" in
       echo "Reason: git diff failed — fail closed, running mutation suite" >&2
       exit 0
     fi
-    if printf '%s\n' "$files" | "$SCOPE_SCRIPT"; then
+    # Feed scope via a file, not a pipe. A pipe + grep -q early-exit causes
+    # SIGPIPE under pipefail and fail-opens to run=false on large in-scope diffs.
+    files_tmp="$(mktemp)"
+    # shellcheck disable=SC2064
+    trap 'rm -f "$files_tmp"' RETURN
+    printf '%s\n' "$files" >"$files_tmp"
+    if "$SCOPE_SCRIPT" <"$files_tmp"; then
       echo "run=true"
       echo "Reason: PR touches mutation scope" >&2
     else

--- a/.github/scripts/mutation-decide.sh
+++ b/.github/scripts/mutation-decide.sh
@@ -42,8 +42,7 @@ case "$mode" in
     # Feed scope via a file, not a pipe. A pipe + grep -q early-exit causes
     # SIGPIPE under pipefail and fail-opens to run=false on large in-scope diffs.
     files_tmp="$(mktemp)"
-    # shellcheck disable=SC2064
-    trap 'rm -f "$files_tmp"' RETURN
+    trap 'rm -f "$files_tmp"' EXIT
     printf '%s\n' "$files" >"$files_tmp"
     if "$SCOPE_SCRIPT" <"$files_tmp"; then
       echo "run=true"

--- a/.github/scripts/mutation-decide.sh
+++ b/.github/scripts/mutation-decide.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Decide whether the mutation gate should run. Writes GITHUB_OUTPUT-style lines
+# to stdout: run=true|false
+#
+# Usage:
+#   mutation-decide.sh always
+#   mutation-decide.sh pr <base_sha> <head_sha>
+#
+# Fail closed: if the PR diff cannot be computed, prints run=true.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SCOPE_SCRIPT="$ROOT/.github/scripts/mutation-scope.sh"
+
+mode="${1:-}"
+case "$mode" in
+  always)
+    echo "run=true"
+    echo "Reason: non-PR event always runs full mutation suite" >&2
+    ;;
+  pr)
+    base="${2:-}"
+    head="${3:-}"
+    if [ -z "$base" ] || [ -z "$head" ]; then
+      echo "run=true"
+      echo "Reason: missing base/head SHAs — fail closed, running mutation suite" >&2
+      exit 0
+    fi
+    if ! files="$(git -C "$ROOT" diff --name-only "$base"..."$head")"; then
+      echo "run=true"
+      echo "Reason: git diff failed — fail closed, running mutation suite" >&2
+      exit 0
+    fi
+    if printf '%s\n' "$files" | "$SCOPE_SCRIPT"; then
+      echo "run=true"
+      echo "Reason: PR touches mutation scope" >&2
+    else
+      echo "run=false"
+      echo "Reason: PR does not touch mutation scope — skipping" >&2
+    fi
+    ;;
+  *)
+    echo "usage: $0 always | pr <base_sha> <head_sha>" >&2
+    exit 2
+    ;;
+esac

--- a/.github/scripts/mutation-scope.selftest.sh
+++ b/.github/scripts/mutation-scope.selftest.sh
@@ -71,10 +71,12 @@ large_list="$(mktemp)"
     i=$((i + 1))
   done
 } >"$large_list"
-if "$SCOPE" <"$large_list"; then
-  echo "ok  in-scope: large list (no SIGPIPE skip)"
+# Must be a pipe (matches production: printf | scope). File redirect cannot
+# SIGPIPE, so it would not catch a grep -q regression.
+if cat "$large_list" | "$SCOPE"; then
+  echo "ok  in-scope: large list via pipe (no SIGPIPE skip)"
 else
-  echo "FAIL in-scope: large list (SIGPIPE or miss)" >&2
+  echo "FAIL in-scope: large list via pipe (SIGPIPE or miss)" >&2
   fail=1
 fi
 rm -f "$large_list"

--- a/.github/scripts/mutation-scope.selftest.sh
+++ b/.github/scripts/mutation-scope.selftest.sh
@@ -59,24 +59,33 @@ assert_in "selftest script" ".github/scripts/mutation-scope.selftest.sh"
 assert_in "future gate script" ".github/scripts/mutation-ratchet.sh"
 assert_in "mixed list" "apps/web/src/app/App.tsx" "apps/api/src/domain/team/Team.ts"
 
-# Large in-scope list: first path matches; grep must drain stdin (no SIGPIPE skip).
+# Static guard: grep -q early-exit + pipefail is the fail-open hazard.
+if grep -nE 'grep[[:space:]]+-q' "$SCOPE" >/dev/null; then
+  echo "FAIL mutation-scope.sh must not use grep -q (SIGPIPE fail-open under pipefail)" >&2
+  fail=1
+else
+  echo "ok  no grep -q in mutation-scope.sh"
+fi
+
+# Large in-scope list through a real pipe under pipefail (Linux runner pipe is
+# ~64KB; pad past that so a -q regression cannot hide). File redirect cannot SIGPIPE.
 large_list="$(mktemp)"
 {
   echo "apps/api/src/domain/asset/Asset.ts"
-  # ~2500 out-of-scope paths after the match — exceeds typical 64KB pipe buffer when
-  # combined with path length, so a -q early-exit would SIGPIPE the writer.
   i=0
-  while [ "$i" -lt 2500 ]; do
-    printf 'apps/web/src/generated/file-%05d.ts\n' "$i"
+  while [ "$i" -lt 8000 ]; do
+    printf 'apps/web/src/generated/file-%05d-padding-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.ts\n' "$i"
     i=$((i + 1))
   done
 } >"$large_list"
-# Must be a pipe (matches production: printf | scope). File redirect cannot
-# SIGPIPE, so it would not catch a grep -q regression.
-if cat "$large_list" | "$SCOPE"; then
-  echo "ok  in-scope: large list via pipe (no SIGPIPE skip)"
+set +e
+cat "$large_list" | "$SCOPE"
+pipe_status=$?
+set -e
+if [ "$pipe_status" -eq 0 ]; then
+  echo "ok  in-scope: large list via pipe (status=$pipe_status)"
 else
-  echo "FAIL in-scope: large list via pipe (SIGPIPE or miss)" >&2
+  echo "FAIL in-scope: large list via pipe (status=$pipe_status — SIGPIPE or miss)" >&2
   fail=1
 fi
 rm -f "$large_list"

--- a/.github/scripts/mutation-scope.selftest.sh
+++ b/.github/scripts/mutation-scope.selftest.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Self-test for mutation-scope.sh and mutation-decide.sh.
+# Run from repo root: .github/scripts/mutation-scope.selftest.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SCOPE="$ROOT/.github/scripts/mutation-scope.sh"
+DECIDE="$ROOT/.github/scripts/mutation-decide.sh"
+fail=0
+
+assert_in() {
+  local label="$1"
+  shift
+  if printf '%s\n' "$@" | "$SCOPE"; then
+    echo "ok  in-scope: $label"
+  else
+    echo "FAIL in-scope: $label" >&2
+    fail=1
+  fi
+}
+
+assert_out() {
+  local label="$1"
+  shift
+  if printf '%s\n' "$@" | "$SCOPE"; then
+    echo "FAIL out-of-scope (matched): $label" >&2
+    fail=1
+  else
+    echo "ok  out-of-scope: $label"
+  fi
+}
+
+assert_decide() {
+  local label="$1"
+  local expect="$2"
+  shift 2
+  local out
+  out="$("$DECIDE" "$@" 2>/dev/null | grep '^run=' | head -1)"
+  if [ "$out" = "run=$expect" ]; then
+    echo "ok  decide $label → run=$expect"
+  else
+    echo "FAIL decide $label: got '$out', want run=$expect" >&2
+    fail=1
+  fi
+}
+
+assert_in "domain" "apps/api/src/domain/asset/Asset.ts"
+assert_in "application" "apps/api/src/application/usecases/GetAsset.ts"
+assert_in "packages/shared" "packages/shared/src/Result.ts"
+assert_in "stryker.conf" "apps/api/stryker.conf.json"
+assert_in "package.json" "apps/api/package.json"
+assert_in "lockfile" "pnpm-lock.yaml"
+assert_in "workflow" ".github/workflows/mutation.yml"
+assert_in "scope script" ".github/scripts/mutation-scope.sh"
+assert_in "decide script" ".github/scripts/mutation-decide.sh"
+assert_in "selftest script" ".github/scripts/mutation-scope.selftest.sh"
+assert_in "mixed list" "apps/web/src/app/App.tsx" "apps/api/src/domain/team/Team.ts"
+
+assert_out "web" "apps/web/src/app/App.tsx"
+assert_out "infrastructure" "apps/api/src/infrastructure/persistence/D1.ts"
+assert_out "api layer" "apps/api/src/api/schemas/foo.ts"
+assert_out "docs" "docs/specs/cross-cutting/testing.md"
+assert_out "empty" ""
+
+assert_decide "always" "true" always
+assert_decide "pr missing shas" "true" pr
+assert_decide "pr bad shas" "true" pr not-a-real-sha also-not-real
+
+if [ "$fail" -ne 0 ]; then
+  echo "mutation-scope selftest FAILED" >&2
+  exit 1
+fi
+echo "mutation-scope selftest passed"

--- a/.github/scripts/mutation-scope.selftest.sh
+++ b/.github/scripts/mutation-scope.selftest.sh
@@ -59,12 +59,13 @@ assert_in "selftest script" ".github/scripts/mutation-scope.selftest.sh"
 assert_in "future gate script" ".github/scripts/mutation-ratchet.sh"
 assert_in "mixed list" "apps/web/src/app/App.tsx" "apps/api/src/domain/team/Team.ts"
 
-# Static guard: grep -q early-exit + pipefail is the fail-open hazard.
-if grep -nE 'grep[[:space:]]+-q' "$SCOPE" >/dev/null; then
-  echo "FAIL mutation-scope.sh must not use grep -q (SIGPIPE fail-open under pipefail)" >&2
+# Static guard: quiet early-exit + pipefail is the fail-open hazard.
+# Inspect code lines only (comments may discuss the hazard by name).
+if grep -nE '^[^#]*grep[[:space:]]+-q' "$SCOPE" >/dev/null; then
+  echo "FAIL mutation-scope.sh must not use quiet grep (SIGPIPE fail-open under pipefail)" >&2
   fail=1
 else
-  echo "ok  no grep -q in mutation-scope.sh"
+  echo "ok  no quiet-grep early-exit in mutation-scope.sh"
 fi
 
 # Large in-scope list through a real pipe under pipefail (Linux runner pipe is

--- a/.github/scripts/mutation-scope.selftest.sh
+++ b/.github/scripts/mutation-scope.selftest.sh
@@ -35,7 +35,7 @@ assert_decide() {
   local expect="$2"
   shift 2
   local out
-  out="$("$DECIDE" "$@" 2>/dev/null | grep '^run=' | head -1)"
+  out="$("$DECIDE" "$@" 2>/dev/null | grep '^run=' | head -1 || true)"
   if [ "$out" = "run=$expect" ]; then
     echo "ok  decide $label → run=$expect"
   else
@@ -49,22 +49,75 @@ assert_in "application" "apps/api/src/application/usecases/GetAsset.ts"
 assert_in "packages/shared" "packages/shared/src/Result.ts"
 assert_in "stryker.conf" "apps/api/stryker.conf.json"
 assert_in "package.json" "apps/api/package.json"
+assert_in "vitest.config" "apps/api/vitest.config.ts"
+assert_in "tsconfig" "apps/api/tsconfig.json"
 assert_in "lockfile" "pnpm-lock.yaml"
 assert_in "workflow" ".github/workflows/mutation.yml"
 assert_in "scope script" ".github/scripts/mutation-scope.sh"
 assert_in "decide script" ".github/scripts/mutation-decide.sh"
 assert_in "selftest script" ".github/scripts/mutation-scope.selftest.sh"
+assert_in "future gate script" ".github/scripts/mutation-ratchet.sh"
 assert_in "mixed list" "apps/web/src/app/App.tsx" "apps/api/src/domain/team/Team.ts"
+
+# Large in-scope list: first path matches; grep must drain stdin (no SIGPIPE skip).
+large_list="$(mktemp)"
+{
+  echo "apps/api/src/domain/asset/Asset.ts"
+  # ~2500 out-of-scope paths after the match — exceeds typical 64KB pipe buffer when
+  # combined with path length, so a -q early-exit would SIGPIPE the writer.
+  i=0
+  while [ "$i" -lt 2500 ]; do
+    printf 'apps/web/src/generated/file-%05d.ts\n' "$i"
+    i=$((i + 1))
+  done
+} >"$large_list"
+if "$SCOPE" <"$large_list"; then
+  echo "ok  in-scope: large list (no SIGPIPE skip)"
+else
+  echo "FAIL in-scope: large list (SIGPIPE or miss)" >&2
+  fail=1
+fi
+rm -f "$large_list"
 
 assert_out "web" "apps/web/src/app/App.tsx"
 assert_out "infrastructure" "apps/api/src/infrastructure/persistence/D1.ts"
 assert_out "api layer" "apps/api/src/api/schemas/foo.ts"
 assert_out "docs" "docs/specs/cross-cutting/testing.md"
-assert_out "empty" ""
+assert_out "blank line" ""
+if "$SCOPE" </dev/null; then
+  echo "FAIL out-of-scope (matched): empty stdin" >&2
+  fail=1
+else
+  echo "ok  out-of-scope: empty stdin"
+fi
 
 assert_decide "always" "true" always
 assert_decide "pr missing shas" "true" pr
 assert_decide "pr bad shas" "true" pr not-a-real-sha also-not-real
+
+# Fixture repo: real git diffs through decide (covers scope path both directions).
+fixture="$(mktemp -d)"
+cleanup() { rm -rf "$fixture"; }
+trap cleanup EXIT
+git -C "$fixture" init -q
+git -C "$fixture" config user.email "selftest@example.com"
+git -C "$fixture" config user.name "selftest"
+mkdir -p "$fixture/apps/web/src" "$fixture/apps/api/src/domain"
+echo a >"$fixture/apps/web/src/App.tsx"
+git -C "$fixture" add apps/web/src/App.tsx
+git -C "$fixture" commit -q -m base
+base_sha="$(git -C "$fixture" rev-parse HEAD)"
+echo b >"$fixture/apps/web/src/App.tsx"
+git -C "$fixture" add apps/web/src/App.tsx
+git -C "$fixture" commit -q -m out-of-scope
+out_sha="$(git -C "$fixture" rev-parse HEAD)"
+echo c >"$fixture/apps/api/src/domain/Asset.ts"
+git -C "$fixture" add apps/api/src/domain/Asset.ts
+git -C "$fixture" commit -q -m in-scope
+in_sha="$(git -C "$fixture" rev-parse HEAD)"
+
+MUTATION_REPO_DIR="$fixture" assert_decide "pr out-of-scope diff" "false" pr "$base_sha" "$out_sha"
+MUTATION_REPO_DIR="$fixture" assert_decide "pr in-scope diff" "true" pr "$out_sha" "$in_sha"
 
 if [ "$fail" -ne 0 ]; then
   echo "mutation-scope selftest FAILED" >&2

--- a/.github/scripts/mutation-scope.sh
+++ b/.github/scripts/mutation-scope.sh
@@ -12,7 +12,8 @@ set -euo pipefail
 # packages/shared is included: domain/application import branded IDs, Result, and
 # DomainError from it, so shared changes can move the mutation score.
 # vitest/tsconfig: Stryker discovers the runner config and transform settings from these.
-# Do not use grep -q: early exit causes SIGPIPE when stdin is large (pipefail → false skip).
+# Drain stdin fully (no quiet early-exit): a short-circuiting match under pipefail
+# SIGPIPEs the writer and fail-opens large in-scope PRs to run=false.
 SCOPE_RE='^(apps/api/src/(domain|application)/|packages/shared/|apps/api/stryker\.conf\.json|apps/api/package\.json|apps/api/vitest\.config\.ts|apps/api/tsconfig\.json|pnpm-lock\.yaml|\.github/workflows/mutation\.yml|\.github/scripts/mutation-[a-z0-9.-]*\.sh)'
 
 grep -E "$SCOPE_RE" > /dev/null

--- a/.github/scripts/mutation-scope.sh
+++ b/.github/scripts/mutation-scope.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Pure path-scope check for the mutation gate (ADR-0016 / testing.md).
+#
+# Usage:
+#   printf '%s\n' <paths...> | .github/scripts/mutation-scope.sh
+#
+# Exit 0 if any path is in mutation scope; exit 1 if none are.
+# Reads newline-separated paths from stdin.
+set -euo pipefail
+
+# Keep in sync with docs/specs/cross-cutting/testing.md "Run scope".
+# packages/shared is included: domain/application import branded IDs, Result, and
+# DomainError from it, so shared changes can move the mutation score.
+# shellcheck disable=SC2016
+SCOPE_RE='^(apps/api/src/(domain|application)/|packages/shared/|apps/api/stryker\.conf\.json|apps/api/package\.json|pnpm-lock\.yaml|\.github/workflows/mutation\.yml|\.github/scripts/mutation-(scope|decide|scope\.selftest)\.sh)'
+
+grep -qE "$SCOPE_RE"

--- a/.github/scripts/mutation-scope.sh
+++ b/.github/scripts/mutation-scope.sh
@@ -11,7 +11,8 @@ set -euo pipefail
 # Keep in sync with docs/specs/cross-cutting/testing.md "Run scope".
 # packages/shared is included: domain/application import branded IDs, Result, and
 # DomainError from it, so shared changes can move the mutation score.
-# shellcheck disable=SC2016
-SCOPE_RE='^(apps/api/src/(domain|application)/|packages/shared/|apps/api/stryker\.conf\.json|apps/api/package\.json|pnpm-lock\.yaml|\.github/workflows/mutation\.yml|\.github/scripts/mutation-(scope|decide|scope\.selftest)\.sh)'
+# vitest/tsconfig: Stryker discovers the runner config and transform settings from these.
+# Do not use grep -q: early exit causes SIGPIPE when stdin is large (pipefail → false skip).
+SCOPE_RE='^(apps/api/src/(domain|application)/|packages/shared/|apps/api/stryker\.conf\.json|apps/api/package\.json|apps/api/vitest\.config\.ts|apps/api/tsconfig\.json|pnpm-lock\.yaml|\.github/workflows/mutation\.yml|\.github/scripts/mutation-[a-z0-9.-]*\.sh)'
 
-grep -qE "$SCOPE_RE"
+grep -E "$SCOPE_RE" > /dev/null

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,11 @@ jobs:
       - name: Test
         run: pnpm -r test
 
+      # Gate-logic selftest for the mutation path filter (ADR-0016). Cheap; runs
+      # on every PR so a regex typo cannot silently widen/narrow the trust boundary.
+      - name: Mutation scope selftest
+        run: .github/scripts/mutation-scope.selftest.sh
+
       # The committed OpenAPI spec must match what the code generates, so the
       # static file (read by codebase tools) never drifts from the live API.
       - name: Check OpenAPI spec is up to date

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -12,8 +12,9 @@ on:
   workflow_dispatch:
 
 concurrency:
+  # Cancel superseded PR runs; never cancel schedule/dispatch on main against each other.
   group: mutation-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read
@@ -33,31 +34,16 @@ jobs:
         run: |
           set -euo pipefail
           if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-            echo "Reason: ${{ github.event_name }} always runs full mutation suite"
-            exit 0
-          fi
-          base="${{ github.event.pull_request.base.sha }}"
-          head="${{ github.event.pull_request.head.sha }}"
-          # Fail closed: if we cannot compute the diff, run the gate rather than
-          # silently skip (a required check that skips on error is worse than none).
-          if ! files="$(git diff --name-only "$base"..."$head")"; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-            echo "Reason: git diff failed — fail closed, running mutation suite"
-            exit 0
-          fi
-          scope_re='^(apps/api/src/(domain|application)/|apps/api/stryker\.conf\.json|apps/api/package\.json|pnpm-lock\.yaml|\.github/workflows/mutation\.yml)'
-          if printf '%s\n' "$files" | grep -qE "$scope_re"; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-            echo "Reason: PR touches mutation scope"
+            .github/scripts/mutation-decide.sh always >> "$GITHUB_OUTPUT"
           else
-            echo "run=false" >> "$GITHUB_OUTPUT"
-            echo "Reason: PR does not touch mutation scope — skipping"
+            .github/scripts/mutation-decide.sh pr \
+              "${{ github.event.pull_request.base.sha }}" \
+              "${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Install pnpm
         if: steps.scope.outputs.run == 'true'
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@v5 # version comes from package.json "packageManager"
 
       - name: Setup Node
         if: steps.scope.outputs.run == 'true'
@@ -84,7 +70,8 @@ jobs:
           retention-days: 30
 
       # Scheduled/manual runs on main are not merge-blocking. Surface failure via a
-      # single sticky issue; green runs close it. Marker in body enables dedupe.
+      # single sticky issue labeled mutation-gate (label list is strongly consistent;
+      # body-search is not). Green runs close it.
       - name: Open or update failure issue
         if: >-
           failure() &&
@@ -95,24 +82,24 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
-          marker="<!-- mutation-gate-nightly -->"
           title="Mutation gate failed on main"
           body="$(cat <<EOF
-          ${marker}
+          <!-- mutation-gate-nightly -->
           The scheduled mutation gate on \`main\` failed.
 
           - **Run:** ${RUN_URL}
           - **Report artifact:** \`mutation-report\` on that run (HTML/JSON under \`apps/api/reports/mutation/\`)
 
-          This issue is opened by \`.github/workflows/mutation.yml\`. A green scheduled run closes it; further failures comment here instead of opening duplicates.
+          This issue is opened by \`.github/workflows/mutation.yml\` with the \`mutation-gate\` label.
+          A green scheduled run closes it; further failures comment here instead of opening duplicates.
           EOF
           )"
-          existing="$(gh issue list --state open --search "mutation-gate-nightly in:body" --json number --jq '.[0].number // empty')"
+          existing="$(gh issue list --label mutation-gate --state open --json number --jq '.[0].number // empty')"
           if [ -n "$existing" ]; then
             gh issue comment "$existing" --body "Still failing: ${RUN_URL}"
             echo "Commented on existing issue #$existing"
           else
-            url="$(gh issue create --title "$title" --body "$body")"
+            url="$(gh issue create --title "$title" --body "$body" --label mutation-gate)"
             echo "Opened $url"
           fi
 
@@ -126,7 +113,7 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
-          existing="$(gh issue list --state open --search "mutation-gate-nightly in:body" --json number --jq '.[0].number // empty')"
+          existing="$(gh issue list --label mutation-gate --state open --json number --jq '.[0].number // empty')"
           if [ -z "$existing" ]; then
             echo "No open mutation-gate failure issue"
             exit 0

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -88,6 +88,7 @@ jobs:
           )
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           MUTATE_OUTCOME: ${{ steps.mutate.outcome }}
           SCOPE_OUTCOME: ${{ steps.scope.outcome }}

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,0 +1,75 @@
+name: Mutation
+
+# Blocking mutation gate for domain + application (ADR-0016 / testing.md).
+# Separate from the hot `verify` path. Always reports a status on PRs so it can
+# be a required check; the expensive run is skipped when scope is untouched.
+on:
+  pull_request:
+  schedule:
+    # Full run on main backstops what the PR path filter misses.
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: mutation-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  mutation:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Decide whether to run
+        id: scope
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            echo "Reason: ${{ github.event_name }} always runs full mutation suite"
+            exit 0
+          fi
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+          if git diff --name-only "$base"..."$head" | grep -qE \
+            '^(apps/api/src/(domain|application)/|apps/api/stryker\.conf\.json|apps/api/package\.json|pnpm-lock\.yaml|\.github/workflows/mutation\.yml)'; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            echo "Reason: PR touches mutation scope"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "Reason: PR does not touch domain/application mutation scope — skipping"
+          fi
+
+      - name: Install pnpm
+        if: steps.scope.outputs.run == 'true'
+        uses: pnpm/action-setup@v5
+
+      - name: Setup Node
+        if: steps.scope.outputs.run == 'true'
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        if: steps.scope.outputs.run == 'true'
+        run: pnpm install --frozen-lockfile
+
+      - name: Mutation test (domain + application)
+        if: steps.scope.outputs.run == 'true'
+        run: pnpm --filter @snaveevans/pineapple-api test:mutation
+
+      - name: Upload mutation report
+        if: always() && steps.scope.outputs.run == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: mutation-report
+          path: apps/api/reports/mutation/
+          if-no-files-found: ignore
+          retention-days: 30

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -3,6 +3,7 @@ name: Mutation
 # Blocking mutation gate for domain + application (ADR-0016 / testing.md).
 # Separate from the hot `verify` path. Always reports a status on PRs so it can
 # be a required check; the expensive run is skipped when scope is untouched.
+# Scheduled failures open/update a GitHub issue so a red main is not silent.
 on:
   pull_request:
   schedule:
@@ -16,6 +17,7 @@ concurrency:
 
 permissions:
   contents: read
+  issues: write
 
 jobs:
   mutation:
@@ -80,3 +82,55 @@ jobs:
           path: apps/api/reports/mutation/
           if-no-files-found: ignore
           retention-days: 30
+
+      # Scheduled/manual runs on main are not merge-blocking. Surface failure via a
+      # single sticky issue; green runs close it. Marker in body enables dedupe.
+      - name: Open or update failure issue
+        if: >-
+          failure() &&
+          steps.scope.outputs.run == 'true' &&
+          (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          marker="<!-- mutation-gate-nightly -->"
+          title="Mutation gate failed on main"
+          body="$(cat <<EOF
+          ${marker}
+          The scheduled mutation gate on \`main\` failed.
+
+          - **Run:** ${RUN_URL}
+          - **Report artifact:** \`mutation-report\` on that run (HTML/JSON under \`apps/api/reports/mutation/\`)
+
+          This issue is opened by \`.github/workflows/mutation.yml\`. A green scheduled run closes it; further failures comment here instead of opening duplicates.
+          EOF
+          )"
+          existing="$(gh issue list --state open --search "mutation-gate-nightly in:body" --json number --jq '.[0].number // empty')"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "Still failing: ${RUN_URL}"
+            echo "Commented on existing issue #$existing"
+          else
+            url="$(gh issue create --title "$title" --body "$body")"
+            echo "Opened $url"
+          fi
+
+      - name: Close recovered failure issue
+        if: >-
+          success() &&
+          steps.scope.outputs.run == 'true' &&
+          (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          existing="$(gh issue list --state open --search "mutation-gate-nightly in:body" --json number --jq '.[0].number // empty')"
+          if [ -z "$existing" ]; then
+            echo "No open mutation-gate failure issue"
+            exit 0
+          fi
+          gh issue comment "$existing" --body "Recovered: mutation gate green again. ${RUN_URL}"
+          gh issue close "$existing" --reason completed
+          echo "Closed issue #$existing"

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -72,7 +72,8 @@ jobs:
 
       # Sticky issue only on main. Key off mutate/scope step outcomes — not job-level
       # failure() — so an upload-only failure after a green suite does not page, and
-      # infra failure before mutate still does.
+      # infra failure before mutate (including checkout, which leaves scope skipped)
+      # still does.
       - name: Notify sticky mutation-gate issue
         if: >-
           always() &&
@@ -83,8 +84,7 @@ jobs:
             steps.mutate.outcome == 'failure' ||
             steps.mutate.outcome == 'cancelled' ||
             (steps.scope.outputs.run == 'true' && steps.mutate.outcome == 'skipped') ||
-            steps.scope.outcome == 'failure' ||
-            steps.scope.outcome == 'cancelled'
+            steps.scope.outcome != 'success'
           )
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -37,13 +37,20 @@ jobs:
           fi
           base="${{ github.event.pull_request.base.sha }}"
           head="${{ github.event.pull_request.head.sha }}"
-          if git diff --name-only "$base"..."$head" | grep -qE \
-            '^(apps/api/src/(domain|application)/|apps/api/stryker\.conf\.json|apps/api/package\.json|pnpm-lock\.yaml|\.github/workflows/mutation\.yml)'; then
+          # Fail closed: if we cannot compute the diff, run the gate rather than
+          # silently skip (a required check that skips on error is worse than none).
+          if ! files="$(git diff --name-only "$base"..."$head")"; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            echo "Reason: git diff failed — fail closed, running mutation suite"
+            exit 0
+          fi
+          scope_re='^(apps/api/src/(domain|application)/|apps/api/stryker\.conf\.json|apps/api/package\.json|pnpm-lock\.yaml|\.github/workflows/mutation\.yml)'
+          if printf '%s\n' "$files" | grep -qE "$scope_re"; then
             echo "run=true" >> "$GITHUB_OUTPUT"
             echo "Reason: PR touches mutation scope"
           else
             echo "run=false" >> "$GITHUB_OUTPUT"
-            echo "Reason: PR does not touch domain/application mutation scope — skipping"
+            echo "Reason: PR does not touch mutation scope — skipping"
           fi
 
       - name: Install pnpm

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -3,7 +3,7 @@ name: Mutation
 # Blocking mutation gate for domain + application (ADR-0016 / testing.md).
 # Separate from the hot `verify` path. Always reports a status on PRs so it can
 # be a required check; the expensive run is skipped when scope is untouched.
-# Scheduled failures open/update a GitHub issue so a red main is not silent.
+# Scheduled failures on main open/update a sticky GitHub issue so red main is not silent.
 on:
   pull_request:
   schedule:
@@ -57,6 +57,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Mutation test (domain + application)
+        id: mutate
         if: steps.scope.outputs.run == 'true'
         run: pnpm --filter @snaveevans/pineapple-api test:mutation
 
@@ -66,58 +67,71 @@ jobs:
         with:
           name: mutation-report
           path: apps/api/reports/mutation/
-          if-no-files-found: ignore
+          if-no-files-found: warn
           retention-days: 30
 
-      # Scheduled/manual runs on main are not merge-blocking. Surface failure via a
-      # single sticky issue labeled mutation-gate (label list is strongly consistent;
-      # body-search is not). Green runs close it.
-      - name: Open or update failure issue
+      # Sticky issue only on main. Key off mutate/scope step outcomes — not job-level
+      # failure() — so an upload-only failure after a green suite does not page, and
+      # infra failure before mutate still does.
+      - name: Notify sticky mutation-gate issue
         if: >-
-          failure() &&
-          steps.scope.outputs.run == 'true' &&
-          (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+          always() &&
+          github.ref == 'refs/heads/main' &&
+          (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
+          (
+            steps.mutate.outcome == 'success' ||
+            steps.mutate.outcome == 'failure' ||
+            steps.mutate.outcome == 'cancelled' ||
+            (steps.scope.outputs.run == 'true' && steps.mutate.outcome == 'skipped') ||
+            steps.scope.outcome == 'failure' ||
+            steps.scope.outcome == 'cancelled'
+          )
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          MUTATE_OUTCOME: ${{ steps.mutate.outcome }}
+          SCOPE_OUTCOME: ${{ steps.scope.outcome }}
+          SCOPE_RUN: ${{ steps.scope.outputs.run }}
         run: |
           set -euo pipefail
+
+          # Ensure label exists (IaC; forks / renames / deletions must not silence paging).
+          gh label create mutation-gate \
+            --color B60205 \
+            --description "Sticky mutation-gate failure on main (opened by Mutation workflow)" \
+            --force >/dev/null
+
+          existing="$(gh issue list --label mutation-gate --state open --json number --jq '.[0].number // empty')"
+
+          if [ "${MUTATE_OUTCOME}" = "success" ]; then
+            if [ -z "$existing" ]; then
+              echo "No open mutation-gate failure issue"
+              exit 0
+            fi
+            gh issue comment "$existing" --body "Recovered: mutation gate green again. ${RUN_URL}"
+            gh issue close "$existing" --reason completed
+            echo "Closed issue #$existing"
+            exit 0
+          fi
+
           title="Mutation gate failed on main"
           body="$(cat <<EOF
           <!-- mutation-gate-nightly -->
-          The scheduled mutation gate on \`main\` failed.
+          The mutation gate on \`main\` failed.
 
           - **Run:** ${RUN_URL}
-          - **Report artifact:** \`mutation-report\` on that run (HTML/JSON under \`apps/api/reports/mutation/\`)
+          - **scope outcome:** ${SCOPE_OUTCOME} (run=${SCOPE_RUN})
+          - **mutate outcome:** ${MUTATE_OUTCOME}
+          - **Report artifact:** \`mutation-report\` on that run when Stryker produced one
 
           This issue is opened by \`.github/workflows/mutation.yml\` with the \`mutation-gate\` label.
-          A green scheduled run closes it; further failures comment here instead of opening duplicates.
+          A green run on \`main\` closes it; further failures comment here instead of opening duplicates.
           EOF
           )"
-          existing="$(gh issue list --label mutation-gate --state open --json number --jq '.[0].number // empty')"
           if [ -n "$existing" ]; then
-            gh issue comment "$existing" --body "Still failing: ${RUN_URL}"
+            gh issue comment "$existing" --body "Still failing: ${RUN_URL} (mutate=${MUTATE_OUTCOME}, scope=${SCOPE_OUTCOME})"
             echo "Commented on existing issue #$existing"
           else
             url="$(gh issue create --title "$title" --body "$body" --label mutation-gate)"
             echo "Opened $url"
           fi
-
-      - name: Close recovered failure issue
-        if: >-
-          success() &&
-          steps.scope.outputs.run == 'true' &&
-          (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          set -euo pipefail
-          existing="$(gh issue list --label mutation-gate --state open --json number --jq '.[0].number // empty')"
-          if [ -z "$existing" ]; then
-            echo "No open mutation-gate failure issue"
-            exit 0
-          fi
-          gh issue comment "$existing" --body "Recovered: mutation gate green again. ${RUN_URL}"
-          gh issue close "$existing" --reason completed
-          echo "Closed issue #$existing"

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ node_modules
 .DS_Store
 .wrangler
 coverage
+**/reports/mutation
+.stryker-tmp
 dist
 tmp
 *.log

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -22,6 +22,8 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.0.0",
+    "@stryker-mutator/core": "^9.6.1",
+    "@stryker-mutator/vitest-runner": "^9.6.1",
     "tsx": "^4.19.0",
     "vitest": "^3.0.0",
     "wrangler": "^4.95.0"

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -9,6 +9,7 @@
     "type-check": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:mutation": "stryker run",
     "openapi:generate": "tsx scripts/generate-openapi.ts"
   },
   "dependencies": {

--- a/apps/api/stryker.conf.json
+++ b/apps/api/stryker.conf.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "./node_modules/@stryker-mutator/core/schema/stryker-schema.json",
+  "testRunner": "vitest",
+  "plugins": ["./node_modules/@stryker-mutator/vitest-runner/dist/src/index.js"],
+  "mutate": ["src/domain/**/*.ts", "src/application/**/*.ts", "!src/**/*.test.ts"],
+  "coverageAnalysis": "perTest",
+  "reporters": ["html", "json", "clear-text", "progress"],
+  "jsonReporter": { "fileName": "reports/mutation/mutation.json" },
+  "htmlReporter": { "fileName": "reports/mutation/index.html" },
+  "clearTextReporter": { "maxTestsToLog": 0, "reportTests": false },
+  "concurrency": 4,
+  "timeoutMS": 20000
+}

--- a/apps/api/stryker.conf.json
+++ b/apps/api/stryker.conf.json
@@ -9,5 +9,8 @@
   "htmlReporter": { "fileName": "reports/mutation/index.html" },
   "clearTextReporter": { "maxTestsToLog": 0, "reportTests": false },
   "concurrency": 4,
-  "timeoutMS": 20000
+  "timeoutMS": 20000,
+  "thresholds": {
+    "break": 68
+  }
 }

--- a/docs/decisions/0016-mutation-testing-as-the-ci-trust-boundary.md
+++ b/docs/decisions/0016-mutation-testing-as-the-ci-trust-boundary.md
@@ -1,0 +1,191 @@
+# Mutation Testing as the CI Trust Boundary
+
+- Status: accepted
+- Date: 2026-07-23
+
+## Context and Problem Statement
+
+`main` auto-merges on green CI with `required_approving_review_count: 0`. There is no human
+review gate, which makes **CI the entire trust boundary**: whatever the checks accept, ships.
+That arrangement is only safe if the checks can tell good output from bad.
+
+Today they cannot. `pnpm lint` and `pnpm type-check` catch structural and typing faults, and
+the test suite runs green — but nothing measures whether those tests _assert_ behavior or
+merely _execute_ lines. We collect no coverage at all, and coverage would not answer the
+question anyway: a suite can touch every line while asserting almost nothing. That is the
+characteristic failure mode of a largely AI-authored test suite, which is what this one is.
+
+A spike ([#86](https://github.com/snaveevans/pineapple/issues/86)) confirmed the gap is not
+hypothetical: mutants that silently break real behavior — including the team-scoping on
+shared-asset access — survive the current suite. The measured baseline and the full list of
+surviving mutants live on that issue; this record does not reproduce them, because they are a
+point-in-time snapshot and this is a durable decision.
+
+The question this record answers is therefore not "should we test more?" but **what check,
+standing at the merge boundary, can discriminate a suite that pins behavior from one that only
+runs it — and how much authority should that check have over merges?**
+
+This decision records the gate and its authority only. The live break-threshold value, the
+Stryker configuration, the CI job wiring (including how the gate is kept fast), mutator tuning,
+and the procedure for triaging a surviving mutant are mechanism and belong in the Testing &
+Verification spec (authored next). The threshold in particular is expected to move — this
+record deliberately does not pin it.
+
+## Decision Drivers
+
+- **CI is the only gate.** With zero required reviewers, a check that cannot discriminate
+  quality is not a safety net. This dominates every other driver.
+- **Assertion quality, not execution volume.** The needed evidence is "the suite fails when
+  behavior changes," which line coverage structurally cannot provide.
+- **Consequential logic first.** Effort should land where novel business rules live — domain
+  invariants, authorization, computed read models — not on persistence plumbing whose
+  behavior is the database's.
+- **Fast feedback.** The hot `verify` path must stay quick. A gate that makes every PR slow
+  gets routed around, and a routed-around gate is worse than none.
+- **Monotonic quality.** A floor that can be quietly lowered is decorative. The guarantee has
+  to be that the number only moves up.
+- **Runtime fit.** Whatever we adopt must run against the source-first ESM TypeScript and
+  pnpm workspace layout established by [ADR-0006](0006-deployment-platform.md) without
+  introducing a build step.
+- **Honest partiality.** A gate covering some layers must not be mistaken for a guarantee
+  covering all of them.
+
+## Considered Options
+
+- **A. A blocking mutation-testing gate on the pure-logic layers.** _(chosen)_
+- **B. Mutation testing, advisory only — reported but never blocking.**
+- **C. Line/branch coverage thresholds.**
+- **D. Require at least one human approving review.**
+- **E. Status quo — lint, type-check, and the existing suite.**
+
+Property-based testing was considered adjacent but not competing: it strengthens individual
+tests, it does not measure whether the suite as a whole asserts behavior — which is the gate's
+job. It could later raise the score; it is not an alternative to measuring it.
+
+## Decision Outcome
+
+Chosen option: **A — a blocking mutation-testing gate on the pure-logic layers.**
+
+Mutation testing is adopted as the discrimination gate on the merge boundary, scoped to
+`apps/api/src/domain/**` and `apps/api/src/application/**`. `apps/api/src/infrastructure/**`
+is deliberately excluded: mutating D1 glue is slow and mostly re-asserts what the database
+already guarantees. The gate is **merge-blocking** — how it is kept fast enough to block
+without dragging on iteration (path-filtering to touched layers, a scheduled backstop, the job
+wiring itself) is mechanism and lives in the spec.
+
+Mutation testing for TypeScript is, in practice, **Stryker** — the one actively maintained
+mutator with a Vitest runner. Adopting mutation testing is therefore adopting Stryker; the
+tool was not an independently weighed choice, and the spike confirmed it runs on our
+source-first ESM/pnpm setup with no build step.
+
+The gate carries a **break threshold established by measurement, not aspiration** — set just
+below the score measured at adoption, and thereafter **ratcheted upward and never lowered**.
+The floor's job is to make regression impossible, not to be immediately comfortable. Starting
+at the honest measured baseline means the gate is live from day one; raising it is tracked,
+ongoing work ([#91](https://github.com/snaveevans/pineapple/issues/91)–[#98](https://github.com/snaveevans/pineapple/issues/98))
+rather than a precondition for turning the gate on.
+
+Blocking wins over advisory (Option B) directly on the dominating driver: with no human
+reviewer, an advisory check is a notification nobody is obliged to act on, and a regression it
+reports has already merged by the time anyone reads it. The spike showed the run is fast enough
+that blocking imposes little friction today, so the usual objection to a blocking mutation gate
+does not currently apply here.
+
+### Revisit Trigger
+
+Reconsider if the blocking run becomes a routine drag on iteration as the codebase grows; if
+equivalent-mutant noise comes to dominate triage such that the gate is producing low-value
+assertions rather than real ones; or if a human review requirement is ever introduced, since
+that would mean CI is no longer the sole trust boundary and the calculus above changes.
+
+### Layering
+
+Mutation scope follows the layer boundaries in
+[ADR-0003](0003-monorepo-layer-architecture-and-dependency-rules.md): the pure inward layers
+are gated, the outward adapters are not. Domain and application code must remain unaware of
+the mutation tooling — no annotations, no test-framework coupling, no production code shaped
+to satisfy a mutator. If passing the gate ever requires changing production code rather than
+tests, that is a defect in the gate's configuration, not a signal to change the code.
+
+### Positive Consequences
+
+- The merge boundary now measures whether tests pin behavior, closing the specific gap that
+  `required_approving_review_count: 0` opens.
+- It converts a vague worry ("are these AI-written tests any good?") into a number with a
+  floor, and into located, actionable work rather than a general anxiety.
+- It already surfaced real gaps in the safety net during the spike (see
+  [#86](https://github.com/snaveevans/pineapple/issues/86)).
+- The ratchet makes test quality monotonic: it can improve, and cannot silently decay.
+- It composes with the existing checks rather than replacing them; lint and type-check keep
+  their jobs.
+
+### Negative Consequences
+
+- Domain and application PRs get slower, and the run grows with the codebase — a real and
+  permanent tax on the layers that change most.
+- **Equivalent and low-value mutants create false pressure.** Some survivors are not real
+  gaps — error-message copy the suite deliberately does not pin, for one. Left untuned, the
+  gate pushes toward writing worthless assertions that freeze that prose, degrading the suite
+  it exists to protect.
+- The threshold is a number someone must own and advance. It can be gamed — by excluding
+  files or lowering the floor — and nothing but discipline prevents that.
+- A blocking gate can hold up an unrelated urgent fix because of a mutation regression
+  elsewhere in the touched layers.
+- `infrastructure/`, `api/`, and all of `apps/web` remain ungated. The guarantee is partial,
+  and a green badge risks reading as broader assurance than it is.
+- A high mutation score is not correctness. It proves the tests pin the behavior the code
+  has, not that the behavior is the behavior we wanted — a well-asserted wrong rule still
+  ships.
+
+---
+
+## Pros and Cons of the Options
+
+### A. A blocking mutation-testing gate on the pure-logic layers
+
+- Good, because it is the only option that directly measures assertion quality, which is the
+  actual gap at the trust boundary.
+- Good, because blocking gives the check real authority in a repo with no human reviewer.
+- Good, because scoping to domain and application concentrates cost where novel logic lives.
+- Good, because it runs on the source-first ESM/pnpm setup with no build step.
+- Bad, because it taxes the most frequently changed layers with every run.
+- Bad, because equivalent mutants require ongoing tuning to avoid incentivizing junk
+  assertions.
+
+### B. Mutation testing, advisory only — reported but never blocking
+
+- Good, because it surfaces the same information at zero risk of blocking a merge.
+- Good, because it allows the score to stabilize before anyone is held to it.
+- Bad, because with no required reviewer there is no human in the loop to act on advice; the
+  report arrives after the merge it should have stopped.
+- Bad, because an unenforced threshold decays — the failure mode is that it is ignored until
+  it is meaningless.
+
+### C. Line/branch coverage thresholds
+
+- Good, because it is cheap, universally understood, and trivially wired into Vitest.
+- Good, because it would at least catch code with no tests exercising it at all.
+- Bad, because it measures execution, not assertion — a test with zero `expect` calls raises
+  coverage. It cannot detect the exact failure mode we are worried about.
+- Bad, because it invites the illusion of safety: a high coverage number on this suite would
+  report all-clear while an access check could be quietly broken.
+
+### D. Require at least one human approving review
+
+- Good, because a competent reviewer catches classes of problems no tool can, including wrong
+  requirements.
+- Good, because it removes the single point of failure that motivates this entire record.
+- Bad, because this is a two-person team where the reviewer is frequently the author; the
+  requirement would either block work or be satisfied pro forma.
+- Bad, because human review is not a reliable detector of weak assertions specifically —
+  reviewers read code far more carefully than they read test suites.
+- Not mutually exclusive: if review is added later, this gate remains useful and its
+  blocking status should be revisited.
+
+### E. Status quo — lint, type-check, and the existing suite
+
+- Good, because it costs nothing and keeps CI fast.
+- Bad, because it is the arrangement under which checks that should catch broken
+  authorization, miscomputed read models, and dropped domain-event data do not fail.
+- Bad, because the risk grows with every AI-authored test added under a boundary that cannot
+  evaluate them.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -67,3 +67,4 @@ Use [`0000-template.md`](0000-template.md) as your starting point.
 | [0013](0013-reminder-scheduler-via-cron-sweeps.md)               | Reminder scheduler via Cron sweeps               | accepted                                                    |
 | [0014](0014-layered-error-handling-policy.md)                    | Layered error handling policy                    | accepted                                                    |
 | [0015](0015-teams-as-opt-in-sharing-scope.md)                    | Teams as an opt-in sharing scope                 | proposed                                                    |
+| [0016](0016-mutation-testing-as-the-ci-trust-boundary.md)        | Mutation testing as the CI trust boundary        | accepted                                                    |

--- a/docs/specs/SPECS.md
+++ b/docs/specs/SPECS.md
@@ -17,14 +17,15 @@ generate or sync specs from code and PRs.
 Concerns that apply to every feature. When writing a feature spec, reference the
 relevant cross-cutting specs rather than re-describing the behavior.
 
-| Spec                                                   | Concern                         | Status |
-| ------------------------------------------------------ | ------------------------------- | ------ |
-| [authentication.md](./cross-cutting/authentication.md) | Auth, sessions, identity        | active |
-| [error-handling.md](./cross-cutting/error-handling.md) | Error states and user messaging | active |
-| [permissions.md](./cross-cutting/permissions.md)       | Role-based access control       | active |
-| [validation.md](./cross-cutting/validation.md)         | Input validation patterns       | active |
-| [loading-states.md](./cross-cutting/loading-states.md) | Async UI states                 | active |
-| [telemetry.md](./cross-cutting/telemetry.md)           | Telemetry and observability     | active |
+| Spec                                                   | Concern                          | Status |
+| ------------------------------------------------------ | -------------------------------- | ------ |
+| [authentication.md](./cross-cutting/authentication.md) | Auth, sessions, identity         | active |
+| [error-handling.md](./cross-cutting/error-handling.md) | Error states and user messaging  | active |
+| [permissions.md](./cross-cutting/permissions.md)       | Role-based access control        | active |
+| [validation.md](./cross-cutting/validation.md)         | Input validation patterns        | active |
+| [loading-states.md](./cross-cutting/loading-states.md) | Async UI states                  | active |
+| [telemetry.md](./cross-cutting/telemetry.md)           | Telemetry and observability      | active |
+| [testing.md](./cross-cutting/testing.md)               | Test verification, mutation gate | review |
 
 ## Feature Specs
 
@@ -78,6 +79,7 @@ docs/specs/
     loading-states.md
     permissions.md
     telemetry.md
+    testing.md
     validation.md
   features/
     [feature-name].md

--- a/docs/specs/SPECS.md
+++ b/docs/specs/SPECS.md
@@ -25,7 +25,7 @@ relevant cross-cutting specs rather than re-describing the behavior.
 | [validation.md](./cross-cutting/validation.md)         | Input validation patterns        | active |
 | [loading-states.md](./cross-cutting/loading-states.md) | Async UI states                  | active |
 | [telemetry.md](./cross-cutting/telemetry.md)           | Telemetry and observability      | active |
-| [testing.md](./cross-cutting/testing.md)               | Test verification, mutation gate | review |
+| [testing.md](./cross-cutting/testing.md)               | Test verification, mutation gate | active |
 
 ## Feature Specs
 

--- a/docs/specs/SPECS.md
+++ b/docs/specs/SPECS.md
@@ -17,15 +17,15 @@ generate or sync specs from code and PRs.
 Concerns that apply to every feature. When writing a feature spec, reference the
 relevant cross-cutting specs rather than re-describing the behavior.
 
-| Spec                                                   | Concern                          | Status |
-| ------------------------------------------------------ | -------------------------------- | ------ |
-| [authentication.md](./cross-cutting/authentication.md) | Auth, sessions, identity         | active |
-| [error-handling.md](./cross-cutting/error-handling.md) | Error states and user messaging  | active |
-| [permissions.md](./cross-cutting/permissions.md)       | Role-based access control        | active |
-| [validation.md](./cross-cutting/validation.md)         | Input validation patterns        | active |
-| [loading-states.md](./cross-cutting/loading-states.md) | Async UI states                  | active |
-| [telemetry.md](./cross-cutting/telemetry.md)           | Telemetry and observability      | active |
-| [testing.md](./cross-cutting/testing.md)               | Test verification, mutation gate | active |
+| Spec                                                   | Concern                          | Status      |
+| ------------------------------------------------------ | -------------------------------- | ----------- |
+| [authentication.md](./cross-cutting/authentication.md) | Auth, sessions, identity         | active      |
+| [error-handling.md](./cross-cutting/error-handling.md) | Error states and user messaging  | active      |
+| [permissions.md](./cross-cutting/permissions.md)       | Role-based access control        | active      |
+| [validation.md](./cross-cutting/validation.md)         | Input validation patterns        | active      |
+| [loading-states.md](./cross-cutting/loading-states.md) | Async UI states                  | active      |
+| [telemetry.md](./cross-cutting/telemetry.md)           | Telemetry and observability      | active      |
+| [testing.md](./cross-cutting/testing.md)               | Test verification, mutation gate | in-progress |
 
 ## Feature Specs
 

--- a/docs/specs/SPECS.md
+++ b/docs/specs/SPECS.md
@@ -17,15 +17,15 @@ generate or sync specs from code and PRs.
 Concerns that apply to every feature. When writing a feature spec, reference the
 relevant cross-cutting specs rather than re-describing the behavior.
 
-| Spec                                                   | Concern                          | Status      |
-| ------------------------------------------------------ | -------------------------------- | ----------- |
-| [authentication.md](./cross-cutting/authentication.md) | Auth, sessions, identity         | active      |
-| [error-handling.md](./cross-cutting/error-handling.md) | Error states and user messaging  | active      |
-| [permissions.md](./cross-cutting/permissions.md)       | Role-based access control        | active      |
-| [validation.md](./cross-cutting/validation.md)         | Input validation patterns        | active      |
-| [loading-states.md](./cross-cutting/loading-states.md) | Async UI states                  | active      |
-| [telemetry.md](./cross-cutting/telemetry.md)           | Telemetry and observability      | active      |
-| [testing.md](./cross-cutting/testing.md)               | Test verification, mutation gate | in-progress |
+| Spec                                                   | Concern                          | Status |
+| ------------------------------------------------------ | -------------------------------- | ------ |
+| [authentication.md](./cross-cutting/authentication.md) | Auth, sessions, identity         | active |
+| [error-handling.md](./cross-cutting/error-handling.md) | Error states and user messaging  | active |
+| [permissions.md](./cross-cutting/permissions.md)       | Role-based access control        | active |
+| [validation.md](./cross-cutting/validation.md)         | Input validation patterns        | active |
+| [loading-states.md](./cross-cutting/loading-states.md) | Async UI states                  | active |
+| [telemetry.md](./cross-cutting/telemetry.md)           | Telemetry and observability      | active |
+| [testing.md](./cross-cutting/testing.md)               | Test verification, mutation gate | active |
 
 ## Feature Specs
 

--- a/docs/specs/cross-cutting/testing.md
+++ b/docs/specs/cross-cutting/testing.md
@@ -7,13 +7,12 @@ date: 2026-07-23
 
 # Testing & Verification — Cross-Cutting Spec
 
-**Status:** `review`
+**Status:** `active`
 **Owner:** engineering
 **Applies To:** All features with logic in `apps/api/src/domain/**` or `apps/api/src/application/**`
 
-> The mutation gate described here is **agreed but not yet wired into CI**. Implementation is
-> tracked by [#86](https://github.com/snaveevans/pineapple/issues/86); this spec flips to
-> `active` when the blocking job is live. The decision behind it is
+> The mutation gate is live as the `Mutation` workflow (`.github/workflows/mutation.yml`),
+> tracked by [#86](https://github.com/snaveevans/pineapple/issues/86). The decision behind it is
 > [ADR-0016](../../decisions/0016-mutation-testing-as-the-ci-trust-boundary.md).
 
 ---

--- a/docs/specs/cross-cutting/testing.md
+++ b/docs/specs/cross-cutting/testing.md
@@ -38,9 +38,9 @@ moves up.
   mostly re-asserts what the database already guarantees.
 - **`thresholds.break` is `68`.** CI fails when the mutation score drops below it.
 - **Rationale for 68:** the measured baseline on 2026-07-23 was **70.82%** (1518 mutants: 1073
-  killed, 281 survived, 162 no-coverage). The floor sits ~3 points under the measurement to
-  absorb run-to-run variance and the 2 timeout-prone mutants observed, so the gate does not fail
-  spuriously. It is a floor against regression, not a target.
+  killed, 2 timeout, 281 survived, 162 no-coverage). Timeouts count toward the score as killed
+  (`(1073+2)/1518`). The floor sits ~3 points under the measurement to absorb run-to-run
+  variance, so the gate does not fail spuriously. It is a floor against regression, not a target.
 - The score enforced is Stryker's **overall mutation score**, which counts no-coverage mutants in
   the denominator. `thresholds.break` cannot key off the covered-code score (79.28% at baseline),
   so untested code drags the enforced number — deliberately.
@@ -96,6 +96,8 @@ Config lives at `apps/api/stryker.conf.json`.
   - `packages/shared/**` (domain/application import branded IDs, `Result`, `DomainError`)
   - `apps/api/stryker.conf.json`
   - `apps/api/package.json`
+  - `apps/api/vitest.config.ts` (Stryker runner discovery / which tests kill mutants)
+  - `apps/api/tsconfig.json` (esbuild transform settings for instrumentation)
   - `pnpm-lock.yaml`
   - `.github/workflows/mutation.yml`
   - `.github/scripts/mutation-*.sh`
@@ -104,10 +106,12 @@ Config lives at `apps/api/stryker.conf.json`.
   cannot be computed, the suite runs rather than silently skipping.
 
 - **A scheduled full run against `main`** (daily) backstops what the PR path filter misses.
-  Scheduled (and `workflow_dispatch`) failures open or comment on a single sticky GitHub issue
-  with the `mutation-gate` label (label list is strongly consistent; body-search is not). A
-  subsequent green run closes it. PR-path failures already block merge and do not open issues.
-  Concurrent schedule/dispatch runs on `main` queue rather than cancel each other.
+  On `refs/heads/main` only, schedule/dispatch failures (including infra failure before the
+  suite runs) open or comment on a single sticky GitHub issue with the `mutation-gate` label —
+  the label is created idempotently in the workflow. A subsequent green mutate step closes it.
+  Upload-only failures after a green suite do not page. Dispatch on a non-`main` ref does not
+  open issues. PR-path failures already block merge and do not open issues. Concurrent
+  schedule/dispatch runs on `main` queue rather than cancel each other.
 - The HTML/JSON reports are build artifacts. They are generated into `apps/api/reports/mutation/`
   and are **not committed** (gitignored, along with `.stryker-tmp/`).
 - **Local command:** `pnpm --filter @snaveevans/pineapple-api test:mutation`.

--- a/docs/specs/cross-cutting/testing.md
+++ b/docs/specs/cross-cutting/testing.md
@@ -7,13 +7,13 @@ date: 2026-07-23
 
 # Testing & Verification — Cross-Cutting Spec
 
-**Status:** `in-progress`
+**Status:** `active`
 **Owner:** engineering
 **Applies To:** All features with logic in `apps/api/src/domain/**` or `apps/api/src/application/**`
 
-> The mutation gate is implemented as the `Mutation` workflow (`.github/workflows/mutation.yml`),
-> tracked by [#86](https://github.com/snaveevans/pineapple/issues/86). Status flips to `active`
-> once this lands on `main` with `mutation` as a required status check. The decision behind it is
+> The mutation gate is the `Mutation` workflow (`.github/workflows/mutation.yml`), with `mutation`
+> a required status check on `main`. Tracked by [#86](https://github.com/snaveevans/pineapple/issues/86).
+> The decision behind it is
 > [ADR-0016](../../decisions/0016-mutation-testing-as-the-ci-trust-boundary.md).
 
 ---
@@ -100,6 +100,9 @@ Config lives at `apps/api/stryker.conf.json`.
   cannot be computed, the suite runs rather than silently skipping.
 
 - **A scheduled full run against `main`** (daily) backstops what the PR path filter misses.
+  Scheduled (and `workflow_dispatch`) failures open or comment on a single sticky GitHub issue
+  marked `<!-- mutation-gate-nightly -->`; a subsequent green run closes it. PR-path failures
+  already block merge and do not open issues.
 - The HTML/JSON reports are build artifacts. They are generated into `apps/api/reports/mutation/`
   and are **not committed** (gitignored, along with `.stryker-tmp/`).
 - **Local command:** `pnpm --filter @snaveevans/pineapple-api test:mutation`.

--- a/docs/specs/cross-cutting/testing.md
+++ b/docs/specs/cross-cutting/testing.md
@@ -7,12 +7,13 @@ date: 2026-07-23
 
 # Testing & Verification — Cross-Cutting Spec
 
-**Status:** `active`
+**Status:** `in-progress`
 **Owner:** engineering
 **Applies To:** All features with logic in `apps/api/src/domain/**` or `apps/api/src/application/**`
 
-> The mutation gate is live as the `Mutation` workflow (`.github/workflows/mutation.yml`),
-> tracked by [#86](https://github.com/snaveevans/pineapple/issues/86). The decision behind it is
+> The mutation gate is implemented as the `Mutation` workflow (`.github/workflows/mutation.yml`),
+> tracked by [#86](https://github.com/snaveevans/pineapple/issues/86). Status flips to `active`
+> once this lands on `main` with `mutation` as a required status check. The decision behind it is
 > [ADR-0016](../../decisions/0016-mutation-testing-as-the-ci-trust-boundary.md).
 
 ---
@@ -81,12 +82,27 @@ Config lives at `apps/api/stryker.conf.json`.
 
 ### CI wiring
 
-- Runs as a **separate job from the hot `verify` path**, which must stay fast.
-- **Blocking on pull requests** that touch `apps/api/src/domain/**` or
-  `apps/api/src/application/**`, path-filtered so unrelated PRs are unaffected.
-- **A scheduled full run against `main`** backstops what the path filter misses.
+- Runs as a **separate workflow** (`.github/workflows/mutation.yml`) from the hot `verify`
+  path, which must stay fast. The job name is `mutation` — that is the required status-check
+  context on `main`.
+- **Always reports a status on every PR** so it can be a required check without deadlocking
+  unrelated work. The expensive Stryker run is path-scoped; when scope is untouched the job
+  exits green without installing or mutating.
+- **Run scope (fail closed):** the full suite runs when the PR touches any of:
+  - `apps/api/src/domain/**`
+  - `apps/api/src/application/**`
+  - `apps/api/stryker.conf.json`
+  - `apps/api/package.json`
+  - `pnpm-lock.yaml`
+  - `.github/workflows/mutation.yml`
+
+  Dependency and config changes are in scope because they can move the score. If the diff
+  cannot be computed, the suite runs rather than silently skipping.
+
+- **A scheduled full run against `main`** (daily) backstops what the PR path filter misses.
 - The HTML/JSON reports are build artifacts. They are generated into `apps/api/reports/mutation/`
   and are **not committed** (gitignored, along with `.stryker-tmp/`).
+- **Local command:** `pnpm --filter @snaveevans/pineapple-api test:mutation`.
 
 ## Feature Integration Contract
 

--- a/docs/specs/cross-cutting/testing.md
+++ b/docs/specs/cross-cutting/testing.md
@@ -88,21 +88,26 @@ Config lives at `apps/api/stryker.conf.json`.
 - **Always reports a status on every PR** so it can be a required check without deadlocking
   unrelated work. The expensive Stryker run is path-scoped; when scope is untouched the job
   exits green without installing or mutating.
-- **Run scope (fail closed):** the full suite runs when the PR touches any of:
+- **Run scope (fail closed):** logic lives in `.github/scripts/mutation-{scope,decide}.sh`
+  (self-tested by `.github/scripts/mutation-scope.selftest.sh` on every `verify` run). The full
+  suite runs when the PR touches any of:
   - `apps/api/src/domain/**`
   - `apps/api/src/application/**`
+  - `packages/shared/**` (domain/application import branded IDs, `Result`, `DomainError`)
   - `apps/api/stryker.conf.json`
   - `apps/api/package.json`
   - `pnpm-lock.yaml`
   - `.github/workflows/mutation.yml`
+  - `.github/scripts/mutation-*.sh`
 
   Dependency and config changes are in scope because they can move the score. If the diff
   cannot be computed, the suite runs rather than silently skipping.
 
 - **A scheduled full run against `main`** (daily) backstops what the PR path filter misses.
   Scheduled (and `workflow_dispatch`) failures open or comment on a single sticky GitHub issue
-  marked `<!-- mutation-gate-nightly -->`; a subsequent green run closes it. PR-path failures
-  already block merge and do not open issues.
+  with the `mutation-gate` label (label list is strongly consistent; body-search is not). A
+  subsequent green run closes it. PR-path failures already block merge and do not open issues.
+  Concurrent schedule/dispatch runs on `main` queue rather than cancel each other.
 - The HTML/JSON reports are build artifacts. They are generated into `apps/api/reports/mutation/`
   and are **not committed** (gitignored, along with `.stryker-tmp/`).
 - **Local command:** `pnpm --filter @snaveevans/pineapple-api test:mutation`.

--- a/docs/specs/cross-cutting/testing.md
+++ b/docs/specs/cross-cutting/testing.md
@@ -1,0 +1,146 @@
+---
+audience: all contributors
+purpose: canonical verification contract and mutation-testing gate for feature specs
+source: this file
+date: 2026-07-23
+---
+
+# Testing & Verification — Cross-Cutting Spec
+
+**Status:** `review`
+**Owner:** engineering
+**Applies To:** All features with logic in `apps/api/src/domain/**` or `apps/api/src/application/**`
+
+> The mutation gate described here is **agreed but not yet wired into CI**. Implementation is
+> tracked by [#86](https://github.com/snaveevans/pineapple/issues/86); this spec flips to
+> `active` when the blocking job is live. The decision behind it is
+> [ADR-0016](../../decisions/0016-mutation-testing-as-the-ci-trust-boundary.md).
+
+---
+
+## Summary
+
+`main` auto-merges on green CI with `required_approving_review_count: 0`, so **CI is the entire
+trust boundary** and the test suite is not merely the author's safety net — it is the merge gate.
+Lint and type-check catch structural faults; nothing else measures whether tests _assert_
+behavior or merely _execute_ it, and coverage cannot answer that question.
+
+**Mutation testing is the check that closes the gap.** Stryker mutates the pure-logic layers and
+reports what fraction of mutants the suite kills. A floor is enforced in CI, and that floor only
+moves up.
+
+## Canonical Behavior
+
+### The gate
+
+- Mutation testing runs against `apps/api/src/domain/**` and `apps/api/src/application/**`.
+  `apps/api/src/infrastructure/**` is excluded per ADR-0016 — mutating D1 glue is slow and
+  mostly re-asserts what the database already guarantees.
+- **`thresholds.break` is `68`.** CI fails when the mutation score drops below it.
+- **Rationale for 68:** the measured baseline on 2026-07-23 was **70.82%** (1518 mutants: 1073
+  killed, 281 survived, 162 no-coverage). The floor sits ~3 points under the measurement to
+  absorb run-to-run variance and the 2 timeout-prone mutants observed, so the gate does not fail
+  spuriously. It is a floor against regression, not a target.
+- The score enforced is Stryker's **overall mutation score**, which counts no-coverage mutants in
+  the denominator. `thresholds.break` cannot key off the covered-code score (79.28% at baseline),
+  so untested code drags the enforced number — deliberately.
+
+### Ratchet policy
+
+- **The floor is never lowered.** Not to make CI green, not temporarily.
+- When work raises the score materially, **raise `thresholds.break` in the same PR** to just under
+  the newly measured score. The ratchet is part of the change that earned it, not a follow-up.
+- Lowering the floor, excluding files from `mutate`, or muting a mutator to make a red build green
+  are all the same act: gaming the gate. If the gate is genuinely wrong, change it deliberately and
+  say so in Exceptions.
+
+### Configuration
+
+Config lives at `apps/api/stryker.conf.json`.
+
+- `mutate`: `src/domain/**/*.ts` and `src/application/**/*.ts`, excluding `src/**/*.test.ts`.
+- `coverageAnalysis: "perTest"` — required for the run to stay fast enough to block.
+- **pnpm plugin resolution:** `plugins` must point at the runner's entry file directly:
+  `"./node_modules/@stryker-mutator/vitest-runner/dist/src/index.js"`. pnpm's isolated
+  `node_modules` hides the plugin from Stryker's child process when referenced by module name,
+  failing with `Cannot find TestRunner plugin "vitest"`.
+- **No `@stryker-mutator/typescript-checker`.** The source-first ESM TypeScript setup (explicit
+  `.ts` import extensions, no build step) instruments and runs as-is — 0 compile and 0 runtime
+  errors across the baseline run.
+
+### Mutator policy
+
+- **All mutators are enabled** for now. Tuning is deferred until the gate has run for a full cycle
+  in anger (see Known Issues).
+- **Error-message copy is not a contract.** `StringLiteral` mutants that blank an error message
+  (`new NotFoundError("Asset not found")` → `""`) are expected survivors. Assert the error _type_
+  and `field`, never the prose. If these come to dominate triage, tune the mutator — do not write
+  assertions that freeze copy.
+- **Discriminant and status strings _are_ contract.** Values that drive control flow downstream —
+  `"sent"` / `"suppressed"` / `"already_processed"`, `retryable` flags, status labels — must be
+  asserted.
+
+### CI wiring
+
+- Runs as a **separate job from the hot `verify` path**, which must stay fast.
+- **Blocking on pull requests** that touch `apps/api/src/domain/**` or
+  `apps/api/src/application/**`, path-filtered so unrelated PRs are unaffected.
+- **A scheduled full run against `main`** backstops what the path filter misses.
+- The HTML/JSON reports are build artifacts. They are generated into `apps/api/reports/mutation/`
+  and are **not committed** (gitignored, along with `.stryker-tmp/`).
+
+## Feature Integration Contract
+
+Every feature that adds or changes logic in `domain/**` or `application/**` must:
+
+- **Write acceptance criteria that a mutation would break.** State the rule behaviorally, so a
+  test asserting it fails when the rule is inverted or removed. A criterion that can pass without
+  asserting the rule ("returns without throwing", "renders the list") is too weak to gate on.
+- **Assert outcomes, not execution.** Check returned values, error types, emitted event payloads,
+  and computed numbers — not merely that the code path ran.
+- **Not lower the mutation floor.** If a change drops the score, add the missing assertions. If
+  the drop is legitimate and unavoidable, record it in Exceptions with a reason — do not lower
+  `thresholds.break`.
+- **Raise the floor in the same PR** when the change materially improves the score.
+- **Not pin error-message copy** to kill a mutant. See Mutator policy.
+
+## Exceptions
+
+| Feature | Deviation | Reason |
+| ------- | --------- | ------ |
+
+## Anti-Patterns
+
+- **Lowering `thresholds.break` to make CI green.** The floor exists precisely to make this
+  visible. Add assertions instead.
+- **Excluding a file from `mutate` to raise the score.** Scope changes are decisions, not
+  build fixes.
+- **Freezing error prose in an assertion** to kill a `StringLiteral` mutant. This degrades the
+  suite it is meant to protect — the test now fails on harmless copy edits and still asserts
+  nothing about behavior.
+- **Shaping production code to satisfy a mutator.** Per ADR-0016, if passing the gate requires
+  changing production code rather than tests, that is a defect in the gate's configuration.
+- **Reaching through infrastructure to test domain logic.** Domain and application tests are pure
+  and run outside the Workers runtime; exercising D1 to cover a business rule is slow and
+  low-signal.
+- **Reading a high mutation score as correctness.** It proves the tests pin the behavior the code
+  _has_, not that the behavior is the one intended. A well-asserted wrong rule still ships.
+
+## Known Issues
+
+- **Mutator tuning is deferred.** At baseline, 84 of 281 survivors were `StringLiteral`, largely
+  error-message copy that we deliberately do not pin. Whether to disable the mutator for error
+  paths, scope it, or accept the noise is an open decision to revisit after one full cycle of use.
+- **The floor is depressed by untested code.** 162 no-coverage mutants at baseline, including two
+  use cases (`GetAsset`, `ListActivity`) scoring 0% because no test exercises them
+  ([#91](https://github.com/snaveevans/pineapple/issues/91)). These count against the enforced
+  score; clearing them is the cheapest available lift.
+- **Test-tightening backlog:** [#91](https://github.com/snaveevans/pineapple/issues/91)–[#98](https://github.com/snaveevans/pineapple/issues/98)
+  track the located weak spots, ranked by high-signal survivors.
+  [#95](https://github.com/snaveevans/pineapple/issues/95) (shared-asset access scoping) is
+  security-relevant.
+- **The gate is partial.** `apps/api/src/api/**`, `apps/api/src/infrastructure/**`, and all of
+  `apps/web` are ungated. A green mutation check is not a statement about those layers.
+- **Run time grows with the codebase.** The baseline run was ~80s for 1518 mutants at
+  `concurrency: 4`. If the blocking path becomes a drag on iteration, ADR-0016's revisit trigger
+  applies.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,12 @@ importers:
       '@cloudflare/workers-types':
         specifier: ^4.0.0
         version: 4.20260525.1
+      '@stryker-mutator/core':
+        specifier: ^9.6.1
+        version: 9.6.1(@types/node@25.9.1)
+      '@stryker-mutator/vitest-runner':
+        specifier: ^9.6.1
+        version: 9.6.1(@stryker-mutator/core@9.6.1(@types/node@25.9.1))(vitest@3.2.4(@types/node@25.9.1)(happy-dom@20.10.6)(tsx@4.22.3)(yaml@2.9.0))
       tsx:
         specifier: ^4.19.0
         version: 4.22.3
@@ -147,12 +153,26 @@ packages:
     resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-annotate-as-pure@7.29.7':
+    resolution: {integrity: sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-compilation-targets@7.29.7':
     resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-create-class-features-plugin@7.29.7':
+    resolution: {integrity: sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
   '@babel/helper-globals@7.29.7':
     resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-member-expression-to-functions@7.29.7':
+    resolution: {integrity: sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-module-imports@7.29.7':
@@ -165,8 +185,22 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
+  '@babel/helper-optimise-call-expression@7.29.7':
+    resolution: {integrity: sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-plugin-utils@7.29.7':
     resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-replace-supers@7.29.7':
+    resolution: {integrity: sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-skip-transparent-expression-wrappers@7.29.7':
+    resolution: {integrity: sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-string-parser@7.29.7':
@@ -190,6 +224,48 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/plugin-proposal-decorators@7.29.7':
+    resolution: {integrity: sha512-EtU0Hi3GvrTqD56xKmZvV/uCXK2ZbwVNPNLAquVItcAZpUhkXwWlo3Fmj0c2LxgSf2I8IDULeAepwNP1OefLXg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-decorators@7.29.7':
+    resolution: {integrity: sha512-9MTTLbF39X6sqM92JPEsoI7++26hjZvzkxKZy64aMhWLH2mPkJ/Q3AV4QLmls3R14FpSpkOwQQfUh962JGQxxg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-jsx@7.29.7':
+    resolution: {integrity: sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-typescript@7.29.7':
+    resolution: {integrity: sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-destructuring@7.29.7':
+    resolution: {integrity: sha512-iPX8aD6H9zV5s7ZsqTdNocPN/MGQ5sSMnElKrktxjJRMnB2jN/1p2+R7GkfD6CAYoVFqy5A4XnSIUeGgJzIWpg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-explicit-resource-management@7.29.7':
+    resolution: {integrity: sha512-Rstj7coNz8sE+7Ju7ihpHLI564lsK5pUpNNlvptCIC/16E/S5hbl6n3kESPKdNRmqEWlpn5xpS5Q2dvXBsySLw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-modules-commonjs@7.29.7':
+    resolution: {integrity: sha512-j0vCldybPC5b5dwCQOJ21uKtHzt7hxLygJTg9eF1ScfaikEDNfzn94XoW5Fi+seBR0nCyL23xaBFFkq7dTM8XQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/plugin-transform-react-jsx-self@7.29.7':
     resolution: {integrity: sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==}
     engines: {node: '>=6.9.0'}
@@ -198,6 +274,18 @@ packages:
 
   '@babel/plugin-transform-react-jsx-source@7.29.7':
     resolution: {integrity: sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-typescript@7.29.7':
+    resolution: {integrity: sha512-jK52h8LaLc7JarhQV2ofeFMts4H7vnOXnqZNA6fYglBTZewRBE51KWt3BUltW1P+KoPsYkHoJeXePuz4zo2LMw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/preset-typescript@7.28.5':
+    resolution: {integrity: sha512-+bQy5WOI2V6LJZpPVxY+yp66XdZ2yifu0Mc1aP5CQKgjn4QM5IN2i5fAZ4xKop47pr8rpVhiAeu+nDQa12C8+g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1204,6 +1292,140 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@inquirer/ansi@2.0.7':
+    resolution: {integrity: sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+
+  '@inquirer/checkbox@5.2.1':
+    resolution: {integrity: sha512-b6xmA/VlTe0ZgDQHDui+Nav470u7u49nRd8/iuhOcQPO9Ch7lGuogydhi2VOmNlZ+zXcM8IcPuNSwQcdJaF/kw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/confirm@6.1.1':
+    resolution: {integrity: sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@11.2.1':
+    resolution: {integrity: sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/editor@5.2.2':
+    resolution: {integrity: sha512-ZRVd/oD+sYsUd5zVm0NflqEzlqfYCyHNsqkHl2oWXEUHs12tCbcSFi+wVFEvD8+LGRaMUsVrE7qeo6lSG/S1Vg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/expand@5.1.1':
+    resolution: {integrity: sha512-YmQpenjbFSHAK3sOd44puHh3V1KXXr+JiNpUztoSQ4drLh2rTVzTap/YtlAVu/5xavifIlBfNEzJ/neZJ1a/1g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/external-editor@3.0.3':
+    resolution: {integrity: sha512-6thf5I8q7lZwzGLAxPaaGEREEkZ3nyePPDQ1oyobblxmEE8mqTLguScP7pDjUTAibiyb4hfXl+qjUEJ+di/aNA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/figures@2.0.7':
+    resolution: {integrity: sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+
+  '@inquirer/input@5.1.2':
+    resolution: {integrity: sha512-9K/DDBSQpOyZSkt6sOVP9Vo0TR7atX2kuILsUu0x3wVcVbe97lJwIJKMLdMw25tDYuXl/qp6erT0Xs1rfmcfZg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/number@4.1.1':
+    resolution: {integrity: sha512-XF4IXAbPnGPgw0wsbC/i2tPcyfdZgDpUlhsqU0SfT4IRIGWha6Xm9VRgN5yYxJq+jnyXlfXI/nQ3ulfk0iEICA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/password@5.1.1':
+    resolution: {integrity: sha512-3XBfF7DAsp5qeDsvN5Rd1HmbNokVvEQoUM0QLrRcybC9nX96w3Pbmu7qUsb3IT3J3jBvs2+mTXaKHOUsgHMLzg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/prompts@8.5.2':
+    resolution: {integrity: sha512-IYR/3C/paEVVQYQvdDlFZVjRCJVYHHON0XXMH91KO9GSxs0TdKYWlUdvfQl2EfAHDxUaN3IBffkE/BDTh5nJ6g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/rawlist@5.3.1':
+    resolution: {integrity: sha512-QqdTqQddL3qPX/PPrjobpsO25NZ4dWXgTLenrR445L2ptLEYE6Z+PD5c5CNDJNx4ugRgELAIpSIJxZaO2jJ2Og==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/search@4.2.1':
+    resolution: {integrity: sha512-xJj8QWKRSrfKoBIITLZK61dD3zwo0Rz11fgDImku30/Oe81zMdIdGgrLY2h6RkJ+KZ/GhNYIRMKnH/62qBTA5g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/select@5.2.1':
+    resolution: {integrity: sha512-FlDndEUww8m7BfukO2nJa25vhD+H5jxxCv4oGioKqzyWz3nPHhhw4LKdYRSlXuAx7DsdWia7iyaBPKKS95Evfw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/type@4.0.7':
+    resolution: {integrity: sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -1411,8 +1633,15 @@ packages:
     resolution: {integrity: sha512-tpmmG+/xRE2Kn9RpflU3AIyZv08v10+E1ZrJCx7z6+/91zHVxy0M73kC1LT4/8PbYNt85ywyC8+n+D99JdMcGA==}
     engines: {node: '>=20'}
 
+  '@sec-ant/readable-stream@0.4.1':
+    resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
+
   '@sindresorhus/is@7.2.0':
     resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
+    engines: {node: '>=18'}
+
+  '@sindresorhus/merge-streams@4.0.0':
+    resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
   '@speed-highlight/core@1.2.15':
@@ -1420,6 +1649,29 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@stryker-mutator/api@9.6.1':
+    resolution: {integrity: sha512-g8VNoFWQWbx0pdal3Vt8jVCZW+v3sc3gi94iI0GVtVgUGTqphAjJF6EAruPTx0lqvtonsaAxn5TD36hcG1d6Wg==}
+    engines: {node: '>=20.0.0'}
+
+  '@stryker-mutator/core@9.6.1':
+    resolution: {integrity: sha512-WMgnvf+Wyh/yiruhNZwc8w8DlzmmjXhPjSn5MR8RhAXzlnWji8TQrUYgBUkHk9bEgSaIlB3KZHm37iiU5Q2cLQ==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
+
+  '@stryker-mutator/instrumenter@9.6.1':
+    resolution: {integrity: sha512-5K8wH4Pthly25c2uKKik4Dfcoeou7sbJdFS6u3QIYHlulgFVDJwtEMWTZGkZfs7IiUEXIDNa0keRACq5jn5AvA==}
+    engines: {node: '>=20.0.0'}
+
+  '@stryker-mutator/util@9.6.1':
+    resolution: {integrity: sha512-Lk/ALVctJjFv1vvwR+CFoKzDCWvsBlq7flDUnmnpuwTrGbm156EdZD1Jjq4o8KdOap0ezUZqQNE9OAI1m2+pUQ==}
+
+  '@stryker-mutator/vitest-runner@9.6.1':
+    resolution: {integrity: sha512-eyUHTCf3Ui+SUn/tpFJwzw6MV391kyBLZk/cDHFUfKFELqKMLbvd7e81axArlApKqO6cOnLfrxlwED+2SRN0ow==}
+    engines: {node: '>=14.18.0'}
+    peerDependencies:
+      '@stryker-mutator/core': 9.6.1
+      vitest: '>=2.0.0'
 
   '@tanstack/query-core@5.100.14':
     resolution: {integrity: sha512-5X41dGpxgeaHISCRW2oYwcSycZeULZzAunaudXT9ov1KOTj9xwt0CH6hbwqP1/z74ZWF7rYFnDpyYH07XFcZew==}
@@ -1583,6 +1835,13 @@ packages:
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+
+  angular-html-parser@10.4.0:
+    resolution: {integrity: sha512-++nLNyZwRfHqFh7akH5Gw/JYizoFlMRz0KRigfwfsLqV8ZqlcVRb1LkPEWdYvEKDnbktknM2J4BXaYUGrQZPww==}
+    engines: {node: '>= 14'}
+
   ansi-escapes@7.3.0:
     resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
     engines: {node: '>=18'}
@@ -1722,6 +1981,14 @@ packages:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
 
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
@@ -1737,6 +2004,13 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  chardet@2.2.0:
+    resolution: {integrity: sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==}
+
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
@@ -1749,12 +2023,20 @@ packages:
     resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
     engines: {node: '>=20'}
 
+  cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -1800,9 +2082,15 @@ packages:
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
+  des.js@1.1.0:
+    resolution: {integrity: sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  diff-match-patch@1.0.5:
+    resolution: {integrity: sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==}
 
   drizzle-orm@0.45.2:
     resolution: {integrity: sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==}
@@ -1896,6 +2184,10 @@ packages:
       sqlite3:
         optional: true
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
   electron-to-chromium@1.5.364:
     resolution: {integrity: sha512-G/dYE3+AYhyHwzTwg8UbnXf7zqMERYh7l2jJ3QujhFsH8agSYwtnGAR2aZ7f0AakIKJXd5En/Hre4igIUrdlYw==}
 
@@ -1917,12 +2209,20 @@ packages:
   error-stack-parser-es@1.0.5:
     resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
@@ -2065,6 +2365,10 @@ packages:
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
+  execa@9.6.1:
+    resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
+    engines: {node: ^18.19.0 || >=20.5.0}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -2078,6 +2382,18 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+
+  fast-wrap-ansi@0.2.2:
+    resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -2086,6 +2402,10 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  figures@6.1.0:
+    resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
+    engines: {node: '>=18'}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -2122,6 +2442,18 @@ packages:
     resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
     engines: {node: '>=18'}
 
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  get-stream@9.0.1:
+    resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
+    engines: {node: '>=18'}
+
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
 
@@ -2140,6 +2472,10 @@ packages:
   globrex@0.1.2:
     resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -2156,6 +2492,10 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
   hasown@2.0.3:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
@@ -2164,10 +2504,18 @@ packages:
     resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
     engines: {node: '>=16.9.0'}
 
+  human-signals@8.0.1:
+    resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
+    engines: {node: '>=18.18.0'}
+
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
+    engines: {node: '>=0.10.0'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -2184,6 +2532,9 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   is-core-module@2.16.1:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
@@ -2209,11 +2560,26 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
+
+  is-stream@4.0.1:
+    resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
+    engines: {node: '>=18'}
+
+  is-unicode-supported@2.1.0:
+    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
+    engines: {node: '>=18'}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
+  js-md4@0.3.2:
+    resolution: {integrity: sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2233,8 +2599,14 @@ packages:
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
+  json-rpc-2.0@1.7.1:
+    resolution: {integrity: sha512-JqZjhjAanbpkXIzFE7u8mE/iFblawwlXtONaCvRqI+pyABVz7B4M1EUNpyVW+dZjqgQ2L5HFmZCmOCgUKm00hg==}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -2272,6 +2644,9 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash.groupby@4.6.0:
+    resolution: {integrity: sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==}
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
@@ -2287,6 +2662,10 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -2306,6 +2685,9 @@ packages:
     engines: {node: '>=22.0.0'}
     hasBin: true
 
+  minimalistic-assert@1.0.1:
+    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -2318,6 +2700,23 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mutation-server-protocol@0.4.1:
+    resolution: {integrity: sha512-SBGK0j8hLDne7bktgThKI8kGvGTx3rY3LAeQTmOKZ5bVnL/7TorLMvcVF7dIPJCu5RNUWhkkuF53kurygYVt3g==}
+    engines: {node: '>=18'}
+
+  mutation-testing-elements@3.7.3:
+    resolution: {integrity: sha512-SMeIPxngJpfjfNYctFpYQQtlBlZaVO0aoB3FKdwrI8Ee/2bkyUuCZzAOCLv1U9fnmfA37dPFq0Owduoxs2XgGQ==}
+
+  mutation-testing-metrics@3.7.3:
+    resolution: {integrity: sha512-B8QrP0ZomErzTPNlhrzKWPNBln+3afwBZPHv0Q7N8wZZTYxMptzb/Gdm3ExXVmioVYrtZAtsDs7W/T/b2AixOQ==}
+
+  mutation-testing-report-schema@3.7.3:
+    resolution: {integrity: sha512-BHm3MYq+ckO+t5CtlG8zpqxc75rdJCkxVlE+fGuGJM3F7tNCQ/OW2N+TQVHN3BHsYa84+BFc6g3AwDYkUsw2MA==}
+
+  mute-stream@3.0.0:
+    resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
@@ -2343,6 +2742,14 @@ packages:
     resolution: {integrity: sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==}
     engines: {node: '>=18'}
 
+  npm-run-path@6.0.0:
+    resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
+    engines: {node: '>=18'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
@@ -2366,6 +2773,10 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parse-ms@4.0.0:
+    resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
+    engines: {node: '>=18'}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -2373,6 +2784,10 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-key@4.0.0:
+    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
+    engines: {node: '>=12'}
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
@@ -2411,9 +2826,21 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-ms@9.3.0:
+    resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
+    engines: {node: '>=18'}
+
+  progress@2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  qs@6.15.1:
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+    engines: {node: '>=0.6'}
 
   react-dom@19.2.6:
     resolution: {integrity: sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==}
@@ -2436,6 +2863,10 @@ packages:
 
   react@19.2.6:
     resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
+    engines: {node: '>=0.10.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
   resolve-from@4.0.0:
@@ -2485,11 +2916,22 @@ packages:
   rou3@0.7.12:
     resolution: {integrity: sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==}
 
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
     hasBin: true
 
   semver@7.8.0:
@@ -2515,6 +2957,22 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
+    engines: {node: '>= 0.4'}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
@@ -2538,6 +2996,10 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -2559,6 +3021,10 @@ packages:
   strip-ansi@7.2.0:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
+
+  strip-final-newline@4.0.0:
+    resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
+    engines: {node: '>=18'}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -2617,6 +3083,10 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
@@ -2631,6 +3101,10 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  tunnel@0.0.6:
+    resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
+    engines: {node: '>=0.6.11 <=0.7.0 || >=0.7.3'}
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -2638,6 +3112,14 @@ packages:
   type-fest@5.6.0:
     resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
     engines: {node: '>=20'}
+
+  typed-inject@5.0.0:
+    resolution: {integrity: sha512-0Ql2ORqBORLMdAW89TQKZsb1PQkFGImFfVmncXWe7a+AA3+7dh7Se9exxZowH4kbnlvKEFkMxUYdHUpjYWFJaA==}
+    engines: {node: '>=18'}
+
+  typed-rest-client@2.3.1:
+    resolution: {integrity: sha512-k4kX5Up6qA68D0Cby2AK+6+vM5k3qTxe+/3FqhnHRExjY5cfbOnzjQZbP/LXleF8hVoDvDqxlgk9KK83HoBZlQ==}
+    engines: {node: '>= 16.0.0'}
 
   typescript-eslint@8.59.4:
     resolution: {integrity: sha512-Rw6+44QNFaXtgHSjPy+Kw8hrJniMYzR85E9yLmOLcfZ91/rz+JXQbDTCmc6ccxMPY6K6PgAq26f0JCBfR7LIPQ==}
@@ -2656,6 +3138,9 @@ packages:
     engines: {node: '>=0.8.0'}
     hasBin: true
 
+  underscore@1.13.8:
+    resolution: {integrity: sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==}
+
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
@@ -2668,6 +3153,10 @@ packages:
 
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
+
+  unicorn-magic@0.3.0:
+    resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
+    engines: {node: '>=18'}
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -2791,6 +3280,9 @@ packages:
       jsdom:
         optional: true
 
+  weapon-regex@1.3.6:
+    resolution: {integrity: sha512-wsf1m1jmMrso5nhwVFJJHSubEBf3+pereGd7+nBKtYJ18KoB/PWJOHS3WRkwS04VrOU0iJr2bZU+l1QaTJ+9nA==}
+
   whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
     engines: {node: '>=12'}
@@ -2871,6 +3363,10 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  yoctocolors@2.1.2:
+    resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
+    engines: {node: '>=18'}
+
   youch-core@0.3.3:
     resolution: {integrity: sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==}
 
@@ -2926,6 +3422,10 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
+  '@babel/helper-annotate-as-pure@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
   '@babel/helper-compilation-targets@7.29.7':
     dependencies:
       '@babel/compat-data': 7.29.7
@@ -2934,7 +3434,27 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
+  '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-annotate-as-pure': 7.29.7
+      '@babel/helper-member-expression-to-functions': 7.29.7
+      '@babel/helper-optimise-call-expression': 7.29.7
+      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
+      '@babel/traverse': 7.29.7
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-globals@7.29.7': {}
+
+  '@babel/helper-member-expression-to-functions@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/helper-module-imports@7.29.7':
     dependencies:
@@ -2952,7 +3472,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-optimise-call-expression@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
   '@babel/helper-plugin-utils@7.29.7': {}
+
+  '@babel/helper-replace-supers@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-member-expression-to-functions': 7.29.7
+      '@babel/helper-optimise-call-expression': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-skip-transparent-expression-wrappers@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/helper-string-parser@7.29.7': {}
 
@@ -2969,6 +3509,54 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
+  '@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/plugin-syntax-decorators': 7.29.7(@babel/core@7.29.7)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-syntax-decorators@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-destructuring@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-explicit-resource-management@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@7.29.7)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-modules-commonjs@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
@@ -2978,6 +3566,28 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-annotate-as-pure': 7.29.7
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
+      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/preset-typescript@7.28.5(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/template@7.29.7':
     dependencies:
@@ -3601,6 +4211,125 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
+  '@inquirer/ansi@2.0.7': {}
+
+  '@inquirer/checkbox@5.2.1(@types/node@25.9.1)':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 11.2.1(@types/node@25.9.1)
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@25.9.1)
+    optionalDependencies:
+      '@types/node': 25.9.1
+
+  '@inquirer/confirm@6.1.1(@types/node@25.9.1)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@25.9.1)
+      '@inquirer/type': 4.0.7(@types/node@25.9.1)
+    optionalDependencies:
+      '@types/node': 25.9.1
+
+  '@inquirer/core@11.2.1(@types/node@25.9.1)':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@25.9.1)
+      cli-width: 4.1.0
+      fast-wrap-ansi: 0.2.2
+      mute-stream: 3.0.0
+      signal-exit: 4.1.0
+    optionalDependencies:
+      '@types/node': 25.9.1
+
+  '@inquirer/editor@5.2.2(@types/node@25.9.1)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@25.9.1)
+      '@inquirer/external-editor': 3.0.3(@types/node@25.9.1)
+      '@inquirer/type': 4.0.7(@types/node@25.9.1)
+    optionalDependencies:
+      '@types/node': 25.9.1
+
+  '@inquirer/expand@5.1.1(@types/node@25.9.1)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@25.9.1)
+      '@inquirer/type': 4.0.7(@types/node@25.9.1)
+    optionalDependencies:
+      '@types/node': 25.9.1
+
+  '@inquirer/external-editor@3.0.3(@types/node@25.9.1)':
+    dependencies:
+      chardet: 2.2.0
+      iconv-lite: 0.7.3
+    optionalDependencies:
+      '@types/node': 25.9.1
+
+  '@inquirer/figures@2.0.7': {}
+
+  '@inquirer/input@5.1.2(@types/node@25.9.1)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@25.9.1)
+      '@inquirer/type': 4.0.7(@types/node@25.9.1)
+    optionalDependencies:
+      '@types/node': 25.9.1
+
+  '@inquirer/number@4.1.1(@types/node@25.9.1)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@25.9.1)
+      '@inquirer/type': 4.0.7(@types/node@25.9.1)
+    optionalDependencies:
+      '@types/node': 25.9.1
+
+  '@inquirer/password@5.1.1(@types/node@25.9.1)':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 11.2.1(@types/node@25.9.1)
+      '@inquirer/type': 4.0.7(@types/node@25.9.1)
+    optionalDependencies:
+      '@types/node': 25.9.1
+
+  '@inquirer/prompts@8.5.2(@types/node@25.9.1)':
+    dependencies:
+      '@inquirer/checkbox': 5.2.1(@types/node@25.9.1)
+      '@inquirer/confirm': 6.1.1(@types/node@25.9.1)
+      '@inquirer/editor': 5.2.2(@types/node@25.9.1)
+      '@inquirer/expand': 5.1.1(@types/node@25.9.1)
+      '@inquirer/input': 5.1.2(@types/node@25.9.1)
+      '@inquirer/number': 4.1.1(@types/node@25.9.1)
+      '@inquirer/password': 5.1.1(@types/node@25.9.1)
+      '@inquirer/rawlist': 5.3.1(@types/node@25.9.1)
+      '@inquirer/search': 4.2.1(@types/node@25.9.1)
+      '@inquirer/select': 5.2.1(@types/node@25.9.1)
+    optionalDependencies:
+      '@types/node': 25.9.1
+
+  '@inquirer/rawlist@5.3.1(@types/node@25.9.1)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@25.9.1)
+      '@inquirer/type': 4.0.7(@types/node@25.9.1)
+    optionalDependencies:
+      '@types/node': 25.9.1
+
+  '@inquirer/search@4.2.1(@types/node@25.9.1)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@25.9.1)
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@25.9.1)
+    optionalDependencies:
+      '@types/node': 25.9.1
+
+  '@inquirer/select@5.2.1(@types/node@25.9.1)':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 11.2.1(@types/node@25.9.1)
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@25.9.1)
+    optionalDependencies:
+      '@types/node': 25.9.1
+
+  '@inquirer/type@4.0.7(@types/node@25.9.1)':
+    optionalDependencies:
+      '@types/node': 25.9.1
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -3747,11 +4476,82 @@ snapshots:
 
   '@scalar/validation@0.6.0': {}
 
+  '@sec-ant/readable-stream@0.4.1': {}
+
   '@sindresorhus/is@7.2.0': {}
+
+  '@sindresorhus/merge-streams@4.0.0': {}
 
   '@speed-highlight/core@1.2.15': {}
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@stryker-mutator/api@9.6.1':
+    dependencies:
+      mutation-testing-metrics: 3.7.3
+      mutation-testing-report-schema: 3.7.3
+      tslib: 2.8.1
+      typed-inject: 5.0.0
+
+  '@stryker-mutator/core@9.6.1(@types/node@25.9.1)':
+    dependencies:
+      '@inquirer/prompts': 8.5.2(@types/node@25.9.1)
+      '@stryker-mutator/api': 9.6.1
+      '@stryker-mutator/instrumenter': 9.6.1
+      '@stryker-mutator/util': 9.6.1
+      ajv: 8.18.0
+      chalk: 5.6.2
+      commander: 14.0.3
+      diff-match-patch: 1.0.5
+      emoji-regex: 10.6.0
+      execa: 9.6.1
+      json-rpc-2.0: 1.7.1
+      lodash.groupby: 4.6.0
+      minimatch: 10.2.5
+      mutation-server-protocol: 0.4.1
+      mutation-testing-elements: 3.7.3
+      mutation-testing-metrics: 3.7.3
+      mutation-testing-report-schema: 3.7.3
+      npm-run-path: 6.0.0
+      progress: 2.0.3
+      rxjs: 7.8.2
+      semver: 7.8.0
+      source-map: 0.7.6
+      tree-kill: 1.2.2
+      tslib: 2.8.1
+      typed-inject: 5.0.0
+      typed-rest-client: 2.3.1
+    transitivePeerDependencies:
+      - '@types/node'
+      - supports-color
+
+  '@stryker-mutator/instrumenter@9.6.1':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-explicit-resource-management': 7.29.7(@babel/core@7.29.7)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.7)
+      '@stryker-mutator/api': 9.6.1
+      '@stryker-mutator/util': 9.6.1
+      angular-html-parser: 10.4.0
+      semver: 7.7.4
+      tslib: 2.8.1
+      weapon-regex: 1.3.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@stryker-mutator/util@9.6.1': {}
+
+  '@stryker-mutator/vitest-runner@9.6.1(@stryker-mutator/core@9.6.1(@types/node@25.9.1))(vitest@3.2.4(@types/node@25.9.1)(happy-dom@20.10.6)(tsx@4.22.3)(yaml@2.9.0))':
+    dependencies:
+      '@stryker-mutator/api': 9.6.1
+      '@stryker-mutator/core': 9.6.1(@types/node@25.9.1)
+      '@stryker-mutator/util': 9.6.1
+      semver: 7.8.0
+      tslib: 2.8.1
+      vitest: 3.2.4(@types/node@25.9.1)(happy-dom@20.10.6)(tsx@4.22.3)(yaml@2.9.0)
 
   '@tanstack/query-core@5.100.14': {}
 
@@ -3983,6 +4783,15 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ajv@8.18.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.4
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  angular-html-parser@10.4.0: {}
+
   ansi-escapes@7.3.0:
     dependencies:
       environment: 1.1.0
@@ -4109,6 +4918,16 @@ snapshots:
 
   cac@6.7.14: {}
 
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001793: {}
@@ -4126,6 +4945,10 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  chalk@5.6.2: {}
+
+  chardet@2.2.0: {}
+
   check-error@2.1.3: {}
 
   cli-cursor@5.0.0:
@@ -4137,11 +4960,15 @@ snapshots:
       slice-ansi: 8.0.0
       string-width: 8.2.1
 
+  cli-width@4.1.0: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  commander@14.0.3: {}
 
   concat-map@0.0.1: {}
 
@@ -4171,12 +4998,25 @@ snapshots:
 
   defu@6.1.7: {}
 
+  des.js@1.1.0:
+    dependencies:
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+
   detect-libc@2.1.2: {}
+
+  diff-match-patch@1.0.5: {}
 
   drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260525.1)(kysely@0.28.17):
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260525.1
       kysely: 0.28.17
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
 
   electron-to-chromium@1.5.364: {}
 
@@ -4193,9 +5033,15 @@ snapshots:
 
   error-stack-parser-es@1.0.5: {}
 
+  es-define-property@1.0.1: {}
+
   es-errors@1.3.0: {}
 
   es-module-lexer@1.7.0: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -4454,6 +5300,21 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
+  execa@9.6.1:
+    dependencies:
+      '@sindresorhus/merge-streams': 4.0.0
+      cross-spawn: 7.0.6
+      figures: 6.1.0
+      get-stream: 9.0.1
+      human-signals: 8.0.1
+      is-plain-obj: 4.1.0
+      is-stream: 4.0.1
+      npm-run-path: 6.0.0
+      pretty-ms: 9.3.0
+      signal-exit: 4.1.0
+      strip-final-newline: 4.0.0
+      yoctocolors: 2.1.2
+
   expect-type@1.3.0: {}
 
   fast-deep-equal@3.1.3: {}
@@ -4462,9 +5323,25 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
+  fast-uri@3.1.4: {}
+
+  fast-wrap-ansi@0.2.2:
+    dependencies:
+      fast-string-width: 3.0.2
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  figures@6.1.0:
+    dependencies:
+      is-unicode-supported: 2.1.0
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -4495,6 +5372,29 @@ snapshots:
 
   get-east-asian-width@1.6.0: {}
 
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
+
+  get-stream@9.0.1:
+    dependencies:
+      '@sec-ant/readable-stream': 0.4.1
+      is-stream: 4.0.1
+
   get-tsconfig@4.14.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
@@ -4508,6 +5408,8 @@ snapshots:
   globals@15.15.0: {}
 
   globrex@0.1.2: {}
+
+  gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
 
@@ -4535,13 +5437,21 @@ snapshots:
 
   has-flag@4.0.0: {}
 
+  has-symbols@1.1.0: {}
+
   hasown@2.0.3:
     dependencies:
       function-bind: 1.1.2
 
   hono@4.12.23: {}
 
+  human-signals@8.0.1: {}
+
   husky@9.1.7: {}
+
+  iconv-lite@0.7.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ignore@5.3.2: {}
 
@@ -4553,6 +5463,8 @@ snapshots:
       resolve-from: 4.0.0
 
   imurmurhash@0.1.4: {}
+
+  inherits@2.0.4: {}
 
   is-core-module@2.16.1:
     dependencies:
@@ -4574,9 +5486,17 @@ snapshots:
 
   is-number@7.0.0: {}
 
+  is-plain-obj@4.1.0: {}
+
+  is-stream@4.0.1: {}
+
+  is-unicode-supported@2.1.0: {}
+
   isexe@2.0.0: {}
 
   jose@6.2.3: {}
+
+  js-md4@0.3.2: {}
 
   js-tokens@4.0.0: {}
 
@@ -4590,7 +5510,11 @@ snapshots:
 
   json-buffer@3.0.1: {}
 
+  json-rpc-2.0@1.7.1: {}
+
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -4630,6 +5554,8 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash.groupby@4.6.0: {}
+
   lodash.merge@4.6.2: {}
 
   log-update@6.1.0:
@@ -4649,6 +5575,8 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  math-intrinsics@1.1.0: {}
 
   micromatch@4.0.8:
     dependencies:
@@ -4671,6 +5599,8 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  minimalistic-assert@1.0.1: {}
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.6
@@ -4683,6 +5613,20 @@ snapshots:
 
   ms@2.1.3: {}
 
+  mutation-server-protocol@0.4.1:
+    dependencies:
+      zod: 4.4.3
+
+  mutation-testing-elements@3.7.3: {}
+
+  mutation-testing-metrics@3.7.3:
+    dependencies:
+      mutation-testing-report-schema: 3.7.3
+
+  mutation-testing-report-schema@3.7.3: {}
+
+  mute-stream@3.0.0: {}
+
   nanoid@3.3.12: {}
 
   nanoid@5.1.11: {}
@@ -4694,6 +5638,13 @@ snapshots:
   neo-async@2.6.2: {}
 
   node-releases@2.0.46: {}
+
+  npm-run-path@6.0.0:
+    dependencies:
+      path-key: 4.0.0
+      unicorn-magic: 0.3.0
+
+  object-inspect@1.13.4: {}
 
   onetime@7.0.0:
     dependencies:
@@ -4724,9 +5675,13 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse-ms@4.0.0: {}
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
+
+  path-key@4.0.0: {}
 
   path-parse@1.0.7: {}
 
@@ -4752,7 +5707,17 @@ snapshots:
 
   prettier@3.8.3: {}
 
+  pretty-ms@9.3.0:
+    dependencies:
+      parse-ms: 4.0.0
+
+  progress@2.0.3: {}
+
   punycode@2.3.1: {}
+
+  qs@6.15.1:
+    dependencies:
+      side-channel: 1.1.1
 
   react-dom@19.2.6(react@19.2.6):
     dependencies:
@@ -4770,6 +5735,8 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
 
   react@19.2.6: {}
+
+  require-from-string@2.0.2: {}
 
   resolve-from@4.0.0: {}
 
@@ -4837,9 +5804,17 @@ snapshots:
 
   rou3@0.7.12: {}
 
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
+
+  safer-buffer@2.1.2: {}
+
   scheduler@0.27.0: {}
 
   semver@6.3.1: {}
+
+  semver@7.7.4: {}
 
   semver@7.8.0: {}
 
@@ -4884,6 +5859,34 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
   siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
@@ -4901,6 +5904,8 @@ snapshots:
   source-map-js@1.2.1: {}
 
   source-map@0.6.1: {}
+
+  source-map@0.7.6: {}
 
   stackback@0.0.2: {}
 
@@ -4922,6 +5927,8 @@ snapshots:
   strip-ansi@7.2.0:
     dependencies:
       ansi-regex: 6.2.2
+
+  strip-final-newline@4.0.0: {}
 
   strip-json-comments@3.1.1: {}
 
@@ -4962,18 +5969,21 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  tree-kill@1.2.2: {}
+
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
 
-  tslib@2.8.1:
-    optional: true
+  tslib@2.8.1: {}
 
   tsx@4.22.3:
     dependencies:
       esbuild: 0.28.0
     optionalDependencies:
       fsevents: 2.3.3
+
+  tunnel@0.0.6: {}
 
   type-check@0.4.0:
     dependencies:
@@ -4982,6 +5992,16 @@ snapshots:
   type-fest@5.6.0:
     dependencies:
       tagged-tag: 1.0.0
+
+  typed-inject@5.0.0: {}
+
+  typed-rest-client@2.3.1:
+    dependencies:
+      des.js: 1.1.0
+      js-md4: 0.3.2
+      qs: 6.15.1
+      tunnel: 0.0.6
+      underscore: 1.13.8
 
   typescript-eslint@8.59.4(eslint@9.39.4)(typescript@5.9.3):
     dependencies:
@@ -4999,6 +6019,8 @@ snapshots:
   uglify-js@3.19.3:
     optional: true
 
+  underscore@1.13.8: {}
+
   undici-types@6.21.0: {}
 
   undici-types@7.24.6:
@@ -5009,6 +6031,8 @@ snapshots:
   unenv@2.0.0-rc.24:
     dependencies:
       pathe: 2.0.3
+
+  unicorn-magic@0.3.0: {}
 
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
@@ -5202,6 +6226,8 @@ snapshots:
       - tsx
       - yaml
 
+  weapon-regex@1.3.6: {}
+
   whatwg-mimetype@3.0.0: {}
 
   which@2.0.2:
@@ -5264,6 +6290,8 @@ snapshots:
   yaml@2.9.0: {}
 
   yocto-queue@0.1.0: {}
+
+  yoctocolors@2.1.2: {}
 
   youch-core@0.3.3:
     dependencies:


### PR DESCRIPTION
## Summary

- **ADR-0016** — mutation testing is the CI trust boundary (blocking gate on pure-logic layers; floor ratchets up, never down).
- **Testing & Verification** cross-cutting spec (`docs/specs/cross-cutting/testing.md`) — gate contract, mutator policy, feature integration rules; status `active`.
- **Stryker tooling** — `@stryker-mutator/core` + vitest-runner, `apps/api/stryker.conf.json` scoped to `domain/**` + `application/**`, `thresholds.break: 68` (~3 pts under the 70.82% baseline).
- **CI** — separate `Mutation` workflow (job `mutation`, now a required check alongside `verify`):
  - Always reports on PRs; expensive run is path-scoped (domain/application + config/deps/workflow); fails closed if diff cannot be computed.
  - Daily scheduled full run on `main`; failures open/update a sticky GitHub issue; green closes it.
  - Uploads HTML/JSON reports as artifacts.

## Related

Closes #86
Closes #100

## Test plan

- [x] `pnpm --filter @snaveevans/pineapple-api test:mutation` exits 0 with score **70.82 ≥ 68**
- [x] Branch protection requires `verify` + `mutation` (GitHub Actions)
- [x] Scope detection fails closed when `git diff` errors
- [x] Spec CI-wiring matches workflow path set and sticky-issue behavior
- [ ] CI green on this PR (`verify` + `mutation`)

## Spec / AC

- [docs/specs/cross-cutting/testing.md](docs/specs/cross-cutting/testing.md) — active
- [ADR-0016](docs/decisions/0016-mutation-testing-as-the-ci-trust-boundary.md)

Issue #86 AC:

- [x] Mutation score reported for domain + application (`pnpm --filter @snaveevans/pineapple-api test:mutation`)
- [x] CI fails when score drops below `thresholds.break` (68)
- [x] Threshold and baseline rationale documented in the Testing spec

## Notes

- Follow-up test tightening: #91–#98 (#95 security-relevant).
- Nightly notify implemented in-workflow (closes #100); no Slack/email.