### PR TITLE
chore(api): deepen Workers observability with traces + structured onError logs

### DIFF
--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -189,7 +189,9 @@ const app = new OpenAPIHono<AppEnv>({
 // else → 500. Handlers and middleware just `throw` and this maps it.
 app.onError((err, c) => {
   if (err instanceof DomainError) return toHttpError(c as Context, err);
-  console.error(err);
+  // Structured fields so Workers Observability can search/filter unhandled
+  // errors by request. Matches the codebase logging shape: `{ fields }, message`.
+  console.error({ error: err, method: c.req.method, path: c.req.path }, "Unhandled request error");
   return c.json({ error: "Internal Server Error" }, 500);
 });
 

--- a/apps/api/wrangler.jsonc
+++ b/apps/api/wrangler.jsonc
@@ -27,9 +27,21 @@
     "EMAIL_FROM_NAME": "Pineapple",
   },
 
+  // Workers Observability (logs + traces). Split into the nested logs/traces
+  // shape so each stream samples independently. Logs stay at 100% — this is a
+  // low-traffic two-person app, so full-fidelity logs cost little and pay off
+  // when debugging. Traces are sampled lower (Cloudflare's recommended default)
+  // since they're heavier per invocation; raise head_sampling_rate if trace
+  // coverage matters more than cost.
   "observability": {
     "enabled": true,
-    "head_sampling_rate": 1,
+    "logs": {
+      "head_sampling_rate": 1,
+    },
+    "traces": {
+      "enabled": true,
+      "head_sampling_rate": 0.01,
+    },
   },
 
   "triggers": {

--- a/docs/telemetry-plan.md
+++ b/docs/telemetry-plan.md
@@ -177,11 +177,13 @@ Route normalization:
 | `/api/auth/*`         | `Auth`        | `/api/auth/*`      |
 | unknown               | `Unknown`     | `Unknown`          |
 
-Workers Logs are enabled with `[observability] enabled = true` for invocation
-logs, uncaught exceptions, CPU time, wall time, and debugging. Analytics Engine
-is for custom aggregate queries; Workers Logs, Logpush, R2, or an external
-observability stack should be used for troubleshooting and longer forensic
-workflows.
+Workers Observability is enabled in `wrangler.jsonc` with the nested
+`observability.logs` / `observability.traces` shape. Logs run at full sampling
+(`head_sampling_rate = 1`) for invocation logs, uncaught exceptions, CPU time,
+wall time, and debugging; traces are enabled at a lower sampling rate to bound
+cost. Analytics Engine is for custom aggregate queries; Workers Logs, Logpush,
+R2, or an external observability stack should be used for troubleshooting and
+longer forensic workflows.
 
 ## 6. Anti-Patterns To Avoid
 


### PR DESCRIPTION
## Summary

- Move `apps/api` observability to the nested `logs`/`traces` shape (Cloudflare's current recommended depth): logs stay at 100% head sampling, traces are enabled at a lower default rate to bound cost. Verified `observability.logs`/`observability.traces` are valid keys against wrangler 4.95.0's `config-schema.json`. The issue referenced `wrangler.toml`; this repo uses `wrangler.jsonc`, so the config was translated accordingly.
- Structure the central `app.onError` log for non-domain errors as `{ error, method, path }` + a static message, matching the codebase's existing `console.error({ fields }, "message")` convention so unhandled request errors are searchable/filterable in Workers Observability.
- Update `docs/telemetry-plan.md` to describe the new nested config (it previously documented the old flat `[observability] enabled = true` shape).

## Related

Closes #66

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm type-check` — clean
- [x] `pnpm -r test` — 602 tests pass
- [x] Confirmed nested `observability.logs`/`observability.traces` keys exist in wrangler 4.95.0's config schema

## Spec / AC

No spec/contract change — no route specs or Zod schemas touched, so OpenAPI regeneration was not required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QVPd1Rx9m6pR9M7d3u37Jx)_