### PR TITLE
docs: loosen branch naming convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,14 +202,26 @@ trailer.
 {type}/{slug}           # without
 ```
 
-- **type:** `feat` | `fix` | `docs` | `refactor` | `chore` | `ci` | `test` | `perf`
+- **type:** `feat` | `fix` | `docs` | `refactor` | `chore` | `ci` | `test` |
+  `perf` | `security`
 - **issue:** bare digits only (no `#`) — first segment after `type/` when numeric
 - **slug:** lowercase kebab-case, short
 
 Examples: `feat/42-team-invite`, `fix/87-null-session`, `docs/adr-0016`,
-`chore/upgrade-wrangler`.
+`chore/upgrade-wrangler`, `security/130-react-router-upgrade`.
 
-Regex: `^(feat|fix|docs|refactor|chore|ci|test|perf)/(?:[0-9]+-)?[a-z0-9]+(?:-[a-z0-9]+)*$`
+Regex: `^(feat|fix|docs|refactor|chore|ci|test|perf|security)/(?:[0-9]+-)?[a-z0-9]+(?:-[a-z0-9]+)*$`
+
+**This is a guideline, not a gate.** Nothing enforces it — no workflow, branch
+protection rule, or git hook reads the branch name, and CI runs on every pull
+request regardless of what the branch is called. A nonconforming name is a nit,
+not a review finding. Traceability lives in the PR body's issue link (below),
+which GitHub actually acts on; the branch name is human signal only.
+
+**Agent-assigned branches are exempt.** Cloud agent sessions get their branch
+name from the platform, not from the author — `claude/*`, `codex/*`,
+`opencode/*` and similar prefixes are outside this convention and should be left
+as assigned. The PR body still carries the issue link.
 
 ### Issue linking
 


### PR DESCRIPTION
The documented regex had lost contact with the repo: 19 of 36 merged
branches violated it, and nothing anywhere enforces it — no workflow,
branch protection rule, or git hook reads the branch name, and CI
triggers on every pull request regardless of what the branch is called.

- Add `security` as a type. Advisory remediation is neither `fix` nor
  `chore`, and it has now been reached for twice (#116, #131).
- Exempt agent-assigned prefixes (`claude/*`, `codex/*`, `opencode/*`).
  The platform assigns these, not the author, and they accounted for 16
  of the 19 nonconforming branches.
- Say plainly that the convention is a guideline, not a gate, so a
  nonconforming name stops surfacing as a review finding on otherwise
  clean PRs.

Traceability is unaffected: it lives in the PR body's issue link, which
GitHub actually acts on, not in the branch name.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01A1Zvzg1H2RrkgQGzUa2o2W