### PR TITLE
docs: adopt expand/contract as the schema-migration policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,10 +29,9 @@ app served by a Cloudflare Worker — it currently hosts the marketing home page
   `.catch`, or mark intentionally-detached work with `void`.
 - **D1 (SQLite)** via the `DB` binding. Migrations in `/migrations`, applied
   with `wrangler d1 migrations apply pineapple --local|--remote`. **Schema change
-  follows expand/contract** — add nullable, backfill, ship the code, and drop the
-  old shape in a _later_ PR. `deploy.yml` migrates before it deploys and nothing
-  reverts DDL, so a destructive statement in the same PR as the code that stops
-  reading the column is unrecoverable. Rules and the safe/unsafe DDL table:
+  follows expand/contract** — add nullable, backfill, ship the code, drop the old
+  shape in a _later_ PR; migrations run before the deploy and nothing reverts DDL.
+  Rules and the safe/unsafe DDL table:
   [`docs/specs/cross-cutting/schema-migrations.md`](docs/specs/cross-cutting/schema-migrations.md)
   (ADR-0017).
 - **Cloudflare Queues** are declared in `apps/api/wrangler.jsonc` but `wrangler

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,13 @@ app served by a Cloudflare Worker — it currently hosts the marketing home page
   `@typescript-eslint/no-floating-promises` is an explicit lint error: `await`,
   `.catch`, or mark intentionally-detached work with `void`.
 - **D1 (SQLite)** via the `DB` binding. Migrations in `/migrations`, applied
-  with `wrangler d1 migrations apply pineapple --local|--remote`.
+  with `wrangler d1 migrations apply pineapple --local|--remote`. **Schema change
+  follows expand/contract** — add nullable, backfill, ship the code, and drop the
+  old shape in a _later_ PR. `deploy.yml` migrates before it deploys and nothing
+  reverts DDL, so a destructive statement in the same PR as the code that stops
+  reading the column is unrecoverable. Rules and the safe/unsafe DDL table:
+  [`docs/specs/cross-cutting/schema-migrations.md`](docs/specs/cross-cutting/schema-migrations.md)
+  (ADR-0017).
 - **Cloudflare Queues** are declared in `apps/api/wrangler.jsonc` but `wrangler
 deploy` does NOT create them — it binds to existing queues and fails if one
   is missing. Provisioning is IaC: the "Ensure Queues exist" step in

--- a/docs/decisions/0017-expand-contract-schema-migrations.md
+++ b/docs/decisions/0017-expand-contract-schema-migrations.md
@@ -1,0 +1,204 @@
+# Expand/Contract Schema Migrations
+
+- Status: accepted
+- Date: 2026-08-01
+
+## Context and Problem Statement
+
+Every other stage of this pipeline is recoverable. Schema is not.
+
+`deploy.yml` applies pending D1 migrations to production **before** `wrangler deploy` runs, and
+that ordering is deliberate — the schema has to be ready before code that reads it goes live. It
+opens two windows the deploy cannot close:
+
+- If the Worker deploy fails after the migration succeeds, production sits on **new schema with
+  old code**.
+- If the deploy succeeds and the code is later rolled back, the schema **stays migrated**. Nothing
+  in the rollback path reverts DDL.
+
+For additive, nullable change both windows are harmless: old code ignores a column it does not
+know about. For a `DROP COLUMN`, a rename, or a new `NOT NULL` on a populated table, the second
+window is unrecoverable — the data is gone, and redeploying the previous Worker restores code that
+now queries columns which no longer exist. "Roll back if the smoke test fails" is therefore only
+partly true today, and the untrue half is the half that destroys data.
+
+Two conditions sharpen this. First, `main` auto-merges on green CI with
+`required_approving_review_count: 0`, so — as [ADR-0016](0016-mutation-testing-as-the-ci-trust-boundary.md)
+established — **CI is the entire trust boundary**; there is no reviewer standing between a
+destructive migration and production. Second, `/migrations` is the only stage of the pipeline with
+**zero** automated coverage: no check applies these files, parses them, or looks at them at all
+before `deploy.yml` runs them against the production database.
+
+The question this record answers is **what shape of schema change is permitted, given that the
+deploy ordering cannot make schema change reversible** — and how much authority a check enforcing
+that shape should have.
+
+This record fixes the rule and its enforcement authority. The exact DDL patterns matched, the
+script and workflow wiring, the acknowledgment-comment syntax, and the author checklist are
+mechanism and live in the
+[Schema Migrations cross-cutting spec](../specs/cross-cutting/schema-migrations.md).
+
+## Decision Drivers
+
+- **Schema change is one-way.** Code deploys are reversible and schema is not, so the two cannot
+  be governed by the same "ship it, roll back if it breaks" policy. This dominates the others.
+- **CI is the only gate.** With zero required reviewers, a rule nothing enforces is a rule that
+  holds only while everyone remembers it — and much of this repo's SQL is agent-authored.
+- **The deploy ordering is fixed.** Migrations must precede the Worker deploy. The policy has to
+  make that ordering safe rather than fight it.
+- **Old code must tolerate new schema.** Both failure windows above put old code in front of new
+  schema. Any permitted change must be one that old code survives.
+- **Cheap enough to sit on the hot path.** `verify` gates every PR. A check that makes iteration
+  slow gets routed around, and a routed-around gate is worse than none.
+- **Honest partiality.** Whatever check we adopt will have blind spots. They must be written down,
+  not implied away by a green badge.
+
+## Considered Options
+
+- **A. Expand/contract, enforced by CI.** _(chosen)_
+- **B. Coupled schema + code deploy behind a maintenance window.**
+- **C. Destructive DDL permitted, with database restore as the recovery path.**
+- **D. Write the rule as documentation only, enforce nothing.**
+
+## Decision Outcome
+
+Chosen option: **A — expand/contract, enforced by CI.**
+
+**The rule.** A schema change proceeds in phases, and the destructive phase is separated from the
+additive one by at least one deploy:
+
+1. **Expand** — add the new column or table, nullable, with no `NOT NULL` and no rename in place.
+2. **Backfill** — populate it, in its own migration or at runtime.
+3. **Ship** — deploy code that writes and reads the new shape while tolerating the old.
+4. **Contract** — in a **later PR, after the new code is live**, drop what is now unused.
+
+The load-bearing constraint is step 4's separation: **destructive DDL never rides in the same PR
+as the code that stops using the column.** That is what keeps old code compatible with new schema
+across both failure windows, and it is the part a policy without enforcement reliably loses.
+
+**Two independent checks enforce it,** and neither subsumes the other:
+
+- **A fresh-database apply.** Every migration is applied in order to a clean local D1 on every PR.
+  This catches ordering bugs and invalid SQL — the failures that would otherwise surface for the
+  first time against production. It does **not** prove idempotency; `wrangler` already tracks
+  applied migrations in `d1_migrations` and skips them.
+- **A static scan of the migration SQL** for destructive DDL — drops, renames, and `NOT NULL`
+  added without a default.
+
+That the second check is necessary is not obvious, and the spike that preceded this decision
+([#119](https://github.com/snaveevans/pineapple/issues/119)) established it by measurement:
+**SQLite rejects `ALTER TABLE ... ADD COLUMN ... NOT NULL` without a default only when the table
+is populated.** CI's fresh database is empty by construction, so the apply check succeeds silently
+on exactly the statement that would fail against production. A check that can only pass is not a
+check. The dangerous case is reachable only by reading the SQL text, so the scan is a separate
+mechanism answering a separate question — recorded here because a future maintainer would
+otherwise reasonably assume one covers the other and delete the "redundant" one.
+
+**The scan is a hand-rolled script, not a SQL parser.** [Atlas](https://github.com/ariga/atlas)'s
+`migrate lint` has purpose-built destructive-change analyzers, treats SQLite as a first-class
+dialect, and — unlike a regex — parses the SQL, so it structurally cannot confuse a safe
+`CREATE TABLE (... NOT NULL ...)` with a dangerous `ALTER TABLE ADD COLUMN ... NOT NULL`. It was
+weighed seriously and rejected on cost, not merit: it introduces a Go binary into an otherwise
+pnpm/Node-only pipeline and wants an `atlas.sum` checksum file, adding another
+generated-artifact-plus-drift-check pair. Against 15 small, self-authored, always-reviewed
+migrations, a ~15-line script matching the existing `mutation-scope.sh` convention buys most of
+the value for an hour of work. **This is a deliberate trade, not an oversight**, and Atlas is the
+named upgrade path — see the revisit trigger.
+
+**The scan blocks, and its escape hatch is in-file.** Blocking follows ADR-0016's reasoning
+directly: with no human reviewer, an advisory warning is a notification arriving after the merge it
+should have stopped. Contraction is legitimate and expected, so the gate needs an override — but
+it is an in-file acknowledgment comment on the statement, not a PR label. The distinction is
+structural, not stylistic: the scan reads _every_ migration on _every_ run rather than diffing
+against a base ref, which is what keeps it simple and fail-closed. A label expires with the run
+that carried it, so the first acknowledged destructive migration to land would leave the scan
+permanently red. An in-file marker makes the approval durable and leaves the reason next to the SQL
+it excuses, where the next reader will find it.
+
+### Revisit Trigger
+
+Reconsider if the migration SQL diversifies past what a line-oriented regex can honestly read —
+multi-line `ALTER` statements, generated SQL, or DDL keywords appearing inside string literals — at
+which point false negatives become likely and Atlas's parser earns its cost. Also reconsider if the
+deploy ordering changes such that schema and code can ship atomically, or if a human review
+requirement is introduced, since that would mean CI is no longer the sole trust boundary.
+
+### Positive Consequences
+
+- The unrecoverable case is designed out rather than guarded against: after a contraction lands,
+  the column it dropped has already been unused in production for at least one deploy.
+- `/migrations` gains its first automated coverage of any kind, on the stage where mistakes are
+  least reversible.
+- Rollback becomes an honest story, which is the prerequisite [#89](https://github.com/snaveevans/pineapple/issues/89)'s
+  runbook needs to be worth writing.
+- Turning the scan on is a clean cutover: no current migration contains a drop, a rename, or a
+  `NOT NULL` addition, so no allowlist or grandfathered exception is required — and the gate is
+  therefore never introduced already-suppressed.
+- The fresh-apply fixture is the same setup the future `worker.ts` integration tests need, so it
+  is built once.
+
+### Negative Consequences
+
+- **Schema change now takes at least two PRs and two deploys.** For a two-person team this is real
+  friction on a change that used to be one file, and the second PR is the one everyone forgets —
+  the tail of dropped-but-never-contracted columns is a cost this policy accepts.
+- **The scan is a regex, and a regex is not a parser.** It cannot distinguish a `DROP TABLE`
+  keyword from `'DROP TABLE'` inside a quoted default, cannot follow a statement reformatted across
+  lines, and reads only what the current SQL style makes visible. Its sufficiency is a bet on the
+  team and its agents continuing to write SQL in the present shape — not a structural guarantee.
+- **The acknowledgment comment can be applied thoughtlessly.** With no required reviewer, nothing
+  stops an author — or an agent — from silencing the gate rather than restructuring the change.
+  The comment makes that visible in the diff and permanent in the file; it does not prevent it.
+- Every PR pays the fresh-apply cost, including the large majority that touch no migration at all,
+  and that cost grows with the migration count.
+- The gate says nothing about whether a migration is _correct_ — only that it applies cleanly and
+  destroys nothing. A well-formed migration encoding the wrong model still ships.
+
+---
+
+## Pros and Cons of the Options
+
+### A. Expand/contract, enforced by CI
+
+- Good, because it is the only option that makes the deploy ordering safe instead of merely
+  documenting that it is dangerous.
+- Good, because it keeps old code compatible with new schema, which is precisely the state both
+  failure windows produce.
+- Good, because enforcement does not depend on a reviewer this repo does not have.
+- Good, because it is standard, well-understood practice, so agents and future contributors are
+  likely to recognize the shape without being taught it.
+- Bad, because it doubles the PR count for any change that removes something.
+- Bad, because the enforcing check is pattern matching, with blind spots that cannot be closed
+  without a real parser.
+
+### B. Coupled schema + code deploy behind a maintenance window
+
+- Good, because it eliminates the mixed-version window entirely: nothing serves traffic while
+  schema and code disagree.
+- Good, because a destructive change stays a single PR, keeping the change set small and legible.
+- Bad, because it does not solve the actual problem — a failed or reverted deploy still leaves the
+  schema migrated, and the window it closes is not the window that destroys data.
+- Bad, because it requires downtime tooling and a rehearsed procedure that do not exist here, for
+  an app whose deploys are currently a merge.
+
+### C. Destructive DDL permitted, with database restore as the recovery path
+
+- Good, because it imposes no process cost at all until something actually goes wrong.
+- Good, because D1 does offer point-in-time restore, so the capability is genuinely there.
+- Bad, because restore is whole-database: recovering a mistakenly dropped column also discards
+  every write since the restore point, trading a schema problem for a data-loss problem.
+- Bad, because it converts a preventable error into an incident requiring a correct, timed,
+  never-rehearsed response from a two-person team.
+- Bad, because it is effectively the status quo, and the status quo is what this record exists to
+  change.
+
+### D. Write the rule as documentation only, enforce nothing
+
+- Good, because it costs nothing to adopt and adds no CI time.
+- Good, because it captures the reasoning, which is most of the value for a human who reads it.
+- Bad, because with no required reviewer, an unenforced rule is checked by whoever happens to
+  remember it — and much of this SQL is written by agents working from whatever context they load.
+- Bad, because it would leave `/migrations` with zero coverage, which is the specific gap that
+  makes the rollback story dishonest.
+- Not mutually exclusive with A: the documentation is written either way. The question is only
+  whether anything checks it.

--- a/docs/decisions/0017-expand-contract-schema-migrations.md
+++ b/docs/decisions/0017-expand-contract-schema-migrations.md
@@ -33,10 +33,10 @@ The question this record answers is **what shape of schema change is permitted, 
 deploy ordering cannot make schema change reversible** — and how much authority a check enforcing
 that shape should have.
 
-This record fixes the rule and its enforcement authority, and nothing below it. The DDL patterns, the
-script and workflow wiring, the override's syntax, and the author checklist are mechanism: they live
-in the [Schema Migrations cross-cutting spec](../specs/cross-cutting/schema-migrations.md), whose
-status says whether the gate is live.
+This record fixes the rule and its enforcement authority, and nothing below it. How authors apply
+the rule — the safe/unsafe DDL table and the author checklist — lives in the
+[Schema Migrations cross-cutting spec](../specs/cross-cutting/schema-migrations.md), whose status
+says whether the gate is live. How the gate is built is neither document's business until it exists.
 
 ## Decision Drivers
 
@@ -76,11 +76,20 @@ The load-bearing constraint is step 4's separation: **destructive DDL never ride
 as the code that stops using the column.** That is what keeps old code compatible with new schema
 across both failure windows, and it is the part a policy without enforcement reliably loses.
 
-**The rule will be enforced in CI, and the gate will block.** Blocking follows ADR-0016's reasoning
-directly: with no human reviewer, an advisory warning is a notification arriving after the merge it
-should have stopped. Contraction is legitimate and expected, so the gate carries an override — but
-it is recorded as a durable, in-repo decision rather than a per-run dismissal, so the reason
-outlives the pull request that needed it.
+**The rule is enforced in CI, and the gate blocks.** Blocking follows ADR-0016's reasoning directly:
+with no human reviewer, an advisory warning is a notification arriving after the merge it should
+have stopped. Contraction is legitimate and expected, so the gate carries an override.
+
+**That override is recorded in the repository rather than as a per-PR dismissal** — a deliberate
+departure from the `breaking-api` label that exempts the OpenAPI breaking-change gate, which was
+adopted under these same zero-reviewer, auto-merge conditions. The two differ in how long the
+exempted thing lives. An API break happens once, at the merge that ships it; afterwards the new
+shape is simply the contract and nothing re-examines the old one, so an exemption that expires with
+its pull request is exactly right. A contraction is permanent: the statement that dropped the column
+stays in the migration history and stays destructive to read forever. An override that expired with
+its pull request would leave that statement unexplained and the gate objecting to it indefinitely.
+Recording the reason alongside the statement also puts it where the next reader of that migration
+will actually look.
 
 Enforcement takes **two checks, not one**, and that is the part most likely to be "simplified"
 later. Applying every migration to a clean database catches ordering bugs and invalid SQL. It
@@ -95,22 +104,30 @@ dialect, and — unlike a regex — parses the SQL, so it structurally cannot co
 `CREATE TABLE (... NOT NULL ...)` with a dangerous `ALTER TABLE ADD COLUMN ... NOT NULL`. It was
 weighed seriously and rejected on cost, not merit: it introduces a Go binary into an otherwise
 pnpm/Node-only pipeline and wants an `atlas.sum` checksum file, adding another
-generated-artifact-plus-drift-check pair. Against a small migration set whose destructive-DDL
-surface is uniform — the statements that matter written one per line — a script in the shape of the
-existing `mutation-scope.sh` buys most of the value for a fraction of the effort.
-**This is a deliberate trade, not an oversight**, and Atlas is the named upgrade path.
+generated-artifact-plus-drift-check pair.
 
-The bet is on that uniformity holding, and nothing structural guarantees it — which is what the
-revisit trigger below watches. It is explicitly _not_ a bet on review catching what the regex
-misses: this record's own premise is that no reviewer stands between a migration and production.
+**The trade is deliberate and openly partial.** A keyword scan reaches the destructive statements
+that announce themselves in their own text — drops, renames, a `NOT NULL` addition — cheaply and
+with few false positives. It does not reach a unique index over a pre-existing table, which is
+dangerous because of rows the statement never mentions and whose target table it may not even name
+on the same line. That case is out of reach for pattern matching at any level of effort, and the
+spec carries it as an author obligation rather than implying a check will catch it. Atlas would
+narrow that gap without closing it: parsing tells you which table a statement targets, not what is
+in it.
+
+So the bet is that the cheaply-detectable subset stays worth detecting cheaply, and nothing
+structural guarantees it — which is what the revisit trigger below watches. It is explicitly _not_ a
+bet on review catching the rest: this record's own premise is that no reviewer stands between a
+migration and production.
 
 ### Revisit Trigger
 
-Reconsider if the migration SQL diversifies past what a line-oriented regex can honestly read —
-multi-line `ALTER` statements, generated SQL, or DDL keywords appearing inside string literals — at
-which point false negatives become likely and Atlas's parser earns its cost. Also reconsider if the
-deploy ordering changes such that schema and code can ship atomically, or if a human review
-requirement is introduced, since that would mean CI is no longer the sole trust boundary.
+Reconsider if the migration SQL diversifies past what a line-oriented reader can honestly follow —
+any destructive statement split across lines, generated SQL, or DDL keywords appearing inside string
+literals — at which point false negatives become likely and Atlas's parser earns its cost. Also
+reconsider if the deploy ordering changes such that schema and code can ship atomically, or if a
+human review requirement is introduced, since that would mean CI is no longer the sole trust
+boundary.
 
 ### Positive Consequences
 
@@ -134,8 +151,8 @@ requirement is introduced, since that would mean CI is no longer the sole trust 
 - **The override can be applied thoughtlessly.** With no required reviewer, nothing stops an author
   — or an agent — from silencing the gate rather than restructuring the change. Recording the
   reason in-repo makes that visible and permanent; it does not prevent it.
-- Every PR pays the apply cost, including the large majority that touch no migration at all, and
-  that cost grows with the migration count.
+- The gate adds cost to the hot `verify` path every PR takes, and that cost grows with the migration
+  count.
 - The gate says nothing about whether a migration is _correct_ — only that it applies cleanly and
   destroys nothing. A well-formed migration encoding the wrong model still ships.
 - **A decision is not a gate.** Until the spec's status says the gate is live, this record is a rule

--- a/docs/decisions/0017-expand-contract-schema-migrations.md
+++ b/docs/decisions/0017-expand-contract-schema-migrations.md
@@ -33,10 +33,10 @@ The question this record answers is **what shape of schema change is permitted, 
 deploy ordering cannot make schema change reversible** — and how much authority a check enforcing
 that shape should have.
 
-This record fixes the rule and its enforcement authority. The exact DDL patterns matched, the
-script and workflow wiring, the acknowledgment-comment syntax, and the author checklist are
-mechanism and live in the
-[Schema Migrations cross-cutting spec](../specs/cross-cutting/schema-migrations.md).
+This record fixes the rule and its enforcement authority, and nothing below it. The DDL patterns, the
+script and workflow wiring, the override's syntax, and the author checklist are mechanism: they live
+in the [Schema Migrations cross-cutting spec](../specs/cross-cutting/schema-migrations.md) and, until
+they are built, in [#119](https://github.com/snaveevans/pineapple/issues/119).
 
 ## Decision Drivers
 
@@ -76,23 +76,24 @@ The load-bearing constraint is step 4's separation: **destructive DDL never ride
 as the code that stops using the column.** That is what keeps old code compatible with new schema
 across both failure windows, and it is the part a policy without enforcement reliably loses.
 
-**Two independent checks enforce it,** and neither subsumes the other:
+**The rule will be enforced in CI, and the gate will block.** Blocking follows ADR-0016's reasoning
+directly: with no human reviewer, an advisory warning is a notification arriving after the merge it
+should have stopped. Contraction is legitimate and expected, so the gate carries an override — but
+it is recorded as a durable, in-repo decision rather than a per-run dismissal, so the reason
+outlives the pull request that needed it.
 
-- **A fresh-database apply.** Every migration is applied in order to a clean local D1 on every PR.
-  This catches ordering bugs and invalid SQL — the failures that would otherwise surface for the
-  first time against production. It does **not** prove idempotency; `wrangler` already tracks
-  applied migrations in `d1_migrations` and skips them.
-- **A static scan of the migration SQL** for destructive DDL — drops, renames, and `NOT NULL`
-  added without a default.
+Enforcement takes **two checks, not one**, and that is the part most likely to be "simplified"
+later. Applying every migration to a clean database catches ordering bugs and invalid SQL. It
+cannot catch the statements whose danger is existing rows — `NOT NULL` without a default, or a
+unique index over data that is not yet unique — because a freshly built database has none. Those
+are reachable only by reading the SQL text. The two answer different questions; a future maintainer
+who concludes one is redundant has misread them.
 
-That the second check is necessary is not obvious, and the spike that preceded this decision
-([#119](https://github.com/snaveevans/pineapple/issues/119)) established it by measurement:
-**SQLite rejects `ALTER TABLE ... ADD COLUMN ... NOT NULL` without a default only when the table
-is populated.** CI's fresh database is empty by construction, so the apply check succeeds silently
-on exactly the statement that would fail against production. A check that can only pass is not a
-check. The dangerous case is reachable only by reading the SQL text, so the scan is a separate
-mechanism answering a separate question — recorded here because a future maintainer would
-otherwise reasonably assume one covers the other and delete the "redundant" one.
+**Neither check exists when this record is accepted.** The checks, the patterns they match, and the
+override's syntax are mechanism: they live in the
+[Schema Migrations spec](../specs/cross-cutting/schema-migrations.md) and
+[#119](https://github.com/snaveevans/pineapple/issues/119), and the rule holds on author discipline
+until they land.
 
 **The scan is a hand-rolled script, not a SQL parser.** [Atlas](https://github.com/ariga/atlas)'s
 `migrate lint` has purpose-built destructive-change analyzers, treats SQLite as a first-class
@@ -100,20 +101,14 @@ dialect, and — unlike a regex — parses the SQL, so it structurally cannot co
 `CREATE TABLE (... NOT NULL ...)` with a dangerous `ALTER TABLE ADD COLUMN ... NOT NULL`. It was
 weighed seriously and rejected on cost, not merit: it introduces a Go binary into an otherwise
 pnpm/Node-only pipeline and wants an `atlas.sum` checksum file, adding another
-generated-artifact-plus-drift-check pair. Against 15 small, self-authored, always-reviewed
-migrations, a ~15-line script matching the existing `mutation-scope.sh` convention buys most of
-the value for an hour of work. **This is a deliberate trade, not an oversight**, and Atlas is the
-named upgrade path — see the revisit trigger.
+generated-artifact-plus-drift-check pair. Against 15 migrations whose destructive-DDL surface is
+uniform — every `ALTER TABLE ... ADD COLUMN` in the repo is a single line — a small script in the
+shape of the existing `mutation-scope.sh` buys most of the value for about an hour of work.
+**This is a deliberate trade, not an oversight**, and Atlas is the named upgrade path.
 
-**The scan blocks, and its escape hatch is in-file.** Blocking follows ADR-0016's reasoning
-directly: with no human reviewer, an advisory warning is a notification arriving after the merge it
-should have stopped. Contraction is legitimate and expected, so the gate needs an override — but
-it is an in-file acknowledgment comment on the statement, not a PR label. The distinction is
-structural, not stylistic: the scan reads _every_ migration on _every_ run rather than diffing
-against a base ref, which is what keeps it simple and fail-closed. A label expires with the run
-that carried it, so the first acknowledged destructive migration to land would leave the scan
-permanently red. An in-file marker makes the approval durable and leaves the reason next to the SQL
-it excuses, where the next reader will find it.
+The bet is on that uniformity holding, and nothing structural guarantees it — which is what the
+revisit trigger below watches. It is explicitly _not_ a bet on review catching what the regex
+misses: this record's own premise is that no reviewer stands between a migration and production.
 
 ### Revisit Trigger
 
@@ -127,32 +122,32 @@ requirement is introduced, since that would mean CI is no longer the sole trust 
 
 - The unrecoverable case is designed out rather than guarded against: after a contraction lands,
   the column it dropped has already been unused in production for at least one deploy.
-- `/migrations` gains its first automated coverage of any kind, on the stage where mistakes are
-  least reversible.
+- It sets up `/migrations` to get its first automated coverage of any kind, on the stage where
+  mistakes are least reversible.
 - Rollback becomes an honest story, which is the prerequisite [#89](https://github.com/snaveevans/pineapple/issues/89)'s
   runbook needs to be worth writing.
-- Turning the scan on is a clean cutover: no current migration contains a drop, a rename, or a
-  `NOT NULL` addition, so no allowlist or grandfathered exception is required — and the gate is
-  therefore never introduced already-suppressed.
-- The fresh-apply fixture is the same setup the future `worker.ts` integration tests need, so it
-  is built once.
+- The gate can be introduced as a clean cutover: no current migration contains a drop, a rename, or
+  a `NOT NULL` addition, so it will not need an allowlist and will never start life
+  already-suppressed.
 
 ### Negative Consequences
 
 - **Schema change now takes at least two PRs and two deploys.** For a two-person team this is real
   friction on a change that used to be one file, and the second PR is the one everyone forgets —
   the tail of dropped-but-never-contracted columns is a cost this policy accepts.
-- **The scan is a regex, and a regex is not a parser.** It cannot distinguish a `DROP TABLE`
-  keyword from `'DROP TABLE'` inside a quoted default, cannot follow a statement reformatted across
-  lines, and reads only what the current SQL style makes visible. Its sufficiency is a bet on the
-  team and its agents continuing to write SQL in the present shape — not a structural guarantee.
-- **The acknowledgment comment can be applied thoughtlessly.** With no required reviewer, nothing
-  stops an author — or an agent — from silencing the gate rather than restructuring the change.
-  The comment makes that visible in the diff and permanent in the file; it does not prevent it.
-- Every PR pays the fresh-apply cost, including the large majority that touch no migration at all,
+- **Pattern matching is not parsing.** A regex cannot distinguish a `DROP TABLE` keyword from
+  `'DROP TABLE'` inside a quoted default, and cannot follow a statement reformatted across lines.
+  It reads only what the current SQL style makes visible.
+- **The override can be applied thoughtlessly.** With no required reviewer, nothing stops an author
+  — or an agent — from silencing the gate rather than restructuring the change. Recording the
+  reason in-repo makes that visible and permanent; it does not prevent it.
+- **The rule is unenforced in the interval.** It is accepted here and checked by nothing until
+  [#119](https://github.com/snaveevans/pineapple/issues/119) lands, so the gap this record exists to
+  close stays open in the meantime.
+- Every PR will pay the apply cost, including the large majority that touch no migration at all,
   and that cost grows with the migration count.
-- The gate says nothing about whether a migration is _correct_ — only that it applies cleanly and
-  destroys nothing. A well-formed migration encoding the wrong model still ships.
+- The gate will say nothing about whether a migration is _correct_ — only that it applies cleanly
+  and destroys nothing. A well-formed migration encoding the wrong model still ships.
 
 ---
 

--- a/docs/decisions/0017-expand-contract-schema-migrations.md
+++ b/docs/decisions/0017-expand-contract-schema-migrations.md
@@ -35,8 +35,8 @@ that shape should have.
 
 This record fixes the rule and its enforcement authority, and nothing below it. The DDL patterns, the
 script and workflow wiring, the override's syntax, and the author checklist are mechanism: they live
-in the [Schema Migrations cross-cutting spec](../specs/cross-cutting/schema-migrations.md) and, until
-they are built, in [#119](https://github.com/snaveevans/pineapple/issues/119).
+in the [Schema Migrations cross-cutting spec](../specs/cross-cutting/schema-migrations.md), whose
+status says whether the gate is live.
 
 ## Decision Drivers
 
@@ -89,21 +89,15 @@ unique index over data that is not yet unique — because a freshly built databa
 are reachable only by reading the SQL text. The two answer different questions; a future maintainer
 who concludes one is redundant has misread them.
 
-**Neither check exists when this record is accepted.** The checks, the patterns they match, and the
-override's syntax are mechanism: they live in the
-[Schema Migrations spec](../specs/cross-cutting/schema-migrations.md) and
-[#119](https://github.com/snaveevans/pineapple/issues/119), and the rule holds on author discipline
-until they land.
-
 **The scan is a hand-rolled script, not a SQL parser.** [Atlas](https://github.com/ariga/atlas)'s
 `migrate lint` has purpose-built destructive-change analyzers, treats SQLite as a first-class
 dialect, and — unlike a regex — parses the SQL, so it structurally cannot confuse a safe
 `CREATE TABLE (... NOT NULL ...)` with a dangerous `ALTER TABLE ADD COLUMN ... NOT NULL`. It was
 weighed seriously and rejected on cost, not merit: it introduces a Go binary into an otherwise
 pnpm/Node-only pipeline and wants an `atlas.sum` checksum file, adding another
-generated-artifact-plus-drift-check pair. Against 15 migrations whose destructive-DDL surface is
-uniform — every `ALTER TABLE ... ADD COLUMN` in the repo is a single line — a small script in the
-shape of the existing `mutation-scope.sh` buys most of the value for about an hour of work.
+generated-artifact-plus-drift-check pair. Against a small migration set whose destructive-DDL
+surface is uniform — the statements that matter written one per line — a script in the shape of the
+existing `mutation-scope.sh` buys most of the value for a fraction of the effort.
 **This is a deliberate trade, not an oversight**, and Atlas is the named upgrade path.
 
 The bet is on that uniformity holding, and nothing structural guarantees it — which is what the
@@ -124,11 +118,10 @@ requirement is introduced, since that would mean CI is no longer the sole trust 
   the column it dropped has already been unused in production for at least one deploy.
 - It sets up `/migrations` to get its first automated coverage of any kind, on the stage where
   mistakes are least reversible.
-- Rollback becomes an honest story, which is the prerequisite [#89](https://github.com/snaveevans/pineapple/issues/89)'s
-  runbook needs to be worth writing.
-- The gate can be introduced as a clean cutover: no current migration contains a drop, a rename, or
-  a `NOT NULL` addition, so it will not need an allowlist and will never start life
-  already-suppressed.
+- Rollback becomes an honest story: a runbook can promise schema safety that, before this, it could
+  not deliver.
+- The gate can start with no allowlist, so it never begins life already-suppressed — the usual
+  failure mode when a new check is introduced to an existing codebase.
 
 ### Negative Consequences
 
@@ -141,13 +134,12 @@ requirement is introduced, since that would mean CI is no longer the sole trust 
 - **The override can be applied thoughtlessly.** With no required reviewer, nothing stops an author
   — or an agent — from silencing the gate rather than restructuring the change. Recording the
   reason in-repo makes that visible and permanent; it does not prevent it.
-- **The rule is unenforced in the interval.** It is accepted here and checked by nothing until
-  [#119](https://github.com/snaveevans/pineapple/issues/119) lands, so the gap this record exists to
-  close stays open in the meantime.
-- Every PR will pay the apply cost, including the large majority that touch no migration at all,
-  and that cost grows with the migration count.
-- The gate will say nothing about whether a migration is _correct_ — only that it applies cleanly
-  and destroys nothing. A well-formed migration encoding the wrong model still ships.
+- Every PR pays the apply cost, including the large majority that touch no migration at all, and
+  that cost grows with the migration count.
+- The gate says nothing about whether a migration is _correct_ — only that it applies cleanly and
+  destroys nothing. A well-formed migration encoding the wrong model still ships.
+- **A decision is not a gate.** Until the spec's status says the gate is live, this record is a rule
+  people follow rather than one anything checks.
 
 ---
 

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -68,3 +68,4 @@ Use [`0000-template.md`](0000-template.md) as your starting point.
 | [0014](0014-layered-error-handling-policy.md)                    | Layered error handling policy                    | accepted                                                    |
 | [0015](0015-teams-as-opt-in-sharing-scope.md)                    | Teams as an opt-in sharing scope                 | proposed                                                    |
 | [0016](0016-mutation-testing-as-the-ci-trust-boundary.md)        | Mutation testing as the CI trust boundary        | accepted                                                    |
+| [0017](0017-expand-contract-schema-migrations.md)                | Expand/contract schema migrations                | accepted                                                    |

--- a/docs/specs/SPECS.md
+++ b/docs/specs/SPECS.md
@@ -1,4 +1,4 @@
-> **Audience:** everyone · **Purpose:** authoritative map of all feature and cross-cutting specs · **Source of truth:** this file · **Last reviewed:** 2026-07-03
+> **Audience:** everyone · **Purpose:** authoritative map of all feature and cross-cutting specs · **Source of truth:** this file · **Last reviewed:** 2026-08-01
 
 # Spec Index
 
@@ -17,15 +17,16 @@ generate or sync specs from code and PRs.
 Concerns that apply to every feature. When writing a feature spec, reference the
 relevant cross-cutting specs rather than re-describing the behavior.
 
-| Spec                                                   | Concern                          | Status |
-| ------------------------------------------------------ | -------------------------------- | ------ |
-| [authentication.md](./cross-cutting/authentication.md) | Auth, sessions, identity         | active |
-| [error-handling.md](./cross-cutting/error-handling.md) | Error states and user messaging  | active |
-| [permissions.md](./cross-cutting/permissions.md)       | Role-based access control        | active |
-| [validation.md](./cross-cutting/validation.md)         | Input validation patterns        | active |
-| [loading-states.md](./cross-cutting/loading-states.md) | Async UI states                  | active |
-| [telemetry.md](./cross-cutting/telemetry.md)           | Telemetry and observability      | active |
-| [testing.md](./cross-cutting/testing.md)               | Test verification, mutation gate | active |
+| Spec                                                         | Concern                          | Status |
+| ------------------------------------------------------------ | -------------------------------- | ------ |
+| [authentication.md](./cross-cutting/authentication.md)       | Auth, sessions, identity         | active |
+| [error-handling.md](./cross-cutting/error-handling.md)       | Error states and user messaging  | active |
+| [permissions.md](./cross-cutting/permissions.md)             | Role-based access control        | active |
+| [validation.md](./cross-cutting/validation.md)               | Input validation patterns        | active |
+| [loading-states.md](./cross-cutting/loading-states.md)       | Async UI states                  | active |
+| [telemetry.md](./cross-cutting/telemetry.md)                 | Telemetry and observability      | active |
+| [testing.md](./cross-cutting/testing.md)                     | Test verification, mutation gate | active |
+| [schema-migrations.md](./cross-cutting/schema-migrations.md) | D1 schema change and rollout     | active |
 
 ## Feature Specs
 
@@ -78,6 +79,7 @@ docs/specs/
     error-handling.md
     loading-states.md
     permissions.md
+    schema-migrations.md
     telemetry.md
     testing.md
     validation.md

--- a/docs/specs/SPECS.md
+++ b/docs/specs/SPECS.md
@@ -26,7 +26,7 @@ relevant cross-cutting specs rather than re-describing the behavior.
 | [loading-states.md](./cross-cutting/loading-states.md)       | Async UI states                  | active |
 | [telemetry.md](./cross-cutting/telemetry.md)                 | Telemetry and observability      | active |
 | [testing.md](./cross-cutting/testing.md)                     | Test verification, mutation gate | active |
-| [schema-migrations.md](./cross-cutting/schema-migrations.md) | D1 schema change and rollout     | active |
+| [schema-migrations.md](./cross-cutting/schema-migrations.md) | D1 schema change and rollout     | review |
 
 ## Feature Specs
 

--- a/docs/specs/cross-cutting/schema-migrations.md
+++ b/docs/specs/cross-cutting/schema-migrations.md
@@ -1,0 +1,186 @@
+---
+audience: all contributors
+purpose: how D1 schema changes are staged so a code rollback never leaves production broken
+source: this file
+date: 2026-08-01
+---
+
+# Schema Migrations — Cross-Cutting Spec
+
+**Status:** `active`
+**Owner:** engineering
+**Applies To:** Every change that adds or edits a file in `/migrations`
+
+> The rule is expand/contract, decided in
+> [ADR-0017](../../decisions/0017-expand-contract-schema-migrations.md). The two CI checks that
+> enforce it are tracked by [#119](https://github.com/snaveevans/pineapple/issues/119) and land in
+> a follow-up PR — see [Enforcement](#enforcement) for what is and is not automated today.
+
+---
+
+## Summary
+
+`deploy.yml` applies pending migrations to production **before** `wrangler deploy`. Schema
+therefore moves first and, unlike code, never moves back: no rollback path reverts DDL. Two
+situations put old code in front of new schema — a Worker deploy that fails after the migration
+succeeded, and a deploy that succeeds and is rolled back later.
+
+Additive, nullable change survives both; old code simply ignores a column it does not know about.
+A drop, a rename, or a `NOT NULL` addition does not, and the damage is unrecoverable.
+
+**So schema change is staged: add first, remove much later.** The removal is separated from the
+code that stops using the column by at least one deploy. Nothing else about this spec matters as
+much as that separation.
+
+## Canonical Behavior
+
+### The expand/contract sequence
+
+A schema change proceeds in phases. Phases 1-3 usually ride together; **phase 4 is always a
+separate, later PR.**
+
+1. **Expand.** Add the new column or table — nullable, no `NOT NULL`, no rename in place. The old
+   shape stays exactly as it was and keeps working.
+2. **Backfill.** Populate the new shape, either in its own migration or lazily at runtime. Old code
+   is still reading the old columns while this happens.
+3. **Ship.** Deploy code that writes and reads the new shape while still tolerating the old. After
+   this deploy is live and healthy, nothing reads the old shape any more.
+4. **Contract.** In a **later PR**, drop what is now unused.
+
+**The separation is the whole point.** Destructive DDL must never ride in the same PR as the code
+that stops using the column. If it does, a failed or reverted deploy leaves production running code
+that queries columns the migration already destroyed — and there is no way back.
+
+Renames are not an exception; they are a drop wearing a disguise. Rename by adding the new column,
+backfilling it, shipping code that reads it, and dropping the old one later — the same four phases.
+
+### Which DDL is safe
+
+| Statement                                                 | Verdict                                        |
+| --------------------------------------------------------- | ---------------------------------------------- |
+| `CREATE TABLE` (including `NOT NULL` columns)             | **safe** — the table has no rows yet           |
+| `CREATE INDEX`, `CREATE VIEW`, `CREATE TRIGGER`           | **safe**                                       |
+| `ALTER TABLE ... ADD COLUMN <name> <type>` (nullable)     | **safe**                                       |
+| `ALTER TABLE ... ADD COLUMN ... NOT NULL DEFAULT <const>` | **safe** — every existing row gets the default |
+| `INSERT` / `UPDATE` backfills                             | **safe**                                       |
+| `ALTER TABLE ... ADD COLUMN ... NOT NULL` (no default)    | **requires acknowledgment**                    |
+| `ALTER TABLE ... DROP COLUMN`                             | **requires acknowledgment**                    |
+| `DROP TABLE`                                              | **requires acknowledgment**                    |
+| `ALTER TABLE ... RENAME COLUMN` / `RENAME TO`             | **requires acknowledgment**                    |
+
+"Requires acknowledgment" means the statement is legitimate at phase 4 — it is how contraction
+happens — but it must be an explicit, recorded decision rather than something that slips through
+unnoticed. See [Enforcement](#enforcement).
+
+### Why `NOT NULL` without a default is the subtle one
+
+SQLite rejects `ALTER TABLE ... ADD COLUMN ... NOT NULL` with no default **only when the table
+already has rows**:
+
+```sql
+-- Against an empty table: succeeds silently.
+ALTER TABLE t ADD COLUMN required_field TEXT NOT NULL;   -- ok
+
+-- The identical statement, against a table with one row:
+ALTER TABLE t ADD COLUMN required_field TEXT NOT NULL;   -- Cannot add a NOT NULL column with default value NULL
+```
+
+A local or CI database created fresh from `/migrations` is empty at the moment each migration runs,
+so this statement passes every test that applies migrations to a clean database — and then fails
+against production, where the rows are. **Applying migrations somewhere cannot catch this.** Only
+reading the SQL can. This is why enforcement is two checks rather than one.
+
+To add a genuinely required column: add it nullable, backfill it, and enforce the requirement in
+the domain layer. A `NOT NULL` constraint added after the fact requires a table rebuild in SQLite,
+which is a contraction — phase 4, later PR.
+
+### Adding a foreign-key column
+
+Add it nullable, like any other column. Both existing examples do —
+`0004_maintenance_tasks.sql` and `0014_asset_sharing.sql` — and the reason is the ordinary one:
+existing rows have no value to point at, so a required FK on a populated table has the same problem
+as any other `NOT NULL` addition.
+
+### Migration files
+
+- Sequentially numbered, `NNNN_snake_case_description.sql`, never renumbered or edited once merged
+  — `wrangler` tracks applied migrations by filename in the `d1_migrations` table, so editing a
+  merged file changes nothing in an environment that already ran it while silently diverging from
+  one that has not.
+- A migration that got the schema wrong is fixed by a **new** migration, not by rewriting history.
+- Applied locally with
+  `pnpm --filter @snaveevans/pineapple-api wrangler d1 migrations apply pineapple --local`.
+
+## Enforcement
+
+**Today this rule is enforced by review, not by CI.** `/migrations` currently has no automated
+coverage of any kind. Two checks close that gap, tracked by
+[#119](https://github.com/snaveevans/pineapple/issues/119):
+
+| Check                                        | Answers                                | Cannot answer                    |
+| -------------------------------------------- | -------------------------------------- | -------------------------------- |
+| Apply every migration in order to a fresh D1 | Does this SQL run, in this order?      | Anything requiring existing rows |
+| Static scan of the migration SQL             | Does this destroy or narrow something? | Whether the SQL is valid         |
+
+**These are two checks solving two problems, and neither is redundant with the other.** The fresh
+apply catches ordering bugs and invalid SQL. It does _not_ prove idempotency — `wrangler` already
+skips migrations recorded in `d1_migrations`, so idempotency is not the fresh apply's contribution
+— and it structurally cannot catch the `NOT NULL` case above, because its database is empty. If a
+future change makes one of these look redundant, re-read that paragraph before deleting it.
+
+The scan blocks rather than warns, because with `required_approving_review_count: 0` on `main` an
+advisory warning arrives after the merge it should have stopped (same reasoning as
+[ADR-0016](../../decisions/0016-mutation-testing-as-the-ci-trust-boundary.md)). Its override is an
+**in-file acknowledgment comment** on the statement, carrying a reason — durable, and sitting next
+to the SQL it excuses. Not a PR label, which would expire with the run that carried it.
+
+## Feature Integration Contract
+
+Every feature that changes the database must:
+
+- **State which phase it is in.** A feature PR is expanding, backfilling, shipping, or contracting.
+  If it is doing more than one of expand and contract, it is doing too much.
+- **Keep the old shape readable** until the code that reads it is no longer deployed.
+- **Add columns nullable**, and enforce required-ness in the domain layer rather than with a
+  `NOT NULL` constraint added to a populated table.
+- **File the contraction as an issue** when shipping the expansion, so phase 4 is tracked rather
+  than remembered. Per [`docs/README.md`](../../README.md), that follow-up lives in the issue
+  tracker, not as a TODO in the migration file.
+- **Justify any acknowledged destructive statement** in the PR body — which deploy made the column
+  unused, and how that was confirmed.
+
+## Exceptions
+
+| Feature | Deviation | Reason                                                                                                                                   |
+| ------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| —       | —         | No current migration contains a drop, a rename, or a `NOT NULL` addition. The rule starts from a clean slate with nothing grandfathered. |
+
+## Anti-Patterns
+
+- **Contracting in the same PR as the code that stops reading the column.** The single failure this
+  spec exists to prevent. The migration runs before the deploy, so a deploy failure leaves live
+  code querying a column that no longer exists.
+- **`ALTER TABLE ... ADD COLUMN ... NOT NULL` with no default.** Passes locally and in CI against
+  empty tables; fails against production. Add it nullable and enforce the rule in the domain.
+- **Renaming a column in place.** A rename is a drop plus an add with no migration path for code
+  that has not been redeployed yet.
+- **Editing a migration that is already merged.** Environments that already applied it will never
+  see the change, so the schema silently diverges by environment. Write a new migration.
+- **Acknowledging a destructive statement to get CI green.** The acknowledgment records a decision
+  someone made; it is not a way to skip making one. If the column is still being read, the answer
+  is to wait a deploy, not to annotate the drop.
+- **Reading a green migration check as "this migration is correct."** It says the SQL applies and
+  destroys nothing. It says nothing about whether the schema models the right thing.
+
+## Known Issues
+
+- **The static scan will be pattern matching, not SQL parsing.** It cannot distinguish a
+  `DROP TABLE` keyword from `'DROP TABLE'` inside a quoted string, and will not see a statement
+  reformatted across multiple lines. Every migration is single-line-per-statement today, which is
+  what makes this viable; ADR-0017 names [Atlas](https://github.com/ariga/atlas) as the upgrade
+  path if that stops being true.
+- **Nothing enforces that phase 4 ever happens.** Columns that went unused at phase 3 can linger
+  indefinitely. Filing the contraction issue at expansion time is the only guard, and it is a
+  human one.
+- **The fresh-apply cost grows with the migration count** — roughly half a second per migration on
+  top of a fixed few seconds of D1 bootstrap. Not a concern at the current count or growth rate.

--- a/docs/specs/cross-cutting/schema-migrations.md
+++ b/docs/specs/cross-cutting/schema-migrations.md
@@ -7,14 +7,15 @@ date: 2026-08-01
 
 # Schema Migrations — Cross-Cutting Spec
 
-**Status:** `active`
+**Status:** `review`
 **Owner:** engineering
 **Applies To:** Every change that adds or edits a file in `/migrations`
 
 > The rule is expand/contract, decided in
-> [ADR-0017](../../decisions/0017-expand-contract-schema-migrations.md). The two CI checks that
-> enforce it are tracked by [#119](https://github.com/snaveevans/pineapple/issues/119) and land in
-> a follow-up PR — see [Enforcement](#enforcement) for what is and is not automated today.
+> [ADR-0017](../../decisions/0017-expand-contract-schema-migrations.md). **It is in force now and
+> enforced by author discipline — no automated check reads `/migrations` today.** CI enforcement is
+> tracked by [#119](https://github.com/snaveevans/pineapple/issues/119); this spec moves to
+> `active` when it lands.
 
 ---
 
@@ -56,43 +57,58 @@ backfilling it, shipping code that reads it, and dropping the old one later — 
 
 ### Which DDL is safe
 
-| Statement                                                 | Verdict                                        |
-| --------------------------------------------------------- | ---------------------------------------------- |
-| `CREATE TABLE` (including `NOT NULL` columns)             | **safe** — the table has no rows yet           |
-| `CREATE INDEX`, `CREATE VIEW`, `CREATE TRIGGER`           | **safe**                                       |
-| `ALTER TABLE ... ADD COLUMN <name> <type>` (nullable)     | **safe**                                       |
-| `ALTER TABLE ... ADD COLUMN ... NOT NULL DEFAULT <const>` | **safe** — every existing row gets the default |
-| `INSERT` / `UPDATE` backfills                             | **safe**                                       |
-| `ALTER TABLE ... ADD COLUMN ... NOT NULL` (no default)    | **requires acknowledgment**                    |
-| `ALTER TABLE ... DROP COLUMN`                             | **requires acknowledgment**                    |
-| `DROP TABLE`                                              | **requires acknowledgment**                    |
-| `ALTER TABLE ... RENAME COLUMN` / `RENAME TO`             | **requires acknowledgment**                    |
+Three verdicts. **Safe** — old code survives it and it cannot behave differently against production
+rows. **Contract only** — it destroys something, so it belongs in phase 4 and nowhere else.
+**Empty-table trap** — it succeeds against a fresh database and can fail or narrow against a
+populated one, so a clean local run proves nothing about it.
 
-"Requires acknowledgment" means the statement is legitimate at phase 4 — it is how contraction
-happens — but it must be an explicit, recorded decision rather than something that slips through
-unnoticed. See [Enforcement](#enforcement).
+| Statement                                                      | Verdict                     |
+| -------------------------------------------------------------- | --------------------------- |
+| `CREATE TABLE` (including `NOT NULL` columns)                  | safe — no rows yet          |
+| `CREATE INDEX` (non-unique)                                    | safe                        |
+| `CREATE UNIQUE INDEX` on a table created in the same migration | safe — no rows yet          |
+| `CREATE VIEW`, `CREATE TRIGGER`                                | safe                        |
+| `ALTER TABLE ... ADD COLUMN <name> <type>` (nullable)          | safe                        |
+| `ALTER TABLE ... ADD COLUMN ... NOT NULL DEFAULT <const>`      | safe — rows get the default |
+| `INSERT` / `UPDATE` backfills                                  | safe                        |
+| `ALTER TABLE ... ADD COLUMN ... NOT NULL` (no default)         | **empty-table trap**        |
+| `CREATE UNIQUE INDEX` on a pre-existing table                  | **empty-table trap**        |
+| `ALTER TABLE ... DROP COLUMN`                                  | **contract only**           |
+| `DROP TABLE`                                                   | **contract only**           |
+| `ALTER TABLE ... RENAME COLUMN` / `RENAME TO`                  | **contract only**           |
 
-### Why `NOT NULL` without a default is the subtle one
+### The empty-table trap
 
-SQLite rejects `ALTER TABLE ... ADD COLUMN ... NOT NULL` with no default **only when the table
-already has rows**:
+Two statements pass against a database built fresh from `/migrations` and can still fail against
+production. They share a cause: **the thing that makes them dangerous is existing rows, and a
+freshly built database has none.** Verified against SQLite 3.51.2:
 
 ```sql
