### PR TITLE
test(web): exclude transient 401 states from gallery

### DIFF
--- a/apps/web/src/app/AppActivityHistory.test.tsx
+++ b/apps/web/src/app/AppActivityHistory.test.tsx
@@ -5,6 +5,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { assert, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ActivityEntry, ActivityResponse } from "../api/activity";
+import { ApiError } from "../api/client";
 import { AppActivityHistory } from "./AppActivityHistory";
 
 declare global {
@@ -187,5 +188,24 @@ describe("AppActivityHistory", () => {
 
     expect(document.body.textContent).toContain("by you");
     expect(document.body.textContent).toContain("by Pat Rivera");
+  });
+
+  it("redirects 401 responses to sign in", async () => {
+    activityQueryResult = {
+      data: undefined,
+      dataUpdatedAt: 0,
+      isPending: false,
+      isError: true,
+      error: new ApiError(401, { error: "Unauthorized" }),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      fetchNextPage: vi.fn(),
+      refetch: vi.fn(),
+    };
+
+    await renderHistory();
+
+    expect(document.body.textContent).toContain("Redirecting to sign in");
+    expect(navigate).toHaveBeenCalledWith("/login", { replace: true });
   });
 });

--- a/docs/web/FEATURES.md
+++ b/docs/web/FEATURES.md
@@ -11,13 +11,23 @@ Each entry lists its renderable states using the vocabulary from
 `loading`, `error`, `empty`, `populated` for reads; `pending` and `error` for
 mutations. Content-stress states (long strings, pagination boundaries) and
 documented exceptions are noted per entry. These state lists are the input the
