### PR TITLE
docs: record validate-external-config pitfall and CLAUDE.md convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,15 @@ repositories live in `worker.ts`. Keep it that way.
   an asset name on a maintenance event) are assembled in the application layer, not by
   an aggregate. Telemetry handlers stay thin selective readers and must not write the
   PII-bearing fields to Analytics Engine. (ADR-0010)
+- **Validate external config against current docs, not training data.**
+  When writing config for an external service or library (Dependabot, Renovate,
+  Wrangler, GitHub Actions, etc.), validate keys and structure against the
+  service's current documentation or JSON schema — via Context7, the schema
+  registry (e.g. `json.schemastore.org`), or the official docs page — before
+  committing. Two tools with similar surfaces do not have interchangeable
+  config contracts. CI does not catch this class of error: lint/type-check/tests
+  don't parse most external config files, so the failure mode is silent and
+  post-merge. (See `pitfalls.md` 2026-08-06.)
 
 ## API documentation is generated — don't hand-edit the spec
 

--- a/pitfalls.md
+++ b/pitfalls.md
@@ -1,0 +1,48 @@
+# Pitfalls (errors + fixes)
+
+This file is a running log of small-but-annoying issues we've hit, plus the fix that worked.
+
+## 2026-08-06 — Assumed Dependabot config key from training data (auto-merge)
+
+### Symptom
+
+Added `auto-merge: true` to two update blocks in `.github/dependabot.yml`. CI
+went green (lint/type-check/tests don't validate Dependabot config), but the
+key is not part of the Dependabot schema (`additionalProperties: false` on
+update entries). Dependabot would have rejected the entire config file after
+merge and stopped opening version-update PRs entirely — the opposite of the
+PR's stated goal. The breakage surfaces silently as PRs that never appear.
+
+### Cause
+
+Wrote config based on pre-trained knowledge without verifying against the
+service's actual schema. The `auto-merge: true` key was carried over from
+Renovate's config (which _does_ have an `automerge` key at the package-rule
+level) — the issue title "Renovate **or** Dependabot" primed the assumption
+that the two tools had interchangeable config concepts. Neither Context7, the
+JSON schema at `json.schemastore.org/dependabot-2.0.json`, nor the GitHub
+docs page was consulted before committing.
+
+### Fix
+
+Reverted `.github/dependabot.yml` to the committed state and added
+`.github/workflows/dependabot-automerge.yml` instead — a workflow that
+triggers on Dependabot-opened PRs and calls `gh pr merge --auto --squash` to
+enable GitHub's native auto-merge. Auto-merge fires only after all required
+checks pass; the workflow is the mechanism Dependabot actually supports.
+
+### How to avoid next time
+
+When writing config for an external service or library, validate keys/shape
+against the service's current docs or JSON schema — Context7, schemastore,
+or official docs — not pre-trained knowledge. Two tools with similar
+surfaces (Renovate vs Dependabot) do not have interchangeable config
+contracts. CI does not catch this class of error: lint/type-check/tests
+don't parse `.github/dependabot.yml`, so the failure mode is silent and
+post-merge.
+
+### Evidence
+
+- PR #176, review comment: https://github.com/snaveevans/pineapple/pull/176#issuecomment-5209057744
+- Fix commit: `eeca7e9` on branch `chore/125-automated-dependency-updates`
+- Schema: https://json.schemastore.org/dependabot-2.0.json (`additionalProperties: false` on update entries)


### PR DESCRIPTION
## Summary

- Adds `pitfalls.md` logging the 2026-08-06 Dependabot `auto-merge` incident — a non-schema key written from training data that CI cannot catch (lint/type-check/tests don't parse `.github/dependabot.yml`)
- Adds a matching `CLAUDE.md` convention bullet directing agents to validate external config against current docs/schemas (Context7, schemastore, or official docs) before committing

## Related

No issue — documents a lesson from PR #176.

## Test plan

- [x] `pnpm lint && pnpm type-check && pnpm -r test` green (docs-only change)
- [x] `pitfalls.md` entry follows the dated symptom/cause/fix/prevention format
- [x] CLAUDE.md bullet references the pitfalls entry

## Spec / AC

No feature spec — docs-only change recording a pitfall and convention.