--- Against an empty table: succeeds silently.
-ALTER TABLE t ADD COLUMN required_field TEXT NOT NULL;   -- ok
+-- 1. NOT NULL with no default.
+-- Empty table:                     succeeds silently.
+-- One existing row:                Cannot add a NOT NULL column with default value NULL
+ALTER TABLE t ADD COLUMN required_field TEXT NOT NULL;
 
--- The identical statement, against a table with one row:
-ALTER TABLE t ADD COLUMN required_field TEXT NOT NULL;   -- Cannot add a NOT NULL column with default value NULL
+-- 2. A unique index over data that is not actually unique yet.
+-- Empty table:                     succeeds silently.
+-- Two rows sharing (a, b):         UNIQUE constraint failed: t.a, t.b
+CREATE UNIQUE INDEX idx ON t (a, b);
 ```
 
-A local or CI database created fresh from `/migrations` is empty at the moment each migration runs,
-so this statement passes every test that applies migrations to a clean database — and then fails
-against production, where the rows are. **Applying migrations somewhere cannot catch this.** Only
-reading the SQL can. This is why enforcement is two checks rather than one.
+`IF NOT EXISTS` does **not** rescue the second one — the index does not exist, so SQLite proceeds
+to build it and hits the duplicate. `0011_bootstrap_scheduled_reminders.sql` adds exactly this kind
+of index to `scheduled_reminders`, a table created back in `0009`; it is fine only because the data
+happened to be unique.
 
-To add a genuinely required column: add it nullable, backfill it, and enforce the requirement in
-the domain layer. A `NOT NULL` constraint added after the fact requires a table rebuild in SQLite,
-which is a contraction — phase 4, later PR.
+The unique index carries a second hazard the `NOT NULL` case does not: **even when it succeeds it
+narrows the schema.** Old code still writing what used to be legal duplicates starts failing the
+moment the index exists — during precisely the window where old code is running against new schema.
+A unique index on an existing table therefore belongs at phase 3 or later, after the code that
+would violate it is no longer deployed, and it needs the data checked first.
+
+To add a genuinely required column: add it nullable, backfill it, and enforce the requirement in the
+domain layer. A `NOT NULL` constraint added after the fact requires a table rebuild in SQLite, which
+is a contraction — phase 4, later PR.
 
 ### Adding a foreign-key column
 
@@ -113,26 +129,20 @@ as any other `NOT NULL` addition.
 
 ## Enforcement
 
-**Today this rule is enforced by review, not by CI.** `/migrations` currently has no automated
-coverage of any kind. Two checks close that gap, tracked by
-[#119](https://github.com/snaveevans/pineapple/issues/119):
+**Nothing automated reads `/migrations` today.** No check applies these files, parses them, or
+inspects them before `deploy.yml` runs them against production. This rule currently holds because
+authors follow it.
 
-| Check                                        | Answers                                | Cannot answer                    |
-| -------------------------------------------- | -------------------------------------- | -------------------------------- |
-| Apply every migration in order to a fresh D1 | Does this SQL run, in this order?      | Anything requiring existing rows |
-| Static scan of the migration SQL             | Does this destroy or narrow something? | Whether the SQL is valid         |
+That is a gap, not a design: with `required_approving_review_count: 0` and auto-merge on `main`,
+there is no reviewer standing behind it either. ADR-0017 decided the rule will be **enforced in CI,
+blocking**, with an override for the legitimate contraction case. The checks and their design are
+tracked by [#119](https://github.com/snaveevans/pineapple/issues/119) and documented here when they
+land.
 
-**These are two checks solving two problems, and neither is redundant with the other.** The fresh
-apply catches ordering bugs and invalid SQL. It does _not_ prove idempotency — `wrangler` already
-skips migrations recorded in `d1_migrations`, so idempotency is not the fresh apply's contribution
-— and it structurally cannot catch the `NOT NULL` case above, because its database is empty. If a
-future change makes one of these look redundant, re-read that paragraph before deleting it.
-
-The scan blocks rather than warns, because with `required_approving_review_count: 0` on `main` an
-advisory warning arrives after the merge it should have stopped (same reasoning as
-[ADR-0016](../../decisions/0016-mutation-testing-as-the-ci-trust-boundary.md)). Its override is an
-**in-file acknowledgment comment** on the statement, carrying a reason — durable, and sitting next
-to the SQL it excuses. Not a PR label, which would expire with the run that carried it.
+One property of that future enforcement is worth stating now, because it shapes what authors can
+rely on: **applying migrations to a clean database cannot catch the empty-table trap above.** A
+check of that kind will exist, and it will not cover those two statements. Do not read a green
+migration check as clearance for either.
 
 ## Feature Integration Contract
 
@@ -143,11 +153,13 @@ Every feature that changes the database must:
 - **Keep the old shape readable** until the code that reads it is no longer deployed.
 - **Add columns nullable**, and enforce required-ness in the domain layer rather than with a
   `NOT NULL` constraint added to a populated table.
+- **Check the data before adding a unique index** to a table that already has rows, and add it no
+  earlier than phase 3.
 - **File the contraction as an issue** when shipping the expansion, so phase 4 is tracked rather
   than remembered. Per [`docs/README.md`](../../README.md), that follow-up lives in the issue
   tracker, not as a TODO in the migration file.
-- **Justify any acknowledged destructive statement** in the PR body — which deploy made the column
-  unused, and how that was confirmed.
+- **Justify any contract-phase statement** in the PR body — which deploy made the column unused,
+  and how that was confirmed.
 
 ## Exceptions
 
@@ -160,27 +172,21 @@ Every feature that changes the database must:
 - **Contracting in the same PR as the code that stops reading the column.** The single failure this
   spec exists to prevent. The migration runs before the deploy, so a deploy failure leaves live
   code querying a column that no longer exists.
-- **`ALTER TABLE ... ADD COLUMN ... NOT NULL` with no default.** Passes locally and in CI against
-  empty tables; fails against production. Add it nullable and enforce the rule in the domain.
+- **`ALTER TABLE ... ADD COLUMN ... NOT NULL` with no default.** Passes against every empty
+  database; fails against production. Add it nullable and enforce the rule in the domain.
+- **Adding a unique index to a populated table without checking the data.** Same trap, and it also
+  narrows the schema under old code that is still writing duplicates.
 - **Renaming a column in place.** A rename is a drop plus an add with no migration path for code
   that has not been redeployed yet.
 - **Editing a migration that is already merged.** Environments that already applied it will never
   see the change, so the schema silently diverges by environment. Write a new migration.
-- **Acknowledging a destructive statement to get CI green.** The acknowledgment records a decision
-  someone made; it is not a way to skip making one. If the column is still being read, the answer
-  is to wait a deploy, not to annotate the drop.
-- **Reading a green migration check as "this migration is correct."** It says the SQL applies and
-  destroys nothing. It says nothing about whether the schema models the right thing.
+- **Treating "it applied cleanly locally" as evidence.** A local database is built fresh from these
+  same files, so it shares every blind spot production does not.
 
 ## Known Issues
 
-- **The static scan will be pattern matching, not SQL parsing.** It cannot distinguish a
-  `DROP TABLE` keyword from `'DROP TABLE'` inside a quoted string, and will not see a statement
-  reformatted across multiple lines. Every migration is single-line-per-statement today, which is
-  what makes this viable; ADR-0017 names [Atlas](https://github.com/ariga/atlas) as the upgrade
-  path if that stops being true.
-- **Nothing enforces that phase 4 ever happens.** Columns that went unused at phase 3 can linger
-  indefinitely. Filing the contraction issue at expansion time is the only guard, and it is a
-  human one.
-- **The fresh-apply cost grows with the migration count** — roughly half a second per migration on
-  top of a fixed few seconds of D1 bootstrap. Not a concern at the current count or growth rate.
+- **Nothing enforces phase 4 ever happens.** Columns that went unused at phase 3 can linger
+  indefinitely. Filing the contraction issue at expansion time is the only guard, and it is a human
+  one.
+- **The rule is unenforced until [#119](https://github.com/snaveevans/pineapple/issues/119) lands.**
+  Between now and then, a destructive migration can reach production with nothing objecting.

--- a/docs/specs/cross-cutting/schema-migrations.md
+++ b/docs/specs/cross-cutting/schema-migrations.md
@@ -133,22 +133,21 @@ legitimate contraction case. While this spec's status is `review`, that gate is 
 rule holds on author discipline alone — with `required_approving_review_count: 0` and auto-merge on
 `main`, nothing else stands behind it.
 
-Enforcement takes two checks, and one bounds what the other can promise:
+Enforcement takes two checks rather than one; why that is not redundant, and must not be
+"simplified" later, is recorded in
+[ADR-0017](../../decisions/0017-expand-contract-schema-migrations.md).
 
-- **Applying every migration in order to a clean database** proves the SQL is valid and correctly
-  ordered.
-- **Reading the SQL** is the only way to reach destructive DDL and the empty-table trap, because a
-  clean database has no rows for either to go wrong against.
-
-**A green migration check is therefore never clearance for the empty-table trap.** Whatever
-automation exists, those two statements stay the author's responsibility.
+What matters to an author is the consequence: **a green migration check is never clearance for the
+empty-table trap.** No check that applies migrations to a clean database can reach those two
+statements, because a clean database has none of the rows that make them dangerous. They stay the
+author's responsibility regardless of what automation exists.
 
 ## Feature Integration Contract
 
 Every feature that changes the database must:
 
-- **State which phase it is in.** A feature PR is expanding, backfilling, shipping, or contracting.
-  If it is doing more than one of expand and contract, it is doing too much.
+- **Never expand and contract in the same PR.** Phases 1-3 may ride together; phase 4 is always its
+  own. Say in the PR body which phases it covers.
 - **Keep the old shape readable** until the code that reads it is no longer deployed.
 - **Add columns nullable**, and enforce required-ness in the domain layer rather than with a
   `NOT NULL` constraint added to a populated table.

--- a/docs/specs/cross-cutting/schema-migrations.md
+++ b/docs/specs/cross-cutting/schema-migrations.md
@@ -12,10 +12,9 @@ date: 2026-08-01
 **Applies To:** Every change that adds or edits a file in `/migrations`
 
 > The rule is expand/contract, decided in
-> [ADR-0017](../../decisions/0017-expand-contract-schema-migrations.md). **It is in force now and
-> enforced by author discipline — no automated check reads `/migrations` today.** CI enforcement is
-> tracked by [#119](https://github.com/snaveevans/pineapple/issues/119); this spec moves to
-> `active` when it lands.
+> [ADR-0017](../../decisions/0017-expand-contract-schema-migrations.md), which also decided it is
+> enforced by a blocking CI gate. **While this spec's status is `review`, that gate is not live and
+> the rule holds on author discipline.**
 
 ---
 
@@ -81,7 +80,7 @@ populated one, so a clean local run proves nothing about it.
 
 Two statements pass against a database built fresh from `/migrations` and can still fail against
 production. They share a cause: **the thing that makes them dangerous is existing rows, and a
-freshly built database has none.** Verified against SQLite 3.51.2:
+freshly built database has none.**
 
 ```sql
 -- 1. NOT NULL with no default.
