### PR TITLE
test: AssetMetadata validation invariants

### DIFF
--- a/apps/api/src/domain/asset/Asset.test.ts
+++ b/apps/api/src/domain/asset/Asset.test.ts
@@ -2,9 +2,30 @@ import { describe, it, expect } from "vitest";
 import { TeamId, UserId, ValidationError } from "@snaveevans/pineapple-shared";
 import { Asset } from "./Asset";
 
+function expectValidationField(run: () => void, field: string): void {
+  try {
+    run();
+    expect.fail("Expected validation to fail");
+  } catch (error) {
+    expect(error).toBeInstanceOf(ValidationError);
+    expect((error as ValidationError).field).toBe(field);
+  }
+}
+
 describe("Asset", () => {
   const ownerId = UserId.generate();
   const validVehicle = { kind: "vehicle" as const, make: "Ram", model: "2500", year: 2016 };
+  const validProperty = {
+    kind: "property" as const,
+    address: {
+      street: "123 Main St",
+      city: "Austin",
+      state: "TX",
+      postalCode: "78701",
+      country: "US",
+    },
+  };
+  const validEquipment = { kind: "equipment" as const, manufacturer: "Honda" };
 
   it("creates a vehicle asset and emits AssetCreated", () => {
     const asset = Asset.create({ ownerId, name: "My Truck", metadata: validVehicle });
@@ -14,11 +35,15 @@ describe("Asset", () => {
     expect(asset.ownerId).toBe(ownerId);
     expect(asset.sharedTeamId).toBeNull();
     expect(asset.isShared).toBe(false);
+    expect(asset.archivedAt).toBeNull();
+    expect(asset.metadata).toEqual(validVehicle);
 
     const events = asset.pullEvents();
     expect(events).toHaveLength(1);
     expect(events[0]?.type).toBe("AssetCreated");
     expect(events[0]).toMatchObject({
+      assetId: asset.id,
+      ownerId,
       actorId: ownerId,
       assetName: "My Truck",
       assetType: "vehicle",
@@ -29,31 +54,92 @@ describe("Asset", () => {
     expect(asset.pullEvents()).toHaveLength(0);
   });
 
+  it("creates a property asset without assetModelYear on AssetCreated", () => {
+    const asset = Asset.create({ ownerId, name: "Cabin", metadata: validProperty });
+
+    expect(asset.type).toBe("property");
+    expect(asset.metadata).toEqual(validProperty);
+
+    const events = asset.pullEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: "AssetCreated",
+      assetId: asset.id,
+      ownerId,
+      actorId: ownerId,
+      assetName: "Cabin",
+      assetType: "property",
+    });
+    expect(events[0]).not.toHaveProperty("assetModelYear");
+  });
+
+  it("creates an equipment asset without assetModelYear on AssetCreated", () => {
+    const asset = Asset.create({ ownerId, name: "Generator", metadata: validEquipment });
+
+    expect(asset.type).toBe("equipment");
+    const events = asset.pullEvents();
+    expect(events[0]).toMatchObject({
+      type: "AssetCreated",
+      assetType: "equipment",
+      assetName: "Generator",
+    });
+    expect(events[0]).not.toHaveProperty("assetModelYear");
+  });
+
   it("trims whitespace from name", () => {
     const asset = Asset.create({ ownerId, name: "  My Truck  ", metadata: validVehicle });
     expect(asset.name).toBe("My Truck");
   });
 
-  it("rejects blank name", () => {
-    expect(() => Asset.create({ ownerId, name: "   ", metadata: validVehicle })).toThrow(
-      ValidationError,
+  it.each([
+    ["empty", ""],
+    ["whitespace-only", "   "],
+    ["absent", undefined],
+  ] as const)("rejects %s name with field name", (_label, name) => {
+    expectValidationField(
+      () =>
+        Asset.create({
+          ownerId,
+          name: name as string,
+          metadata: validVehicle,
+        }),
+      "name",
     );
   });
 
-  it("rejects invalid vehicle year", () => {
-    expect(() =>
-      Asset.create({ ownerId, name: "Old Truck", metadata: { ...validVehicle, year: 1800 } }),
-    ).toThrow(ValidationError);
+  it("rejects invalid vehicle metadata via create", () => {
+    expectValidationField(
+      () =>
+        Asset.create({
+          ownerId,
+          name: "Old Truck",
+          metadata: { ...validVehicle, year: 1899 },
+        }),
+      "metadata.year",
+    );
   });
 
   it("rejects VIN that is not 17 characters", () => {
-    expect(() =>
-      Asset.create({
-        ownerId,
-        name: "Truck",
-        metadata: { ...validVehicle, vin: "TOOSHORT" },
-      }),
-    ).toThrow(ValidationError);
+    expectValidationField(
+      () =>
+        Asset.create({
+          ownerId,
+          name: "Truck",
+          metadata: { ...validVehicle, vin: "TOOSHORT" },
+        }),
+      "metadata.vin",
+    );
+  });
+
+  it("rename trims and rejects blank names", () => {
+    const asset = Asset.create({ ownerId, name: "Truck", metadata: validVehicle });
+    asset.pullEvents();
+
+    asset.rename("  New Name  ");
+    expect(asset.name).toBe("New Name");
+
+    expectValidationField(() => asset.rename(""), "name");
+    expectValidationField(() => asset.rename("   "), "name");
   });
 
   it("reconstitutes without emitting events", () => {

--- a/apps/api/src/domain/asset/AssetMetadata.test.ts
+++ b/apps/api/src/domain/asset/AssetMetadata.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import { ValidationError } from "@snaveevans/pineapple-shared";
+import {
+  validateMetadata,
+  type Address,
+  type AssetMetadata,
+  type EquipmentMetadata,
+  type PropertyMetadata,
+  type VehicleMetadata,
+} from "./AssetMetadata.ts";
+
+function expectValidationField(run: () => void, field: string): void {
+  try {
+    run();
+    expect.fail("Expected validation to fail");
+  } catch (error) {
+    expect(error).toBeInstanceOf(ValidationError);
+    expect((error as ValidationError).field).toBe(field);
+  }
+}
+
+const validAddress: Address = {
+  street: "123 Main St",
+  city: "Austin",
+  state: "TX",
+  postalCode: "78701",
+  country: "US",
+};
+
+const validVehicle: VehicleMetadata = {
+  kind: "vehicle",
+  make: "Ram",
+  model: "2500",
+  year: 2016,
+};
+
+const validProperty: PropertyMetadata = {
+  kind: "property",
+  address: { ...validAddress },
+};
+
+const validEquipment: EquipmentMetadata = {
+  kind: "equipment",
+  manufacturer: "Honda",
+};
+
+describe("validateMetadata", () => {
+  describe("vehicle", () => {
+    it("accepts valid vehicle metadata", () => {
+      expect(() => validateMetadata(validVehicle)).not.toThrow();
+    });
+
+    it("accepts a 17-character VIN", () => {
+      expect(() => validateMetadata({ ...validVehicle, vin: "1HGBH41JXMN109186" })).not.toThrow();
+    });
+
+    it.each([
+      ["empty", ""],
+      ["whitespace-only", "   "],
+      ["absent", undefined],
+    ] as const)("rejects %s make with field metadata.make", (_label, make) => {
+      const metadata = { ...validVehicle, make } as VehicleMetadata;
+      expectValidationField(() => validateMetadata(metadata), "metadata.make");
+    });
+
+    it.each([
+      ["empty", ""],
+      ["whitespace-only", "   "],
+      ["absent", undefined],
+    ] as const)("rejects %s model with field metadata.model", (_label, model) => {
+      const metadata = { ...validVehicle, model } as VehicleMetadata;
+      expectValidationField(() => validateMetadata(metadata), "metadata.model");
+    });
+
+    it("accepts year at the lower bound 1900", () => {
+      expect(() => validateMetadata({ ...validVehicle, year: 1900 })).not.toThrow();
+    });
+
+    it("rejects year below 1900", () => {
+      expectValidationField(
+        () => validateMetadata({ ...validVehicle, year: 1899 }),
+        "metadata.year",
+      );
+    });
+
+    it("accepts year at the upper bound currentYear + 1", () => {
+      const upper = new Date().getFullYear() + 1;
+      expect(() => validateMetadata({ ...validVehicle, year: upper })).not.toThrow();
+    });
+
+    it("rejects year above currentYear + 1", () => {
+      const above = new Date().getFullYear() + 2;
+      expectValidationField(
+        () => validateMetadata({ ...validVehicle, year: above }),
+        "metadata.year",
+      );
+    });
+
+    it.each([
+      ["too short", "TOOSHORT"],
+      ["16 chars", "A".repeat(16)],
+      ["18 chars", "A".repeat(18)],
+    ] as const)("rejects VIN that is %s with field metadata.vin", (_label, vin) => {
+      expectValidationField(() => validateMetadata({ ...validVehicle, vin }), "metadata.vin");
+    });
+  });
+
+  describe("property", () => {
+    it("accepts valid property metadata", () => {
+      expect(() => validateMetadata(validProperty)).not.toThrow();
+    });
+
+    it.each([
+      ["street", "metadata.address.street"],
+      ["city", "metadata.address.city"],
+      ["state", "metadata.address.state"],
+      ["postalCode", "metadata.address.postalCode"],
+      ["country", "metadata.address.country"],
+    ] as const)("rejects empty %s", (key, field) => {
+      const address = { ...validAddress, [key]: "" };
+      expectValidationField(() => validateMetadata({ kind: "property", address }), field);
+    });
+
+    it.each([
+      ["street", "metadata.address.street"],
+      ["city", "metadata.address.city"],
+      ["state", "metadata.address.state"],
+      ["postalCode", "metadata.address.postalCode"],
+      ["country", "metadata.address.country"],
+    ] as const)("rejects whitespace-only %s", (key, field) => {
+      const address = { ...validAddress, [key]: "   " };
+      expectValidationField(() => validateMetadata({ kind: "property", address }), field);
+    });
+
+    it.each([
+      ["street", "metadata.address.street"],
+      ["city", "metadata.address.city"],
+      ["state", "metadata.address.state"],
+      ["postalCode", "metadata.address.postalCode"],
+      ["country", "metadata.address.country"],
+    ] as const)("rejects absent %s", (key, field) => {
+      const address = { ...validAddress, [key]: undefined };
+      expectValidationField(() => validateMetadata({ kind: "property", address }), field);
+    });
+  });
+
+  describe("equipment", () => {
+    it("accepts equipment metadata with no required fields", () => {
+      expect(() => validateMetadata({ kind: "equipment" })).not.toThrow();
+      expect(() => validateMetadata(validEquipment)).not.toThrow();
+    });
+  });
+
+  it("is reachable for every AssetMetadata kind discriminant", () => {
+    const kinds: AssetMetadata[] = [validVehicle, validProperty, validEquipment];
+    for (const metadata of kinds) {
+      expect(() => validateMetadata(metadata)).not.toThrow();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Add `AssetMetadata.test.ts` covering vehicle/property required-field guards (empty, whitespace, absent) with `ValidationError` + correct `field` paths
- Assert year boundaries exactly: 1900 and `currentYear+1` accepted; 1899 and `currentYear+2` rejected
- Cover VIN length (17 valid; short/16/18 invalid) and equipment no-op path (kills `NoCoverage`)
- Tighten `Asset.test.ts`: name empty/whitespace/absent + `field`, rename guards, property/equipment `AssetCreated` without `assetModelYear`, create-path metadata field assertions

## Related

Closes #93

## Test plan

- [x] `pnpm --filter @snaveevans/pineapple-api test` green (418)
- [x] New/updated tests assert values, error types, payloads — not merely execution
- [ ] CI `verify` + `mutation` green

## Spec / AC

Issue #93 acceptance criteria:

- [x] Each required-field guard has a test proving empty string / whitespace-only / absent is rejected with `ValidationError` and the correct `field` path
- [x] Year validation asserts both boundaries exactly (1900 and `currentYear + 1`, plus one-outside each)
- [x] `AssetMetadata.ts` non-`StringLiteral` survivors reduced to near zero; no `NoCoverage` mutants remain (direct unit coverage of every branch)