### PR TITLE
ci: group react and react-dom in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,18 @@ updates:
       semver-patch-days: 3
 
     groups:
+      # react-dom asserts at runtime that its version exactly matches react's.
+      # Left ungrouped, a version-locked pair can split across two PRs that
+      # each pin the other stale in pnpm-lock.yaml (#153) — neither goes green
+      # alone. This group must stay ahead of dev-non-major: Dependabot assigns
+      # a dependency to the first matching group, so if these patterns are
+      # ever widened to catch dev-type packages (e.g. @types/*), declaring
+      # this group later would let dev-non-major claim them first.
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+
       # One weekly PR for low-risk dev churn (eslint, prettier, vitest, wrangler,
       # stryker, @types/*). Majors are deliberately excluded so a breaking
       # toolchain bump lands in its own reviewable PR.
@@ -46,9 +58,10 @@ updates:
           - "minor"
           - "patch"
 
-    # Production dependencies (hono, better-auth, zod, @hono/zod-openapi, react,
-    # react-router, ...) are intentionally left ungrouped: each gets its own PR,
-    # so a red CI run points at exactly one package.
+    # Production dependencies (hono, better-auth, zod, @hono/zod-openapi,
+    # react-router, ...) are intentionally left ungrouped: each gets its own
+    # PR, so a red CI run points at exactly one package. react/react-dom are
+    # the one version-locked exception, grouped above.
 
     commit-message:
       prefix: "chore"


### PR DESCRIPTION
## Summary

- Add a `react` group to `.github/dependabot.yml` matching `react` and `react-dom` exactly, so Dependabot always bundles them into one PR instead of letting them split across two.
- Declare the group before `dev-non-major` so it wins first-match if the patterns are ever widened (per Dependabot's first-match-wins group assignment).
- Update the comment on ungrouped production dependencies to record react/react-dom as the one version-locked exception.

## Related

Closes #153

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"` — YAML parses
- [ ] Confirm on the next Dependabot run that a react/react-dom bump lands as a single PR

## Spec / AC

N/A — config-only change, no feature spec.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VT27yYyTA1divSDmaVPYq8)_