-state gallery (#145) enumerates from — every state listed here must be renderable
-in isolation. Navigate-away transitions (e.g. onboarding complete, create-asset
-success) are noted as transitions, not listed as enumerable states. Non-vocab
-state names — `unauthorized` (401 "Redirecting to sign in" UI), plain-prose
-layout states (e.g. "Desktop", "Closed", "Idle, vehicle type"), and local UI
-states (e.g. "form", "delete-task confirm") — are written plainly or carry an
-**Exceptions** note; they are never wrapped in backticks like vocabulary tokens.
+state gallery (#145) enumerates from — every state listed here must be
+renderable in isolation, unless it carries a gallery marker (below).
+Navigate-away transitions (e.g. onboarding complete, create-asset success) are
+noted as transitions, not listed as enumerable states. Non-vocab state names —
+`unauthorized` (401 "Redirecting to sign in" UI), plain-prose layout states
+(e.g. "Desktop", "Closed", "Idle, vehicle type"), and local UI states (e.g.
+"form", "delete-task confirm") — are written plainly or carry an **Exceptions**
+note; they are never wrapped in backticks like vocabulary tokens.
+
+**Gallery exclusions.** A state whose UI unmounts itself within the same tick
+is not gallery-able — the intermediate tree is gone before a screenshot can
+land. The recurring case is any screen that `navigate`s to `/login` on 401
+(including `OnboardingGuard`). Mark those states with the trailing token
+`[gallery:excluded #N]` (the issue that decided the exclusion) on the state
+bullet, and cover the redirect with an interaction test instead. `excluded` is
+a decision, not a promise; a future `deferred` marker would mean "gallery
+later." Do not change shipped navigate timing to make a transient photographable.
 
 ---
 
@@ -145,7 +155,7 @@ Onboarding "complete" is a navigate-away transition (effect fires `navigate(retu
 
 - `loading` — fetches `GET /api/notifications`; shows row skeletons
 - `error` — retryable load error
-- `unauthorized` (401) — lock icon, "Redirecting to sign in" / "Your session is no longer active." then navigates to `/login`
+- `unauthorized` (401) `[gallery:excluded #195]` — lock icon, "Redirecting to sign in" / "Your session is no longer active." then navigates to `/login`
 - `empty` — "You're all caught up" / "Maintenance reminders will show up here as tasks come due on your assets." CTA: none (passive)
 - `populated` — newest-first notification list with unread marker, asset icon, task title, due copy, asset name, reminder date, and relative created time
 - `populated` (paginated) — "Load older notifications" requests the next cursor when available
@@ -221,7 +231,7 @@ Onboarding "complete" is a navigate-away transition (effect fires `navigate(retu
 
 - `loading` — loading state while fetching; toolbar controls hidden
 - `error` — inline error message with a "Try again" retry button
-- `unauthorized` (401) — spinner + "Redirecting to sign in" then navigates to `/login`
+- `unauthorized` (401) `[gallery:excluded #195]` — spinner + "Redirecting to sign in" then navigates to `/login`
 - `empty` (no assets owned) — prompt to add first asset with a direct link to the add form; no toolbar shown. CTA: link to add-asset form
 - `empty` (filtered) — selected category has no matching assets (library is otherwise non-empty); message names the category. CTA: clear filter or add an asset
 - `populated` — grid view (desktop default) or list/row view; category chips and view toggle shown; each card links to `/app/assets/:id/maintenance`; sharing indicators on cards ("Shared with team" / "Shared by {owner}" / none)
@@ -288,7 +298,7 @@ Onboarding "complete" is a navigate-away transition (effect fires `navigate(retu
 
 - `loading` — fetches `GET /api/activity` before rendering the feed
 - `error` — feed-level retry state
-- `unauthorized` (401) — lock icon, "Redirecting to sign in" / "Your session is no longer active." then navigates to `/login`
+- `unauthorized` (401) `[gallery:excluded #195]` — lock icon, "Redirecting to sign in" / "Your session is no longer active." then navigates to `/login`
 - `empty` (no account history) — explains that future asset, maintenance, and task actions will appear. CTA: none (passive)
 - `empty` (filtered) — active filters/search remain visible and can be cleared. CTA: clear filters
 - `populated` — reverse-chronological timeline grouped by action day, with an all-time activity breakdown rail; each entry shows action type, title/name, asset snapshot, actor attribution ("by you" / teammate name), relative time, and absolute time
@@ -397,7 +407,7 @@ Success is a navigate-away transition (invalidates assets query, navigates to `/
 
 - `loading` — fetches `GET /api/teams/me` before rendering
 - `error` — generic error banner with retry
-- `unauthorized` (401) — "Redirecting to sign in…" then navigates to `/login`
+- `unauthorized` (401) `[gallery:excluded #195]` — "Redirecting to sign in…" then navigates to `/login`
 - `empty` (no team) — EmptyState prompt: "You don't have a team yet" / "Create a team, then invite the one teammate you work with. You'll decide which assets to share — the rest stay yours alone." CTA: "Create a team" button (transitions to the form view)
 - Form (create team) — separate view with name field (placeholder "e.g. The Ortega Household"), char counter, validation, and "Create team" submit; Cancel returns to the empty view
 - `populated` (has team) — team name, member count, and a member list with display name and role

--- a/docs/web/FEATURES.md
+++ b/docs/web/FEATURES.md
@@ -12,22 +12,27 @@ Each entry lists its renderable states using the vocabulary from
 mutations. Content-stress states (long strings, pagination boundaries) and
 documented exceptions are noted per entry. These state lists are the input the
 state gallery (#145) enumerates from — every state listed here must be
-renderable in isolation, unless it carries a gallery marker (below).
-Navigate-away transitions (e.g. onboarding complete, create-asset success) are
-noted as transitions, not listed as enumerable states. Non-vocab state names —
-`unauthorized` (401 "Redirecting to sign in" UI), plain-prose layout states
-(e.g. "Desktop", "Closed", "Idle, vehicle type"), and local UI states (e.g.
-"form", "delete-task confirm") — are written plainly or carry an **Exceptions**
-note; they are never wrapped in backticks like vocabulary tokens.
+renderable in isolation. Navigate-away transitions (e.g. onboarding complete,
+create-asset success) are noted as transitions, not listed as enumerable
+states. Non-vocab state names — `unauthorized` (401 "Redirecting to sign in"
+UI), plain-prose layout states (e.g. "Desktop", "Closed", "Idle, vehicle
+type"), and local UI states (e.g. "form", "delete-task confirm") — are written
+plainly or carry an **Exceptions** note; they are never wrapped in backticks
+like vocabulary tokens.
 
-**Gallery exclusions.** A state whose UI unmounts itself within the same tick
-is not gallery-able — the intermediate tree is gone before a screenshot can
-land. The recurring case is any screen that `navigate`s to `/login` on 401
-(including `OnboardingGuard`). Mark those states with the trailing token
-`[gallery:excluded #N]` (the issue that decided the exclusion) on the state
-bullet, and cover the redirect with an interaction test instead. `excluded` is
-a decision, not a promise; a future `deferred` marker would mean "gallery
-later." Do not change shipped navigate timing to make a transient photographable.
+**Gallery exclusions.** The full-app gallery harness (#145 / #191) photographs
+each state through a single `page.route` seam. A state whose product code
+navigates away within the same tick after the intermediate paints — specifically
+a distinct `unauthorized` UI that `navigate`s to `/login` on 401 — cannot be
+stably captured on that seam, because React Router replaces the tree in memory
+before the shot lands (#191). Those states remain renderable in isolation (and
+are covered by interaction tests); they are excluded from the gallery only.
+Mark them with `[gallery:excluded #N]` **after the em-dash** on the state
+bullet (state IDs derive from the text before `—`; the marker must not enter
+that substring). Do not mark `error` bullets that only note "401 redirects to
+`/login`" as a side effect of an otherwise stable error UI, and do not change
+shipped navigate timing to make a transient photographable. `excluded` is a
+decision, not a promise; a future `deferred` marker would mean "gallery later."
 
 ---
 
@@ -155,7 +160,7 @@ Onboarding "complete" is a navigate-away transition (effect fires `navigate(retu
 
 - `loading` — fetches `GET /api/notifications`; shows row skeletons
 - `error` — retryable load error
-- `unauthorized` (401) `[gallery:excluded #195]` — lock icon, "Redirecting to sign in" / "Your session is no longer active." then navigates to `/login`
+- `unauthorized` (401) — `[gallery:excluded #195]` lock icon, "Redirecting to sign in" / "Your session is no longer active." then navigates to `/login`
 - `empty` — "You're all caught up" / "Maintenance reminders will show up here as tasks come due on your assets." CTA: none (passive)
 - `populated` — newest-first notification list with unread marker, asset icon, task title, due copy, asset name, reminder date, and relative created time
 - `populated` (paginated) — "Load older notifications" requests the next cursor when available
@@ -231,7 +236,7 @@ Onboarding "complete" is a navigate-away transition (effect fires `navigate(retu
 
 - `loading` — loading state while fetching; toolbar controls hidden
 - `error` — inline error message with a "Try again" retry button
-- `unauthorized` (401) `[gallery:excluded #195]` — spinner + "Redirecting to sign in" then navigates to `/login`
+- `unauthorized` (401) — `[gallery:excluded #195]` spinner + "Redirecting to sign in" then navigates to `/login`
 - `empty` (no assets owned) — prompt to add first asset with a direct link to the add form; no toolbar shown. CTA: link to add-asset form
 - `empty` (filtered) — selected category has no matching assets (library is otherwise non-empty); message names the category. CTA: clear filter or add an asset
 - `populated` — grid view (desktop default) or list/row view; category chips and view toggle shown; each card links to `/app/assets/:id/maintenance`; sharing indicators on cards ("Shared with team" / "Shared by {owner}" / none)
@@ -298,7 +303,7 @@ Onboarding "complete" is a navigate-away transition (effect fires `navigate(retu
 
 - `loading` — fetches `GET /api/activity` before rendering the feed
 - `error` — feed-level retry state
-- `unauthorized` (401) `[gallery:excluded #195]` — lock icon, "Redirecting to sign in" / "Your session is no longer active." then navigates to `/login`
+- `unauthorized` (401) — `[gallery:excluded #195]` lock icon, "Redirecting to sign in" / "Your session is no longer active." then navigates to `/login`
 - `empty` (no account history) — explains that future asset, maintenance, and task actions will appear. CTA: none (passive)
 - `empty` (filtered) — active filters/search remain visible and can be cleared. CTA: clear filters
 - `populated` — reverse-chronological timeline grouped by action day, with an all-time activity breakdown rail; each entry shows action type, title/name, asset snapshot, actor attribution ("by you" / teammate name), relative time, and absolute time
@@ -407,7 +412,7 @@ Success is a navigate-away transition (invalidates assets query, navigates to `/
 
 - `loading` — fetches `GET /api/teams/me` before rendering
 - `error` — generic error banner with retry
-- `unauthorized` (401) `[gallery:excluded #195]` — "Redirecting to sign in…" then navigates to `/login`
+- `unauthorized` (401) — `[gallery:excluded #195]` "Redirecting to sign in…" then navigates to `/login`
 - `empty` (no team) — EmptyState prompt: "You don't have a team yet" / "Create a team, then invite the one teammate you work with. You'll decide which assets to share — the rest stay yours alone." CTA: "Create a team" button (transitions to the form view)
 - Form (create team) — separate view with name field (placeholder "e.g. The Ortega Household"), char counter, validation, and "Create team" submit; Cancel returns to the empty view
 - `populated` (has team) — team name, member count, and a member list with display name and role


### PR DESCRIPTION
## Summary

- Mark the four same-tick `unauthorized` (401) states as gallery-excluded in `docs/web/FEATURES.md`, under one general rule scoped to distinct unauthorized intermediates under the full-app harness.
- Add the missing Activity History 401 → `/login` interaction test; Assets, Team, and Notifications already had coverage.
- No product-code changes — decision from the #191 spike stands (do not gate navigate, photograph `/login`, or abandon the one-seam property for isolation stubs).

## Related

Closes #195
Refs #143, #191, #145

## Marker syntax for #145

Exact token, applied identically on all four state bullets:

```
[gallery:excluded #N]
```

- **Placement: after the em-dash**, in the description half of the bullet. State IDs derive from the text *before* `—` (backticks and parentheses stripped, kebab-cased); the marker must not enter that substring or IDs become `unauthorized-401-gallery-excluded-195`.
- `#N` is the issue that decided the exclusion (here `#195`).
- Parser contract: match `\[gallery:excluded #(\d+)\]` on a state bullet → category `excluded`. Unmarked states default to `rendered`. A future `deferred` form would be `[gallery:deferred #N]` (not used in this PR).
- The general rule lives once in the FEATURES.md intro under **Gallery exclusions.**; individual bullets only carry the token. Scope is the distinct `unauthorized` intermediate UIs — not `error` bullets that fold "401 redirects to `/login`" into a stable error state, and not OnboardingGuard (no distinct intermediate tree).

Example:

```md
- `unauthorized` (401) — `[gallery:excluded #195]` spinner + "Redirecting to sign in" then navigates to `/login`
```

## Interaction tests

| Screen | File | Status |
| --- | --- | --- |
| Asset Library | `AppAssets.test.tsx` | already existed |
| Team | `AppTeam.test.tsx` | already existed |
| Notifications | `AppNotifications.test.tsx` | already existed |
| Activity History | `AppActivityHistory.test.tsx` | **added in this PR** |

All four assert `navigate("/login", { replace: true })` (and the redirecting copy where the screen shows it). Mechanism coverage is complete across the four slice-1 screens; no product components touched.

## Test plan

- [x] `pnpm lint && pnpm type-check && pnpm -r test`
- [x] New Activity History 401 test passes
- [x] Grep confirms four identical `[gallery:excluded #195]` markers **after** the em-dash
- [x] Intro states the harness-scoped exclusion rule once; "renderable in isolation" restored

## Spec / AC

From #195:

- [x] The four `unauthorized` states are marked excluded in `docs/web/FEATURES.md`, each naming this issue
- [x] The rule is stated once, in general terms, rather than repeated per screen
- [x] An interaction test covers the 401 → `/login` redirect
- [x] No changes to `apps/web/src` product code