@@ -96,9 +95,9 @@ CREATE UNIQUE INDEX idx ON t (a, b);
 ```
 
 `IF NOT EXISTS` does **not** rescue the second one — the index does not exist, so SQLite proceeds
-to build it and hits the duplicate. `0011_bootstrap_scheduled_reminders.sql` adds exactly this kind
-of index to `scheduled_reminders`, a table created back in `0009`; it is fine only because the data
-happened to be unique.
+to build it and hits the duplicate. `0011_bootstrap_scheduled_reminders.sql` is this exact shape: a
+unique index added to `scheduled_reminders`, a table created back in `0009`. Whether a statement
+like that applies cleanly depends on the rows in the database, not on anything the SQL says.
 
 The unique index carries a second hazard the `NOT NULL` case does not: **even when it succeeds it
 narrows the schema.** Old code still writing what used to be legal duplicates starts failing the
@@ -129,20 +128,20 @@ as any other `NOT NULL` addition.
 
 ## Enforcement
 
-**Nothing automated reads `/migrations` today.** No check applies these files, parses them, or
-inspects them before `deploy.yml` runs them against production. This rule currently holds because
-authors follow it.
+ADR-0017 decided this rule is **enforced in CI by a blocking gate**, with an override for the
+legitimate contraction case. While this spec's status is `review`, that gate is not live and the
+rule holds on author discipline alone — with `required_approving_review_count: 0` and auto-merge on
+`main`, nothing else stands behind it.
 
-That is a gap, not a design: with `required_approving_review_count: 0` and auto-merge on `main`,
-there is no reviewer standing behind it either. ADR-0017 decided the rule will be **enforced in CI,
-blocking**, with an override for the legitimate contraction case. The checks and their design are
-tracked by [#119](https://github.com/snaveevans/pineapple/issues/119) and documented here when they
-land.
+Enforcement takes two checks, and one bounds what the other can promise:
 
-One property of that future enforcement is worth stating now, because it shapes what authors can
-rely on: **applying migrations to a clean database cannot catch the empty-table trap above.** A
-check of that kind will exist, and it will not cover those two statements. Do not read a green
-migration check as clearance for either.
+- **Applying every migration in order to a clean database** proves the SQL is valid and correctly
+  ordered.
+- **Reading the SQL** is the only way to reach destructive DDL and the empty-table trap, because a
+  clean database has no rows for either to go wrong against.
+
+**A green migration check is therefore never clearance for the empty-table trap.** Whatever
+automation exists, those two statements stay the author's responsibility.
 
 ## Feature Integration Contract
 
@@ -163,9 +162,8 @@ Every feature that changes the database must:
 
 ## Exceptions
 
-| Feature | Deviation | Reason                                                                                                                                   |
-| ------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| —       | —         | No current migration contains a drop, a rename, or a `NOT NULL` addition. The rule starts from a clean slate with nothing grandfathered. |
+| Feature | Deviation | Reason |
+| ------- | --------- | ------ |
 
 ## Anti-Patterns
 
@@ -188,5 +186,6 @@ Every feature that changes the database must:
 - **Nothing enforces phase 4 ever happens.** Columns that went unused at phase 3 can linger
   indefinitely. Filing the contraction issue at expansion time is the only guard, and it is a human
   one.
-- **The rule is unenforced until [#119](https://github.com/snaveevans/pineapple/issues/119) lands.**
-  Between now and then, a destructive migration can reach production with nothing objecting.
+- **A unique index on an existing table cannot be judged from the SQL alone.** Whether it is safe
+  depends on the rows, so no static check can clear it. It stays an author obligation regardless of
+  what automation exists.


### PR DESCRIPTION
## Summary

- **Adopts expand/contract as the required shape for D1 schema change** — add nullable, backfill, ship the code, contract in a *later* PR once the new code is live. The load-bearing constraint is that separation: destructive DDL never rides in the same PR as the code that stops reading the column. `deploy.yml` migrates before it deploys and nothing reverts DDL, so a drop that ships alongside its code is unrecoverable if the deploy fails or is later rolled back.
- **[ADR-0017](https://github.com/snaveevans/pineapple/blob/docs/119-expand-contract-migration-policy/docs/decisions/0017-expand-contract-schema-migrations.md)** records the decision at decision altitude: the rule, the drivers, the alternatives weighed (coupled deploy behind a maintenance window, restore-based recovery, docs-only-no-enforcement), the consequences, and the decision that enforcement is a blocking CI gate with an override.
- **[`schema-migrations.md`](https://github.com/snaveevans/pineapple/blob/docs/119-expand-contract-migration-policy/docs/specs/cross-cutting/schema-migrations.md)** carries the rule as authors apply it: the four phases, a safe/unsafe DDL table, the empty-table trap, the author contract, and anti-patterns. Follows the ADR-0016 / `testing.md` split — ADR for the *why*, spec for the *rule*.

**Policy only — no CI change**, per the two-branch split agreed on #119. The spec ships at `review`, not `active`, matching the precedent `testing.md` set (`review` → `in-progress` → `active`, reaching `active` only once its gate was live and blocking). **That status field is how the docs say whether the gate is live** — no prose to maintain, and it self-corrects when the enforcement PR flips it.

The non-obvious thing this documents: **applying migrations to a clean database cannot catch the cases whose danger is existing rows.** `ADD COLUMN ... NOT NULL` without a default, and `CREATE UNIQUE INDEX` over data that is not yet unique, both succeed against a fresh database and can fail against production. No migration-apply check will cover them — only reading the SQL can — so the spec groups them as the *empty-table trap* rather than letting a green check read as clearance.

## Related

Refs #119

Policy half of the two-branch split; the CI enforcement branch follows and depends on this.

## Commits

1. `7120d2c` — the ADR, the spec, and the index/`CLAUDE.md` wiring.
2. `f168798` — responds to review by trimming both documents to their altitude. The escape-hatch design and scan internals were mechanism describing checks that do not exist. Also fixes two real defects: `CREATE UNIQUE INDEX` was marked unconditionally safe, and "every migration is single-line-per-statement" was false. Full detail [in-thread](https://github.com/snaveevans/pineapple/pull/169#issuecomment-5149763835).
3. `cb0f7a0` — strips point-in-time facts: issue links, migration counts, a SQLite version pin, and a tree audit. Each read as durable but described one moment, needed hand-editing later, and gave no signal when it went stale.

Rebased onto `d10f658` (a merge of `main` into this branch) after vite 6→8 and `@vitejs/plugin-react` 4→6 landed on `main`. Full suite re-run against the merged base.

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm type-check` — clean
- [x] `pnpm -r test` — 615 tests (508 api + 107 web), all passing, re-run after the `main` merge brought in the vite majors
- [x] `prettier --check` on every touched path — clean
- [x] **Every SQLite claim verified empirically** rather than asserted, against SQLite 3.51.2: `NOT NULL` without a default succeeds on an empty table and is rejected on a populated one (the spec quotes the engine's error verbatim); `NOT NULL DEFAULT <const>` is safe on a populated table; `CREATE UNIQUE INDEX` fails on a populated table with duplicates and **is not rescued by `IF NOT EXISTS`**; `CREATE TABLE` with `NOT NULL` columns is always safe.
- [x] Checked the whole tree for destructive DDL: zero `DROP TABLE`, `DROP COLUMN`, and `RENAME` anywhere in `/migrations`, including inside comments — so the gate can start with no allowlist.

The version and the tree audit above are deliberately recorded **here** rather than in the docs. Provenance of a one-time verification is exactly the kind of fact that belongs in the PR that performed it.

**Two claims were cut rather than shipped**, both after testing contradicted them:

1. An early draft said SQLite requires an added `REFERENCES` column to default to `NULL`. `ADD COLUMN ... NOT NULL DEFAULT 'x' REFERENCES ...` is accepted under both `foreign_keys=ON` and `OFF`, so it was replaced with the ordinary reason FK columns are added nullable here.
2. "Every migration is single-line-per-statement" — only the `ALTER TABLE ... ADD COLUMN` statements are. That sentence was the stated precondition for a line-oriented regex, so as written the revisit trigger read as already fired on day one.

`prettier --check` also flags `docs/reference/api.md`, which this PR does not touch — pre-existing on `main`, confirmed by checking the file out from `origin/main` and re-running. Left alone as unrelated.

## Spec / AC

New cross-cutting spec: [`docs/specs/cross-cutting/schema-migrations.md`](https://github.com/snaveevans/pineapple/blob/docs/119-expand-contract-migration-policy/docs/specs/cross-cutting/schema-migrations.md)

Acceptance criteria from #119's Branch 1:

- [x] Expand/contract rule is written where implementers (human + agent) will see it — ADR + spec, both indexed, `CLAUDE.md` links the spec from the D1 bullet
- [x] The spec states explicitly that applying migrations to a clean database cannot catch `NOT NULL`-without-default
- [x] `pnpm lint && pnpm type-check && pnpm -r test` green

#119's third top-level criterion (CI applies migrations to a fresh D1) is deliberately **not** addressed here — it belongs to the enforcement branch, so #119 stays open.

**One gap left open deliberately:** a unique index on an existing table cannot be judged from the SQL alone, since safety depends on the rows. The spec carries this as a Known Issue and an author obligation rather than implying a check will catch it. Whether the enforcement PR should flag `CREATE UNIQUE INDEX` on a table it did not create in the same file is a decision for that branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uq2uh6PLBpa4BJuaKARKRM)_