### PR TITLE
test: maintenance date/interval arithmetic boundaries

### DIFF
--- a/apps/api/src/application/usecases/CreateMaintenanceRecord.test.ts
+++ b/apps/api/src/application/usecases/CreateMaintenanceRecord.test.ts
@@ -248,6 +248,76 @@ describe("CreateMaintenanceRecord", () => {
     }
   });
 
+  it("returns validation error for an invalid calendar performed date", async () => {
+    const asset = assetFor();
+    const result = await new CreateMaintenanceRecord(
+      new AssetRepositoryFake(asset),
+      new TeamRepositoryFake(),
+      new MaintenanceRecordWriterFake(),
+      new MaintenanceTaskRepositoryFake(),
+      new EventBusFake(),
+      dates,
+    ).execute({
+      assetId: asset.id,
+      requesterId: ownerId,
+      title: "Changed oil",
+      performedAt: "2026-02-30",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(ValidationError);
+      expect((result.error as ValidationError).field).toBe("performedAt");
+    }
+  });
+
+  it("returns validation error for a title of 101 characters", async () => {
+    const asset = assetFor();
+    const result = await new CreateMaintenanceRecord(
+      new AssetRepositoryFake(asset),
+      new TeamRepositoryFake(),
+      new MaintenanceRecordWriterFake(),
+      new MaintenanceTaskRepositoryFake(),
+      new EventBusFake(),
+      dates,
+    ).execute({
+      assetId: asset.id,
+      requesterId: ownerId,
+      title: "a".repeat(101),
+      performedAt: "2026-06-09",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(ValidationError);
+      expect((result.error as ValidationError).field).toBe("title");
+    }
+  });
+
+  it("accepts a title of exactly 100 characters", async () => {
+    const asset = assetFor();
+    const title = "a".repeat(100);
+    const result = await new CreateMaintenanceRecord(
+      new AssetRepositoryFake(asset),
+      new TeamRepositoryFake(),
+      new MaintenanceRecordWriterFake(),
+      new MaintenanceTaskRepositoryFake(),
+      new EventBusFake(),
+      dates,
+    ).execute({
+      assetId: asset.id,
+      requesterId: ownerId,
+      title,
+      performedAt: "2026-06-09",
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.title).toBe(title);
+      expect(result.value.title).toHaveLength(100);
+    }
+  });
+
   it("normalizes blank notes to null before persistence and response", async () => {
     const asset = assetFor();
     const records = new MaintenanceRecordWriterFake();

--- a/apps/api/src/domain/maintenance/DateOnly.test.ts
+++ b/apps/api/src/domain/maintenance/DateOnly.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { ValidationError } from "@snaveevans/pineapple-shared";
+import { isValidDateOnly, validateDateOnly } from "./DateOnly.ts";
+
+describe("isValidDateOnly", () => {
+  it("accepts well-formed calendar dates including boundaries", () => {
+    expect(isValidDateOnly("0001-01-01")).toBe(true);
+    expect(isValidDateOnly("2026-01-01")).toBe(true);
+    expect(isValidDateOnly("2026-12-31")).toBe(true);
+    expect(isValidDateOnly("2024-02-29")).toBe(true);
+    expect(isValidDateOnly("2026-02-28")).toBe(true);
+  });
+
+  it("rejects bad format", () => {
+    expect(isValidDateOnly("")).toBe(false);
+    expect(isValidDateOnly("not-a-date")).toBe(false);
+    expect(isValidDateOnly("2026/01/01")).toBe(false);
+    expect(isValidDateOnly("2026-1-01")).toBe(false);
+    expect(isValidDateOnly("2026-01-1")).toBe(false);
+    expect(isValidDateOnly("26-01-01")).toBe(false);
+    expect(isValidDateOnly("2026-01-01T00:00:00Z")).toBe(false);
+  });
+
+  it("rejects year 0", () => {
+    expect(isValidDateOnly("0000-01-01")).toBe(false);
+  });
+
+  it("rejects month 0 and month 13", () => {
+    expect(isValidDateOnly("2026-00-15")).toBe(false);
+    expect(isValidDateOnly("2026-13-01")).toBe(false);
+  });
+
+  it("rejects day 0 and days past month end", () => {
+    expect(isValidDateOnly("2026-01-00")).toBe(false);
+    expect(isValidDateOnly("2026-02-30")).toBe(false);
+    expect(isValidDateOnly("2026-02-29")).toBe(false);
+    expect(isValidDateOnly("2026-04-31")).toBe(false);
+    expect(isValidDateOnly("2026-01-32")).toBe(false);
+  });
+});
+
+describe("validateDateOnly", () => {
+  it("accepts a valid date without throwing", () => {
+    expect(() => validateDateOnly("2026-06-11")).not.toThrow();
+  });
+
+  it("throws ValidationError with field for bad format", () => {
+    expect(() => validateDateOnly("nope", "lastCompletedDate")).toThrow(ValidationError);
+    try {
+      validateDateOnly("nope", "lastCompletedDate");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ValidationError);
+      expect((error as ValidationError).field).toBe("lastCompletedDate");
+    }
+  });
+
+  it("throws ValidationError with default field for invalid calendar date", () => {
+    expect(() => validateDateOnly("2026-02-30")).toThrow(ValidationError);
+    try {
+      validateDateOnly("2026-02-30");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ValidationError);
+      expect((error as ValidationError).field).toBe("performedAt");
+    }
+  });
+});

--- a/apps/api/src/domain/maintenance/IntervalUnit.test.ts
+++ b/apps/api/src/domain/maintenance/IntervalUnit.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { INTERVAL_UNITS, addInterval } from "./IntervalUnit.ts";
+
+describe("INTERVAL_UNITS", () => {
+  it("lists day, week, month, and year", () => {
+    expect(INTERVAL_UNITS).toEqual(["day", "week", "month", "year"]);
+  });
+});
+
+describe("addInterval", () => {
+  describe("day", () => {
+    it("advances forward by the given number of days", () => {
+      expect(addInterval("2026-01-15", 1, "day")).toBe("2026-01-16");
+      expect(addInterval("2026-01-15", 30, "day")).toBe("2026-02-14");
+    });
+
+    it("keeps the last day of the month when day equals month length", () => {
+      // kills while (d >= daysInMonth) — Jan 31 must stay Jan 31, not roll to Feb
+      expect(addInterval("2026-01-15", 16, "day")).toBe("2026-01-31");
+      expect(addInterval("2026-01-31", 0, "day")).toBe("2026-01-31");
+    });
+
+    it("rolls across month and year boundaries", () => {
+      expect(addInterval("2026-01-31", 1, "day")).toBe("2026-02-01");
+      expect(addInterval("2026-12-31", 1, "day")).toBe("2027-01-01");
+    });
+  });
+
+  describe("week", () => {
+    it("advances forward by weeks (7-day multiples)", () => {
+      expect(addInterval("2026-01-15", 1, "week")).toBe("2026-01-22");
+      expect(addInterval("2026-01-15", 2, "week")).toBe("2026-01-29");
+    });
+  });
+
+  describe("month", () => {
+    it("advances forward by months", () => {
+      expect(addInterval("2026-01-15", 1, "month")).toBe("2026-02-15");
+      expect(addInterval("2026-01-15", 2, "month")).toBe("2026-03-15");
+    });
+
+    it("clamps end-of-month when target month is shorter (Jan 31 + 1 month)", () => {
+      expect(addInterval("2026-01-31", 1, "month")).toBe("2026-02-28");
+    });
+
+    it("clamps to Feb 29 in a leap year", () => {
+      expect(addInterval("2024-01-31", 1, "month")).toBe("2024-02-29");
+    });
+
+    it("rolls year forward when month overflows (Dec + 1 month)", () => {
+      expect(addInterval("2026-12-15", 1, "month")).toBe("2027-01-15");
+      expect(addInterval("2026-11-30", 2, "month")).toBe("2027-01-30");
+      expect(addInterval("2026-12-31", 1, "month")).toBe("2027-01-31");
+    });
+  });
+
+  describe("year", () => {
+    it("advances forward by years", () => {
+      expect(addInterval("2026-06-11", 1, "year")).toBe("2027-06-11");
+      expect(addInterval("2026-06-11", 3, "year")).toBe("2029-06-11");
+    });
+
+    it("clamps leap-day Feb 29 to Feb 28 in a non-leap year", () => {
+      expect(addInterval("2024-02-29", 1, "year")).toBe("2025-02-28");
+    });
+
+    it("keeps Feb 29 when the target year is also a leap year", () => {
+      expect(addInterval("2024-02-29", 4, "year")).toBe("2028-02-29");
+    });
+  });
+});

--- a/apps/api/src/domain/maintenance/MaintenanceTask.test.ts
+++ b/apps/api/src/domain/maintenance/MaintenanceTask.test.ts
@@ -75,14 +75,45 @@ describe("MaintenanceTask.create", () => {
 
   it("throws ValidationError for empty title", () => {
     expect(() => makeTask({ title: "   " })).toThrow(ValidationError);
+    try {
+      makeTask({ title: "   " });
+    } catch (error) {
+      expect(error).toBeInstanceOf(ValidationError);
+      expect((error as ValidationError).field).toBe("title");
+    }
   });
 
-  it("throws ValidationError for title over 100 chars", () => {
+  it("accepts a title of exactly 100 characters", () => {
+    const title = "a".repeat(100);
+    const task = makeTask({ title });
+    expect(task.title).toBe(title);
+    expect(task.title).toHaveLength(100);
+  });
+
+  it("throws ValidationError for title of 101 characters", () => {
     expect(() => makeTask({ title: "a".repeat(101) })).toThrow(ValidationError);
+    try {
+      makeTask({ title: "a".repeat(101) });
+    } catch (error) {
+      expect(error).toBeInstanceOf(ValidationError);
+      expect((error as ValidationError).field).toBe("title");
+    }
+  });
+
+  it("accepts intervalValue of 1", () => {
+    const task = makeTask({ intervalValue: 1, intervalUnit: "day" });
+    expect(task.intervalValue).toBe(1);
+    expect(task.nextDue).toBe("2026-06-12");
   });
 
   it("throws ValidationError for intervalValue of 0", () => {
     expect(() => makeTask({ intervalValue: 0 })).toThrow(ValidationError);
+    try {
+      makeTask({ intervalValue: 0 });
+    } catch (error) {
+      expect(error).toBeInstanceOf(ValidationError);
+      expect((error as ValidationError).field).toBe("intervalValue");
+    }
   });
 
   it("throws ValidationError for negative intervalValue", () => {
@@ -93,12 +124,38 @@ describe("MaintenanceTask.create", () => {
     expect(() => makeTask({ intervalValue: 1.5 })).toThrow(ValidationError);
   });
 
+  it("throws ValidationError for invalid intervalUnit", () => {
+    expect(() => makeTask({ intervalUnit: "fortnight" as "day" })).toThrow(ValidationError);
+    try {
+      makeTask({ intervalUnit: "fortnight" as "day" });
+    } catch (error) {
+      expect(error).toBeInstanceOf(ValidationError);
+      expect((error as ValidationError).field).toBe("intervalUnit");
+    }
+  });
+
+  it("accepts lastCompletedDate equal to today", () => {
+    const task = makeTask({ lastCompletedDate: today });
+    expect(task.lastCompletedDate).toBe(today);
+    expect(task.nextDue).toBe("2026-08-11");
+  });
+
   it("throws ValidationError for future lastCompletedDate", () => {
     expect(() => makeTask({ lastCompletedDate: "2026-12-31" })).toThrow(ValidationError);
+    try {
+      makeTask({ lastCompletedDate: "2026-12-31" });
+    } catch (error) {
+      expect(error).toBeInstanceOf(ValidationError);
+      expect((error as ValidationError).field).toBe("lastCompletedDate");
+    }
   });
 
   it("throws ValidationError for malformed lastCompletedDate", () => {
     expect(() => makeTask({ lastCompletedDate: "not-a-date" })).toThrow(ValidationError);
+  });
+
+  it("throws ValidationError for invalid calendar lastCompletedDate", () => {
+    expect(() => makeTask({ lastCompletedDate: "2026-02-30" })).toThrow(ValidationError);
   });
 });
 


### PR DESCRIPTION
## Summary

- Add `DateOnly.test.ts` proving invalid dates are rejected (bad format, year 0, month 0/13, day 0, Feb 30 / non-leap Feb 29) and boundary valids (year 1, month 1/12, leap Feb 29).
- Add `IntervalUnit.test.ts` asserting advancement **direction** and end-of-month clamping (Jan 31 + 1mo → Feb 28/29, Dec + 1mo year rollover, day-equality EOM stay, leap Feb 29 year clamp).
- Tighten `MaintenanceTask` title length: exactly 100 accepted, 101 rejected with `field: "title"`; plus intervalValue=1, invalid unit, lastCompletedDate=today.
- Extend `CreateMaintenanceRecord` with invalid calendar `performedAt`, title 100/101 boundaries.

Targets sample survivors from #96 (ArithmeticOperator direction, EqualityOperator EOM/`>=` vs `>`, ConditionalExpression always-true validation, title `>` vs `>=`).

## Related

Closes #96

## Test plan

- [x] `pnpm --filter @snaveevans/pineapple-api test` green
- [x] New/updated tests assert values, error types/fields — not merely execution
- [ ] CI `verify` + `mutation` green

## Spec / AC

Issue #96 acceptance criteria:

- [x] `DateOnly` rejects invalid dates (bad format, month 0/13, day 0, Feb 30, year 0)
- [x] `IntervalUnit` advancement asserts direction and EOM clamp (Jan 31+1mo, Dec+1mo rollover, leap Feb 29)
- [x] `MaintenanceTask` title length asserts exactly 100 (valid) and 101 (invalid)
- [x] Non-`StringLiteral` survivors across these files reduced toward zero (direct boundary assertions for listed mutants)