### PR TITLE
test: cover GetAsset and ListActivity

### DIFF
--- a/apps/api/src/application/usecases/GetAsset.test.ts
+++ b/apps/api/src/application/usecases/GetAsset.test.ts
@@ -1,0 +1,285 @@
+import { describe, expect, it } from "vitest";
+import {
+  AssetId,
+  Email,
+  ForbiddenError,
+  NotFoundError,
+  UserId,
+  ValidationError,
+} from "@snaveevans/pineapple-shared";
+import { Asset } from "../../domain/asset/Asset.ts";
+import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
+import { User } from "../../domain/identity/User.ts";
+import type { UserRepository } from "../../domain/identity/UserRepository.ts";
+import { createMembership } from "../../domain/team/Membership.ts";
+import { Team } from "../../domain/team/Team.ts";
+import type { TeamRepository } from "../../domain/team/TeamRepository.ts";
+import { GetAsset } from "./GetAsset.ts";
+
+class FakeAssetRepository implements AssetRepository {
+  constructor(private readonly asset: Asset | null) {}
+
+  findById(id: AssetId): Promise<Asset | null> {
+    if (this.asset && this.asset.id === id) return Promise.resolve(this.asset);
+    if (this.asset && id !== this.asset.id) return Promise.resolve(null);
+    return Promise.resolve(this.asset);
+  }
+
+  findVisibleTo(): Promise<Asset[]> {
+    return Promise.resolve([]);
+  }
+
+  save(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+class FakeTeamRepository implements TeamRepository {
+  constructor(private readonly team: Team | null) {}
+
+  findByMember(): Promise<Team | null> {
+    return Promise.resolve(this.team);
+  }
+
+  findById(): Promise<Team | null> {
+    return Promise.resolve(this.team);
+  }
+
+  save(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+class FakeUserRepository implements UserRepository {
+  requestedIds: UserId[] | null = null;
+
+  constructor(private readonly users: User[] = []) {}
+
+  findById(): Promise<User | null> {
+    return Promise.resolve(this.users[0] ?? null);
+  }
+
+  findByIds(ids: readonly UserId[]): Promise<User[]> {
+    this.requestedIds = [...ids];
+    return Promise.resolve(this.users.filter((user) => ids.includes(user.id)));
+  }
+
+  findByEmail(): Promise<User | null> {
+    return Promise.resolve(null);
+  }
+
+  save(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+class ThrowingAssetRepository implements AssetRepository {
+  constructor(private readonly error: Error) {}
+
+  findById(): Promise<Asset | null> {
+    return Promise.reject(this.error);
+  }
+
+  findVisibleTo(): Promise<Asset[]> {
+    return Promise.resolve([]);
+  }
+
+  save(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+function makeAsset(ownerId: UserId): Asset {
+  const asset = Asset.create({
+    ownerId,
+    name: "Truck",
+    metadata: { kind: "vehicle", make: "Ram", model: "2500", year: 2016 },
+  });
+  asset.pullEvents();
+  return asset;
+}
+
+describe("GetAsset", () => {
+  const ownerId = UserId.generate();
+  const memberId = UserId.generate();
+  const strangerId = UserId.generate();
+
+  it("returns the asset with personal sharing when the owner requests it", async () => {
+    const asset = makeAsset(ownerId);
+    const users = new FakeUserRepository();
+
+    const result = await new GetAsset(
+      new FakeAssetRepository(asset),
+      new FakeTeamRepository(null),
+      users,
+    ).execute({ assetId: asset.id, requesterId: ownerId });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.asset).toBe(asset);
+    expect(result.value.sharing).toEqual({ scope: "personal", isOwner: true });
+    expect(users.requestedIds).toBeNull();
+  });
+
+  it("returns team sharing with owner display name for a teammate", async () => {
+    const asset = makeAsset(ownerId);
+    const team = Team.create({ ownerId, name: "Field Ops" });
+    team.pullEvents();
+    const memberTeam = Team.reconstitute({
+      id: team.id,
+      ownerId: team.ownerId,
+      name: team.name,
+      createdAt: team.createdAt,
+      members: [
+        ...team.members,
+        createMembership({ userId: memberId, role: "member", joinedAt: new Date() }),
+      ],
+    });
+    asset.shareToTeam({ teamId: team.id, teamName: team.name, actorId: ownerId });
+    asset.pullEvents();
+
+    const owner = User.reconstitute({
+      id: ownerId,
+      email: Email.from("owner@example.com"),
+      name: "Dale",
+      onboardingCompletedAt: new Date("2026-01-01T00:00:00.000Z"),
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    });
+    const users = new FakeUserRepository([owner]);
+
+    const result = await new GetAsset(
+      new FakeAssetRepository(asset),
+      new FakeTeamRepository(memberTeam),
+      users,
+    ).execute({ assetId: asset.id, requesterId: memberId });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.asset).toBe(asset);
+    expect(result.value.sharing).toEqual({
+      scope: "team",
+      isOwner: false,
+      ownerDisplayName: "Dale",
+    });
+    expect(users.requestedIds).toEqual([ownerId]);
+  });
+
+  it("falls back to Unknown when the owner has no display name", async () => {
+    const asset = makeAsset(ownerId);
+    const team = Team.create({ ownerId, name: "Field Ops" });
+    team.pullEvents();
+    const memberTeam = Team.reconstitute({
+      id: team.id,
+      ownerId: team.ownerId,
+      name: team.name,
+      createdAt: team.createdAt,
+      members: [
+        ...team.members,
+        createMembership({ userId: memberId, role: "member", joinedAt: new Date() }),
+      ],
+    });
+    asset.shareToTeam({ teamId: team.id, teamName: team.name, actorId: ownerId });
+    asset.pullEvents();
+
+    const owner = User.reconstitute({
+      id: ownerId,
+      email: Email.from("owner@example.com"),
+      name: null,
+      onboardingCompletedAt: null,
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    });
+
+    const result = await new GetAsset(
+      new FakeAssetRepository(asset),
+      new FakeTeamRepository(memberTeam),
+      new FakeUserRepository([owner]),
+    ).execute({ assetId: asset.id, requesterId: memberId });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.sharing).toEqual({
+      scope: "team",
+      isOwner: false,
+      ownerDisplayName: "Unknown",
+    });
+  });
+
+  it("falls back to Unknown when the owner user row is missing", async () => {
+    const asset = makeAsset(ownerId);
+    const team = Team.create({ ownerId, name: "Field Ops" });
+    team.pullEvents();
+    const memberTeam = Team.reconstitute({
+      id: team.id,
+      ownerId: team.ownerId,
+      name: team.name,
+      createdAt: team.createdAt,
+      members: [
+        ...team.members,
+        createMembership({ userId: memberId, role: "member", joinedAt: new Date() }),
+      ],
+    });
+    asset.shareToTeam({ teamId: team.id, teamName: team.name, actorId: ownerId });
+    asset.pullEvents();
+
+    const result = await new GetAsset(
+      new FakeAssetRepository(asset),
+      new FakeTeamRepository(memberTeam),
+      new FakeUserRepository([]),
+    ).execute({ assetId: asset.id, requesterId: memberId });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.sharing.ownerDisplayName).toBe("Unknown");
+    expect(result.value.sharing.isOwner).toBe(false);
+    expect(result.value.sharing.scope).toBe("team");
+  });
+
+  it("returns NotFoundError when the asset does not exist", async () => {
+    const result = await new GetAsset(
+      new FakeAssetRepository(null),
+      new FakeTeamRepository(null),
+      new FakeUserRepository(),
+    ).execute({ assetId: AssetId.generate(), requesterId: ownerId });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBeInstanceOf(NotFoundError);
+  });
+
+  it("returns ForbiddenError when a stranger cannot access the asset", async () => {
+    const asset = makeAsset(ownerId);
+
+    const result = await new GetAsset(
+      new FakeAssetRepository(asset),
+      new FakeTeamRepository(null),
+      new FakeUserRepository(),
+    ).execute({ assetId: asset.id, requesterId: strangerId });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBeInstanceOf(ForbiddenError);
+  });
+
+  it("returns DomainError thrown by a dependency as err", async () => {
+    const result = await new GetAsset(
+      new ThrowingAssetRepository(new ValidationError("bad id", "assetId")),
+      new FakeTeamRepository(null),
+      new FakeUserRepository(),
+    ).execute({ assetId: AssetId.generate(), requesterId: ownerId });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBeInstanceOf(ValidationError);
+    expect((result.error as ValidationError).field).toBe("assetId");
+  });
+
+  it("rethrows non-domain errors", async () => {
+    await expect(
+      new GetAsset(
+        new ThrowingAssetRepository(new Error("db down")),
+        new FakeTeamRepository(null),
+        new FakeUserRepository(),
+      ).execute({ assetId: AssetId.generate(), requesterId: ownerId }),
+    ).rejects.toThrow("db down");
+  });
+});

--- a/apps/api/src/application/usecases/ListActivity.test.ts
+++ b/apps/api/src/application/usecases/ListActivity.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+import { ActivityEntryId, AssetId, UserId, ValidationError } from "@snaveevans/pineapple-shared";
+import type { ActivityEntry, ActivityReadModel } from "../../domain/activity/ActivityEntry.ts";
+import type { ActivityLogQuery, ActivityLogRepository } from "../ports/ActivityLogRepository.ts";
+import { DEFAULT_ACTIVITY_LIMIT, ListActivity, MAX_ACTIVITY_LIMIT } from "./ListActivity.ts";
+
+class FakeActivityLogRepository implements ActivityLogRepository {
+  lastQuery: ActivityLogQuery | null = null;
+
+  constructor(private readonly model: ActivityReadModel | (() => Promise<ActivityReadModel>)) {}
+
+  list(query: ActivityLogQuery): Promise<ActivityReadModel> {
+    this.lastQuery = query;
+    if (typeof this.model === "function") return this.model();
+    return Promise.resolve(this.model);
+  }
+}
+
+class ThrowingActivityLogRepository implements ActivityLogRepository {
+  constructor(private readonly error: Error) {}
+
+  list(): Promise<ActivityReadModel> {
+    return Promise.reject(this.error);
+  }
+}
+
+function entry(overrides: Partial<ActivityEntry> = {}): ActivityEntry {
+  const assetId = AssetId.generate();
+  const actorId = UserId.generate();
+  return {
+    id: ActivityEntryId.generate(),
+    type: "asset_added",
+    occurredAt: new Date("2026-07-01T12:00:00.000Z"),
+    asset: { id: assetId, name: "Truck", type: "vehicle" },
+    actor: { id: actorId, displayName: "Dale" },
+    ...overrides,
+  };
+}
+
+function readModel(overrides: Partial<ActivityReadModel> = {}): ActivityReadModel {
+  const viewerUserId = UserId.generate();
+  return {
+    viewerUserId,
+    entries: [],
+    availableFilters: { types: [], assets: [] },
+    nextCursor: null,
+    ...overrides,
+  };
+}
+
+describe("ListActivity", () => {
+  it("exports the activity page size contract", () => {
+    expect(DEFAULT_ACTIVITY_LIMIT).toBe(25);
+    expect(MAX_ACTIVITY_LIMIT).toBe(50);
+  });
+
+  it("returns the activity read model from the repository", async () => {
+    const ownerId = UserId.generate();
+    const assetId = AssetId.generate();
+    const item = entry({
+      type: "maintenance_logged",
+      asset: { id: assetId, name: "Truck", type: "vehicle" },
+      title: "Oil change",
+      performedAt: "2026-06-15",
+    });
+    const model = readModel({
+      viewerUserId: ownerId,
+      entries: [item],
+      availableFilters: {
+        types: [
+          { type: "maintenance_logged", count: 1 },
+          { type: "asset_added", count: 2 },
+        ],
+        assets: [{ asset: { id: assetId, name: "Truck", type: "vehicle" }, count: 1 }],
+      },
+      nextCursor: "cursor-2",
+    });
+    const repo = new FakeActivityLogRepository(model);
+
+    const result = await new ListActivity(repo).execute({
+      ownerId,
+      limit: DEFAULT_ACTIVITY_LIMIT,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toEqual(model);
+    expect(result.value.entries).toHaveLength(1);
+    expect(result.value.entries[0]?.type).toBe("maintenance_logged");
+    expect(result.value.entries[0]?.title).toBe("Oil change");
+    expect(result.value.availableFilters.types).toEqual([
+      { type: "maintenance_logged", count: 1 },
+      { type: "asset_added", count: 2 },
+    ]);
+    expect(result.value.nextCursor).toBe("cursor-2");
+    expect(repo.lastQuery).toEqual({ ownerId, limit: DEFAULT_ACTIVITY_LIMIT });
+  });
+
+  it("forwards type, assetId, and cursor filters to the repository", async () => {
+    const ownerId = UserId.generate();
+    const assetId = AssetId.generate();
+    const model = readModel({ viewerUserId: ownerId });
+    const repo = new FakeActivityLogRepository(model);
+
+    const result = await new ListActivity(repo).execute({
+      ownerId,
+      limit: MAX_ACTIVITY_LIMIT,
+      type: "task_completed",
+      assetId,
+      cursor: "page-token",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toBe(model);
+    expect(repo.lastQuery).toEqual({
+      ownerId,
+      limit: MAX_ACTIVITY_LIMIT,
+      type: "task_completed",
+      assetId,
+      cursor: "page-token",
+    });
+  });
+
+  it("returns an empty page when the repository has no activity", async () => {
+    const ownerId = UserId.generate();
+    const model = readModel({ viewerUserId: ownerId });
+    const repo = new FakeActivityLogRepository(model);
+
+    const result = await new ListActivity(repo).execute({ ownerId, limit: 10 });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.entries).toEqual([]);
+    expect(result.value.nextCursor).toBeNull();
+    expect(result.value.viewerUserId).toBe(ownerId);
+    expect(repo.lastQuery?.limit).toBe(10);
+  });
+
+  it("returns DomainError thrown by the repository as err", async () => {
+    const result = await new ListActivity(
+      new ThrowingActivityLogRepository(new ValidationError("bad cursor", "cursor")),
+    ).execute({ ownerId: UserId.generate(), limit: 25 });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBeInstanceOf(ValidationError);
+    expect((result.error as ValidationError).field).toBe("cursor");
+  });
+
+  it("rethrows non-domain errors", async () => {
+    await expect(
+      new ListActivity(new ThrowingActivityLogRepository(new Error("db down"))).execute({
+        ownerId: UserId.generate(),
+        limit: 25,
+      }),
+    ).rejects.toThrow("db down");
+  });
+});


### PR DESCRIPTION
## Summary

- Add unit tests for `GetAsset`: owner found path (sharing descriptor), teammate path with owner display name / Unknown fallback, not-found (`NotFoundError`), access-denied (`ForbiddenError`), DomainError wrap, non-domain rethrow
- Add unit tests for `ListActivity`: read-model pass-through, filter forwarding (`type`/`assetId`/`cursor`/`limit`), empty page, DomainError wrap, non-domain rethrow, page-size constants
- Assertions pin returned values and error types/fields — not error-message prose

## Related

Closes #91

## Test plan

- [x] `pnpm --filter @snaveevans/pineapple-api test` green (394 tests)
- [x] New tests assert values, error types, payloads — not merely execution
- [ ] CI `verify` + `mutation` green

## Spec / AC

Issue #91 acceptance criteria:

- [x] `GetAsset` has unit tests covering the found / not-found / access-denied paths
- [x] `ListActivity` has unit tests covering its read path and any filtering
- [x] Both files report **no `NoCoverage` mutants** (paths exercised with real assertions)
- [x] Assertions check returned values and error types — not merely that the call doesn't throw