### PR TITLE
ci: enforce expand/contract migration policy (issue #119 Branch 2)

### DIFF
--- a/.github/scripts/migration-ddl-scan.selftest.sh
+++ b/.github/scripts/migration-ddl-scan.selftest.sh
@@ -138,6 +138,18 @@ assert_flag "DROP COLUMN wrapped onto multiple lines, no acknowledgment" \
 assert_flag "ADD COLUMN NOT NULL wrapped onto multiple lines, no default" \
   $'ALTER TABLE assets\n  ADD COLUMN status TEXT NOT NULL;'
 
+# Paired with the two assert_flag cases above, in the other direction: a
+# *safe* statement wrapped across lines must still pass. Detection spans the
+# whole open statement now (alter_table_open), so the DEFAULT half of
+# pattern 4 must too, or a same-line-only DEFAULT check flags legitimate SQL
+# whose DEFAULT clause lands on its own continuation line (PR #173 3rd-pass
+# review).
+assert_pass "ADD COLUMN NOT NULL wrapped, DEFAULT on its own continuation line" \
+  $'ALTER TABLE assets\n  ADD COLUMN status TEXT NOT NULL\n  DEFAULT \'active\';'
+
+assert_pass "ADD COLUMN wrapped, DEFAULT before NOT NULL on separate lines" \
+  $'ALTER TABLE assets\n  ADD COLUMN status TEXT DEFAULT \'active\'\n  NOT NULL;'
+
 assert_flag "RENAME COLUMN wrapped onto multiple lines, no acknowledgment" \
   $'ALTER TABLE t\n  RENAME COLUMN a TO b;'
 

--- a/.github/scripts/migration-ddl-scan.selftest.sh
+++ b/.github/scripts/migration-ddl-scan.selftest.sh
@@ -128,6 +128,19 @@ assert_flag "trailing comment mentioning DEFAULT does not suppress the finding" 
 assert_pass "destructive-ok acknowledges a statement wrapped onto multiple lines" \
   $'-- destructive-ok: superseded by 0042\nALTER TABLE t\n  DROP COLUMN c;'
 
+# Paired with the assert_pass above: the same fixture minus the
+# acknowledgment must still be *detected* and flagged. Without this, a
+# fixture that is never classified as destructive in the first place would
+# pass the ack test too, for the wrong reason (PR #173 2nd-pass review).
+assert_flag "DROP COLUMN wrapped onto multiple lines, no acknowledgment" \
+  $'ALTER TABLE t\n  DROP COLUMN c;'
+
+assert_flag "ADD COLUMN NOT NULL wrapped onto multiple lines, no default" \
+  $'ALTER TABLE assets\n  ADD COLUMN status TEXT NOT NULL;'
+
+assert_flag "RENAME COLUMN wrapped onto multiple lines, no acknowledgment" \
+  $'ALTER TABLE t\n  RENAME COLUMN a TO b;'
+
 assert_pass "destructive-ok marker is matched case-insensitively" \
   $'-- DESTRUCTIVE-OK: reason here\nDROP TABLE t;'
 

--- a/.github/scripts/migration-ddl-scan.selftest.sh
+++ b/.github/scripts/migration-ddl-scan.selftest.sh
@@ -153,6 +153,19 @@ assert_pass "ADD COLUMN wrapped, DEFAULT before NOT NULL on separate lines" \
 assert_flag "RENAME COLUMN wrapped onto multiple lines, no acknowledgment" \
   $'ALTER TABLE t\n  RENAME COLUMN a TO b;'
 
+# A file's last statement can omit its terminating semicolon — SQLite still
+# executes it, so migrations-fresh-apply.sh stays green on one too. Pattern
+# 4's deferred check must flush at EOF, not only on a `;`, or this is a
+# fail-open hole with no other check behind it (PR #173 4th-pass review).
+assert_flag "ADD COLUMN NOT NULL, file ends with no terminating semicolon" \
+  'ALTER TABLE assets ADD COLUMN status TEXT NOT NULL'
+
+assert_flag "ADD COLUMN NOT NULL wrapped, file ends with no terminating semicolon" \
+  $'ALTER TABLE assets\n  ADD COLUMN status TEXT NOT NULL'
+
+assert_pass "ADD COLUMN NOT NULL with DEFAULT, file ends with no terminating semicolon" \
+  $'ALTER TABLE assets\n  ADD COLUMN status TEXT NOT NULL DEFAULT \'active\''
+
 assert_pass "destructive-ok marker is matched case-insensitively" \
   $'-- DESTRUCTIVE-OK: reason here\nDROP TABLE t;'
 

--- a/.github/scripts/migration-ddl-scan.selftest.sh
+++ b/.github/scripts/migration-ddl-scan.selftest.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Self-test for migration-ddl-scan.sh.
+# Run from repo root: .github/scripts/migration-ddl-scan.selftest.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SCAN="$ROOT/.github/scripts/migration-ddl-scan.sh"
+fail=0
+
+# Runs the scanner against a single-file fixture directory. Prints the
+# scanner's combined output and exit status via the out/status globals.
+run_fixture() {
+  local sql="$1"
+  local dir
+  dir="$(mktemp -d)"
+  printf '%s\n' "$sql" >"$dir/0001_fixture.sql"
+  set +e
+  out="$("$SCAN" "$dir" 2>&1)"
+  status=$?
+  set -e
+  rm -rf "$dir"
+}
+
+assert_pass() {
+  local label="$1" sql="$2"
+  run_fixture "$sql"
+  if [ "$status" -eq 0 ]; then
+    echo "ok  pass: $label"
+  else
+    echo "FAIL pass: $label (status=$status)" >&2
+    printf '%s\n' "$out" >&2
+    fail=1
+  fi
+}
+
+assert_flag() {
+  local label="$1" sql="$2"
+  run_fixture "$sql"
+  if [ "$status" -ne 0 ] && printf '%s' "$out" | grep -q '::error'; then
+    echo "ok  flag: $label"
+  else
+    echo "FAIL flag: $label (status=$status)" >&2
+    printf '%s\n' "$out" >&2
+    fail=1
+  fi
+}
+
+# --- fixture table from issue #119 ---
+
+assert_pass "CREATE TABLE with several NOT NULL columns" \
+  'CREATE TABLE t (
+  id TEXT PRIMARY KEY NOT NULL,
+  name TEXT NOT NULL,
+  created_at TEXT NOT NULL
+);'
+
+assert_pass "ADD COLUMN, nullable" \
+  'ALTER TABLE t ADD COLUMN c TEXT;'
+
+assert_pass "ADD COLUMN NOT NULL with DEFAULT" \
+  "ALTER TABLE t ADD COLUMN c TEXT NOT NULL DEFAULT '';"
+
+assert_pass "comment line mentioning drop table" \
+  '-- we should drop table foo later'
+
+assert_flag "DROP TABLE" \
+  'DROP TABLE t;'
+
+assert_flag "DROP COLUMN" \
+  'ALTER TABLE t DROP COLUMN c;'
+
+assert_flag "RENAME COLUMN" \
+  'ALTER TABLE t RENAME COLUMN a TO b;'
+
+assert_flag "ADD COLUMN NOT NULL, no default" \
+  'ALTER TABLE t ADD COLUMN c TEXT NOT NULL;'
+
+assert_pass "DROP COLUMN acknowledged by destructive-ok" \
+  $'-- destructive-ok: superseded by 0042, unused since\nALTER TABLE t DROP COLUMN c;'
+
+# multiple findings in one file: flags all, exit 1
+dir="$(mktemp -d)"
+printf '%s\n' 'DROP TABLE a;' 'ALTER TABLE t DROP COLUMN c;' >"$dir/0001_fixture.sql"
+set +e
+out="$("$SCAN" "$dir" 2>&1)"
+status=$?
+set -e
+rm -rf "$dir"
+count="$(printf '%s\n' "$out" | grep -c '::error' || true)"
+if [ "$status" -ne 0 ] && [ "$count" -eq 2 ]; then
+  echo "ok  flag: multiple findings in one file (flags all)"
+else
+  echo "FAIL flag: multiple findings in one file (status=$status count=$count)" >&2
+  printf '%s\n' "$out" >&2
+  fail=1
+fi
+
+# --- additional edge cases named explicitly in issue #119's design ---
+
+assert_flag "ALTER TABLE ... RENAME TO (table rename)" \
+  'ALTER TABLE t RENAME TO t2;'
+
+assert_flag "destructive-ok with no reason does not acknowledge" \
+  $'-- destructive-ok:\nDROP TABLE t;'
+
+assert_pass "destructive-ok acknowledgment across a blank line" \
+  $'-- destructive-ok: cleanup, see #123\n\nDROP TABLE t;'
+
+if [ "$fail" -ne 0 ]; then
+  echo "migration-ddl-scan selftest FAILED" >&2
+  exit 1
+fi
+echo "migration-ddl-scan selftest passed"

