### PR TITLE
chore: group zod and @hono/zod-openapi in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,6 +49,18 @@ updates:
           - "react"
           - "react-dom"
 
+      # @hono/zod-openapi's peer dependency on zod moves in lockstep with its
+      # own major version (v0.x -> zod v3, v1.x -> zod v4). Left ungrouped, a
+      # bump on either side can land as two PRs that can't both go green
+      # (#158, #155) — bumping zod alone crashed openapi:generate and broke
+      # Worker boot; bumping @hono/zod-openapi alone failed tests against the
+      # v3 objects still in the tree. Must stay ahead of dev-non-major for the
+      # same first-match ordering reason as react above.
+      zod-openapi:
+        patterns:
+          - "zod"
+          - "@hono/zod-openapi"
+
       # One weekly PR for low-risk dev churn (eslint, prettier, vitest, wrangler,
       # stryker, @types/*). Majors are deliberately excluded so a breaking
       # toolchain bump lands in its own reviewable PR.
@@ -58,10 +70,10 @@ updates:
           - "minor"
           - "patch"
 
-    # Production dependencies (hono, better-auth, zod, @hono/zod-openapi,
-    # react-router, ...) are intentionally left ungrouped: each gets its own
-    # PR, so a red CI run points at exactly one package. react/react-dom are
-    # the one version-locked exception, grouped above.
+    # Production dependencies (hono, better-auth, react-router, ...) are
+    # intentionally left ungrouped: each gets its own PR, so a red CI run
+    # points at exactly one package. react/react-dom and zod/@hono/zod-openapi
+    # are the version-locked exceptions, grouped above.
 
     commit-message:
       prefix: "chore"


### PR DESCRIPTION
## Summary

- Adds a `zod-openapi` Dependabot group for `zod` and `@hono/zod-openapi`, mirroring the existing `react`/`react-dom` group
- `@hono/zod-openapi`'s peer dependency on `zod` moves in lockstep with its own major version (v0.x → zod v3, v1.x → zod v4). Left ungrouped, a bump on either side can land as two PRs that can't both go green independently — this already happened with #158 and #155
- Declared ahead of `dev-non-major` in the file, preserving the first-match ordering Dependabot uses to assign a dependency to a group
- No `update-types` restriction, matching the `react` group precedent — grouping bumps of all sizes is the safer default for a tightly-coupled pair like this

## Related

Closes #159

## Test plan

- [x] Validated `.github/dependabot.yml` YAML parses correctly and group ordering (`zod-openapi` before `dev-non-major`) is preserved
- [ ] Confirm on the next Dependabot run that a `zod`/`@hono/zod-openapi` bump lands as a single grouped PR

## Spec / AC

N/A — CI/tooling config change, no application code or spec affected.

---
_Generated by [Claude Code](https://claude.ai/code/session_014ypXNGTPucydy2VjL1Zbwe)_