### PR TITLE
docs(web): correct App Shell profile states and Add Asset goal

### DIFF
--- a/docs/web/FEATURES.md
+++ b/docs/web/FEATURES.md
@@ -118,13 +118,15 @@ Onboarding "complete" is a navigate-away transition (effect fires `navigate(retu
 
 **Own async states (in `HFTopBar`):**
 
-- `loading` (profile) — avatar initial absent until `GET /api/users/me` resolves
+- `loading` (profile) — avatar renders the `?` placeholder initial until `GET /api/users/me` resolves; tooltip falls back to "Profile settings"
+- `populated` (profile) — avatar renders the first character of the display name, uppercased; tooltip is the display name
+- `error` (profile) — avatar stays on the `?` placeholder; the shell offers no retry affordance
 - `loading` (notifications) — unread badge absent until `GET /api/notifications?limit=1` resolves
 - `populated` (notifications, zero unread) — badge hidden
 - `populated` (notifications, has unread) — badge shows unread count
 - `error` (notifications) — badge degrades to hidden; a 401 is not retried (falls through to page-level redirect)
 
-**Exceptions:** The shell owns two `useQuery` calls (`getUserProfile` and `listNotifications({ limit: 1 })`) — these are real async states the gallery must cover. The notifications badge query uses a separate key (`notificationsPageQueryKey({ limit: 1 })`) from the Notifications page (`notificationsPageQueryKey({ limit: PAGE_SIZE })`), so it is not the same query.
+**Exceptions:** The shell owns two `useQuery` calls (`getUserProfile` and `listNotifications({ limit: 1 })`) — these are real async states the gallery must cover. The avatar never renders empty: `profileAvatarInitial` returns `?` for an absent or blank name, so the profile `loading` and `error` states are visually identical. The notifications badge query uses a separate key (`notificationsPageQueryKey({ limit: 1 })`) from the Notifications page (`notificationsPageQueryKey({ limit: PAGE_SIZE })`), so it is not the same query.
 
 **Non-obvious behavior:**
 
@@ -314,7 +316,7 @@ Onboarding "complete" is a navigate-away transition (effect fires `navigate(retu
 ## Add Asset
 
 **Route:** `/app/assets/new`
-**Goal:** Let the user register a new asset (vehicle, equipment, or property) with a name, type, and optional notes.
+**Goal:** Let the user register a new asset (vehicle, equipment, or property) with a name, type, and the type-specific details for that asset kind.
 
 **States:**
 


### PR DESCRIPTION
## Summary

- **App Shell profile states were wrong.** The entry described `loading` (profile) as "avatar initial absent", but [`profileAvatarInitial`](https://github.com/snaveevans/pineapple/blob/main/apps/web/src/app/profilePresentation.ts#L12-L16) returns a `?` placeholder for an absent or blank name, so a character always renders. Replaced with the three real states (`loading`, `populated`, `error`) — the `error` path was missing entirely — and noted in **Exceptions** that `loading` and `error` are visually identical, since the state gallery has to reproduce both.
- **Dropped the stale "optional notes" from the Add Asset goal.** The form has no notes input and `CreateAssetBody` has no such property (the spec's only `notes` belongs to maintenance records). It was the last surviving trace of a claim #189 already removed from that entry's content-stress line.

Follow-up to the review on #189; docs only, no code touched.

## Related

Refs #144

## Test plan

- [ ] `docs/web/FEATURES.md` is the only file changed
- [ ] Profile states match `AppChrome.tsx` (`HFTopBar` avatar render + `title` fallback) and `profilePresentation.ts`
- [ ] Add Asset goal matches the form's actual inputs and `CreateAssetBody` in `openapi.json`
- [ ] No remaining "notes" claim on the Add Asset entry

## Spec / AC

No new acceptance criteria — this corrects factual drift in the state lists #145 enumerates from. `docs/specs/cross-cutting/loading-states.md` vocabulary is unchanged; both added bullets use existing tokens (`populated`, `error`).

---

_Generated with [Claude Code](https://claude.com/claude-code)_
