### PR TITLE
Fix: bump hono to ^4.12.25 to clear CORS/serve-static/Lambda advisories

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -18,7 +18,7 @@
     "@snaveevans/pineapple-shared": "workspace:*",
     "better-auth": "^1.6.11",
     "better-auth-cloudflare": "^0.3.0",
-    "hono": "^4.12.0",
+    "hono": "^4.12.25",
     "zod": "^3.0.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,10 +46,10 @@ importers:
     dependencies:
       '@hono/zod-openapi':
         specifier: ^0.19.10
-        version: 0.19.10(hono@4.12.23)(zod@3.25.76)
+        version: 0.19.10(hono@4.12.32)(zod@3.25.76)
       '@scalar/hono-api-reference':
         specifier: ^0.10.19
-        version: 0.10.19(hono@4.12.23)
+        version: 0.10.19(hono@4.12.32)
       '@snaveevans/pineapple-shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -60,8 +60,8 @@ importers:
         specifier: ^0.3.0
         version: 0.3.0(@better-auth/drizzle-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260525.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260525.1)(kysely@0.28.17)))(@cloudflare/workers-types@4.20260525.1)(better-auth@1.6.11(@cloudflare/workers-types@4.20260525.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260525.1)(kysely@0.28.17))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@3.2.4(@types/node@25.9.1)(happy-dom@20.10.6)(tsx@4.22.3)(yaml@2.9.0)))(kysely@0.28.17)
       hono:
-        specifier: ^4.12.0
-        version: 4.12.23
+        specifier: ^4.12.25
+        version: 4.12.32
       zod:
         specifier: ^3.0.0
         version: 3.25.76
@@ -2500,8 +2500,8 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
-  hono@4.12.23:
-    resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
+  hono@4.12.32:
+    resolution: {integrity: sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==}
     engines: {node: '>=16.9.0'}
 
   human-signals@8.0.1:
@@ -4086,17 +4086,17 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
-  '@hono/zod-openapi@0.19.10(hono@4.12.23)(zod@3.25.76)':
+  '@hono/zod-openapi@0.19.10(hono@4.12.32)(zod@3.25.76)':
     dependencies:
       '@asteasolutions/zod-to-openapi': 7.3.4(zod@3.25.76)
-      '@hono/zod-validator': 0.7.6(hono@4.12.23)(zod@3.25.76)
-      hono: 4.12.23
+      '@hono/zod-validator': 0.7.6(hono@4.12.32)(zod@3.25.76)
+      hono: 4.12.32
       openapi3-ts: 4.5.0
       zod: 3.25.76
 
-  '@hono/zod-validator@0.7.6(hono@4.12.23)(zod@3.25.76)':
+  '@hono/zod-validator@0.7.6(hono@4.12.32)(zod@3.25.76)':
     dependencies:
-      hono: 4.12.23
+      hono: 4.12.32
       zod: 3.25.76
 
   '@humanfs/core@0.19.2':
@@ -4457,10 +4457,10 @@ snapshots:
 
   '@scalar/helpers@0.8.0': {}
 
-  '@scalar/hono-api-reference@0.10.19(hono@4.12.23)':
+  '@scalar/hono-api-reference@0.10.19(hono@4.12.32)':
     dependencies:
       '@scalar/client-side-rendering': 0.1.12
-      hono: 4.12.23
+      hono: 4.12.32
 
   '@scalar/schemas@0.3.2':
     dependencies:
@@ -5443,7 +5443,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hono@4.12.23: {}
+  hono@4.12.32: {}
 
   human-signals@8.0.1: {}
 


### PR DESCRIPTION
## Summary

- Bumps `apps/api`'s `hono` dependency from `^4.12.0` (resolved 4.12.23) to `^4.12.25`, which now resolves to `4.12.32` — above the patched floor for the advisories `pnpm audit` reported against `hono < 4.12.25`.
- No code changes: the app registers no `hono/cors` middleware and no `serve-static`/Lambda adapters, so none of the advisories were reachable in this deployment, but the dependency is now current regardless.
- `pnpm-lock.yaml` updated accordingly.

## Related

Fixes #85
Refs #18

## Test plan

- [x] `pnpm lint && pnpm type-check && pnpm -r test` all green (480 tests passing)
- [x] Confirmed `hono` resolves to `4.12.32` in `pnpm-lock.yaml` (was `4.12.23`)
- [x] No API contract change — `openapi:generate` not required

## Spec / AC

N/A — dependency hygiene fix, not a feature change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5xBFEwG73H6b5sFVBbzpz)_