### PR TITLE
Fix: bump react-router to remediate multiple advisories

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,7 +17,7 @@
     "@tanstack/react-query": "^5.100.14",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-router": "^7.16.0"
+    "react-router": "^7.18.0"
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,8 +97,8 @@ importers:
         specifier: ^19.1.0
         version: 19.2.6(react@19.2.6)
       react-router:
-        specifier: ^7.16.0
-        version: 7.16.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^7.18.0
+        version: 7.18.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ^1.1.0
@@ -2848,8 +2848,8 @@ packages:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
 
-  react-router@7.16.0:
-    resolution: {integrity: sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==}
+  react-router@7.18.1:
+    resolution: {integrity: sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -5715,7 +5715,7 @@ snapshots:
 
   react-refresh@0.17.0: {}
 
-  react-router@7.16.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  react-router@7.18.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       cookie: 1.1.1
       react: 19.2.6


### PR DESCRIPTION
## Summary

- `apps/web` pinned `react-router: ^7.16.0`, which resolves below the `7.18.0` security line (`pnpm audit` reports several advisories against `< 7.18.0`, including a high-severity unauthenticated DoS and an RSC-mode CSRF bypass).
- Bumped to `^7.18.0` (resolves `7.18.1`).
- None of the reported advisories are reachable in this app's current configuration per #130's reachability analysis: `apps/web` is a client-only SPA (no SSR/RSC, no server-side route matching) and no navigation destination is fed from user-controlled input. This is preventative hardening — it removes the affected code from the shipped bundle.

## Related

Fixes #130

## Test plan

- [x] `pnpm lint`
- [x] `pnpm type-check`
- [x] `pnpm -r test` (604 tests passing)

## Spec / AC

N/A — dependency security patch, no feature/contract change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KhbMMbK2ceFR2zZgnumnpZ)_