### PR TITLE
ci: fail PRs on backward-incompatible OpenAPI changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,11 @@ name: CI
 # before a PR can be merged — so merging from your phone stays safe.
 on:
   pull_request:
+    # Default types omit `labeled`/`unlabeled` — without them, applying the
+    # breaking-api escape-hatch label to an already-red PR wouldn't retrigger
+    # this workflow, leaving the gate stuck red until a new commit or manual
+    # re-run (issue #118 review).
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   push:
     branches: [main]
 
@@ -84,6 +89,11 @@ jobs:
       # available to apply, whether or not this run finds a breaking change.
       - name: Ensure breaking-api escape-hatch label exists
         if: github.event_name == 'pull_request'
+        # GITHUB_TOKEN is forced read-only on fork-originated PRs regardless
+        # of the job's requested permissions, so this write would 403 there.
+        # It's best-effort housekeeping, not the gate itself — don't fail the
+        # whole job over it (issue #118 review).
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,12 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # Overrides the workflow-level permissions above (job-level replaces,
+    # it does not add). `issues: write` is only needed to idempotently
+    # create the `breaking-api` escape-hatch label (issue #118).
+    permissions:
+      contents: read
+      issues: write
     steps:
       - uses: actions/checkout@v7
 
@@ -69,3 +75,55 @@ jobs:
         run: |
           pnpm --filter @snaveevans/pineapple-web api:types
           git diff --exit-code apps/web/src/api/schema.ts
+
+      # Staleness (above) and backward-compatibility are different questions —
+      # with required_approving_review_count 0 and auto-merge, a removed
+      # response field, narrowed enum, or newly-required request field can
+      # merge and deploy unseen (issue #118). `breaking-api` is the escape
+      # hatch for a deliberate break; ensure it exists so it's always
+      # available to apply, whether or not this run finds a breaking change.
+      - name: Ensure breaking-api escape-hatch label exists
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          gh label create breaking-api \
+            --color D93F0B \
+            --description "Deliberately allows a backward-incompatible OpenAPI change past the breaking-change gate" \
+            --force >/dev/null
+
+      # Skip the gate when the spec is untouched, so it stays off the hot
+      # path. Fails closed: if the base ref can't be fetched, run the gate
+      # rather than silently skip it.
+      - name: Check whether OpenAPI spec changed vs base branch
+        id: openapi-spec-diff
+        if: github.event_name == 'pull_request'
+        run: |
+          set -uo pipefail
+          if ! git fetch --no-tags --depth=1 origin "$GITHUB_BASE_REF"; then
+            echo "::warning::Could not fetch base ref $GITHUB_BASE_REF — running breaking-change gate to fail closed"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if git diff --quiet "origin/$GITHUB_BASE_REF" -- docs/reference/openapi.json; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: OpenAPI breaking-change gate
+        if: >-
+          github.event_name == 'pull_request' &&
+          steps.openapi-spec-diff.outputs.changed == 'true' &&
+          !contains(github.event.pull_request.labels.*.name, 'breaking-api')
+        uses: oasdiff/oasdiff-action/breaking@v0
+        with:
+          base: "origin/${{ github.base_ref }}:docs/reference/openapi.json"
+          revision: docs/reference/openapi.json
+          fail-on: ERR
+          # No spec leaves CI, and no PR-comment token/permission is needed:
+          # breaking changes still fail the job with inline ::error::
+          # annotations on the Files changed tab and in the job log.
+          review: false
+          github-token: ""


### PR DESCRIPTION
## Summary

- Add an `OpenAPI breaking-change gate` step to the `verify` job that runs `oasdiff/oasdiff-action/breaking` against the PR head spec vs. the base branch's `docs/reference/openapi.json`, failing on `ERR`-level breaking changes (removed fields, narrowed enums, newly-required request fields, etc).
- Skip the gate when the spec is untouched by the PR (fails closed — if the base ref can't be fetched, the gate still runs).
- Add a `breaking-api` escape-hatch label, created idempotently in the same job (mirrors the `mutation-gate` label pattern in `mutation.yml`); applying it to a PR bypasses the gate. `labeled`/`unlabeled` are in the trigger types so applying/removing it retriggers CI immediately.
- `review: false` / `github-token: ""` so no spec data leaves CI and no extra PR-comment permissions are needed — breaking changes still surface as inline `::error::` annotations and in the job log.
- The label-creation step is `continue-on-error: true` since `GITHUB_TOKEN` is forced read-only on fork-originated PRs; it's best-effort housekeeping, not the gate itself.

## Related

Closes #118

## Test plan

- [x] `pnpm lint && pnpm type-check && pnpm -r test` pass locally
- [ ] A PR removing a response field / narrowing an enum / adding a required request field → CI red on this step, with the specific breaking change named in the output
- [ ] The same PR with the `breaking-api` label → green
- [ ] A PR with additive-only spec changes → green
- [x] A PR that doesn't touch `docs/reference/openapi.json` → step skipped (this PR's own CI run: gate skipped, label-creation step ran successfully)

## Spec / AC

- [ ] A PR removing a response field, narrowing an enum, or adding a required request field → CI red, with the specific breaking change named in the output (mechanism reviewed, not yet exercised end-to-end)
- [ ] The same PR with the escape-hatch label → green (mechanism reviewed, not yet exercised end-to-end)
- [ ] A PR with additive-only spec changes → green (mechanism reviewed, not yet exercised end-to-end)
- [x] A PR that doesn't touch the spec → skipped or trivially green
- [x] Escape-hatch label (`breaking-api`) created in the repo

## Review notes

Two gaps found in review and fixed in 05613fe:
- `pull_request`'s default trigger types don't include `labeled`/`unlabeled`, so the escape hatch wouldn't turn CI green until a new commit or manual re-run — added those types.
- The label-creation step would 403 and fail the whole job on fork PRs (forced-read-only `GITHUB_TOKEN`) — marked `continue-on-error: true`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Maa7qsgR6xpigda7fLqJjX)_