### PR TITLE
chore(skills): vendor a PR review skill for cloud agents

### DIFF
--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -1,0 +1,12 @@
+---
+description: Review a PR or the current branch diff (wrapper around the pr-review skill)
+argument-hint: "[PR number or URL — omit to review the current branch]"
+disable-model-invocation: true
+---
+
+Use the `pr-review` skill to review $ARGUMENTS.
+
+If no argument was given, review the current branch against `main`.
+
+This file is a slash-command shortcut only. The review procedure itself lives in
+`.claude/skills/pr-review/SKILL.md` — edit that, not this.

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -12,10 +12,15 @@ rules are tuned to what this repo's CI already enforces.
 
 ## Pick the target
 
-- A PR number or URL in the request → review that PR (`gh pr diff`, `gh pr view`).
+- A PR number or URL in the request → read that PR's diff and metadata using
+  whatever GitHub access this environment provides: the `gh` CLI (`gh pr diff`,
+  `gh pr view`), the GitHub MCP tools (e.g. a `pull_request_read` tool), or the
+  API. Do not assume `gh` exists — a cloud-agent session typically has GitHub MCP
+  tools instead. If none is available, fall back to the branch diff and say so.
 - Otherwise → review the current branch against `main` (`git diff main...HEAD`).
 
-State which one you picked in a single line before starting.
+State which target you picked, and which access path, in a single line before
+starting.
 
 ## 1. Eligibility (PR targets only)
 
@@ -54,7 +59,7 @@ verbatim:
 - **25** — Somewhat confident. Might be real; could not verify. Stylistic issues the
   relevant `CLAUDE.md` does not explicitly call out land here.
 - **50** — Moderately confident. Verified real, but a nitpick or rare in practice.
-- **75** — Highly confident. Double-checked, very likely hit in practice, and the PR's
+- **80** — Highly confident. Double-checked, very likely hit in practice, and the PR's
   approach is insufficient. Or it is named directly in the relevant `CLAUDE.md`.
 - **100** — Certain. Confirmed, frequent in practice, evidence directly supports it.
 
@@ -70,9 +75,11 @@ each with file and line, why it matters, and a fix direction — not a patch.
 
 **Do not comment on GitHub unless the request that invoked this skill explicitly asked
 you to.** Posting is public and outward-facing. When it is asked for, confirm the text