--- a/.github/scripts/migration-ddl-scan.selftest.sh
+++ b/.github/scripts/migration-ddl-scan.selftest.sh
@@ -106,6 +106,61 @@ assert_flag "destructive-ok with no reason does not acknowledge" \
 assert_pass "destructive-ok acknowledgment across a blank line" \
   $'-- destructive-ok: cleanup, see #123\n\nDROP TABLE t;'
 
+# --- regressions from PR #173 review: COLUMN is optional in SQLite's ALTER
+# TABLE grammar, and DEFAULT/the ack marker must be matched as whole words,
+# not raw substrings ---
+
+assert_flag "ADD without the optional COLUMN keyword, NOT NULL no default" \
+  'ALTER TABLE t ADD c TEXT NOT NULL;'
+
+assert_flag "DROP without the optional COLUMN keyword" \
+  'ALTER TABLE t DROP c;'
+
+assert_flag "RENAME without the optional COLUMN keyword" \
+  'ALTER TABLE t RENAME a TO b;'
+
+assert_flag "NOT NULL column named default_* is not suppressed by its own name" \
+  'ALTER TABLE assets ADD COLUMN default_location TEXT NOT NULL;'
+
+assert_flag "trailing comment mentioning DEFAULT does not suppress the finding" \
+  'ALTER TABLE assets ADD COLUMN status TEXT NOT NULL; -- TODO: add a DEFAULT'
+
+assert_pass "destructive-ok acknowledges a statement wrapped onto multiple lines" \
+  $'-- destructive-ok: superseded by 0042\nALTER TABLE t\n  DROP COLUMN c;'
+
+assert_pass "destructive-ok marker is matched case-insensitively" \
+  $'-- DESTRUCTIVE-OK: reason here\nDROP TABLE t;'
+
+# Fail closed: a missing or empty migrations dir must not scan zero files and
+# report success — that would leave the gate permanently green if the
+# directory were ever relocated without updating this script's default.
+missing_dir="$(mktemp -u)/does-not-exist"
+set +e
+out="$("$SCAN" "$missing_dir" 2>&1)"
+status=$?
+set -e
+if [ "$status" -ne 0 ]; then
+  echo "ok  flag: nonexistent migrations dir fails closed"
+else
+  echo "FAIL flag: nonexistent migrations dir should fail closed, got status=$status" >&2
+  printf '%s\n' "$out" >&2
+  fail=1
+fi
+
+empty_dir="$(mktemp -d)"
+set +e
+out="$("$SCAN" "$empty_dir" 2>&1)"
+status=$?
+set -e
+rm -rf "$empty_dir"
+if [ "$status" -ne 0 ]; then
+  echo "ok  flag: empty migrations dir fails closed"
+else
+  echo "FAIL flag: empty migrations dir should fail closed, got status=$status" >&2
+  printf '%s\n' "$out" >&2
+  fail=1
+fi
+
 if [ "$fail" -ne 0 ]; then
   echo "migration-ddl-scan selftest FAILED" >&2
   exit 1

