### PR TITLE
test: kill SearchAssets mutation survivors

### DIFF
--- a/apps/api/src/application/usecases/SearchAssets.test.ts
+++ b/apps/api/src/application/usecases/SearchAssets.test.ts
@@ -9,6 +9,7 @@ import { SearchAssets } from "./SearchAssets.ts";
 
 class AssetRepositoryFake implements AssetRepository {
   requestedUserId: UserId | null = null;
+  findVisibleToCalls = 0;
 
   constructor(private readonly assets: Asset[]) {}
 
@@ -17,6 +18,7 @@ class AssetRepositoryFake implements AssetRepository {
   }
 
   findVisibleTo(userId: UserId): Promise<Asset[]> {
+    this.findVisibleToCalls += 1;
     this.requestedUserId = userId;
     return Promise.resolve(this.assets);
   }
@@ -27,6 +29,8 @@ class AssetRepositoryFake implements AssetRepository {
 }
 
 class UserRepositoryFake implements UserRepository {
+  findByIdsCalls: UserId[][] = [];
+
   constructor(private readonly users: User[] = []) {}
 
   findById(): Promise<User | null> {
@@ -34,6 +38,7 @@ class UserRepositoryFake implements UserRepository {
   }
 
   findByIds(ids: readonly UserId[]): Promise<User[]> {
+    this.findByIdsCalls.push([...ids]);
     return Promise.resolve(this.users.filter((user) => ids.includes(user.id)));
   }
 
@@ -48,6 +53,7 @@ class UserRepositoryFake implements UserRepository {
 
 const ownerId = UserId.from("195d0ef0-47f5-439f-abfd-29f892c9a040");
 const otherOwnerId = UserId.from("d614dbf6-7f08-4c2d-aab9-091c8c2633dd");
+const thirdOwnerId = UserId.from("e725ec07-8f19-5d3e-bbc0-1a2d9d3744ee");
 const teamId = TeamId.from("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
 
 function asset(props: {
@@ -71,15 +77,26 @@ function asset(props: {
   });
 }
 
+function user(id: UserId, name: string | null, email = "user@example.com"): User {
+  return User.reconstitute({
+    id,
+    email: Email.from(email),
+    name,
+    onboardingCompletedAt: new Date("2026-01-01T00:00:00.000Z"),
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  });
+}
+
 async function search(assets: Asset[], q: string, users: User[] = []) {
   const repository = new AssetRepositoryFake(assets);
-  const result = await new SearchAssets(repository, new UserRepositoryFake(users)).execute({
+  const userRepository = new UserRepositoryFake(users);
+  const result = await new SearchAssets(repository, userRepository).execute({
     requesterId: ownerId,
     q,
   });
   expect(result.ok).toBe(true);
   if (!result.ok) throw result.error;
-  return { repository, results: result.value };
+  return { repository, userRepository, results: result.value };
 }
 
 describe("SearchAssets", () => {
@@ -103,6 +120,131 @@ describe("SearchAssets", () => {
 
     expect(repository.requestedUserId).toBe(ownerId);
     expect(results.map((result) => result.id)).toEqual([active.id]);
+  });
+
+  it("short-circuits empty and whitespace-only queries without loading assets", async () => {
+    const truck = asset({
+      id: "00000000-0000-0000-0000-000000000030",
+      name: "Work Truck",
+      metadata: { kind: "vehicle", make: "Ford", model: "F-150", year: 2020 },
+    });
+
+    for (const q of ["", "   ", "\t\n  "]) {
+      const { repository, userRepository, results } = await search([truck], q);
+      expect(results).toEqual([]);
+      expect(repository.findVisibleToCalls).toBe(0);
+      expect(userRepository.findByIdsCalls).toEqual([]);
+    }
+  });
+
+  it("does not resolve owner names when every match is owned by the requester", async () => {
+    const owned = asset({
+      id: "00000000-0000-0000-0000-000000000031",
+      name: "My Ram",
+      metadata: { kind: "vehicle", make: "Ram", model: "2500", year: 2021 },
+    });
+    const teammate = user(otherOwnerId, "Pat", "teammate@example.com");
+
+    const { userRepository, results } = await search([owned], "ram", [teammate]);
+
+    expect(userRepository.findByIdsCalls).toEqual([]);
+    expect(results).toHaveLength(1);
+    expect(results[0]?.sharing).toEqual({
+      scope: "personal",
+      isOwner: true,
+    });
+    expect(results[0]?.sharing).not.toHaveProperty("ownerDisplayName");
+  });
+
+  it("resolves other owners only — never the requester — and maps display names", async () => {
+    const owned = asset({
+      id: "00000000-0000-0000-0000-000000000032",
+      name: "My Ram",
+      metadata: { kind: "vehicle", make: "Ram", model: "2500", year: 2021 },
+      sharedTeamId: teamId,
+    });
+    const sharedFromPat = asset({
+      id: "00000000-0000-0000-0000-000000000033",
+      name: "Pat Ram",
+      ownerId: otherOwnerId,
+      metadata: { kind: "vehicle", make: "Ram", model: "1500", year: 2019 },
+      sharedTeamId: teamId,
+    });
+    const sharedFromSam = asset({
+      id: "00000000-0000-0000-0000-000000000034",
+      name: "Sam Ram",
+      ownerId: thirdOwnerId,
+      metadata: { kind: "vehicle", make: "Ram", model: "3500", year: 2022 },
+      sharedTeamId: teamId,
+    });
+    const duplicatePatAsset = asset({
+      id: "00000000-0000-0000-0000-000000000035",
+      name: "Pat Second Ram",
+      ownerId: otherOwnerId,
+      metadata: { kind: "vehicle", make: "Ram", model: "Rebel", year: 2023 },
+      sharedTeamId: teamId,
+    });
+    const users = [
+      user(otherOwnerId, "Pat", "pat@example.com"),
+      user(thirdOwnerId, "Sam", "sam@example.com"),
+      user(ownerId, "Me", "me@example.com"),
+    ];
+
+    const { userRepository, results } = await search(
+      [owned, sharedFromPat, sharedFromSam, duplicatePatAsset],
+      "ram",
+      users,
+    );
+
+    expect(userRepository.findByIdsCalls).toHaveLength(1);
+    const requestedOwnerIds = userRepository.findByIdsCalls[0] ?? [];
+    expect(requestedOwnerIds).toHaveLength(2);
+    expect(new Set(requestedOwnerIds)).toEqual(new Set([otherOwnerId, thirdOwnerId]));
+    expect(requestedOwnerIds).not.toContain(ownerId);
+
+    const byName = Object.fromEntries(results.map((r) => [r.name, r.sharing]));
+    expect(byName["My Ram"]).toEqual({ scope: "team", isOwner: true });
+    expect(byName["My Ram"]).not.toHaveProperty("ownerDisplayName");
+    expect(byName["Pat Ram"]).toEqual({
+      scope: "team",
+      isOwner: false,
+      ownerDisplayName: "Pat",
+    });
+    expect(byName["Sam Ram"]).toEqual({
+      scope: "team",
+      isOwner: false,
+      ownerDisplayName: "Sam",
+    });
+    expect(byName["Pat Second Ram"]).toEqual({
+      scope: "team",
+      isOwner: false,
+      ownerDisplayName: "Pat",
+    });
+  });
+
+  it("uses Unknown when another owner is missing or has a null name", async () => {
+    const missingOwnerAsset = asset({
+      id: "00000000-0000-0000-0000-000000000036",
+      name: "Missing Owner Ram",
+      ownerId: otherOwnerId,
+      metadata: { kind: "vehicle", make: "Ram", model: "2500", year: 2021 },
+      sharedTeamId: teamId,
+    });
+    const nullNameAsset = asset({
+      id: "00000000-0000-0000-0000-000000000037",
+      name: "Null Name Ram",
+      ownerId: thirdOwnerId,
+      metadata: { kind: "vehicle", make: "Ram", model: "1500", year: 2018 },
+      sharedTeamId: teamId,
+    });
+
+    const { results } = await search([missingOwnerAsset, nullNameAsset], "ram", [
+      user(thirdOwnerId, null, "null@example.com"),
+    ]);
+
+    const byName = Object.fromEntries(results.map((r) => [r.name, r.sharing.ownerDisplayName]));
+    expect(byName["Missing Owner Ram"]).toBe("Unknown");
+    expect(byName["Null Name Ram"]).toBe("Unknown");
   });
 
   it("matches case-insensitive substrings across all type-specific metadata", async () => {
@@ -154,6 +296,28 @@ describe("SearchAssets", () => {
     expect((await search(assets, "honda 2200")).results.map((result) => result.name)).toEqual([
       "Generator",
     ]);
+    expect((await search(assets, "1c6rr7lt")).results.map((result) => result.name)).toEqual([
+      "Truck",
+    ]);
+    expect((await search(assets, "80443")).results.map((result) => result.name)).toEqual([
+      "Retreat",
+    ]);
+    expect((await search(assets, "usa")).results.map((result) => result.name)).toEqual(["Retreat"]);
+    expect((await search(assets, "eamt-123")).results.map((result) => result.name)).toEqual([
+      "Generator",
+    ]);
+  });
+
+  it("requires every search term to match (AND), not any term (OR)", async () => {
+    const vehicle = asset({
+      id: "00000000-0000-0000-0000-000000000038",
+      name: "Work Truck",
+      metadata: { kind: "vehicle", make: "Ram", model: "2500", year: 2021 },
+    });
+
+    const { results } = await search([vehicle], "truck tractor");
+
+    expect(results).toEqual([]);
   });
 
   it("does not match on the asset type enum", async () => {
@@ -216,6 +380,16 @@ describe("SearchAssets", () => {
         name: "Spare asset",
         metadata: { kind: "equipment" },
       }),
+      asset({
+        id: "00000000-0000-0000-0000-000000000039",
+        name: "Whitespace serial asset",
+        metadata: { kind: "equipment", serialNumber: "   " },
+      }),
+      asset({
+        id: "00000000-0000-0000-0000-000000000040",
+        name: "Manufacturer only asset",
+        metadata: { kind: "equipment", manufacturer: "Kohler" },
+      }),
     ];
 
     const { results } = await search(assets, "asset");
@@ -227,6 +401,8 @@ describe("SearchAssets", () => {
       "Generator asset": "Honda EU2200i",
       "Trailer asset": "TRL-123",
       "Spare asset": "Equipment details not added",
+      "Whitespace serial asset": "Equipment details not added",
+      "Manufacturer only asset": "Kohler",
     });
   });
 
@@ -259,6 +435,125 @@ describe("SearchAssets", () => {
       "Old Ram Name",
       "New Metadata Match",
     ]);
+  });
+
+  it("breaks name ties by alphabetical name even when ids disagree", async () => {
+    const sameInstant = new Date("2026-03-01T00:00:00.000Z");
+    // Three names so inconsistent comparators cannot accidentally preserve order.
+    // Ids are reverse of alphabetical order so id-only fallback cannot fake name sort.
+    const charlie = asset({
+      id: "00000000-0000-0000-0000-000000000010",
+      name: "Charlie Ford",
+      metadata: { kind: "vehicle", make: "Chevy", model: "C", year: 2020 },
+      updatedAt: sameInstant,
+    });
+    const bravo = asset({
+      id: "00000000-0000-0000-0000-000000000020",
+      name: "Bravo Ford",
+      metadata: { kind: "vehicle", make: "Chevy", model: "B", year: 2020 },
+      updatedAt: sameInstant,
+    });
+    const alpha = asset({
+      id: "00000000-0000-0000-0000-000000000030",
+      name: "Alpha Ford",
+      metadata: { kind: "vehicle", make: "Chevy", model: "A", year: 2020 },
+      updatedAt: sameInstant,
+    });
+
+    const { results } = await search([charlie, bravo, alpha], "ford");
+
+    expect(results.map((result) => result.name)).toEqual([
+      "Alpha Ford",
+      "Bravo Ford",
+      "Charlie Ford",
+    ]);
+  });
+
+  it("breaks identical-name ties by asset id ascending", async () => {
+    const sameInstant = new Date("2026-03-01T00:00:00.000Z");
+    // Input order is mid, high, low — id ascending must win regardless of input.
+    const mid = asset({
+      id: "00000000-0000-0000-0000-000000000050",
+      name: "Same Name",
+      metadata: { kind: "vehicle", make: "Ford", model: "M", year: 2020 },
+      updatedAt: sameInstant,
+    });
+    const high = asset({
+      id: "00000000-0000-0000-0000-000000000090",
+      name: "Same Name",
+      metadata: { kind: "vehicle", make: "Ford", model: "H", year: 2020 },
+      updatedAt: sameInstant,
+    });
+    const low = asset({
+      id: "00000000-0000-0000-0000-000000000010",
+      name: "Same Name",
+      metadata: { kind: "vehicle", make: "Ford", model: "L", year: 2020 },
+      updatedAt: sameInstant,
+    });
+
+    const { results } = await search([mid, high, low], "ford");
+
+    expect(results.map((result) => result.id)).toEqual([low.id, mid.id, high.id]);
+  });
+
+  it("ranks a lowercase name hit above metadata when the query is uppercase", async () => {
+    const nameHit = asset({
+      id: "00000000-0000-0000-0000-000000000060",
+      name: "rambler",
+      metadata: { kind: "vehicle", make: "Ford", model: "X", year: 2020 },
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    });
+    const metaOnly = asset({
+      id: "00000000-0000-0000-0000-000000000061",
+      name: "Other",
+      metadata: { kind: "vehicle", make: "RAM", model: "Y", year: 2020 },
+      updatedAt: new Date("2026-06-01T00:00:00.000Z"),
+    });
+
+    const { results } = await search([nameHit, metaOnly], "RAM");
+
+    // nameMatchesAnyTerm lowercases the asset name; query terms are lowercased
+    // in searchTerms — "rambler" must count as a name hit for term "ram".
+    expect(results.map((r) => r.name)).toEqual(["rambler", "Other"]);
+  });
+
+  it("name-ranks when any single term hits the name (not every term)", async () => {
+    // Both match AND across fields. Name contains only "truck"; "ford" is in metadata.
+    // nameMatchesAnyTerm must use some() so this ranks above a metadata-only hit.
+    const partialNameHit = asset({
+      id: "00000000-0000-0000-0000-000000000047",
+      name: "Alpha Truck",
+      metadata: { kind: "vehicle", make: "Ford", model: "X", year: 2020 },
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    });
+    const metaOnly = asset({
+      id: "00000000-0000-0000-0000-000000000048",
+      name: "Zed Unit",
+      metadata: { kind: "vehicle", make: "Ford Truck", model: "Y", year: 2020 },
+      updatedAt: new Date("2026-06-01T00:00:00.000Z"),
+    });
+
+    const { results } = await search([partialNameHit, metaOnly], "truck ford");
+
+    expect(results.map((r) => r.name)).toEqual(["Alpha Truck", "Zed Unit"]);
+  });
+
+  it("drops whitespace-only metadata parts from equipment summaries", async () => {
+    const equipment = asset({
+      id: "00000000-0000-0000-0000-000000000051",
+      name: "Pump asset",
+      metadata: {
+        kind: "equipment",
+        manufacturer: "  ",
+        modelNumber: "MX-1",
+        serialNumber: "\t",
+      },
+    });
+
+    const { results } = await search([equipment], "pump");
+
+    // compactStrings must trim + drop empty parts so join is "MX-1", not "  MX-1" / " MX-1".
+    expect(results[0]?.summary).toBe("MX-1");
   });
 
   it("caps results at 20", async () => {
@@ -329,13 +624,7 @@ describe("SearchAssets", () => {
       metadata: { kind: "vehicle", make: "Ram", model: "2500", year: 2021 },
       sharedTeamId: teamId,
     });
-    const teammate = User.reconstitute({
-      id: otherOwnerId,
-      email: Email.from("teammate@example.com"),
-      name: "Pat",
-      onboardingCompletedAt: new Date("2026-01-01T00:00:00.000Z"),
-      createdAt: new Date("2026-01-01T00:00:00.000Z"),
-    });
+    const teammate = user(otherOwnerId, "Pat", "teammate@example.com");
 
     const { results } = await search([shared], "ram", [teammate]);
 
@@ -343,6 +632,23 @@ describe("SearchAssets", () => {
       scope: "team",
       isOwner: false,
       ownerDisplayName: "Pat",
+    });
+  });
+
+  it("returns id, name, and type on each hit", async () => {
+    const truck = asset({
+      id: "00000000-0000-0000-0000-000000000049",
+      name: "Work Truck",
+      metadata: { kind: "vehicle", make: "Ford", model: "F-150", year: 2020 },
+    });
+
+    const { results } = await search([truck], "ford");
+
+    expect(results[0]).toMatchObject({
+      id: truck.id,
+      name: "Work Truck",
+      type: "vehicle",
+      summary: "2020 Ford F-150",
     });
   });
 });


### PR DESCRIPTION
## Summary

- Strengthen `SearchAssets` unit tests to kill high-signal mutants: empty/whitespace short-circuit, owner-vs-other partitioning, no-other-owners `findByIds` boundary, name/id sort ties, AND matching, summaries, and sharing descriptors.
- Scoped Stryker on `SearchAssets.ts`: **66.20% → 90.85%** (33 survivors → 10; remaining are V8-sort-equivalent or unobservable empty-owners filler / masked owner ternary / redundant `trim`+`\s+`).

## Related

Closes #92

## Test plan

- [x] `pnpm --filter @snaveevans/pineapple-api test` green
- [x] `vitest run src/application/usecases/SearchAssets.test.ts` green (22 tests)
- [x] Scoped `stryker run --mutate src/application/usecases/SearchAssets.ts` score 90.85
- [x] New/updated tests assert values, call boundaries, payloads — not merely execution
- [ ] CI `verify` + `mutation` green

## Spec / AC

Issue #92 acceptance criteria:

- [x] Tests assert empty/whitespace search-term behavior (`terms.length === 0` short-circuit; no `findVisibleTo` / `findByIds`)
- [x] Tests assert owner-name resolution: requester-owned vs others (`findByIds` ids, display names, `Unknown` fallback)
- [x] Boundary tests around the "no other owners" branch (`findByIds` not called when all matches are owned)
- [x] `SearchAssets.ts` surviving non-`StringLiteral` mutants reduced near zero (33 → 10; score 66% → 91%)