-first, keep it brief, skip emojis, and cite code with full-SHA permalinks
-(`https://github.com/snaveevans/pineapple/blob/<full-sha>/path#L4-L7`) — a `git rev-parse`
-subshell will not render in Markdown.
+first, then post it with whatever GitHub access this environment provides (`gh pr comment`,
+a GitHub MCP comment/review tool, or the API). Keep it brief, skip emojis, and cite code
+with full-SHA permalinks (`https://github.com/snaveevans/pineapple/blob/<full-sha>/path#L4-L7`)
+— resolve the SHA to a literal value first, since a `git rev-parse` subshell will not
+render in Markdown.
 
 ## What CI already covers — do not flag
 

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: pr-review
+description: Review a pull request or the current branch diff for bugs, CLAUDE.md adherence, and architectural fit. Fans out parallel reviewers, scores each finding for confidence, and reports only what survives. Use when asked to review a PR, review a branch before opening one, or check a change before merge.
+---
+
+# PR review
+
+Adapted from Anthropic's `code-review` plugin (`anthropics/claude-plugins-official`).
+Three changes from upstream: it reviews a **branch diff** as well as a PR, it **never
+posts to GitHub** unless the invoking request explicitly asks, and its false-positive
+rules are tuned to what this repo's CI already enforces.
+
+## Pick the target
+
+- A PR number or URL in the request → review that PR (`gh pr diff`, `gh pr view`).
+- Otherwise → review the current branch against `main` (`git diff main...HEAD`).
+
+State which one you picked in a single line before starting.
+
+## 1. Eligibility (PR targets only)
+
+Check whether the PR is closed, a draft, automated, trivially safe, or already carries
+a review from you. If any of those hold, stop and say why. Skip this step for a branch
+diff — an unopened branch is always eligible.
+
+## 2. Gather context
+
+Collect the paths (not the contents) of the root `CLAUDE.md` and any `CLAUDE.md` in
+directories the change touches. Summarize the change in a few lines: what it does and
+which layers it crosses.
+
+## 3. Fan out reviewers
+
+Launch these in parallel. Each returns a list of issues, and for each issue the reason
+it was flagged.
+
+1. **Conventions** — audit against `CLAUDE.md` and the repo-specific targets below.
+   `CLAUDE.md` is guidance for writing code, so not every line applies to review.
+2. **Bugs** — read only the diff and scan for real defects. Favor large problems over
+   nitpicks. Do not go hunting for extra context.
+3. **History** — read `git blame` and history of the modified code; judge the change
+   against why the code got that way.
+4. **Prior review** — read earlier PRs touching these files and check whether comments
+   there apply again.
+5. **Comments and docs** — check the change against guidance in nearby code comments,
+   the relevant spec in `docs/specs/features/`, and any ADR it depends on.
+
+## 4. Score every finding
+
+For each issue, independently score confidence 0-100. Give the scorer this rubric
+verbatim:
+
+- **0** — Not confident. False positive under light scrutiny, or pre-existing.
+- **25** — Somewhat confident. Might be real; could not verify. Stylistic issues the
+  relevant `CLAUDE.md` does not explicitly call out land here.
+- **50** — Moderately confident. Verified real, but a nitpick or rare in practice.
+- **75** — Highly confident. Double-checked, very likely hit in practice, and the PR's
+  approach is insufficient. Or it is named directly in the relevant `CLAUDE.md`.
+- **100** — Certain. Confirmed, frequent in practice, evidence directly supports it.
+
+For anything flagged on `CLAUDE.md` grounds, the scorer must confirm `CLAUDE.md`
+actually says that. **Drop everything under 80.** If nothing survives, say so — a quiet
+review is a valid result, not a failure.
+
+## 5. Report
+
+Report in-session by default. If the `ReportFindings` tool is available, use it, ranked
+most-severe first, and do not also print the findings as prose. Otherwise print them:
+each with file and line, why it matters, and a fix direction — not a patch.
+
+**Do not comment on GitHub unless the request that invoked this skill explicitly asked
+you to.** Posting is public and outward-facing. When it is asked for, confirm the text
+first, keep it brief, skip emojis, and cite code with full-SHA permalinks
+(`https://github.com/snaveevans/pineapple/blob/<full-sha>/path#L4-L7`) — a `git rev-parse`
+subshell will not render in Markdown.
+
+## What CI already covers — do not flag
+
+`ci.yml` runs `pnpm lint`, `pnpm type-check`, and `pnpm -r test`, so these turn the PR
+red on their own. Flagging them is noise:
+
+- Layer-boundary import violations (`eslint-plugin-boundaries`)
+- Floating promises, `process.env`, and Node built-ins under `apps/api/src/**`
+- Type errors, formatting, import mistakes
+- A stale `docs/reference/openapi.json`
+
+Also skip: pre-existing issues, pedantic nitpicks a senior engineer would not raise,
+missing test coverage or general security posture unless `CLAUDE.md` requires it,
+findings on lines the change did not touch, intentional behavior changes that are part
+of the point, and anything explicitly silenced with a lint-ignore.
+
+## Repo-specific review targets
+
+These are the judgment calls lint **cannot** make. This is where the review earns its
+keep — in each case both files can be individually clean.
+
+- **Computed fields (ADR-0009)** — derived values (status labels like `overdue`/`soon`/
+  `ok`, per-bucket counts, available filter categories) belong in the application layer
+  and ship inside read-model responses. Flag a client recomputing business logic from
+  raw data. UI-only state — selected filter, hover — correctly stays client-side.
+- **Smart Events (ADR-0010)** — events consumed by durable handlers must carry the state
+  and producer-owned conclusions those consumers need. Flag a consumer that re-reads the
+  source aggregate or re-derives a conclusion. Flag presentation copy on an event.
+  Cross-aggregate fields belong to the application layer, never assembled by an aggregate.
+  **Highest priority: a telemetry handler writing PII-bearing fields to Analytics
+  Engine.** Telemetry handlers stay thin selective readers.
+- **Error contract (ADR-0004)** — use cases return `Result<T, DomainError>`; handlers
+  throw; `app.onError` maps to status. Flag a use case that throws, or a handler that
+  hand-rolls a status code instead of an existing `DomainError` subclass.
+- **Branded types (ADR-0002)** — `UserId`, `AssetId`, `Email` constructed via `.from()`
+  or `.generate()`. Flag raw strings crossing into domain types.
+- **Composition root** — route _specs_ live in `api/`, handlers that instantiate
+  repositories live in `worker.ts`. Lint catches the bad import; you catch a spec that
+  has drifted from the handler it describes.
+- **`exactOptionalPropertyTypes`** — absent is not `undefined`. Check casts at the Zod
+  boundary are deliberate rather than a `as any` escape.
+- **Scope discipline** — a branch delivers one concern. ~40 files or ~800 net lines is a
+  signal to split. Flag a diff that has quietly absorbed an unrelated refactor, rename,
+  or infra change.
+- **Docs sync** — a merged feature slice should tick its spec checkbox and update
+  `docs/specs/SPECS.md`; an `apps/web` flow change should update `docs/web/FEATURES.md`;
+  a contract change should have a spec behind it. Flag field tables in
+  `docs/reference/data-model.md` that duplicate what `openapi.json` already specifies.


