### PR TITLE
test: dashboard & list-assets computed read models

### DIFF
--- a/apps/api/src/application/usecases/GetDashboard.test.ts
+++ b/apps/api/src/application/usecases/GetDashboard.test.ts
@@ -50,6 +50,8 @@ class MaintenanceTaskRepositoryFake implements MaintenanceTaskRepository {
 }
 
 class UserRepositoryFake implements UserRepository {
+  findByIdsCalls: UserId[][] = [];
+
   constructor(private readonly users: User[] = []) {}
 
   findById(): Promise<User | null> {
@@ -57,6 +59,7 @@ class UserRepositoryFake implements UserRepository {
   }
 
   findByIds(ids: readonly UserId[]): Promise<User[]> {
+    this.findByIdsCalls.push([...ids]);
     return Promise.resolve(this.users.filter((user) => ids.includes(user.id)));
   }
 
@@ -72,15 +75,32 @@ class UserRepositoryFake implements UserRepository {
 describe("GetDashboard", () => {
   const ownerId = UserId.generate();
   const teammateId = UserId.generate();
+  const otherTeammateId = UserId.generate();
   const teamId = TeamId.generate();
   const todayUtc = "2026-06-16";
 
-  function vehicle(name = "Truck", props?: { ownerId?: UserId; sharedTeamId?: TeamId | null }) {
+  function vehicle(
+    name = "Truck",
+    props?: { ownerId?: UserId; sharedTeamId?: TeamId | null; archivedAt?: Date | null },
+  ) {
     return Asset.reconstitute({
       id: AssetId.generate(),
       ownerId: props?.ownerId ?? ownerId,
       name,
       metadata: { kind: "vehicle", make: "Ford", model: "F-150", year: 2020 },
+      archivedAt: props?.archivedAt ?? null,
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+      sharedTeamId: props?.sharedTeamId ?? null,
+    });
+  }
+
+  function equipment(name = "Mower", props?: { ownerId?: UserId; sharedTeamId?: TeamId | null }) {
+    return Asset.reconstitute({
+      id: AssetId.generate(),
+      ownerId: props?.ownerId ?? ownerId,
+      name,
+      metadata: { kind: "equipment" },
       archivedAt: null,
       createdAt: new Date("2026-01-01T00:00:00.000Z"),
       updatedAt: new Date("2026-01-01T00:00:00.000Z"),
@@ -88,11 +108,25 @@ describe("GetDashboard", () => {
     });
   }
 
-  function equipment(name = "Mower") {
-    return Asset.create({
+  function property(name = "Cabin") {
+    return Asset.reconstitute({
+      id: AssetId.generate(),
       ownerId,
       name,
-      metadata: { kind: "equipment" },
+      metadata: {
+        kind: "property",
+        address: {
+          street: "123 Main St",
+          city: "Denver",
+          state: "CO",
+          postalCode: "80202",
+          country: "US",
+        },
+      },
+      archivedAt: null,
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+      sharedTeamId: null,
     });
   }
 
@@ -104,6 +138,8 @@ describe("GetDashboard", () => {
       createdAt?: Date;
       lastCompletedDate?: string | null;
       ownerId?: UserId;
+      intervalValue?: number;
+      intervalUnit?: "day" | "week" | "month" | "year";
     },
   ) {
     return MaintenanceTask.reconstitute({
@@ -111,25 +147,44 @@ describe("GetDashboard", () => {
       assetId,
       ownerId: props.ownerId ?? ownerId,
       title: props.title,
-      intervalValue: 1,
-      intervalUnit: "month",
+      intervalValue: props.intervalValue ?? 1,
+      intervalUnit: props.intervalUnit ?? "month",
       lastCompletedDate: props.lastCompletedDate ?? null,
       nextDue: props.nextDue,
       createdAt: props.createdAt ?? new Date("2026-01-01T00:00:00.000Z"),
     });
   }
 
-  function dashboard(assets: Asset[], tasks: MaintenanceTask[], users: User[] = []): GetDashboard {
-    return new GetDashboard(
-      new AssetRepositoryFake(assets),
-      new MaintenanceTaskRepositoryFake(tasks),
-      new FixedDateProvider(todayUtc),
-      new UserRepositoryFake(users),
-    );
+  function user(id: UserId, name: string | null, email = "user@example.com"): User {
+    return User.reconstitute({
+      id,
+      email: Email.from(email),
+      name,
+      onboardingCompletedAt: name === null ? null : new Date("2026-01-01T00:00:00.000Z"),
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    });
+  }
+
+  function dashboard(
+    assets: Asset[],
+    tasks: MaintenanceTask[],
+    users: User[] = [],
+  ): { useCase: GetDashboard; users: UserRepositoryFake } {
+    const usersFake = new UserRepositoryFake(users);
+    return {
+      useCase: new GetDashboard(
+        new AssetRepositoryFake(assets),
+        new MaintenanceTaskRepositoryFake(tasks),
+        new FixedDateProvider(todayUtc),
+        usersFake,
+      ),
+      users: usersFake,
+    };
   }
 
   it("returns empty dashboard state when the owner has no active assets", async () => {
-    const result = await dashboard([], []).execute({ ownerId, viewerDisplayName: "Dale" });
+    const { useCase, users } = dashboard([], []);
+    const result = await useCase.execute({ ownerId, viewerDisplayName: "Dale" });
 
     expect(result.ok).toBe(true);
     if (!result.ok) return;
@@ -141,19 +196,66 @@ describe("GetDashboard", () => {
       queueCountsByCategory: { all: 0, vehicle: 0, equipment: 0, property: 0 },
       queue: [],
     });
+    expect(users.findByIdsCalls).toEqual([]);
+  });
+
+  it("asserts exact per-type fleet totals and multi-bucket fleet health", async () => {
+    const overdueVehicle = vehicle("Overdue truck");
+    const soonVehicle = vehicle("Soon truck");
+    const onTrackEquipment = equipment("On-track mower");
+    const unscheduledProperty = property("Cabin");
+    const secondUnscheduled = equipment("Spare generator");
+
+    const { useCase } = dashboard(
+      [overdueVehicle, soonVehicle, onTrackEquipment, unscheduledProperty, secondUnscheduled],
+      [
+        task(overdueVehicle.id, { title: "Oil change", nextDue: "2026-06-10" }),
+        task(soonVehicle.id, { title: "Tire rotation", nextDue: "2026-06-20" }),
+        task(onTrackEquipment.id, { title: "Blade sharpen", nextDue: "2026-08-01" }),
+      ],
+    );
+    const result = await useCase.execute({ ownerId, viewerDisplayName: null });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // Exact counts kill totals[type]++ → -- and health bucket ++ → --
+    expect(result.value.fleetTotals).toEqual({
+      total: 5,
+      vehicle: 2,
+      equipment: 2,
+      property: 1,
+    });
+    expect(result.value.fleetHealth).toEqual({
+      overdue: 1,
+      soon: 1,
+      onTrack: 1,
+      unscheduled: 2,
+    });
+    expect(result.value.queueCountsByCategory).toEqual({
+      all: 3,
+      vehicle: 2,
+      equipment: 1,
+      property: 0,
+    });
   });
 
   it("counts unscheduled assets separately from on-track assets", async () => {
     const truck = vehicle();
     const mower = equipment();
-    const result = await dashboard(
+    const { useCase } = dashboard(
       [truck, mower],
       [task(truck.id, { title: "Oil change", nextDue: "2026-08-01" })],
-    ).execute({ ownerId, viewerDisplayName: null });
+    );
+    const result = await useCase.execute({ ownerId, viewerDisplayName: null });
 
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(result.value.fleetTotals.total).toBe(2);
+    expect(result.value.fleetTotals).toEqual({
+      total: 2,
+      vehicle: 1,
+      equipment: 1,
+      property: 0,
+    });
     expect(result.value.fleetHealth).toEqual({
       overdue: 0,
       soon: 0,
@@ -164,13 +266,14 @@ describe("GetDashboard", () => {
 
   it("uses the most urgent task per asset for fleet health counts", async () => {
     const truck = vehicle();
-    const result = await dashboard(
+    const { useCase } = dashboard(
       [truck],
       [
         task(truck.id, { title: "Annual inspection", nextDue: "2026-08-01" }),
         task(truck.id, { title: "Oil change", nextDue: "2026-06-10" }),
       ],
-    ).execute({ ownerId, viewerDisplayName: "Dale" });
+    );
+    const result = await useCase.execute({ ownerId, viewerDisplayName: "Dale" });
 
     expect(result.ok).toBe(true);
     if (!result.ok) return;
@@ -180,13 +283,31 @@ describe("GetDashboard", () => {
       onTrack: 0,
       unscheduled: 0,
     });
+    // Both tasks still appear in the queue with exact order and fields
+    expect(result.value.queue.map((item) => item.taskTitle)).toEqual([
+      "Oil change",
+      "Annual inspection",
+    ]);
+    expect(result.value.queue[0]).toMatchObject({
+      status: "overdue",
+      daysDue: -6,
+      assetId: truck.id,
+      assetName: "Truck",
+      assetType: "vehicle",
+    });
+    expect(result.value.queue[1]).toMatchObject({
+      status: "ok",
+      daysDue: 46,
+      assetType: "vehicle",
+    });
   });
 
   it("sorts queue items by urgency, nextDue, then createdAt", async () => {
     const truck = vehicle();
     const mower = equipment();
-    const result = await dashboard(
-      [truck, mower],
+    const cabin = property();
+    const { useCase } = dashboard(
+      [truck, mower, cabin],
       [
         task(mower.id, {
           title: "Blade sharpen",
@@ -197,89 +318,146 @@ describe("GetDashboard", () => {
           title: "Oil change",
           nextDue: "2026-06-10",
           createdAt: new Date("2026-01-01T00:00:00.000Z"),
+          lastCompletedDate: "2026-05-10",
+          intervalValue: 3,
+          intervalUnit: "month",
         }),
         task(truck.id, {
           title: "Tire rotation",
           nextDue: "2026-06-10",
           createdAt: new Date("2026-03-01T00:00:00.000Z"),
         }),
+        task(cabin.id, {
+          title: "Gutter clean",
+          nextDue: "2026-06-20",
+          createdAt: new Date("2026-01-15T00:00:00.000Z"),
+        }),
+        task(mower.id, {
+          title: "Belt check",
+          nextDue: "2026-09-01",
+          createdAt: new Date("2026-01-01T00:00:00.000Z"),
+        }),
       ],
-    ).execute({ ownerId, viewerDisplayName: "Dale" });
+    );
+    const result = await useCase.execute({ ownerId, viewerDisplayName: "Dale" });
 
     expect(result.ok).toBe(true);
     if (!result.ok) return;
+    // Pin full order: overdue by createdAt, soon by nextDue then createdAt, then ok
     expect(result.value.queue.map((item) => item.taskTitle)).toEqual([
       "Oil change",
       "Tire rotation",
+      "Gutter clean",
       "Blade sharpen",
+      "Belt check",
     ]);
-    expect(result.value.queue[0]?.status).toBe("overdue");
-    expect(result.value.queue[0]?.daysDue).toBe(-6);
-    expect(result.value.queue[2]?.status).toBe("soon");
-    expect(result.value.queue[2]?.daysDue).toBe(4);
+    expect(result.value.queue.map((item) => item.status)).toEqual([
+      "overdue",
+      "overdue",
+      "soon",
+      "soon",
+      "ok",
+    ]);
+    expect(result.value.queue.map((item) => item.daysDue)).toEqual([-6, -6, 4, 4, 77]);
+    expect(result.value.queue[0]).toMatchObject({
+      taskTitle: "Oil change",
+      nextDue: "2026-06-10",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      intervalValue: 3,
+      intervalUnit: "month",
+      lastCompletedDate: "2026-05-10",
+      assetId: truck.id,
+      assetName: "Truck",
+      assetType: "vehicle",
+    });
     expect(result.value.queueCountsByCategory).toEqual({
-      all: 3,
+      all: 5,
       vehicle: 2,
-      equipment: 1,
-      property: 0,
+      equipment: 2,
+      property: 1,
     });
   });
 
   it("omits tasks whose asset is absent from the active asset snapshot", async () => {
     const truck = vehicle("Active truck");
-    const archived = Asset.reconstitute({
-      id: AssetId.generate(),
-      ownerId,
-      name: "Archived truck",
-      metadata: { kind: "vehicle", make: "Ford", model: "Transit", year: 2019 },
+    const archived = vehicle("Archived truck", {
       archivedAt: new Date("2026-05-01T00:00:00.000Z"),
-      createdAt: new Date("2026-01-01T00:00:00.000Z"),
-      updatedAt: new Date("2026-05-01T00:00:00.000Z"),
     });
-    const result = await dashboard(
+    const { useCase } = dashboard(
       [truck, archived],
       [
         task(truck.id, { title: "Active task", nextDue: "2026-06-20" }),
         task(archived.id, { title: "Orphan task", nextDue: "2026-06-10" }),
       ],
-    ).execute({ ownerId, viewerDisplayName: "Dale" });
+    );
+    const result = await useCase.execute({ ownerId, viewerDisplayName: "Dale" });
 
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(result.value.queue).toHaveLength(1);
-    expect(result.value.queue[0]?.taskTitle).toBe("Active task");
+    expect(result.value.queue.map((item) => item.taskTitle)).toEqual(["Active task"]);
+    expect(result.value.fleetTotals).toEqual({
+      total: 1,
+      vehicle: 1,
+      equipment: 0,
+      property: 0,
+    });
+    expect(result.value.queueCountsByCategory).toEqual({
+      all: 1,
+      vehicle: 1,
+      equipment: 0,
+      property: 0,
+    });
   });
 
   it("excludes archived assets from totals and queue", async () => {
     const active = vehicle("Active truck");
-    const archived = Asset.reconstitute({
-      id: AssetId.generate(),
-      ownerId,
-      name: "Archived truck",
-      metadata: { kind: "vehicle", make: "Ford", model: "Transit", year: 2019 },
+    const archived = vehicle("Archived truck", {
       archivedAt: new Date("2026-05-01T00:00:00.000Z"),
-      createdAt: new Date("2026-01-01T00:00:00.000Z"),
-      updatedAt: new Date("2026-05-01T00:00:00.000Z"),
     });
-    const result = await dashboard(
+    const { useCase } = dashboard(
       [active, archived],
       // findForVisibleActiveAssets omits archived-asset tasks; see D1MaintenanceTaskRepository.test.ts
       [task(active.id, { title: "Oil change", nextDue: "2026-06-20" })],
-    ).execute({ ownerId, viewerDisplayName: "Dale" });
+    );
+    const result = await useCase.execute({ ownerId, viewerDisplayName: "Dale" });
 
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(result.value.fleetTotals.total).toBe(1);
+    expect(result.value.fleetTotals).toEqual({
+      total: 1,
+      vehicle: 1,
+      equipment: 0,
+      property: 0,
+    });
     expect(result.value.queue).toHaveLength(1);
     expect(result.value.queue[0]?.assetName).toBe("Active truck");
   });
 
-  it("attaches personal sharing on owned personal assets", async () => {
+  it("does not resolve owner names when every active asset is owned by the requester", async () => {
     const truck = vehicle("Personal truck");
-    const result = await dashboard(
+    const { useCase, users } = dashboard(
       [truck],
       [task(truck.id, { title: "Oil change", nextDue: "2026-06-20" })],
-    ).execute({ ownerId, viewerDisplayName: "Dale" });
+      [user(ownerId, "Dale", "dale@example.com"), user(teammateId, "Pat", "pat@example.com")],
+    );
+    const result = await useCase.execute({ ownerId, viewerDisplayName: "Dale" });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(users.findByIdsCalls).toEqual([]);
+    expect(result.value.queue[0]?.sharing).toEqual({
+      scope: "personal",
+      isOwner: true,
+    });
+  });
+
+  it("attaches personal sharing on owned personal assets", async () => {
+    const truck = vehicle("Personal truck");
+    const { useCase } = dashboard(
+      [truck],
+      [task(truck.id, { title: "Oil change", nextDue: "2026-06-20" })],
+    );
+    const result = await useCase.execute({ ownerId, viewerDisplayName: "Dale" });
 
     expect(result.ok).toBe(true);
     if (!result.ok) return;
@@ -291,46 +469,122 @@ describe("GetDashboard", () => {
 
   it("attaches team sharing without ownerDisplayName when the caller owns a shared asset", async () => {
     const truck = vehicle("Shared truck", { sharedTeamId: teamId });
-    const result = await dashboard(
+    const { useCase, users } = dashboard(
       [truck],
       [task(truck.id, { title: "Oil change", nextDue: "2026-06-20" })],
-    ).execute({ ownerId, viewerDisplayName: "Dale" });
+      [user(teammateId, "Pat", "pat@example.com")],
+    );
+    const result = await useCase.execute({ ownerId, viewerDisplayName: "Dale" });
 
     expect(result.ok).toBe(true);
     if (!result.ok) return;
+    // Own shared asset must not trigger other-owner lookup
+    expect(users.findByIdsCalls).toEqual([]);
     expect(result.value.queue[0]?.sharing).toEqual({
       scope: "team",
       isOwner: true,
     });
   });
 
-  it("attaches team sharing with ownerDisplayName when the asset is shared with the caller", async () => {
-    const shared = vehicle("Teammate truck", { ownerId: teammateId, sharedTeamId: teamId });
-    const teammate = User.reconstitute({
-      id: teammateId,
-      email: Email.from("teammate@example.com"),
-      name: "Pat",
-      onboardingCompletedAt: new Date("2026-01-01T00:00:00.000Z"),
-      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  it("resolves ownerDisplayName only for assets owned by others", async () => {
+    const owned = vehicle("My truck", { sharedTeamId: teamId });
+    const sharedFromTeammate = vehicle("Teammate truck", {
+      ownerId: teammateId,
+      sharedTeamId: teamId,
     });
-    const result = await dashboard(
-      [shared],
+    const sharedFromOther = equipment("Other mower", {
+      ownerId: otherTeammateId,
+      sharedTeamId: teamId,
+    });
+    const teammate = user(teammateId, "Pat", "pat@example.com");
+    const other = user(otherTeammateId, "Sam", "sam@example.com");
+    const { useCase, users } = dashboard(
+      [owned, sharedFromTeammate, sharedFromOther],
       [
-        task(shared.id, {
-          title: "Oil change",
-          nextDue: "2026-06-20",
+        task(owned.id, { title: "Mine", nextDue: "2026-06-20" }),
+        task(sharedFromTeammate.id, {
+          title: "Pat's oil",
+          nextDue: "2026-06-18",
           ownerId: teammateId,
         }),
+        task(sharedFromOther.id, {
+          title: "Sam's blade",
+          nextDue: "2026-06-19",
+          ownerId: otherTeammateId,
+        }),
       ],
-      [teammate],
-    ).execute({ ownerId, viewerDisplayName: "Dale" });
+      [teammate, other, user(ownerId, "Dale", "dale@example.com")],
+    );
+    const result = await useCase.execute({ ownerId, viewerDisplayName: "Dale" });
 
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(result.value.queue[0]?.sharing).toEqual({
+    expect(users.findByIdsCalls).toHaveLength(1);
+    expect(new Set(users.findByIdsCalls[0])).toEqual(new Set([teammateId, otherTeammateId]));
+    expect(users.findByIdsCalls[0]).not.toContain(ownerId);
+
+    const byTitle = Object.fromEntries(
+      result.value.queue.map((item) => [item.taskTitle, item.sharing]),
+    );
+    expect(byTitle["Mine"]).toEqual({ scope: "team", isOwner: true });
+    expect(byTitle["Pat's oil"]).toEqual({
       scope: "team",
       isOwner: false,
       ownerDisplayName: "Pat",
+    });
+    expect(byTitle["Sam's blade"]).toEqual({
+      scope: "team",
+      isOwner: false,
+      ownerDisplayName: "Sam",
+    });
+  });
+
+  it("falls back to Unknown when another owner has a null name or is missing", async () => {
+    const namelessOwnerId = UserId.generate();
+    const missingOwnerId = UserId.generate();
+    const namelessShared = vehicle("Nameless truck", {
+      ownerId: namelessOwnerId,
+      sharedTeamId: teamId,
+    });
+    const missingShared = vehicle("Missing owner truck", {
+      ownerId: missingOwnerId,
+      sharedTeamId: teamId,
+    });
+    const { useCase, users } = dashboard(
+      [namelessShared, missingShared],
+      [
+        task(namelessShared.id, {
+          title: "Nameless task",
+          nextDue: "2026-06-18",
+          ownerId: namelessOwnerId,
+        }),
+        task(missingShared.id, {
+          title: "Missing task",
+          nextDue: "2026-06-19",
+          ownerId: missingOwnerId,
+        }),
+      ],
+      // only nameless owner is returned; missing owner is absent from the repo
+      [user(namelessOwnerId, null, "nameless@example.com")],
+    );
+    const result = await useCase.execute({ ownerId, viewerDisplayName: "Dale" });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(users.findByIdsCalls).toHaveLength(1);
+    expect(new Set(users.findByIdsCalls[0])).toEqual(new Set([namelessOwnerId, missingOwnerId]));
+    const byTitle = Object.fromEntries(
+      result.value.queue.map((item) => [item.taskTitle, item.sharing]),
+    );
+    expect(byTitle["Nameless task"]).toEqual({
+      scope: "team",
+      isOwner: false,
+      ownerDisplayName: "Unknown",
+    });
+    expect(byTitle["Missing task"]).toEqual({
+      scope: "team",
+      isOwner: false,
+      ownerDisplayName: "Unknown",
     });
   });
 });

--- a/apps/api/src/application/usecases/ListAssets.test.ts
+++ b/apps/api/src/application/usecases/ListAssets.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { AssetId, UserId } from "@snaveevans/pineapple-shared";
+import { AssetId, Email, TeamId, UserId } from "@snaveevans/pineapple-shared";
 import { Asset } from "../../domain/asset/Asset.ts";
 import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
 import { User } from "../../domain/identity/User.ts";
@@ -17,7 +17,8 @@ class AssetRepositoryFake implements AssetRepository {
 
   findVisibleTo(userId: UserId): Promise<Asset[]> {
     this.requestedUserId = userId;
-    return Promise.resolve(this.assets.filter((asset) => asset.ownerId === userId));
+    // Return the visible set as-is; owner/team access is enforced by the real repo.
+    return Promise.resolve(this.assets);
   }
 
   save(): Promise<void> {
@@ -26,12 +27,17 @@ class AssetRepositoryFake implements AssetRepository {
 }
 
 class UserRepositoryFake implements UserRepository {
+  findByIdsCalls: UserId[][] = [];
+
+  constructor(private readonly users: User[] = []) {}
+
   findById(): Promise<User | null> {
     return Promise.resolve(null);
   }
 
-  findByIds(): Promise<User[]> {
-    return Promise.resolve([]);
+  findByIds(ids: readonly UserId[]): Promise<User[]> {
+    this.findByIdsCalls.push([...ids]);
+    return Promise.resolve(this.users.filter((user) => ids.includes(user.id)));
   }
 
   findByEmail(): Promise<User | null> {
@@ -45,21 +51,62 @@ class UserRepositoryFake implements UserRepository {
 
 describe("ListAssets", () => {
   const ownerId = UserId.generate();
+  const teammateId = UserId.generate();
+  const otherTeammateId = UserId.generate();
+  const teamId = TeamId.generate();
 
-  it("returns active owner assets with counts from the same set", async () => {
-    const vehicle = Asset.create({
-      ownerId,
-      name: "Truck",
+  function user(id: UserId, name: string | null, email: string): User {
+    return User.reconstitute({
+      id,
+      email: Email.from(email),
+      name,
+      onboardingCompletedAt: name === null ? null : new Date("2026-01-01T00:00:00.000Z"),
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    });
+  }
+
+  function vehicle(
+    name: string,
+    props?: {
+      ownerId?: UserId;
+      sharedTeamId?: TeamId | null;
+      archivedAt?: Date | null;
+      id?: AssetId;
+    },
+  ): Asset {
+    return Asset.reconstitute({
+      id: props?.id ?? AssetId.generate(),
+      ownerId: props?.ownerId ?? ownerId,
+      name,
       metadata: { kind: "vehicle", make: "Ford", model: "F-150", year: 2020 },
+      archivedAt: props?.archivedAt ?? null,
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+      sharedTeamId: props?.sharedTeamId ?? null,
     });
-    const equipment = Asset.create({
-      ownerId,
-      name: "Generator",
+  }
+
+  function equipment(
+    name: string,
+    props?: { ownerId?: UserId; sharedTeamId?: TeamId | null },
+  ): Asset {
+    return Asset.reconstitute({
+      id: AssetId.generate(),
+      ownerId: props?.ownerId ?? ownerId,
+      name,
       metadata: { kind: "equipment" },
+      archivedAt: null,
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+      sharedTeamId: props?.sharedTeamId ?? null,
     });
-    const property = Asset.create({
+  }
+
+  function property(name: string): Asset {
+    return Asset.reconstitute({
+      id: AssetId.generate(),
       ownerId,
-      name: "Cabin",
+      name,
       metadata: {
         kind: "property",
         address: {
@@ -70,56 +117,73 @@ describe("ListAssets", () => {
           country: "US",
         },
       },
-    });
-    const archived = Asset.reconstitute({
-      id: AssetId.generate(),
-      ownerId,
-      name: "Archived mower",
-      metadata: { kind: "equipment" },
-      archivedAt: new Date("2026-06-01T00:00:00.000Z"),
+      archivedAt: null,
       createdAt: new Date("2026-01-01T00:00:00.000Z"),
-      updatedAt: new Date("2026-06-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+      sharedTeamId: null,
     });
-    const otherOwnerAsset = Asset.create({
-      ownerId: UserId.generate(),
-      name: "Other truck",
-      metadata: { kind: "vehicle", make: "Ford", model: "Ranger", year: 2020 },
-    });
-    const repository = new AssetRepositoryFake([
-      vehicle,
-      equipment,
-      property,
-      archived,
-      otherOwnerAsset,
-    ]);
+  }
 
-    const result = await new ListAssets(repository, new UserRepositoryFake()).execute({
+  it("returns active assets with exact per-type counts in repository order", async () => {
+    const vehicleA = vehicle("Truck A");
+    const vehicleB = vehicle("Truck B");
+    const equip = equipment("Generator");
+    const cabin = property("Cabin");
+    const secondEquip = equipment("Mower");
+    const archived = vehicle("Archived mower", {
+      archivedAt: new Date("2026-06-01T00:00:00.000Z"),
+    });
+    // Visible set includes a foreign asset that findVisibleTo would not return in
+    // production for a non-shared case — here the fake returns the full list so we
+    // can pin order preservation and archived filtering independently.
+    const repository = new AssetRepositoryFake([
+      vehicleA,
+      archived,
+      equip,
+      cabin,
+      vehicleB,
+      secondEquip,
+    ]);
+    const users = new UserRepositoryFake();
+
+    const result = await new ListAssets(repository, users).execute({
       requesterId: ownerId,
     });
 
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(result.value.assets.map((item) => item.asset)).toEqual([vehicle, equipment, property]);
+    // Order is repository order with archived stripped — not re-sorted
+    expect(result.value.assets.map((item) => item.asset.name)).toEqual([
+      "Truck A",
+      "Generator",
+      "Cabin",
+      "Truck B",
+      "Mower",
+    ]);
+    expect(result.value.assets.map((item) => item.asset.id)).toEqual([
+      vehicleA.id,
+      equip.id,
+      cabin.id,
+      vehicleB.id,
+      secondEquip.id,
+    ]);
     expect(result.value.assets.every((item) => item.sharing.isOwner)).toBe(true);
-    expect(result.value.counts).toEqual({ all: 3, vehicle: 1, equipment: 1, property: 1 });
+    expect(result.value.assets.every((item) => item.sharing.scope === "personal")).toBe(true);
+    // Exact multi-type totals kill counts[type]++ → --
+    expect(result.value.counts).toEqual({ all: 5, vehicle: 2, equipment: 2, property: 1 });
     expect(repository.requestedUserId).toBe(ownerId);
+    expect(users.findByIdsCalls).toEqual([]);
   });
 
   it("returns zero counts when the owner has no active assets", async () => {
-    const archived = Asset.reconstitute({
-      id: AssetId.generate(),
-      ownerId,
-      name: "Archived truck",
-      metadata: { kind: "vehicle", make: "Ford", model: "Transit", year: 2020 },
+    const archived = vehicle("Archived truck", {
       archivedAt: new Date("2026-06-01T00:00:00.000Z"),
-      createdAt: new Date("2026-01-01T00:00:00.000Z"),
-      updatedAt: new Date("2026-06-01T00:00:00.000Z"),
     });
+    const users = new UserRepositoryFake([user(teammateId, "Pat", "pat@example.com")]);
 
-    const result = await new ListAssets(
-      new AssetRepositoryFake([archived]),
-      new UserRepositoryFake(),
-    ).execute({ requesterId: ownerId });
+    const result = await new ListAssets(new AssetRepositoryFake([archived]), users).execute({
+      requesterId: ownerId,
+    });
 
     expect(result).toEqual({
       ok: true,
@@ -127,6 +191,119 @@ describe("ListAssets", () => {
         assets: [],
         counts: { all: 0, vehicle: 0, equipment: 0, property: 0 },
       },
+    });
+    expect(users.findByIdsCalls).toEqual([]);
+  });
+
+  it("does not look up owner names when every active asset is owned by the requester", async () => {
+    const ownedShared = vehicle("Shared truck", { sharedTeamId: teamId });
+    const users = new UserRepositoryFake([
+      user(ownerId, "Dale", "dale@example.com"),
+      user(teammateId, "Pat", "pat@example.com"),
+    ]);
+
+    const result = await new ListAssets(new AssetRepositoryFake([ownedShared]), users).execute({
+      requesterId: ownerId,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(users.findByIdsCalls).toEqual([]);
+    expect(result.value.assets[0]?.sharing).toEqual({
+      scope: "team",
+      isOwner: true,
+    });
+    expect(result.value.counts).toEqual({ all: 1, vehicle: 1, equipment: 0, property: 0 });
+  });
+
+  it("resolves ownerDisplayName for assets owned by others and not the requester", async () => {
+    const owned = vehicle("My truck", { sharedTeamId: teamId });
+    const fromTeammate = vehicle("Pat truck", {
+      ownerId: teammateId,
+      sharedTeamId: teamId,
+    });
+    const fromOther = equipment("Sam mower", {
+      ownerId: otherTeammateId,
+      sharedTeamId: teamId,
+    });
+    // Duplicate other-owner assets must still produce a single id in the lookup set
+    const fromTeammateAgain = vehicle("Pat second truck", {
+      ownerId: teammateId,
+      sharedTeamId: teamId,
+    });
+    const users = new UserRepositoryFake([
+      user(teammateId, "Pat", "pat@example.com"),
+      user(otherTeammateId, "Sam", "sam@example.com"),
+      user(ownerId, "Dale", "dale@example.com"),
+    ]);
+    const repository = new AssetRepositoryFake([owned, fromTeammate, fromOther, fromTeammateAgain]);
+
+    const result = await new ListAssets(repository, users).execute({ requesterId: ownerId });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(users.findByIdsCalls).toHaveLength(1);
+    expect(new Set(users.findByIdsCalls[0])).toEqual(new Set([teammateId, otherTeammateId]));
+    expect(users.findByIdsCalls[0]).not.toContain(ownerId);
+    // Deduped set — two assets from teammateId still yield one id
+    expect(users.findByIdsCalls[0]).toHaveLength(2);
+
+    expect(result.value.assets.map((item) => item.asset.name)).toEqual([
+      "My truck",
+      "Pat truck",
+      "Sam mower",
+      "Pat second truck",
+    ]);
+    expect(result.value.assets.map((item) => item.sharing)).toEqual([
+      { scope: "team", isOwner: true },
+      { scope: "team", isOwner: false, ownerDisplayName: "Pat" },
+      { scope: "team", isOwner: false, ownerDisplayName: "Sam" },
+      { scope: "team", isOwner: false, ownerDisplayName: "Pat" },
+    ]);
+    expect(result.value.counts).toEqual({ all: 4, vehicle: 3, equipment: 1, property: 0 });
+  });
+
+  it("falls back to Unknown when another owner has a null name or is missing", async () => {
+    const namelessOwnerId = UserId.generate();
+    const missingOwnerId = UserId.generate();
+    const nameless = vehicle("Nameless truck", {
+      ownerId: namelessOwnerId,
+      sharedTeamId: teamId,
+    });
+    const missing = equipment("Missing mower", {
+      ownerId: missingOwnerId,
+      sharedTeamId: teamId,
+    });
+    const users = new UserRepositoryFake([user(namelessOwnerId, null, "nameless@example.com")]);
+
+    const result = await new ListAssets(
+      new AssetRepositoryFake([nameless, missing]),
+      users,
+    ).execute({ requesterId: ownerId });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(users.findByIdsCalls).toHaveLength(1);
+    expect(new Set(users.findByIdsCalls[0])).toEqual(new Set([namelessOwnerId, missingOwnerId]));
+    expect(result.value.assets.map((item) => item.sharing)).toEqual([
+      { scope: "team", isOwner: false, ownerDisplayName: "Unknown" },
+      { scope: "team", isOwner: false, ownerDisplayName: "Unknown" },
+    ]);
+    expect(result.value.counts).toEqual({ all: 2, vehicle: 1, equipment: 1, property: 0 });
+  });
+
+  it("attaches personal sharing on owned personal assets", async () => {
+    const truck = vehicle("Personal truck");
+    const result = await new ListAssets(
+      new AssetRepositoryFake([truck]),
+      new UserRepositoryFake(),
+    ).execute({ requesterId: ownerId });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.assets[0]?.sharing).toEqual({
+      scope: "personal",
+      isOwner: true,
     });
   });
 });


### PR DESCRIPTION
## Summary

- Strengthen `GetDashboard` tests: exact per-type fleet totals, multi-bucket fleet health, queue order + field payloads, owner-name lookup only for non-requester owners (incl. Unknown fallback).
- Strengthen `ListAssets` tests: exact multi-type counts, repository order (not length-only), owner partitioning / `findByIds` set, shared-asset `ownerDisplayName` vs owned assets.
- Targets high-signal survivors from #94 (`++` → `--`, owner filter conditionals, empty `otherOwnerIds`).

## Related

Closes #94

## Test plan

- [x] `pnpm --filter @snaveevans/pineapple-api exec vitest run src/application/usecases/GetDashboard.test.ts src/application/usecases/ListAssets.test.ts` green
- [x] `pnpm --filter @snaveevans/pineapple-api test` green (387)
- [x] Pre-push hook: full workspace tests green (487)
- [x] Diff is test-only (`*.test.ts`); no production / Stryker config changes
- [ ] CI `verify` + `mutation` green

## Spec / AC

Issue #94 acceptance criteria:

- [x] Dashboard tests assert exact per-bucket counts and per-type totals, not just presence of keys
- [x] Tests assert owner-name resolution for assets owned by others vs. the requester
- [x] Sorting/ordering assertions pin actual order, not just length
- [x] Non-`StringLiteral` survivors in both files reduced to near zero (asserted via exact counts, owner filter call sets, queue titles/status/daysDue order)