### PR TITLE
test: asset sharing and access authorization

### DIFF
--- a/apps/api/src/application/usecases/ShareAsset.test.ts
+++ b/apps/api/src/application/usecases/ShareAsset.test.ts
@@ -5,6 +5,7 @@ import {
   ForbiddenError,
   NotFoundError,
   UserId,
+  ValidationError,
 } from "@snaveevans/pineapple-shared";
 import { Asset } from "../../domain/asset/Asset.ts";
 import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
@@ -18,6 +19,7 @@ import { ShareAsset } from "./ShareAsset.ts";
 class FakeAssetRepository implements AssetRepository {
   saved: Asset | null = null;
   savedEvents: readonly DomainEvent[] = [];
+  saveCalls = 0;
 
   constructor(private asset: Asset | null) {}
 
@@ -30,6 +32,7 @@ class FakeAssetRepository implements AssetRepository {
   }
 
   save(asset: Asset, events: readonly DomainEvent[] = []): Promise<void> {
+    this.saveCalls += 1;
     this.saved = asset;
     this.savedEvents = events;
     return Promise.resolve();
@@ -54,6 +57,7 @@ class FakeTeamRepository implements TeamRepository {
 
 class RecordingEventBus implements EventBus {
   readonly events: DomainEvent[] = [];
+  publishAllCalls = 0;
 
   publish(event: DomainEvent): Promise<void> {
     this.events.push(event);
@@ -61,6 +65,7 @@ class RecordingEventBus implements EventBus {
   }
 
   publishAll(events: readonly DomainEvent[]): Promise<void> {
+    this.publishAllCalls += 1;
     for (const event of events) this.events.push(event);
     return Promise.resolve();
   }
@@ -78,14 +83,31 @@ function makeAsset(ownerId: UserId): Asset {
   return asset;
 }
 
+function makeTeam(ownerId: UserId, name: string, extraMemberIds: UserId[] = []): Team {
+  const team = Team.create({ ownerId, name });
+  team.pullEvents();
+  if (extraMemberIds.length === 0) return team;
+  return Team.reconstitute({
+    id: team.id,
+    ownerId: team.ownerId,
+    name: team.name,
+    createdAt: team.createdAt,
+    members: [
+      ...team.members,
+      ...extraMemberIds.map((userId) =>
+        createMembership({ userId, role: "member", joinedAt: new Date() }),
+      ),
+    ],
+  });
+}
+
 describe("ShareAsset", () => {
   const ownerId = UserId.generate();
   const otherId = UserId.generate();
 
   it("shares the asset to the owner's team and publishes AssetSharedToTeam", async () => {
     const asset = makeAsset(ownerId);
-    const team = Team.create({ ownerId, name: "Field Ops" });
-    team.pullEvents();
+    const team = makeTeam(ownerId, "Field Ops");
     const assets = new FakeAssetRepository(asset);
     const eventBus = new RecordingEventBus();
 
@@ -99,31 +121,35 @@ describe("ShareAsset", () => {
     expect(result.value.sharedTeamId).toBe(team.id);
     expect(eventBus.events).toHaveLength(1);
     expect(eventBus.events[0]?.type).toBe("AssetSharedToTeam");
+    expect(eventBus.publishAllCalls).toBe(1);
     expect(assets.savedEvents).toHaveLength(1);
+    expect(assets.saveCalls).toBe(1);
   });
 
   it("is idempotent when already shared to the caller's team", async () => {
     const asset = makeAsset(ownerId);
-    const team = Team.create({ ownerId, name: "Field Ops" });
-    team.pullEvents();
+    const team = makeTeam(ownerId, "Field Ops");
     asset.shareToTeam({ teamId: team.id, teamName: team.name, actorId: ownerId });
     asset.pullEvents();
+    const assets = new FakeAssetRepository(asset);
     const eventBus = new RecordingEventBus();
 
-    const result = await new ShareAsset(
-      new FakeAssetRepository(asset),
-      new FakeTeamRepository(team),
-      eventBus,
-    ).execute({ assetId: asset.id, requesterId: ownerId });
+    const result = await new ShareAsset(assets, new FakeTeamRepository(team), eventBus).execute({
+      assetId: asset.id,
+      requesterId: ownerId,
+    });
 
     expect(result.ok).toBe(true);
     expect(eventBus.events).toHaveLength(0);
+    expect(eventBus.publishAllCalls).toBe(0);
+    expect(assets.savedEvents).toHaveLength(0);
   });
 
-  it("returns 409 when the owner has no team", async () => {
+  it("returns ConflictError when the owner has no team", async () => {
     const asset = makeAsset(ownerId);
+    const assets = new FakeAssetRepository(asset);
     const result = await new ShareAsset(
-      new FakeAssetRepository(asset),
+      assets,
       new FakeTeamRepository(null),
       new RecordingEventBus(),
     ).execute({ assetId: asset.id, requesterId: ownerId });
@@ -131,38 +157,71 @@ describe("ShareAsset", () => {
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.error).toBeInstanceOf(ConflictError);
+    expect(assets.saveCalls).toBe(0);
   });
 
-  it("returns 403 when a non-owner tries to share", async () => {
+  it("returns ForbiddenError when a non-owner team member tries to share", async () => {
     const asset = makeAsset(ownerId);
-    const team = Team.create({ ownerId, name: "Field Ops" });
-    team.pullEvents();
-    // Simulate other user as member of same team (would need membership API; use reconstitute)
-    const memberTeam = Team.reconstitute({
-      id: team.id,
-      ownerId: team.ownerId,
-      name: team.name,
-      createdAt: team.createdAt,
-      members: [
-        ...team.members,
-        createMembership({ userId: otherId, role: "member", joinedAt: new Date() }),
-      ],
-    });
+    const team = makeTeam(ownerId, "Field Ops", [otherId]);
     asset.shareToTeam({ teamId: team.id, teamName: team.name, actorId: ownerId });
     asset.pullEvents();
+    const assets = new FakeAssetRepository(asset);
+    const eventBus = new RecordingEventBus();
+
+    const result = await new ShareAsset(assets, new FakeTeamRepository(team), eventBus).execute({
+      assetId: asset.id,
+      requesterId: otherId,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBeInstanceOf(ForbiddenError);
+    expect(assets.saveCalls).toBe(0);
+    expect(eventBus.publishAllCalls).toBe(0);
+    expect(asset.sharedTeamId).toBe(team.id);
+  });
+
+  it("returns ForbiddenError when a stranger with no team relationship tries to share a shared asset", async () => {
+    const asset = makeAsset(ownerId);
+    const ownerTeam = makeTeam(ownerId, "Field Ops");
+    asset.shareToTeam({ teamId: ownerTeam.id, teamName: ownerTeam.name, actorId: ownerId });
+    asset.pullEvents();
+    const assets = new FakeAssetRepository(asset);
+    const eventBus = new RecordingEventBus();
+
+    const result = await new ShareAsset(assets, new FakeTeamRepository(null), eventBus).execute({
+      assetId: asset.id,
+      requesterId: otherId,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBeInstanceOf(ForbiddenError);
+    expect(assets.saveCalls).toBe(0);
+    expect(eventBus.publishAllCalls).toBe(0);
+  });
+
+  it("returns ForbiddenError when a stranger tries to share someone else's personal asset", async () => {
+    const asset = makeAsset(ownerId);
+    const assets = new FakeAssetRepository(asset);
+    const strangerTeam = makeTeam(otherId, "Other");
+    const eventBus = new RecordingEventBus();
 
     const result = await new ShareAsset(
-      new FakeAssetRepository(asset),
-      new FakeTeamRepository(memberTeam),
-      new RecordingEventBus(),
+      assets,
+      new FakeTeamRepository(strangerTeam),
+      eventBus,
     ).execute({ assetId: asset.id, requesterId: otherId });
 
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.error).toBeInstanceOf(ForbiddenError);
+    expect(assets.saveCalls).toBe(0);
+    expect(eventBus.publishAllCalls).toBe(0);
+    expect(asset.sharedTeamId).toBeNull();
   });
 
-  it("returns 404 when the asset does not exist", async () => {
+  it("returns NotFoundError when the asset does not exist", async () => {
     const result = await new ShareAsset(
       new FakeAssetRepository(null),
       new FakeTeamRepository(null),
@@ -174,16 +233,39 @@ describe("ShareAsset", () => {
     expect(result.error).toBeInstanceOf(NotFoundError);
   });
 
-  it("returns 403 when a stranger tries to share someone else's personal asset", async () => {
+  it("returns a domain error thrown while saving", async () => {
     const asset = makeAsset(ownerId);
+    const team = makeTeam(ownerId, "Field Ops");
+    const assets = new FakeAssetRepository(asset);
+    assets.save = () => Promise.reject(new ValidationError("save failed", "asset"));
+
     const result = await new ShareAsset(
-      new FakeAssetRepository(asset),
-      new FakeTeamRepository(Team.create({ ownerId: otherId, name: "Other" })),
+      assets,
+      new FakeTeamRepository(team),
       new RecordingEventBus(),
-    ).execute({ assetId: asset.id, requesterId: otherId });
+    ).execute({
+      assetId: asset.id,
+      requesterId: ownerId,
+    });
 
     expect(result.ok).toBe(false);
     if (result.ok) return;
-    expect(result.error).toBeInstanceOf(ForbiddenError);
+    expect(result.error).toBeInstanceOf(ValidationError);
+    if (!(result.error instanceof ValidationError)) return;
+    expect(result.error.field).toBe("asset");
+  });
+
+  it("rethrows non-domain errors from save", async () => {
+    const asset = makeAsset(ownerId);
+    const team = makeTeam(ownerId, "Field Ops");
+    const assets = new FakeAssetRepository(asset);
+    assets.save = () => Promise.reject(new TypeError("disk full"));
+
+    await expect(
+      new ShareAsset(assets, new FakeTeamRepository(team), new RecordingEventBus()).execute({
+        assetId: asset.id,
+        requesterId: ownerId,
+      }),
+    ).rejects.toBeInstanceOf(TypeError);
   });
 });

--- a/apps/api/src/application/usecases/UnshareAsset.test.ts
+++ b/apps/api/src/application/usecases/UnshareAsset.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { ForbiddenError, NotFoundError, UserId } from "@snaveevans/pineapple-shared";
+import {
+  AssetId,
+  ForbiddenError,
+  NotFoundError,
+  UserId,
+  ValidationError,
+} from "@snaveevans/pineapple-shared";
 import { Asset } from "../../domain/asset/Asset.ts";
 import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
 import type { DomainEvent } from "../../domain/events/DomainEvent.ts";
@@ -10,6 +16,10 @@ import type { EventBus } from "../ports/EventBus.ts";
 import { UnshareAsset } from "./UnshareAsset.ts";
 
 class FakeAssetRepository implements AssetRepository {
+  saved: Asset | null = null;
+  savedEvents: readonly DomainEvent[] = [];
+  saveCalls = 0;
+
   constructor(private asset: Asset | null) {}
 
   findById(): Promise<Asset | null> {
@@ -20,20 +30,31 @@ class FakeAssetRepository implements AssetRepository {
     return Promise.resolve([]);
   }
 
-  save(): Promise<void> {
+  save(asset: Asset, events: readonly DomainEvent[] = []): Promise<void> {
+    this.saveCalls += 1;
+    this.saved = asset;
+    this.savedEvents = events;
     return Promise.resolve();
   }
 }
 
 class FakeTeamRepository implements TeamRepository {
-  constructor(private team: Team | null) {}
+  findByIdCalls = 0;
+  lastFindById: string | null = null;
+
+  constructor(
+    private readonly byMember: Team | null,
+    private readonly byId: Team | null = byMember,
+  ) {}
 
   findByMember(): Promise<Team | null> {
-    return Promise.resolve(this.team);
+    return Promise.resolve(this.byMember);
   }
 
-  findById(): Promise<Team | null> {
-    return Promise.resolve(this.team);
+  findById(id: Team["id"]): Promise<Team | null> {
+    this.findByIdCalls += 1;
+    this.lastFindById = id;
+    return Promise.resolve(this.byId);
   }
 
   save(): Promise<void> {
@@ -43,6 +64,7 @@ class FakeTeamRepository implements TeamRepository {
 
 class RecordingEventBus implements EventBus {
   readonly events: DomainEvent[] = [];
+  publishAllCalls = 0;
 
   publish(event: DomainEvent): Promise<void> {
     this.events.push(event);
@@ -50,6 +72,7 @@ class RecordingEventBus implements EventBus {
   }
 
   publishAll(events: readonly DomainEvent[]): Promise<void> {
+    this.publishAllCalls += 1;
     for (const event of events) this.events.push(event);
     return Promise.resolve();
   }
@@ -67,85 +90,234 @@ function makeAsset(ownerId: UserId): Asset {
   return asset;
 }
 
+function makeTeam(ownerId: UserId, name: string, extraMemberIds: UserId[] = []): Team {
+  const team = Team.create({ ownerId, name });
+  team.pullEvents();
+  if (extraMemberIds.length === 0) return team;
+  return Team.reconstitute({
+    id: team.id,
+    ownerId: team.ownerId,
+    name: team.name,
+    createdAt: team.createdAt,
+    members: [
+      ...team.members,
+      ...extraMemberIds.map((userId) =>
+        createMembership({ userId, role: "member", joinedAt: new Date() }),
+      ),
+    ],
+  });
+}
+
 describe("UnshareAsset", () => {
   const ownerId = UserId.generate();
   const otherId = UserId.generate();
 
-  it("unshares a shared asset and publishes AssetUnsharedFromTeam", async () => {
+  it("unshares a shared asset and publishes AssetUnsharedFromTeam with team details", async () => {
     const asset = makeAsset(ownerId);
-    const team = Team.create({ ownerId, name: "Field Ops" });
-    team.pullEvents();
+    const team = makeTeam(ownerId, "Field Ops");
     asset.shareToTeam({ teamId: team.id, teamName: team.name, actorId: ownerId });
     asset.pullEvents();
+    const assets = new FakeAssetRepository(asset);
     const eventBus = new RecordingEventBus();
 
-    const result = await new UnshareAsset(
-      new FakeAssetRepository(asset),
-      new FakeTeamRepository(team),
-      eventBus,
-    ).execute({ assetId: asset.id, requesterId: ownerId });
+    const result = await new UnshareAsset(assets, new FakeTeamRepository(team), eventBus).execute({
+      assetId: asset.id,
+      requesterId: ownerId,
+    });
 
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.value.sharedTeamId).toBeNull();
     expect(eventBus.events).toHaveLength(1);
-    expect(eventBus.events[0]?.type).toBe("AssetUnsharedFromTeam");
+    expect(eventBus.publishAllCalls).toBe(1);
+    expect(eventBus.events[0]).toMatchObject({
+      type: "AssetUnsharedFromTeam",
+      assetId: asset.id,
+      ownerId,
+      actorId: ownerId,
+      assetName: "Truck",
+      teamId: team.id,
+      teamName: "Field Ops",
+    });
+    expect(assets.saveCalls).toBe(1);
+    expect(assets.savedEvents).toHaveLength(1);
   });
 
-  it("is idempotent when the asset is already personal", async () => {
+  it("uses Unknown team when the shared team row is missing", async () => {
     const asset = makeAsset(ownerId);
+    const team = makeTeam(ownerId, "Field Ops");
+    asset.shareToTeam({ teamId: team.id, teamName: team.name, actorId: ownerId });
+    asset.pullEvents();
     const eventBus = new RecordingEventBus();
 
     const result = await new UnshareAsset(
       new FakeAssetRepository(asset),
-      new FakeTeamRepository(null),
+      new FakeTeamRepository(null, null),
       eventBus,
     ).execute({ assetId: asset.id, requesterId: ownerId });
 
     expect(result.ok).toBe(true);
-    expect(eventBus.events).toHaveLength(0);
+    expect(eventBus.events).toHaveLength(1);
+    expect(eventBus.events[0]).toMatchObject({
+      type: "AssetUnsharedFromTeam",
+      teamId: team.id,
+      teamName: "Unknown team",
+    });
   });
 
-  it("returns 403 when a non-owner tries to unshare", async () => {
+  it("is idempotent when the asset is already personal", async () => {
     const asset = makeAsset(ownerId);
-    const team = Team.create({ ownerId, name: "Field Ops" });
-    team.pullEvents();
-    asset.shareToTeam({ teamId: team.id, teamName: team.name, actorId: ownerId });
-    asset.pullEvents();
-    const memberTeam = Team.reconstitute({
-      id: team.id,
-      ownerId: team.ownerId,
-      name: team.name,
-      createdAt: team.createdAt,
-      members: [
-        ...team.members,
-        createMembership({ userId: otherId, role: "member", joinedAt: new Date() }),
-      ],
+    const assets = new FakeAssetRepository(asset);
+    const teams = new FakeTeamRepository(null);
+    const eventBus = new RecordingEventBus();
+
+    const result = await new UnshareAsset(assets, teams, eventBus).execute({
+      assetId: asset.id,
+      requesterId: ownerId,
     });
 
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.sharedTeamId).toBeNull();
+    expect(eventBus.events).toHaveLength(0);
+    expect(eventBus.publishAllCalls).toBe(0);
+    expect(teams.findByIdCalls).toBe(0);
+    expect(assets.saveCalls).toBe(0);
+  });
+
+  it("returns ForbiddenError when a non-owner team member tries to unshare", async () => {
+    const asset = makeAsset(ownerId);
+    const team = makeTeam(ownerId, "Field Ops", [otherId]);
+    asset.shareToTeam({ teamId: team.id, teamName: team.name, actorId: ownerId });
+    asset.pullEvents();
+    const assets = new FakeAssetRepository(asset);
+    const eventBus = new RecordingEventBus();
+
+    const result = await new UnshareAsset(assets, new FakeTeamRepository(team), eventBus).execute({
+      assetId: asset.id,
+      requesterId: otherId,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBeInstanceOf(ForbiddenError);
+    expect(assets.saveCalls).toBe(0);
+    expect(eventBus.publishAllCalls).toBe(0);
+    expect(asset.sharedTeamId).toBe(team.id);
+  });
+
+  it("returns ForbiddenError when a stranger with no team relationship tries to unshare", async () => {
+    const asset = makeAsset(ownerId);
+    const team = makeTeam(ownerId, "Field Ops");
+    asset.shareToTeam({ teamId: team.id, teamName: team.name, actorId: ownerId });
+    asset.pullEvents();
+    const assets = new FakeAssetRepository(asset);
+    const eventBus = new RecordingEventBus();
+
+    const result = await new UnshareAsset(assets, new FakeTeamRepository(null), eventBus).execute({
+      assetId: asset.id,
+      requesterId: otherId,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBeInstanceOf(ForbiddenError);
+    expect(assets.saveCalls).toBe(0);
+    expect(eventBus.publishAllCalls).toBe(0);
+    expect(asset.sharedTeamId).toBe(team.id);
+  });
+
+  it("returns ForbiddenError when a stranger on another team tries to unshare", async () => {
+    const asset = makeAsset(ownerId);
+    const ownerTeam = makeTeam(ownerId, "Field Ops");
+    asset.shareToTeam({ teamId: ownerTeam.id, teamName: ownerTeam.name, actorId: ownerId });
+    asset.pullEvents();
+    const strangerTeam = makeTeam(otherId, "Other");
+    const assets = new FakeAssetRepository(asset);
+    const eventBus = new RecordingEventBus();
+
     const result = await new UnshareAsset(
-      new FakeAssetRepository(asset),
-      new FakeTeamRepository(memberTeam),
-      new RecordingEventBus(),
+      assets,
+      new FakeTeamRepository(strangerTeam),
+      eventBus,
     ).execute({ assetId: asset.id, requesterId: otherId });
 
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.error).toBeInstanceOf(ForbiddenError);
+    expect(assets.saveCalls).toBe(0);
+    expect(eventBus.publishAllCalls).toBe(0);
   });
 
-  it("returns 404 when the asset does not exist", async () => {
+  it("returns NotFoundError when the asset does not exist", async () => {
     const result = await new UnshareAsset(
       new FakeAssetRepository(null),
       new FakeTeamRepository(null),
       new RecordingEventBus(),
     ).execute({
-      assetId: makeAsset(ownerId).id,
+      assetId: AssetId.generate(),
       requesterId: ownerId,
     });
 
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.error).toBeInstanceOf(NotFoundError);
+  });
+
+  it("returns a domain error thrown while saving", async () => {
+    const asset = makeAsset(ownerId);
+    const team = makeTeam(ownerId, "Field Ops");
+    asset.shareToTeam({ teamId: team.id, teamName: team.name, actorId: ownerId });
+    asset.pullEvents();
+    const assets = new FakeAssetRepository(asset);
+    assets.save = () => Promise.reject(new ValidationError("save failed", "asset"));
+
+    const result = await new UnshareAsset(
+      assets,
+      new FakeTeamRepository(team),
+      new RecordingEventBus(),
+    ).execute({ assetId: asset.id, requesterId: ownerId });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBeInstanceOf(ValidationError);
+    if (!(result.error instanceof ValidationError)) return;
+    expect(result.error.field).toBe("asset");
+  });
+
+  it("rethrows non-domain errors from save", async () => {
+    const asset = makeAsset(ownerId);
+    const team = makeTeam(ownerId, "Field Ops");
+    asset.shareToTeam({ teamId: team.id, teamName: team.name, actorId: ownerId });
+    asset.pullEvents();
+    const assets = new FakeAssetRepository(asset);
+    assets.save = () => Promise.reject(new TypeError("disk full"));
+
+    await expect(
+      new UnshareAsset(assets, new FakeTeamRepository(team), new RecordingEventBus()).execute({
+        assetId: asset.id,
+        requesterId: ownerId,
+      }),
+    ).rejects.toBeInstanceOf(TypeError);
+  });
+
+  it("does not publish when unshare yields no events", async () => {
+    const asset = makeAsset(ownerId);
+    const team = makeTeam(ownerId, "Field Ops");
+    asset.shareToTeam({ teamId: team.id, teamName: team.name, actorId: ownerId });
+    asset.pullEvents();
+    asset.pullEvents = () => [];
+    const assets = new FakeAssetRepository(asset);
+    const eventBus = new RecordingEventBus();
+
+    const result = await new UnshareAsset(assets, new FakeTeamRepository(team), eventBus).execute({
+      assetId: asset.id,
+      requesterId: ownerId,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(assets.saveCalls).toBe(1);
+    expect(eventBus.publishAllCalls).toBe(0);
+    expect(eventBus.events).toHaveLength(0);
   });
 });

--- a/apps/api/src/application/usecases/assetAccess.test.ts
+++ b/apps/api/src/application/usecases/assetAccess.test.ts
@@ -29,13 +29,40 @@ function makeAsset(ownerId: UserId): Asset {
   return asset;
 }
 
+function makeTeam(ownerId: UserId, name: string, extraMemberIds: UserId[] = []): Team {
+  const team = Team.create({ ownerId, name });
+  team.pullEvents();
+  if (extraMemberIds.length === 0) return team;
+  return Team.reconstitute({
+    id: team.id,
+    ownerId: team.ownerId,
+    name: team.name,
+    createdAt: team.createdAt,
+    members: [
+      ...team.members,
+      ...extraMemberIds.map((userId) =>
+        createMembership({ userId, role: "member", joinedAt: new Date() }),
+      ),
+    ],
+  });
+}
+
 describe("canAccessAsset", () => {
   const ownerId = UserId.generate();
   const memberId = UserId.generate();
   const strangerId = UserId.generate();
 
-  it("allows the asset owner", async () => {
+  it("allows the asset owner (personal)", async () => {
     const asset = makeAsset(ownerId);
+    await expect(canAccessAsset(asset, ownerId, new TeamRepositoryFake(null))).resolves.toBe(true);
+  });
+
+  it("allows the asset owner even when shared to a team", async () => {
+    const asset = makeAsset(ownerId);
+    const team = makeTeam(ownerId, "Field Ops");
+    asset.shareToTeam({ teamId: team.id, teamName: team.name, actorId: ownerId });
+    asset.pullEvents();
+
     await expect(canAccessAsset(asset, ownerId, new TeamRepositoryFake(null))).resolves.toBe(true);
   });
 
@@ -46,39 +73,43 @@ describe("canAccessAsset", () => {
     );
   });
 
+  it("denies a non-owner with a team when the asset is personal", async () => {
+    const asset = makeAsset(ownerId);
+    const otherTeam = makeTeam(memberId, "Other crew");
+    await expect(canAccessAsset(asset, memberId, new TeamRepositoryFake(otherTeam))).resolves.toBe(
+      false,
+    );
+  });
+
   it("allows a team member when the asset is shared to their team", async () => {
     const asset = makeAsset(ownerId);
-    const team = Team.create({ ownerId, name: "Field Ops" });
-    team.pullEvents();
-    const memberTeam = Team.reconstitute({
-      id: team.id,
-      ownerId: team.ownerId,
-      name: team.name,
-      createdAt: team.createdAt,
-      members: [
-        ...team.members,
-        createMembership({ userId: memberId, role: "member", joinedAt: new Date() }),
-      ],
-    });
+    const team = makeTeam(ownerId, "Field Ops", [memberId]);
     asset.shareToTeam({ teamId: team.id, teamName: team.name, actorId: ownerId });
     asset.pullEvents();
 
-    await expect(canAccessAsset(asset, memberId, new TeamRepositoryFake(memberTeam))).resolves.toBe(
-      true,
-    );
+    await expect(canAccessAsset(asset, memberId, new TeamRepositoryFake(team))).resolves.toBe(true);
   });
 
   it("denies a stranger when the asset is shared to another team", async () => {
     const asset = makeAsset(ownerId);
-    const team = Team.create({ ownerId, name: "Field Ops" });
-    team.pullEvents();
+    const team = makeTeam(ownerId, "Field Ops");
     asset.shareToTeam({ teamId: team.id, teamName: team.name, actorId: ownerId });
     asset.pullEvents();
-    const otherTeam = Team.create({ ownerId: strangerId, name: "Other" });
-    otherTeam.pullEvents();
+    const otherTeam = makeTeam(strangerId, "Other");
 
     await expect(
       canAccessAsset(asset, strangerId, new TeamRepositoryFake(otherTeam)),
     ).resolves.toBe(false);
+  });
+
+  it("denies a requester with no team when the asset is shared", async () => {
+    const asset = makeAsset(ownerId);
+    const team = makeTeam(ownerId, "Field Ops");
+    asset.shareToTeam({ teamId: team.id, teamName: team.name, actorId: ownerId });
+    asset.pullEvents();
+
+    await expect(canAccessAsset(asset, strangerId, new TeamRepositoryFake(null))).resolves.toBe(
+      false,
+    );
   });
 });

--- a/apps/api/src/application/usecases/assetSharing.test.ts
+++ b/apps/api/src/application/usecases/assetSharing.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { UserId } from "@snaveevans/pineapple-shared";
+import { Asset } from "../../domain/asset/Asset.ts";
+import { Team } from "../../domain/team/Team.ts";
+import { toSharingDescriptor } from "./assetSharing.ts";
+
+function makeAsset(ownerId: UserId): Asset {
+  const asset = Asset.create({
+    ownerId,
+    name: "Truck",
+    metadata: { kind: "vehicle", make: "Ram", model: "2500", year: 2016 },
+  });
+  asset.pullEvents();
+  return asset;
+}
+
+describe("toSharingDescriptor", () => {
+  const ownerId = UserId.generate();
+  const memberId = UserId.generate();
+
+  it("marks a personal asset as personal for the owner without ownerDisplayName", () => {
+    const asset = makeAsset(ownerId);
+
+    expect(toSharingDescriptor(asset, ownerId, null)).toEqual({
+      scope: "personal",
+      isOwner: true,
+    });
+    expect(toSharingDescriptor(asset, ownerId, "Owner Name")).toEqual({
+      scope: "personal",
+      isOwner: true,
+    });
+  });
+
+  it("marks a shared asset as team for the owner without ownerDisplayName even when a name is supplied", () => {
+    const asset = makeAsset(ownerId);
+    const team = Team.create({ ownerId, name: "Field Ops" });
+    team.pullEvents();
+    asset.shareToTeam({ teamId: team.id, teamName: team.name, actorId: ownerId });
+    asset.pullEvents();
+
+    expect(toSharingDescriptor(asset, ownerId, "Owner Name")).toEqual({
+      scope: "team",
+      isOwner: true,
+    });
+  });
+
+  it("includes ownerDisplayName for a non-owner of a shared asset", () => {
+    const asset = makeAsset(ownerId);
+    const team = Team.create({ ownerId, name: "Field Ops" });
+    team.pullEvents();
+    asset.shareToTeam({ teamId: team.id, teamName: team.name, actorId: ownerId });
+    asset.pullEvents();
+
+    expect(toSharingDescriptor(asset, memberId, "Pat")).toEqual({
+      scope: "team",
+      isOwner: false,
+      ownerDisplayName: "Pat",
+    });
+  });
+
+  it("omits ownerDisplayName for a non-owner when the display name is null", () => {
+    const asset = makeAsset(ownerId);
+    const team = Team.create({ ownerId, name: "Field Ops" });
+    team.pullEvents();
+    asset.shareToTeam({ teamId: team.id, teamName: team.name, actorId: ownerId });
+    asset.pullEvents();
+
+    expect(toSharingDescriptor(asset, memberId, null)).toEqual({
+      scope: "team",
+      isOwner: false,
+    });
+  });
+
+  it("marks a personal asset as personal and not owned for a non-owner", () => {
+    const asset = makeAsset(ownerId);
+
+    expect(toSharingDescriptor(asset, memberId, "Pat")).toEqual({
+      scope: "personal",
+      isOwner: false,
+      ownerDisplayName: "Pat",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Negative-path tests pin `ForbiddenError` for non-owner share/unshare and requesters with no team relationship to a shared asset
- Direct `canAccessAsset` coverage for personal, my-team, other-team, and no-team branches (kills always-grant)
- Direct `toSharingDescriptor` coverage for owner/non-owner × personal/team × display-name present/absent
- Share/Unshare assert no save/publish on deny paths; event payloads and empty-events publish guards

## Related

Closes #95

## Test plan

- [x] `pnpm --filter @snaveevans/pineapple-api test` green
- [x] Scoped Stryker on the four files: **84.78%** (was lower); `assetSharing` 100%; `assetAccess` 93.75%
- [x] Manual invert: `canAccessAsset` → `return true` fails stranger/no-team tests
- [x] New/updated tests assert error **types**, values, payloads — not message prose
- [ ] CI `verify` + `mutation` green

## Spec / AC

Issue #95 acceptance criteria:

- [x] `ForbiddenError` for non-owner share/unshare
- [x] `ForbiddenError` when requester has no team relationship to a shared asset
- [x] `canAccessAsset` branches: personal, my-team, other-team, no team
- [x] Authz predicate unconditionally `true` fails tests (always-grant killed)
- [x] High-signal non-`StringLiteral` survivors on security paths reduced; remaining non-string survivors are **equivalent** only:
  - `assetAccess` L15 personal early-return skip (redundant with L17 when `sharedTeamId === null`)
  - Share/Unshare inner `if (!visible)` message-routing (both branches return `ForbiddenError`; distinguishing would require pinning error prose, forbidden by testing.md)

Critical security targets:

- [x] `assetAccess` always-grant mutant dead
- [x] Share/Unshare non-owner authz body removal dead (outer owner check + deny without side effects)