### PR DESCRIPTION
## Summary

- Vendors a `pr-review` skill into `.claude/skills/` so code review is available anywhere the repo is checked out — local, cloud agent, or CI.
- Motivation: the built-in `/code-review` is harness-delivered and **user-triggered**, so it is neither committable nor invokable by an unattended agent. The `code-review` plugin it derives from lives only in a user-scope marketplace cache, which a cloud environment never sees.
- Adds a thin `.claude/commands/pr-review.md` slash-command shortcut with `disable-model-invocation: true`, so it does not compete with the skill for triggering. The skill is the single source of truth.

## What was adapted

Derived from Anthropic's `code-review` plugin (`anthropics/claude-plugins-official`), with three deliberate departures:

1. **Reviews a branch diff when no PR exists.** Upstream is PR-only; cloud agents often have no PR yet.
2. **Never posts to GitHub unless the invoking request asks.** Upstream ends in an unconditional `gh pr comment` — posting is public and outward-facing, so it should not be a side effect of asking for a review.
3. **False-positive rules retuned for this repo.** CI already runs lint, type-check, and tests, so boundary violations and floating promises turn the PR red on their own; re-flagging them is noise. In their place the skill names the calls lint *cannot* make — ADR-0009 computed fields leaking to the client, ADR-0010 events forcing consumers to re-derive, telemetry handlers writing PII to Analytics Engine, `Result`-vs-throw at the use-case boundary, scope creep, and docs sync.

The upstream multi-agent fan-out and 0-100 confidence scoring (drop everything under 80) are kept — that filter is what keeps the review quiet.

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm type-check` — clean
- [x] `pnpm -r test` — 602 passing (502 api / 100 web), exit 0
- [x] Confirm the skill loads and triggers in a **cloud agent** session — done: the reviewing agent on this PR ran with no `gh` CLI and GitHub MCP tools instead, so a repo-committed `.claude/skills/` skill does reach cloud agents. (That review also surfaced the `gh` hard-coding, now fixed in 2088b35.)

## Notes for the reviewer

- **Naming.** Called `pr-review`, not `code-review`, so it cannot shadow the built-in `/code-review` or collide with the `sdd:code-reviewer` agent.
- **Skill over command.** `.claude/skills/` already ships three committed skills and is proven in this repo; `.claude/commands/` has never been exercised here. Skills are also model-invocable by description, which is the unattended-cloud case.
- **Cost.** The skill fans out parallel subagents by design. That is what makes it good and it is not free.
- **Redundancy to settle later.** This is now a third review path alongside `sdd:code-reviewer` and the harness built-in. Worth converging on one rather than accumulating; out of scope here.
- **Branch name** does not match the `CLAUDE.md` convention (`chore/vendor-pr-review-skill` would). It was created by the harness before the concern was known; CI does not enforce it.
- No related issue — this came out of a review of which skills survive into cloud environments.