--- a/.github/scripts/migration-ddl-scan.sh
+++ b/.github/scripts/migration-ddl-scan.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Static scan for destructive DDL in migrations/*.sql (ADR-0017,
+# docs/specs/cross-cutting/schema-migrations.md). Convention twin of
+# mutation-scope.sh: small, pure, selftested.
+#
+# Not redundant with migrations-fresh-apply.sh: a fresh D1 is empty, and
+# SQLite only rejects `ADD COLUMN ... NOT NULL` without a default against a
+# *populated* table (the empty-table trap). Applying migrations to a clean
+# database can never reach that case — only reading the SQL text can. The two
+# checks answer different questions; neither subsumes the other.
+#
+# Usage:
+#   .github/scripts/migration-ddl-scan.sh [dir]   (default: migrations/)
+#
+# Scans every *.sql file in dir. Skips comment lines (first non-whitespace
+# character is `--`) entirely — matching happens only on SQL lines.
+# Case-insensitively flags a line containing:
+#   1. DROP TABLE
+#   2. DROP COLUMN
+#   3. RENAME COLUMN, or (ALTER TABLE and RENAME TO together)
+#   4. ALTER TABLE and ADD COLUMN and NOT NULL, without DEFAULT
+#
+# A finding is acknowledged when the immediately preceding non-blank line
+# (comment or not) matches:
+#   -- destructive-ok: <reason>
+# with a reason present — this must live in the file so the acknowledgment is
+# durable across every future run, not just the one PR. Blank lines between
+# the acknowledgment and the finding are allowed.
+#
+# Emits one `::error file=<path>,line=<n>::<message>` per unacknowledged
+# finding. Exit 1 if any unacknowledged finding, else 0.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+DIR="${1:-$ROOT/migrations}"
+
+ACK_RE='^[[:space:]]*--[[:space:]]*destructive-ok:[[:space:]]*[^[:space:]]'
+
+is_destructive() {
+  local upper="$1"
+  case "$upper" in
+    *'DROP TABLE'*) return 0 ;;
+    *'DROP COLUMN'*) return 0 ;;
+    *'RENAME COLUMN'*) return 0 ;;
+  esac
+  if [[ "$upper" == *'ALTER TABLE'* && "$upper" == *'RENAME TO'* ]]; then
+    return 0
+  fi
+  if [[ "$upper" == *'ALTER TABLE'* && "$upper" == *'ADD COLUMN'* \
+        && "$upper" == *'NOT NULL'* && "$upper" != *'DEFAULT'* ]]; then
+    return 0
+  fi
+  return 1
+}
+
+fail=0
+
+shopt -s nullglob
+files=("$DIR"/*.sql)
+shopt -u nullglob
+
+for file in "${files[@]}"; do
+  rel="$file"
+  [[ "$file" == "$ROOT"/* ]] && rel="${file#"$ROOT"/}"
+
+  prev_nonblank=""
+  line_no=0
+  while IFS= read -r line || [ -n "$line" ]; do
+    line_no=$((line_no + 1))
+
+    # Leading-whitespace-stripped view, used only to classify the line.
+    trimmed="${line#"${line%%[![:space:]]*}"}"
+
+    if [ -z "$trimmed" ]; then
+      continue # blank line: does not update prev_nonblank
+    fi
+
+    if [[ "$trimmed" == --* ]]; then
+      prev_nonblank="$line"
+      continue # comment line: never scanned for destructive DDL
+    fi
+
+    upper="$(printf '%s' "$line" | tr '[:lower:]' '[:upper:]')"
+    if is_destructive "$upper"; then
+      if [[ "$prev_nonblank" =~ $ACK_RE ]]; then
+        : # acknowledged in-file — pass
+      else
+        echo "::error file=${rel},line=${line_no}::Destructive DDL with no preceding '-- destructive-ok: <reason>' comment: ${trimmed}"
+        fail=1
+      fi
+    fi
+
+    prev_nonblank="$line"
+  done < "$file"
+done
+
+exit "$fail"

--- a/.github/scripts/migration-ddl-scan.sh
+++ b/.github/scripts/migration-ddl-scan.sh
@@ -33,7 +33,10 @@
 # whose `DEFAULT` clause lands on its own continuation line must not be
 # flagged just because that DEFAULT isn't on the same physical line as
 # NOT NULL, so its "no DEFAULT" half is evaluated against every line of the
-# open statement, not just the one that tripped the trigger.
+# open statement, not just the one that tripped the trigger. That deferral
+# is flushed both when a statement closes with `;` and after a file's last
+# line, so a final statement missing its terminating semicolon — which
+# SQLite still executes — cannot silently drop a pending finding.
 #
 # A finding is acknowledged when the immediately preceding non-blank line —
 # or, if the finding is on a continuation line of a still-open statement, the
@@ -113,6 +116,19 @@ report() {
   fail=1
 }
 
+# Emits pattern 4's deferred finding, if one is armed and no DEFAULT ever
+# showed up in the statement. Called both when a statement closes with `;`
+# and after a file's last line, so a statement with no terminating
+# semicolon — which SQLite still executes — cannot silently drop a pending
+# finding (fail-open is worse than none).
+flush_pending_addnotnull() {
+  if [ -n "$pending_addnotnull_line" ] && [ "$stmt_has_default" != true ]; then
+    report "$pending_addnotnull_line" "$pending_addnotnull_text"
+  fi
+  pending_addnotnull_line=""
+  stmt_has_default=false
+}
+
 shopt -s nullglob
 files=("$DIR"/*.sql)
 shopt -u nullglob
@@ -186,18 +202,17 @@ for file in "${files[@]}"; do
     fi
 
     if [[ "$sql_part" =~ \;[[:space:]]*$ ]]; then
-      if [ -n "$pending_addnotnull_line" ] && [ "$stmt_has_default" != true ]; then
-        report "$pending_addnotnull_line" "$pending_addnotnull_text"
-      fi
+      flush_pending_addnotnull
       in_statement=false
-      pending_addnotnull_line=""
-      stmt_has_default=false
     else
       in_statement=true
     fi
 
     prev_nonblank="$line"
   done < "$file"
+
+  # The file may end mid-statement — no trailing `;` on the last line.
+  flush_pending_addnotnull
 done
 
 exit "$fail"

--- a/.github/scripts/migration-ddl-scan.sh
+++ b/.github/scripts/migration-ddl-scan.sh
@@ -15,8 +15,11 @@
 # Scans every *.sql file in dir. Skips comment lines (first non-whitespace
 # character is `--`) entirely, and ignores a trailing `-- ...` comment on an
 # otherwise-SQL line so prose after a statement can't suppress a match or
-# fake an acknowledgment. Case-insensitively flags a line whose SQL content
-# (after this stripping) is:
+# fake an acknowledgment. A clause belongs to ALTER TABLE if the current
+# *statement* opened with it, not just the current physical line — so a
+# clause keyword on a continuation line (ALTER TABLE on the line above) is
+# still recognized. Case-insensitively flags a line whose SQL content (after
+# this stripping) is:
 #   1. `DROP TABLE`
 #   2. `ALTER TABLE ... DROP [COLUMN] <name>`      (COLUMN is optional in SQLite)
 #   3. `ALTER TABLE ... RENAME TO <name>`, or
@@ -54,11 +57,16 @@ has_default() {
 
 is_destructive() {
   local upper="$1"
+  local alter_table_open="$2"
 
   [[ "$upper" == *'DROP TABLE'* ]] && return 0
 
-  # Everything else is a clause of ALTER TABLE.
-  [[ "$upper" == *'ALTER TABLE'* ]] || return 1
+  # Everything else is a clause of ALTER TABLE — either this line names it
+  # directly, or we're on a continuation line of a statement that opened
+  # with it (alter_table_open, tracked by the caller across physical lines).
+  if [[ "$upper" != *'ALTER TABLE'* ]] && [ "$alter_table_open" != true ]; then
+    return 1
+  fi
 
   # ALTER TABLE ... DROP [COLUMN] <name>
   [[ "$upper" =~ DROP[[:space:]]+(COLUMN[[:space:]]+)?[A-Z_][A-Z0-9_]* ]] && return 0
@@ -96,6 +104,7 @@ for file in "${files[@]}"; do
   prev_nonblank=""
   ack_anchor=""
   in_statement=false
+  alter_table_open=false
   line_no=0
   while IFS= read -r line || [ -n "$line" ]; do
     line_no=$((line_no + 1))
@@ -120,12 +129,20 @@ for file in "${files[@]}"; do
     # The acknowledgment must precede the *statement*, not just this line —
     # a destructive statement wrapped onto multiple lines is still one
     # statement, and the comment above its first line is what an author
-    # actually wrote the acknowledgment against.
+    # actually wrote the acknowledgment against. Likewise, whether a clause
+    # belongs to ALTER TABLE is a property of the statement, decided once
+    # when it opens, not re-derived per physical line — a clause keyword can
+    # land on a continuation line with ALTER TABLE above it.
     if [ "$in_statement" = false ]; then
       ack_anchor="$prev_nonblank"
+      if [[ "$upper" == *'ALTER TABLE'* ]]; then
+        alter_table_open=true
+      else
+        alter_table_open=false
+      fi
     fi
 
-    if is_destructive "$upper"; then
+    if is_destructive "$upper" "$alter_table_open"; then
       ack_anchor_upper="$(printf '%s' "$ack_anchor" | tr '[:lower:]' '[:upper:]')"
       if [[ "$ack_anchor_upper" =~ $ACK_RE ]]; then
         : # acknowledged in-file — pass

--- a/.github/scripts/migration-ddl-scan.sh
+++ b/.github/scripts/migration-ddl-scan.sh
@@ -18,15 +18,22 @@
 # fake an acknowledgment. A clause belongs to ALTER TABLE if the current
 # *statement* opened with it, not just the current physical line — so a
 # clause keyword on a continuation line (ALTER TABLE on the line above) is
-# still recognized. Case-insensitively flags a line whose SQL content (after
-# this stripping) is:
+# still recognized. Case-insensitively flags:
 #   1. `DROP TABLE`
 #   2. `ALTER TABLE ... DROP [COLUMN] <name>`      (COLUMN is optional in SQLite)
 #   3. `ALTER TABLE ... RENAME TO <name>`, or
 #      `ALTER TABLE ... RENAME [COLUMN] <a> TO <b>` (COLUMN is optional in SQLite)
-#   4. `ALTER TABLE ... ADD [COLUMN] ... NOT NULL`, without a `DEFAULT` clause
-#      of its own (COLUMN is optional; a `DEFAULT` inside an identifier or a
-#      trailing comment does not count)
+#   4. `ALTER TABLE ... ADD [COLUMN] ... NOT NULL`, with no `DEFAULT` anywhere
+#      in the statement (COLUMN is optional; a `DEFAULT` inside an identifier
+#      or a trailing comment does not count)
+#
+# Patterns 1-3 are decided per line: the trigger keyword alone proves danger
+# regardless of what the rest of the statement says. Pattern 4 is decided
+# only once the whole statement is seen — a safe `ADD COLUMN ... NOT NULL`
+# whose `DEFAULT` clause lands on its own continuation line must not be
+# flagged just because that DEFAULT isn't on the same physical line as
+# NOT NULL, so its "no DEFAULT" half is evaluated against every line of the
+# open statement, not just the one that tripped the trigger.
 #
 # A finding is acknowledged when the immediately preceding non-blank line —
 # or, if the finding is on a continuation line of a still-open statement, the
@@ -55,15 +62,14 @@ has_default() {
   [[ "$1" =~ (^|[^A-Z0-9_])DEFAULT([^A-Z0-9_]|$) ]]
 }
 
-is_destructive() {
+# Patterns 1-3: DROP TABLE, ALTER TABLE ... DROP/RENAME [COLUMN]. Decided
+# from a single line — no whole-statement context needed.
+is_destructive_immediate() {
   local upper="$1"
   local alter_table_open="$2"
 
   [[ "$upper" == *'DROP TABLE'* ]] && return 0
 
-  # Everything else is a clause of ALTER TABLE — either this line names it
-  # directly, or we're on a continuation line of a statement that opened
-  # with it (alter_table_open, tracked by the caller across physical lines).
   if [[ "$upper" != *'ALTER TABLE'* ]] && [ "$alter_table_open" != true ]; then
     return 1
   fi
@@ -76,17 +82,36 @@ is_destructive() {
   [[ "$upper" == *'RENAME TO'* ]] && return 0
   [[ "$upper" =~ RENAME[[:space:]]+(COLUMN[[:space:]]+)?[A-Z_][A-Z0-9_]*[[:space:]]+TO ]] && return 0
 
-  # ALTER TABLE ... ADD [COLUMN] ... NOT NULL, without its own DEFAULT
-  if [[ "$upper" =~ ADD[[:space:]]+(COLUMN[[:space:]]+)?[A-Z_][A-Z0-9_]* ]] \
-      && [[ "$upper" == *'NOT NULL'* ]] \
-      && ! has_default "$upper"; then
-    return 0
-  fi
-
   return 1
 }
 
+# Pattern 4's trigger half: ALTER TABLE ... ADD [COLUMN] ... NOT NULL. Says
+# nothing about DEFAULT — the caller accumulates that across the statement.
+has_add_not_null() {
+  local upper="$1"
+  local alter_table_open="$2"
+
+  if [[ "$upper" != *'ALTER TABLE'* ]] && [ "$alter_table_open" != true ]; then
+    return 1
+  fi
+
+  [[ "$upper" =~ ADD[[:space:]]+(COLUMN[[:space:]]+)?[A-Z_][A-Z0-9_]* ]] && [[ "$upper" == *'NOT NULL'* ]]
+}
+
 fail=0
+
+# Reads the current $rel/$ack_anchor/$fail at call time — safe to define once
+# and call once per file per finding.
+report() {
+  local finding_line="$1" text="$2"
+  local ack_anchor_upper
+  ack_anchor_upper="$(printf '%s' "$ack_anchor" | tr '[:lower:]' '[:upper:]')"
+  if [[ "$ack_anchor_upper" =~ $ACK_RE ]]; then
+    return
+  fi
+  echo "::error file=${rel},line=${finding_line}::Destructive DDL with no preceding '-- destructive-ok: <reason>' comment: ${text}"
+  fail=1
+}
 
 shopt -s nullglob
 files=("$DIR"/*.sql)
@@ -105,6 +130,9 @@ for file in "${files[@]}"; do
   ack_anchor=""
   in_statement=false
   alter_table_open=false
+  pending_addnotnull_line=""
+  pending_addnotnull_text=""
+  stmt_has_default=false
   line_no=0
   while IFS= read -r line || [ -n "$line" ]; do
     line_no=$((line_no + 1))
@@ -140,20 +168,30 @@ for file in "${files[@]}"; do
       else
         alter_table_open=false
       fi
+      pending_addnotnull_line=""
+      stmt_has_default=false
     fi
 
-    if is_destructive "$upper" "$alter_table_open"; then
-      ack_anchor_upper="$(printf '%s' "$ack_anchor" | tr '[:lower:]' '[:upper:]')"
-      if [[ "$ack_anchor_upper" =~ $ACK_RE ]]; then
-        : # acknowledged in-file — pass
-      else
-        echo "::error file=${rel},line=${line_no}::Destructive DDL with no preceding '-- destructive-ok: <reason>' comment: ${trimmed}"
-        fail=1
-      fi
+    if is_destructive_immediate "$upper" "$alter_table_open"; then
+      report "$line_no" "$trimmed"
+    fi
+
+    if has_default "$upper"; then
+      stmt_has_default=true
+    fi
+
+    if [ -z "$pending_addnotnull_line" ] && has_add_not_null "$upper" "$alter_table_open"; then
+      pending_addnotnull_line="$line_no"
+      pending_addnotnull_text="$trimmed"
     fi
 
     if [[ "$sql_part" =~ \;[[:space:]]*$ ]]; then
+      if [ -n "$pending_addnotnull_line" ] && [ "$stmt_has_default" != true ]; then
+        report "$pending_addnotnull_line" "$pending_addnotnull_text"
+      fi
       in_statement=false
+      pending_addnotnull_line=""
+      stmt_has_default=false
     else
       in_statement=true
     fi

--- a/.github/scripts/migration-ddl-scan.sh
+++ b/.github/scripts/migration-ddl-scan.sh
@@ -13,43 +13,68 @@
 #   .github/scripts/migration-ddl-scan.sh [dir]   (default: migrations/)
 #
 # Scans every *.sql file in dir. Skips comment lines (first non-whitespace
-# character is `--`) entirely — matching happens only on SQL lines.
-# Case-insensitively flags a line containing:
-#   1. DROP TABLE
-#   2. DROP COLUMN
-#   3. RENAME COLUMN, or (ALTER TABLE and RENAME TO together)
-#   4. ALTER TABLE and ADD COLUMN and NOT NULL, without DEFAULT
+# character is `--`) entirely, and ignores a trailing `-- ...` comment on an
+# otherwise-SQL line so prose after a statement can't suppress a match or
+# fake an acknowledgment. Case-insensitively flags a line whose SQL content
+# (after this stripping) is:
+#   1. `DROP TABLE`
+#   2. `ALTER TABLE ... DROP [COLUMN] <name>`      (COLUMN is optional in SQLite)
+#   3. `ALTER TABLE ... RENAME TO <name>`, or
+#      `ALTER TABLE ... RENAME [COLUMN] <a> TO <b>` (COLUMN is optional in SQLite)
+#   4. `ALTER TABLE ... ADD [COLUMN] ... NOT NULL`, without a `DEFAULT` clause
+#      of its own (COLUMN is optional; a `DEFAULT` inside an identifier or a
+#      trailing comment does not count)
 #
-# A finding is acknowledged when the immediately preceding non-blank line
-# (comment or not) matches:
+# A finding is acknowledged when the immediately preceding non-blank line —
+# or, if the finding is on a continuation line of a still-open statement, the
+# line immediately before that statement began — matches, case-insensitively:
 #   -- destructive-ok: <reason>
-# with a reason present — this must live in the file so the acknowledgment is
+# with a reason present. This must live in the file so the acknowledgment is
 # durable across every future run, not just the one PR. Blank lines between
 # the acknowledgment and the finding are allowed.
 #
 # Emits one `::error file=<path>,line=<n>::<message>` per unacknowledged
-# finding. Exit 1 if any unacknowledged finding, else 0.
+# finding. Fails closed: a missing directory or one with no *.sql files is a
+# scan failure, not a silent pass — a relocated migrations dir must not leave
+# this gate permanently green. Exit 1 on any unacknowledged finding or an
+# empty scan, else 0.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 DIR="${1:-$ROOT/migrations}"
 
-ACK_RE='^[[:space:]]*--[[:space:]]*destructive-ok:[[:space:]]*[^[:space:]]'
+ACK_RE='^[[:space:]]*--[[:space:]]*DESTRUCTIVE-OK:[[:space:]]*[^[:space:]]'
+
+has_default() {
+  # Word-boundary match so a column named e.g. default_location, or the word
+  # DEFAULT inside a trailing comment (already stripped before this is
+  # called), doesn't suppress a genuine missing-DEFAULT finding.
+  [[ "$1" =~ (^|[^A-Z0-9_])DEFAULT([^A-Z0-9_]|$) ]]
+}
 
 is_destructive() {
   local upper="$1"
-  case "$upper" in
-    *'DROP TABLE'*) return 0 ;;
-    *'DROP COLUMN'*) return 0 ;;
-    *'RENAME COLUMN'*) return 0 ;;
-  esac
-  if [[ "$upper" == *'ALTER TABLE'* && "$upper" == *'RENAME TO'* ]]; then
+
+  [[ "$upper" == *'DROP TABLE'* ]] && return 0
+
+  # Everything else is a clause of ALTER TABLE.
+  [[ "$upper" == *'ALTER TABLE'* ]] || return 1
+
+  # ALTER TABLE ... DROP [COLUMN] <name>
+  [[ "$upper" =~ DROP[[:space:]]+(COLUMN[[:space:]]+)?[A-Z_][A-Z0-9_]* ]] && return 0
+
+  # ALTER TABLE ... RENAME TO <name>             (table rename)
+  # ALTER TABLE ... RENAME [COLUMN] <a> TO <b>   (column rename)
+  [[ "$upper" == *'RENAME TO'* ]] && return 0
+  [[ "$upper" =~ RENAME[[:space:]]+(COLUMN[[:space:]]+)?[A-Z_][A-Z0-9_]*[[:space:]]+TO ]] && return 0
+
+  # ALTER TABLE ... ADD [COLUMN] ... NOT NULL, without its own DEFAULT
+  if [[ "$upper" =~ ADD[[:space:]]+(COLUMN[[:space:]]+)?[A-Z_][A-Z0-9_]* ]] \
+      && [[ "$upper" == *'NOT NULL'* ]] \
+      && ! has_default "$upper"; then
     return 0
   fi
-  if [[ "$upper" == *'ALTER TABLE'* && "$upper" == *'ADD COLUMN'* \
-        && "$upper" == *'NOT NULL'* && "$upper" != *'DEFAULT'* ]]; then
-    return 0
-  fi
+
   return 1
 }
 
@@ -59,11 +84,18 @@ shopt -s nullglob
 files=("$DIR"/*.sql)
 shopt -u nullglob
 
+if [ "${#files[@]}" -eq 0 ]; then
+  echo "::error::No .sql files found under '${DIR}' — migration-ddl-scan.sh fails closed rather than passing an empty scan (a relocated or missing migrations dir must not leave this gate silently green)."
+  exit 1
+fi
+
 for file in "${files[@]}"; do
   rel="$file"
   [[ "$file" == "$ROOT"/* ]] && rel="${file#"$ROOT"/}"
 
   prev_nonblank=""
+  ack_anchor=""
+  in_statement=false
   line_no=0
   while IFS= read -r line || [ -n "$line" ]; do
     line_no=$((line_no + 1))
@@ -77,17 +109,36 @@ for file in "${files[@]}"; do
 
     if [[ "$trimmed" == --* ]]; then
       prev_nonblank="$line"
-      continue # comment line: never scanned for destructive DDL
+      continue # whole-line comment: never scanned for destructive DDL
     fi
 
-    upper="$(printf '%s' "$line" | tr '[:lower:]' '[:upper:]')"
+    # Drop a trailing `-- ...` comment before classifying, so prose after a
+    # statement (e.g. "-- TODO: add a DEFAULT") can't hide or fake a finding.
+    sql_part="${line%%--*}"
+    upper="$(printf '%s' "$sql_part" | tr '[:lower:]' '[:upper:]')"
+
+    # The acknowledgment must precede the *statement*, not just this line —
+    # a destructive statement wrapped onto multiple lines is still one
+    # statement, and the comment above its first line is what an author
+    # actually wrote the acknowledgment against.
+    if [ "$in_statement" = false ]; then
+      ack_anchor="$prev_nonblank"
+    fi
+
     if is_destructive "$upper"; then
-      if [[ "$prev_nonblank" =~ $ACK_RE ]]; then
+      ack_anchor_upper="$(printf '%s' "$ack_anchor" | tr '[:lower:]' '[:upper:]')"
+      if [[ "$ack_anchor_upper" =~ $ACK_RE ]]; then
         : # acknowledged in-file — pass
       else
         echo "::error file=${rel},line=${line_no}::Destructive DDL with no preceding '-- destructive-ok: <reason>' comment: ${trimmed}"
         fail=1
       fi
+    fi
+
+    if [[ "$sql_part" =~ \;[[:space:]]*$ ]]; then
+      in_statement=false
+    else
+      in_statement=true
     fi
 
     prev_nonblank="$line"

--- a/.github/scripts/migrations-fresh-apply.sh
+++ b/.github/scripts/migrations-fresh-apply.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Applies every migration in /migrations, in order, to a fresh local D1 — the
+# same command deploy.yml runs --remote against production, one flag
+# different. Catches migration ordering bugs and invalid SQL on the PR,
+# before deploy.yml applies the same files --remote against production
+# (issue #119).
+#
+# Does NOT catch destructive DDL that only misbehaves against a *populated*
+# table (the empty-table trap, docs/specs/cross-cutting/schema-migrations.md)
+# — a fresh D1 has no rows to trip it. migration-ddl-scan.sh answers that
+# question separately, by reading the SQL text instead of applying it.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+
+# Gitignored, so a fresh checkout is already clean — but re-running this
+# script locally (or after a prior failed run) must still start fresh.
+rm -rf "$ROOT/apps/api/.wrangler/state/v3/d1"
+
+cd "$ROOT/apps/api"
+pnpm wrangler d1 migrations apply pineapple --local

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,17 @@ jobs:
       # /migrations has no other coverage. Applying every migration in order to a
       # fresh D1 catches ordering bugs and bad SQL on the PR, before deploy.yml
       # applies the same files --remote against production (issue #119).
+      #
+      # These three steps run unconditionally rather than path-scoped like the
+      # mutation gate or the OpenAPI breaking-change gate below: measured cost is
+      # ~13-20s combined (spike results on issue #119), which is what keeps
+      # `verify` inside its ~2-minute budget even on every PR. Scoping only pays
+      # off once a gate's own cost — not the fixed pnpm/checkout setup shared by
+      # the whole job — is what's driving `verify` over budget; a path filter here
+      # would add a script and a drift risk (the filter's path list silently
+      # diverging from what actually affects the D1 schema) to save single-digit
+      # seconds on PRs that don't touch migrations. Revisit if migration count
+      # growth pushes the apply step's cost materially higher.
       - name: Apply migrations to a fresh D1
         run: .github/scripts/migrations-fresh-apply.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,21 @@ jobs:
       - name: Test
         run: pnpm -r test
 
+      # /migrations has no other coverage. Applying every migration in order to a
+      # fresh D1 catches ordering bugs and bad SQL on the PR, before deploy.yml
+      # applies the same files --remote against production (issue #119).
+      - name: Apply migrations to a fresh D1
+        run: .github/scripts/migrations-fresh-apply.sh
+
+      # Separate check, not redundant with the apply above: a fresh D1 is empty,
+      # and SQLite only rejects `ADD COLUMN ... NOT NULL` without a default on a
+      # populated table. Only a static scan can catch it (issue #119).
+      - name: Scan migrations for destructive DDL
+        run: .github/scripts/migration-ddl-scan.sh
+
+      - name: Migration DDL scan selftest
+        run: .github/scripts/migration-ddl-scan.selftest.sh
+
       # Gate-logic selftest for the mutation path filter (ADR-0016). Cheap; runs
       # on every PR so a regex typo cannot silently widen/narrow the trust boundary.
       - name: Mutation scope selftest

--- a/docs/specs/SPECS.md
+++ b/docs/specs/SPECS.md
@@ -26,7 +26,7 @@ relevant cross-cutting specs rather than re-describing the behavior.
 | [loading-states.md](./cross-cutting/loading-states.md)       | Async UI states                  | active |
 | [telemetry.md](./cross-cutting/telemetry.md)                 | Telemetry and observability      | active |
 | [testing.md](./cross-cutting/testing.md)                     | Test verification, mutation gate | active |
-| [schema-migrations.md](./cross-cutting/schema-migrations.md) | D1 schema change and rollout     | review |
+| [schema-migrations.md](./cross-cutting/schema-migrations.md) | D1 schema change and rollout     | active |
 
 ## Feature Specs
 

--- a/docs/specs/cross-cutting/schema-migrations.md
+++ b/docs/specs/cross-cutting/schema-migrations.md
@@ -131,32 +131,24 @@ as any other `NOT NULL` addition.
 ## Enforcement
 
 ADR-0017 decided this rule is **enforced in CI by a blocking gate**, with an override for the
-legitimate contraction case. The gate is live, as three steps in the `verify` job of
-[`ci.yml`](../../../.github/workflows/ci.yml), after `Test`:
-
-- **`Apply migrations to a fresh D1`** runs
-  [`migrations-fresh-apply.sh`](../../../.github/scripts/migrations-fresh-apply.sh) — wipes local D1
-  state and applies every migration in order, the same command `deploy.yml` runs `--remote` against
-  production. Catches ordering bugs and invalid SQL.
-- **`Scan migrations for destructive DDL`** runs
-  [`migration-ddl-scan.sh`](../../../.github/scripts/migration-ddl-scan.sh) — a static, case-insensitive
-  scan of every migration file for `DROP TABLE`, `DROP COLUMN`, `RENAME COLUMN`/`RENAME TO`, and
-  `ADD COLUMN ... NOT NULL` without `DEFAULT`. A finding fails the job with a
-  `::error file=,line=::` annotation unless the immediately preceding non-blank line is
-  `-- destructive-ok: <reason>` — an in-file, permanent acknowledgment for the legitimate contraction
-  case, not a per-PR label.
-- **`Migration DDL scan selftest`** runs
-  [`migration-ddl-scan.selftest.sh`](../../../.github/scripts/migration-ddl-scan.selftest.sh) so a
-  regression in the scan's own patterns fails the PR that introduces it, not a later one.
+legitimate contraction case. The gate is live: three steps in the `verify` job of
+[`ci.yml`](../../../.github/workflows/ci.yml), after `Test`, run
+[`migrations-fresh-apply.sh`](../../../.github/scripts/migrations-fresh-apply.sh),
+[`migration-ddl-scan.sh`](../../../.github/scripts/migration-ddl-scan.sh), and that scan's own
+selftest. The exact patterns, the trailing-comment and multi-line handling, and the
+`-- destructive-ok: <reason>` override syntax live in `migration-ddl-scan.sh` itself and its
+selftest, not here, so there is exactly one place to keep them correct.
 
 Enforcement takes two checks rather than one; why that is not redundant, and must not be
 "simplified" later, is recorded in
 [ADR-0017](../../decisions/0017-expand-contract-schema-migrations.md).
 
-What matters to an author is the consequence: **a green migration check is never clearance for the
-empty-table trap.** No check that applies migrations to a clean database can reach those two
-statements, because a clean database has none of the rows that make them dangerous. They stay the
-author's responsibility regardless of what automation exists.
+What matters to an author is the consequence: **a green migration check is not clearance for the
+whole empty-table trap.** `migration-ddl-scan.sh` now reaches one of the two statements in the table
+above — `ADD COLUMN ... NOT NULL` with no default — by reading the SQL text. It does not, and by
+design cannot, reach a unique index over a pre-existing table: that statement's danger is in rows it
+never mentions, which no check that applies migrations to a clean database can see either. That case
+stays the author's responsibility regardless of what automation exists.
 
 ## Feature Integration Contract
 

--- a/docs/specs/cross-cutting/schema-migrations.md
+++ b/docs/specs/cross-cutting/schema-migrations.md
@@ -7,14 +7,16 @@ date: 2026-08-01
 
 # Schema Migrations — Cross-Cutting Spec
 
-**Status:** `review`
+**Status:** `active`
 **Owner:** engineering
 **Applies To:** Every change that adds or edits a file in `/migrations`
 
 > The rule is expand/contract, decided in
 > [ADR-0017](../../decisions/0017-expand-contract-schema-migrations.md), which also decided it is
-> enforced by a blocking CI gate. **While this spec's status is `review`, that gate is not live and
-> the rule holds on author discipline.**
+> enforced by a blocking CI gate. That gate is live: the `verify` job in
+> [`ci.yml`](../../../.github/workflows/ci.yml) runs
+> [`migrations-fresh-apply.sh`](../../../.github/scripts/migrations-fresh-apply.sh) and
+> [`migration-ddl-scan.sh`](../../../.github/scripts/migration-ddl-scan.sh) on every PR.
 
 ---
 
@@ -129,9 +131,23 @@ as any other `NOT NULL` addition.
 ## Enforcement
 
 ADR-0017 decided this rule is **enforced in CI by a blocking gate**, with an override for the
-legitimate contraction case. While this spec's status is `review`, that gate is not live and the
-rule holds on author discipline alone — with `required_approving_review_count: 0` and auto-merge on
-`main`, nothing else stands behind it.
+legitimate contraction case. The gate is live, as three steps in the `verify` job of
+[`ci.yml`](../../../.github/workflows/ci.yml), after `Test`:
+
+- **`Apply migrations to a fresh D1`** runs
+  [`migrations-fresh-apply.sh`](../../../.github/scripts/migrations-fresh-apply.sh) — wipes local D1
+  state and applies every migration in order, the same command `deploy.yml` runs `--remote` against
+  production. Catches ordering bugs and invalid SQL.
+- **`Scan migrations for destructive DDL`** runs
+  [`migration-ddl-scan.sh`](../../../.github/scripts/migration-ddl-scan.sh) — a static, case-insensitive
+  scan of every migration file for `DROP TABLE`, `DROP COLUMN`, `RENAME COLUMN`/`RENAME TO`, and
+  `ADD COLUMN ... NOT NULL` without `DEFAULT`. A finding fails the job with a
+  `::error file=,line=::` annotation unless the immediately preceding non-blank line is
+  `-- destructive-ok: <reason>` — an in-file, permanent acknowledgment for the legitimate contraction
+  case, not a per-PR label.
+- **`Migration DDL scan selftest`** runs
+  [`migration-ddl-scan.selftest.sh`](../../../.github/scripts/migration-ddl-scan.selftest.sh) so a
+  regression in the scan's own patterns fails the PR that introduces it, not a later one.
 
 Enforcement takes two checks rather than one; why that is not redundant, and must not be
 "simplified" later, is recorded in


### PR DESCRIPTION
## Summary

- Adds `migrations-fresh-apply.sh`: applies every migration in order to a fresh local D1, catching ordering bugs and invalid SQL before `deploy.yml` runs the same files `--remote` against production.
- Adds `migration-ddl-scan.sh`: a static, case-insensitive scan of migration SQL for `DROP TABLE`, `DROP COLUMN`, `RENAME COLUMN`/`RENAME TO`, and `ADD COLUMN ... NOT NULL` without `DEFAULT` — the empty-table-trap case a fresh-DB apply can never reach. A `-- destructive-ok: <reason>` comment on the immediately preceding line (or immediately before a multi-line statement) is the in-file, permanent escape hatch for a legitimate contraction.
- Adds `migration-ddl-scan.selftest.sh`, covering every fixture row from the issue plus `RENAME TO`, the mandatory-reason case, and the review-found regressions below.
- Wires all three as steps in `ci.yml`'s `verify` job, right after `Test`. `deploy.yml` is untouched.
- Flips `docs/specs/cross-cutting/schema-migrations.md` `Status:` from `review` to `active`, links the live checks without restating their internals, and updates the `SPECS.md` status column to match.

This is Branch 2 of #119 — Branch 1 (ADR-0017 + the policy spec) already merged in #169.

**Update:** a code review on this PR found 5 real scanner bugs and 2 doc/architecture gaps, all fixed in the follow-up commit:
- SQLite's optional `COLUMN` keyword in `ADD`/`DROP`/`RENAME` clauses let the shortest legal spelling of each destructive statement through unflagged.
- The `DEFAULT` exclusion was an unanchored substring test, so a column named `default_location` (or the word `DEFAULT` in a trailing comment) silently suppressed a real `NOT NULL`-without-default finding.
- The `destructive-ok` escape hatch couldn't acknowledge a statement wrapped across multiple lines, and matched case-sensitively despite the docs claiming case-insensitivity.
- A missing/empty migrations dir scanned zero files and exited 0 (fail-open); now fails closed.
- The spec had re-duplicated the scanner's exact patterns as prose (the same mistake a prior commit deliberately removed) and self-contradicted on empty-table-trap coverage; trimmed back to links.
- The three new `ci.yml` steps run unconditionally rather than path-scoped like the sibling gates — documented that as a deliberate choice in `ci.yml` (measured cost ~13-20s, `verify` completed in 81s on this PR's own CI run) rather than adding a scoping mechanism, since the ADR's own "cheap enough for the hot path" driver is already satisfied at the measured cost.

## Related

Closes #119

## Test plan

- [x] `pnpm lint && pnpm type-check && pnpm -r test` — green
- [x] `migrations-fresh-apply.sh` applies all 15 current migrations cleanly to a fresh local D1
- [x] `migration-ddl-scan.sh` passes against the current `migrations/` with no allowlist
- [x] `migration-ddl-scan.selftest.sh` passes, covering every fixture row plus edge cases (21 assertions after the review fixes)
- [x] Proved both gates actually fail before opening this PR (then reverted):
  - Appended a migration with deliberately broken SQL → `migrations-fresh-apply.sh` exited nonzero
  - Added `ALTER TABLE users DROP COLUMN name;` to a migration → `migration-ddl-scan.sh` flagged it and exited 1
  - Added a `-- destructive-ok:` comment above it → the scan passed
  - No temporary migrations were committed
- [x] `verify` stays under ~2 min — measured 81s on this PR's own CI run (spike predicted ~85-95s)

## Spec / AC

Implements the Branch 2 acceptance criteria from #119:
- [x] CI applies all migrations to a fresh D1 and fails on any error
- [x] Destructive DDL is flagged by an automated check, with a durable in-file acknowledgment as the escape hatch
- [x] Scanner passes against the current 15 migrations with no allowlist
- [x] Selftest covers every row in the issue's fixture table and runs on every PR
- [x] `verify` stays under ~2 min (measured 81s, up from a baseline of ~74s)
- [x] `pnpm lint && pnpm type-check && pnpm -r test` green

See [`docs/specs/cross-cutting/schema-migrations.md`](https://github.com/snaveevans/pineapple/blob/claude/issue-119-second-half-t6rnw7/docs/specs/cross-cutting/schema-migrations.md) (now `Status: active`) and [ADR-0017](https://github.com/snaveevans/pineapple/blob/main/docs/decisions/0017-expand-contract-schema-migrations.md).