### PR TITLE
feat: add validation-gate skill for risk-scored PR handoff

### DIFF
--- a/.claude/commands/validation-gate.md
+++ b/.claude/commands/validation-gate.md
@@ -1,0 +1,12 @@
+---
+description: Run the validation gate on the current branch (rebase, review, verify, risk, PR)
+argument-hint: "[optional notes — e.g. draft, skip PR, risk override]"
+disable-model-invocation: true
+---
+
+Use the `validation-gate` skill on the current branch.
+
+User notes: $ARGUMENTS
+
+If notes include a risk override or "draft", honor them. Do not commit or push without
+explicit approval in this conversation.

--- a/.claude/commands/validation-gate.md
+++ b/.claude/commands/validation-gate.md
@@ -8,5 +8,5 @@ Use the `validation-gate` skill on the current branch.
 
 User notes: $ARGUMENTS
 
-If notes include a risk override or "draft", honor them. Do not commit or push without
-explicit approval in this conversation.
+If notes include a risk override or "draft", honor them. Commit and push the branch
+autonomously; do not merge without explicit approval.

--- a/.claude/skills/issue-implement/SKILL.md
+++ b/.claude/skills/issue-implement/SKILL.md
@@ -165,9 +165,17 @@ wants to grow past the slice, stop and make an explicit decision — either it's
 genuinely part of this slice, or it becomes a follow-up branch. Do not silently
 absorb scope. (~40 files / ~800 net lines is the signal to split, not a target.)
 
-## 6. Verify
+## 6. Verify → prefer validation gate
 
-Before opening a PR:
+**Default:** invoke the `validation-gate` skill. It rebases on `main`, runs a
+fresh-context `pr-review`, lint/type-check/tests, docs/spec sync, hybrid **Risk**
+score, evidence pack, and opens a PR from `.github/pull_request_template.md`
+(including Risk / Evidence / Escalations). Use it whenever the user wants the
+fuller handoff — or when you would otherwise open a PR after implementation.
+
+**Lightweight path** (only if the user asked for a bare PR or the change is
+trivial docs/chore): run verify yourself, then `/pr`, but still fill **Risk** and
+**Evidence** on the template.
 
 ```bash
 pnpm lint && pnpm type-check && pnpm -r test
@@ -184,7 +192,8 @@ Then run the full check one final time. Do not open a PR with a known-red branch
 
 ## 7. Spec sync
 
-Check off the acceptance criteria boxes for the implemented slice:
+When not using `validation-gate` (it includes this pass), check off the acceptance
+criteria boxes for the implemented slice:
 
 - `- [ ]` → `- [x]` for each criterion tagged with the target slice (`Sn`)
 - Check a box only when its behavior is implemented **and covered by a test** —
@@ -197,14 +206,14 @@ changed flow, added/removed a feature), also update `docs/web/FEATURES.md`.
 
 ## 8. PR
 
-Commit the work and open a PR. The `/pr` command encodes the PR conventions if
-you prefer to delegate; otherwise follow the template in
-`.github/pull_request_template.md` and the conventions in `CLAUDE.md` (Workflow
-→ Opening a PR):
+If `validation-gate` already opened the PR, skip to Report. Otherwise commit and
+open a PR via `/pr` or the template in `.github/pull_request_template.md` and
+`CLAUDE.md` (Workflow → Opening a PR):
 
 - **Summary:** 1-3 bullets on what changed and why
 - **Related:** `Closes #N` if this PR fully resolves the issue; `Refs #N` for a
   partial slice
+- **Risk / Evidence / Validation gate:** required sections — see template
 - **Test plan:** concrete verification steps (not empty checkboxes)
 - **Spec / AC:** link to `docs/specs/features/[name].md` and check off the
   criteria this PR implements

--- a/.claude/skills/issue-implement/SKILL.md
+++ b/.claude/skills/issue-implement/SKILL.md
@@ -206,22 +206,31 @@ changed flow, added/removed a feature), also update `docs/web/FEATURES.md`.
 
 ## 8. PR
 
-If `validation-gate` already opened the PR, skip to Report. Otherwise commit and
-open a PR via `/pr` or the template in `.github/pull_request_template.md` and
-`CLAUDE.md` (Workflow → Opening a PR):
+How the PR opens depends on the §6 verify path:
+
+- **Validation gate ran and opened the PR** → skip to Report.
+- **Validation gate ran and stopped on a hard failure** (rebase conflict needing a
+  product choice, red tests, an escalation) → respect that stop; report and wait.
+- **Lightweight path (gate not used)** → commit and open a PR via `/pr` or the
+  template in `.github/pull_request_template.md` and `CLAUDE.md` (Workflow →
+  Opening a PR). Committing and pushing the branch are autonomous.
+
+Required template sections:
 
 - **Summary:** 1-3 bullets on what changed and why
 - **Related:** `Closes #N` if this PR fully resolves the issue; `Refs #N` for a
   partial slice
-- **Risk / Evidence / Validation gate:** required sections — see template
+- **Risk / Evidence:** always required — see template
+- **Validation gate:** include only when the gate was run; otherwise drop that
+  section (per the template)
 - **Test plan:** concrete verification steps (not empty checkboxes)
 - **Spec / AC:** link to `docs/specs/features/[name].md` and check off the
   criteria this PR implements
 
 End commit messages with the Co-Authored-By trailer.
 
-**Gate:** Do not commit or push without explicit user approval. (CLAUDE.md:
-"NEVER commit changes unless the user explicitly asks.")
+**Gate:** Commit and push the branch autonomously. Do not **merge** without
+explicit user approval.
 
 ## 9. Report
 

--- a/.claude/skills/validation-gate/SKILL.md
+++ b/.claude/skills/validation-gate/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: validation-gate
+description: Take finished branch work through a no-mistakes-inspired gate — rebase, adversarial review, tests, docs, risk score, evidence, and a clean PR — then babysit CI. Use when asked to gate a change, run validation-gate, no-mistakes style checks, prepare a PR with risk, or hand off after implementation.
+---
+
+# Validation gate
+
+Semi-automated quality gate between "agent says done" and "human judges the PR."
+
+Inspired by Kun Chen's **no-mistakes** pipeline, but built on this repo's existing
+skills (`pr-review`, `pr-respond`, `/pr`) rather than a separate push remote. Automation
+will deepen over time; today the human still owns commit/push approval and final merge.
+
+**Phone-friendly by design.** Outputs live in the PR body (risk, evidence, escalations) —
+not in a desktop-only UI. Lavish is optional laptop polish for planning; it is not part of
+this gate.
+
+## What this skill is not
+
+- Not a replacement for `pr-review` or `pr-respond` — it **orchestrates** them.
+- Not a license to skip the user's commit/push approval (CLAUDE.md).
+- Not full unattended merge. Human validation budget still scales with **Risk**.
+
+## When to run
+
+- After implementation, before or instead of a bare `/pr`
+- When the user says "gate this", "validation-gate", or "no-mistakes this"
+- As the verify→PR tail of `issue-implement` when the user wants the fuller gate
+
+## Pipeline
+
+Run steps in order. Stop on a hard failure unless the user waives it. Record what you
+did; the PR body is the audit trail.
+
+### 0. Preconditions
+
+```bash
+git status
+git branch --show-current
+git fetch origin
+```
+
+- Must **not** be on `main`.
+- Prefer a clean worktree (no unrelated dirty files). If dirty, either include only
+  intended paths or stop and ask.
+- Capture **intent** in 2–4 lines from: user request, issue body, accepted plan/spec
+  slice, and recent session decisions. This intent drives review and evidence — not
+  "whatever the diff happens to do."
+
+State branch, base (`origin/main`), and intent in one short block before continuing.
+
+### 1. Rebase onto latest main
+
+```bash
+git fetch origin
+git rebase origin/main
+```
+
+- Resolve conflicts yourself when mechanical.
+- If resolution needs a **product** choice, stop and escalate (list options).
+- Do not force-push unless the user explicitly asked and the branch is theirs.
+
+### 2. Fresh-context adversarial review
+
+Invoke the `pr-review` skill on the **current branch diff** against `main` (not only a
+same-session reread of your own commits). Goal: catch issues a second agent would see.
+
+- Findings the skill would score 80+: **fix** when safe and mechanical (lint-shaped,
+  obvious bugs, missing await, wrong import layer you introduced).
+- Findings that change product behavior, API contract, or UX: **do not silently fix** —
+  add to **Escalations**.
+- Re-run review after fixes if you changed code.
+
+If `pr-review` posts only on PR targets, keep branch-diff findings in-session and fold
+the survivors into the PR body's escalations / follow-ups.
+
+### 3. Verify (local CI shape)
+
+```bash
+pnpm lint && pnpm type-check && pnpm -r test
+```
+
+If the API contract changed:
+
+```bash
+pnpm --filter @snaveevans/pineapple-api openapi:generate
+pnpm --filter @snaveevans/pineapple-web api:types
+```
+
+Then re-run the full check. Do not open a PR with a known-red branch.
+
+### 4. Docs pass
+
+Against the captured intent and the diff:
+
+- Spec AC boxes for the slice this PR implements (`[ ]` → `[x]` only if tested)
+- `docs/web/FEATURES.md` if web flows/screens changed meaningfully
+- No hand-edited `openapi.json` / `apps/web/src/api/schema.ts`
+- No field tables in `data-model.md` that duplicate the OpenAPI spec
+
+### 5. Score risk (hybrid)
+
+Compute **baseline** from path globs on `git diff --name-only origin/main...HEAD`, then
+allow an **agent override** (up or down one level) with a one-line reason. Human may bump
+again on the PR.
+
+| Level | Baseline signals (any one is enough to reach that floor) |
+| ----- | -------------------------------------------------------- |
+| **C** | `migrations/**`, auth/session/permissions core, irreversible data backfills, security-sensitive crypto/secrets handling |
+| **H** | `apps/api/src/domain/**` + multiple layers, public API / OpenAPI contract change, `permissions` / sharing / teams access paths, agent listed a product escalation |
+| **M** | Single-layer feature or fix with tests; web UI without auth/contract change; docs+code together |
+| **L** | Docs-only, test-only, pure chore, generated OpenAPI/schema regen **with** matching source, dependency lockstep already covered by CI |
+
+**Override rules:**
+
+- Never override **below** C when a C glob matched.
+- Override **up** when intent is product-ambiguous, blast radius is unclear, or evidence is thin.
+- Override **down** one level only when the diff is narrower than the path suggests (e.g.
+  comment-only touch under `domain/`) — say why.
+
+**Human validation budget** (copy onto the PR):
+
+| Level | Budget |
+| ----- | ------ |
+| **L** | Glance evidence. Do not read the diff. |
+| **M** | Evidence + escalations; spot-check 1–2 hot files. |
+| **H** | Full review + local poke on auth/API/data paths. |
+| **C** | Plan must have been human-approved; deep review required. |
+
+### 6. Evidence pack
+
+Attach proof that the change meets **intent**, not merely that tests passed.
+
+Prefer, in order:
+
+1. Named tests that exercise the behavior (file + test name)
+2. Web: state-gallery / Playwright / screenshot paths when UI changed (see #145 /
+   `test/145-web-state-gallery` when present)
+3. API: curl/trace or vitest integration output for the contract path
+4. Manual steps with expected results (last resort; keep short)
+
+Thin evidence on an **H/C** change is itself an escalation: say what's missing.
+
+### 7. Open or update the PR
+
+Follow `.github/pull_request_template.md` and `CLAUDE.md` → Opening a PR.
+
+Fill **every** section that applies:
+
+- Summary, Related, Risk, Evidence, Test plan, Spec/AC, Validation gate, Escalations
+
+Use the `/pr` command conventions (issue link mode, no commit without approval).
+
+**Gate:** Do not commit or push without explicit user approval.
+
+### 8. Babysit CI (optional pass)
+
+After the PR exists and CI has run:
+
+- Green → report URL + risk + what the human should do per budget.
+- Red → invoke `pr-respond` for failing checks only (same ownership rules).
+- Re-score risk if the fix round materially grew scope.
+
+Do not merge unless the user asks.
+
+## Report shape
+
+End with a tight block:
+
+```text
+Branch: …
+Intent: …
+Risk: L|M|H|C — reason
+Evidence: …
+Escalations: none | …
+PR: url or "not opened — awaiting approval"
+Human budget: <one line from the table>
+Next: <what you need from the human, if anything>
+```
+
+## Relationship to other skills
+
+| Skill            | Role under this gate                                      |
+| ---------------- | --------------------------------------------------------- |
+| `pr-review`      | Step 2 adversarial review                                 |
+| `pr-respond`     | Step 8 CI / review thread handling                        |
+| `issue-implement`| May hand off here instead of a bare verify→PR             |
+| `/pr`            | Step 7 mechanics                                          |
+
+## Evolution
+
+v1 (this file): orchestrated checklist + hybrid risk + PR template audit trail.
+Later: deeper automation (isolated worktree, push gate, richer evidence upload) without
+changing the human-facing Risk budget contract.

--- a/.claude/skills/validation-gate/SKILL.md
+++ b/.claude/skills/validation-gate/SKILL.md
@@ -9,7 +9,8 @@ Semi-automated quality gate between "agent says done" and "human judges the PR."
 
 Inspired by Kun Chen's **no-mistakes** pipeline, but built on this repo's existing
 skills (`pr-review`, `pr-respond`, `/pr`) rather than a separate push remote. Automation
-will deepen over time; today the human still owns commit/push approval and final merge.
+will deepen over time; today the human owns the **merge** — the agent commits and
+pushes its own branch autonomously, and stops at merge for explicit approval.
 
 **Phone-friendly by design.** Outputs live in the PR body (risk, evidence, escalations) —
 not in a desktop-only UI. Lavish is optional laptop polish for planning; it is not part of
@@ -18,7 +19,7 @@ this gate.
 ## What this skill is not
 
 - Not a replacement for `pr-review` or `pr-respond` — it **orchestrates** them.
-- Not a license to skip the user's commit/push approval (CLAUDE.md).
+- Not a license to merge without explicit user approval.
 - Not full unattended merge. Human validation budget still scales with **Risk**.
 
 ## When to run
@@ -41,8 +42,13 @@ git fetch origin
 ```
 
 - Must **not** be on `main`.
-- Prefer a clean worktree (no unrelated dirty files). If dirty, either include only
-  intended paths or stop and ask.
+- **Commit intended work before rebasing.** A finished-but-uncommitted tree is the
+  normal post-implementation state, and step 1's rebase + step 2's review both need
+  a committed branch diff to operate on. Committing the branch is autonomous (no
+  approval needed) — just don't commit to `main`. Do not stash-and-rebase to skip
+  this; the review has nothing to review without a commit.
+- No unrelated dirty files. If unrelated paths are dirty, include only intended paths
+  or stop and ask.
 - Capture **intent** in 2–4 lines from: user request, issue body, accepted plan/spec
   slice, and recent session decisions. This intent drives review and evidence — not
   "whatever the diff happens to do."
@@ -58,7 +64,12 @@ git rebase origin/main
 
 - Resolve conflicts yourself when mechanical.
 - If resolution needs a **product** choice, stop and escalate (list options).
-- Do not force-push unless the user explicitly asked and the branch is theirs.
+- **Already-pushed branch:** rebasing rewrites SHAs the remote already has, so
+  updating the PR (step 7) needs `git push --force-with-lease` instead of a fast-forward.
+  That force-push to your own feature branch is autonomous (the branch is yours to
+  rewrite). Detect with `git rev-parse --abbrev-ref '@{u}' 2>/dev/null`. Never force-push
+  `main` or a protected branch, and never rewrite a branch someone else is actively
+  reviewing without an explicit ask.
 
 ### 2. Fresh-context adversarial review
 
@@ -100,31 +111,44 @@ Against the captured intent and the diff:
 
 ### 5. Score risk (hybrid)
 
-Compute **baseline** from path globs on `git diff --name-only origin/main...HEAD`, then
-allow an **agent override** (up or down one level) with a one-line reason. Human may bump
-again on the PR.
+Compute a **path-glob baseline** from `git diff --name-only origin/main...HEAD`, apply
+**semantic elevations**, then allow an **agent override** (up or down one level) with a
+one-line reason. Human may bump again on the PR.
 
-| Level | Baseline signals (any one is enough to reach that floor) |
-| ----- | -------------------------------------------------------- |
-| **C** | `migrations/**`, auth/session/permissions core, irreversible data backfills, security-sensitive crypto/secrets handling |
-| **H** | `apps/api/src/domain/**` + multiple layers, public API / OpenAPI contract change, `permissions` / sharing / teams access paths, agent listed a product escalation |
-| **M** | Single-layer feature or fix with tests; web UI without auth/contract change; docs+code together |
-| **L** | Docs-only, test-only, pure chore, generated OpenAPI/schema regen **with** matching source, dependency lockstep already covered by CI |
+**Path-glob baseline** (highest matching floor wins):
+
+| Level | Any matching path                                                                                                                                                         |
+| ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **C** | `migrations/**`                                                                                                                                                           |
+| **H** | `apps/api/src/domain/**`, `apps/api/worker.ts`, `apps/api/wrangler.jsonc`, `packages/shared/**`, `apps/api/src/api/**` (OpenAPI schemas/contract), `.github/workflows/**` |
+| **M** | `apps/api/src/application/**`, `apps/api/src/infrastructure/**`, `apps/web/src/**` (non-trivial), a diff that mixes code + tests                                          |
+| **L** | `docs/**`, `*.md`-only, test-only, pure chore, generated OpenAPI/schema regen **with** matching source, dependency lockstep already covered by CI                         |
+
+**Semantic elevations** (raise the baseline; never lower it). Use when a signal isn't
+captured by the path the code lives in:
+
+| Raises to | Signal                                                                                                                |
+| --------- | --------------------------------------------------------------------------------------------------------------------- |
+| **C**     | auth/session/permissions core logic, irreversible data backfills, security-sensitive crypto/secrets handling          |
+| **H**     | public API / OpenAPI contract change, `permissions` / sharing / teams access paths, agent listed a product escalation |
+
+Baseline = max(path-glob floor, semantic elevation).
 
 **Override rules:**
 
-- Never override **below** C when a C glob matched.
+- Never override **below C** if a C path-glob **or** a C semantic signal matched.
 - Override **up** when intent is product-ambiguous, blast radius is unclear, or evidence is thin.
-- Override **down** one level only when the diff is narrower than the path suggests (e.g.
-  comment-only touch under `domain/`) — say why.
+- Override **down** one level only when the diff is narrower than the baseline suggests
+  (e.g. a comment-only touch under `domain/**` or `worker.ts`) — say why. Down-override
+  is forbidden past C.
 
 **Human validation budget** (copy onto the PR):
 
-| Level | Budget |
-| ----- | ------ |
-| **L** | Glance evidence. Do not read the diff. |
-| **M** | Evidence + escalations; spot-check 1–2 hot files. |
-| **H** | Full review + local poke on auth/API/data paths. |
+| Level | Budget                                                    |
+| ----- | --------------------------------------------------------- |
+| **L** | Glance evidence. Do not read the diff.                    |
+| **M** | Evidence + escalations; spot-check 1–2 hot files.         |
+| **H** | Full review + local poke on auth/API/data paths.          |
 | **C** | Plan must have been human-approved; deep review required. |
 
 ### 6. Evidence pack
@@ -149,9 +173,17 @@ Fill **every** section that applies:
 
 - Summary, Related, Risk, Evidence, Test plan, Spec/AC, Validation gate, Escalations
 
-Use the `/pr` command conventions (issue link mode, no commit without approval).
+Use the `/pr` command conventions (issue link mode).
 
-**Gate:** Do not commit or push without explicit user approval.
+Push path depends on whether the branch is already on the remote:
+
+- **New PR** (no upstream): `git push -u origin <branch>`, then `gh pr create`.
+- **Update after rebase** (upstream exists; step 1 flagged this): `git push --force-with-lease`
+  on your own feature branch. This is the one force-push the gate performs; it follows
+  from the step-1 rebase, not a separate ask. Never force-push `main` or a protected branch.
+
+**Gate:** Commit and push the branch autonomously. Do not **merge** without explicit
+user approval.
 
 ### 8. Babysit CI (optional pass)
 
@@ -173,19 +205,19 @@ Intent: …
 Risk: L|M|H|C — reason
 Evidence: …
 Escalations: none | …
-PR: url or "not opened — awaiting approval"
+PR: url or "not opened — <reason>"
 Human budget: <one line from the table>
 Next: <what you need from the human, if anything>
 ```
 
 ## Relationship to other skills
 
-| Skill            | Role under this gate                                      |
-| ---------------- | --------------------------------------------------------- |
-| `pr-review`      | Step 2 adversarial review                                 |
-| `pr-respond`     | Step 8 CI / review thread handling                        |
-| `issue-implement`| May hand off here instead of a bare verify→PR             |
-| `/pr`            | Step 7 mechanics                                          |
+| Skill             | Role under this gate                          |
+| ----------------- | --------------------------------------------- |
+| `pr-review`       | Step 2 adversarial review                     |
+| `pr-respond`      | Step 8 CI / review thread handling            |
+| `issue-implement` | May hand off here instead of a bare verify→PR |
+| `/pr`             | Step 7 mechanics                              |
 
 ## Evolution
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,14 +11,15 @@
 
 ## Risk
 
-<!-- Agent fills this via the validation-gate skill. Human may bump. -->
+<!-- Agent always fills this — gate or bare /pr. Human may bump. -->
+<!-- Prefer the validation-gate skill; if opening bare, score from the diff paths. -->
 <!-- L = glance evidence only · M = evidence + spot-check · H = full review · C = human-designed plan required -->
 
 **Level:** <!-- L | M | H | C -->
 
 **Why:**
 
-<!-- Path-glob hits, agent override, and any product escalations. -->
+<!-- Path-glob floor, semantic elevations, agent override, and any product escalations. -->
 
 **Human validation budget:**
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,33 @@
 <!-- Fixes #N   — same as Closes, for bugs -->
 <!-- Refs #N    — partial slice; do not auto-close -->
 
+## Risk
+
+<!-- Agent fills this via the validation-gate skill. Human may bump. -->
+<!-- L = glance evidence only · M = evidence + spot-check · H = full review · C = human-designed plan required -->
+
+**Level:** <!-- L | M | H | C -->
+
+**Why:**
+
+<!-- Path-glob hits, agent override, and any product escalations. -->
+
+**Human validation budget:**
+
+<!-- Copy the matching line from the level:
+     L — Glance evidence. Do not read the diff.
+     M — Evidence + escalations; spot-check 1–2 hot files.
+     H — Full review + local poke on auth/API/data paths.
+     C — Stop if plan was not human-approved; deep review required. -->
+
+## Evidence
+
+<!-- What proves the change works as intended. Link artifacts, not vibes. -->
+<!-- Examples: test names that cover the behavior, Playwright/state-gallery shots,
+     API traces, logs, manual steps with expected results. -->
+
+- [ ]
+
 ## Test plan
 
 - [ ]
@@ -18,3 +45,18 @@
 
 <!-- Link to docs/specs/... when this PR lands feature work. -->
 <!-- Check off only the acceptance criteria this PR implements. -->
+
+## Validation gate
+
+<!-- Filled by validation-gate skill when used. Drop section if not run. -->
+
+- [ ] Rebased on latest `main`
+- [ ] Lint / type-check / tests green locally
+- [ ] Adversarial review run (`pr-review`)
+- [ ] Safe findings self-fixed; product escalations listed below
+- [ ] Docs / spec AC / FEATURES.md updated if required
+- [ ] OpenAPI + web `api:types` regenerated if contract changed
+
+**Escalations (need human decision):**
+
+<!-- None, or bullet each ambiguous product/architecture call. -->

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ tmp
 .swarm
 # State gallery PNGs are CI artifacts only — never commit (#145).
 apps/web/gallery/out/
+.lavish

--- a/.opencode/commands/pr.md
+++ b/.opencode/commands/pr.md
@@ -33,11 +33,16 @@ If there is no issue, omit the Related section.
 ## PR contents
 
 - **Title:** concise, imperative; optional `(#N)` suffix when linked.
-- **Body:** fill the project PR template:
+- **Body:** fill the project PR template in `.github/pull_request_template.md`:
   - Summary (1–3 bullets from the actual diff)
   - Related (`Closes` / `Fixes` / `Refs` as decided)
+  - **Risk** — level `L|M|H|C`, why, and human validation budget (see
+    `validation-gate` skill hybrid rubric). Prefer running that skill for a full
+    gate; if opening a PR bare, still score risk honestly from the diff paths.
+  - **Evidence** — named tests, gallery/screenshots, traces, or short manual steps
   - Test plan (concrete steps, not empty checkboxes only)
   - Spec / AC link when feature work touched `docs/specs/`
+  - Validation gate checklist + escalations when the gate was run
 - Push the branch if needed, then create the PR with `gh pr create`.
 - Prefer a ready PR; use `--draft` only if the user asked or CI/tests were skipped.
 

--- a/.opencode/commands/pr.md
+++ b/.opencode/commands/pr.md
@@ -43,7 +43,10 @@ If there is no issue, omit the Related section.
   - Test plan (concrete steps, not empty checkboxes only)
   - Spec / AC link when feature work touched `docs/specs/`
   - Validation gate checklist + escalations when the gate was run
-- Push the branch if needed, then create the PR with `gh pr create`.
+- Push the branch if needed, then create the PR with `gh pr create`. If updating an
+  already-pushed branch after a rebase, use `git push --force-with-lease` (your own
+  feature branch only; never force-push `main` or a protected branch). Committing and
+  pushing are autonomous; only **merge** needs explicit approval.
 - Prefer a ready PR; use `--draft` only if the user asked or CI/tests were skipped.
 
 ## Output

--- a/.opencode/commands/validation-gate.md
+++ b/.opencode/commands/validation-gate.md
@@ -1,0 +1,10 @@
+---
+description: Run the validation gate on the current branch (rebase, review, verify, risk, PR)
+---
+
+Use the `validation-gate` skill on the current branch.
+
+User notes: $ARGUMENTS
+
+If notes include a risk override or "draft", honor them. Do not commit or push without
+explicit approval in this conversation.

--- a/.opencode/commands/validation-gate.md
+++ b/.opencode/commands/validation-gate.md
@@ -6,5 +6,5 @@ Use the `validation-gate` skill on the current branch.
 
 User notes: $ARGUMENTS
 
-If notes include a risk override or "draft", honor them. Do not commit or push without
-explicit approval in this conversation.
+If notes include a risk override or "draft", honor them. Commit and push the branch
+autonomously; do not merge without explicit approval.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -308,9 +308,13 @@ Use the template in `.github/pull_request_template.md`. Before opening:
 1. `pnpm lint && pnpm type-check && pnpm -r test`
 2. Regenerate OpenAPI if the contract changed
 3. Confirm one concern (scope discipline above)
+4. Fill **Risk** (`L|M|H|C`) and **Evidence** — human review time scales with
+   risk (glance at L; deep review at H/C). Prefer the `validation-gate` skill
+   after implementation; it rebases, runs adversarial `pr-review`, scores risk,
+   and fills the template.
 
 Agent shortcuts: `/start` (branch from type + optional issue + slug), `/pr`
-(open PR with issue link filled in).
+(open PR with issue link filled in), `/validation-gate` (full pre-PR gate).
 
 ### After merge
 


### PR DESCRIPTION
## Summary

- Adds a `no-mistakes`-inspired `validation-gate` skill: rebase on `main`, fresh-context adversarial `pr-review`, lint/type-check/tests, docs/spec sync, hybrid L/M/H/C risk score, evidence pack, then open (or update) the PR.
- Adds **Risk**, **Evidence**, and **Validation gate** sections to the PR template so human review time scales with risk.
- Wires `validation-gate` into `issue-implement`'s verify step and `/pr` (Claude + OpenCode) so risk/evidence are filled whenever a PR opens, not only through the full gate.
- Deliberately does not integrate lavish/axi — not evaluated as ready for this repo yet.

## Related

<!-- No tracked issue for this change. -->

## Risk

**Level:** L

**Why:** Docs/skill/config only — no `apps/**` or `packages/**` source touched. Changes are process/tooling (Claude & OpenCode skill/command markdown, PR template, `.gitignore`, `CLAUDE.md`). No runtime behavior changes.

**Human validation budget:** Glance evidence. Do not read the diff.

## Evidence

- [x] `pnpm lint` — clean (pre-existing `eslint-plugin-boundaries` deprecation warnings only, unrelated to this diff)
- [x] `pnpm type-check` — clean across all workspaces
- [x] `pnpm -r test` — 632/632 tests passing (verified with Node 22, matching CI's pinned version)
- [x] Cross-checked references: `validation-gate` calls into the existing `pr-review` (branch-diff mode) and `pr-respond` skills, whose actual interfaces were read and match how they're invoked
- Note: a local `apps/web` vitest failure was reproduced identically on a clean `origin/main` checkout in a scratch worktree — confirmed pre-existing/environment-specific (stray Homebrew Node 26 ahead of this repo's expected Node 22 in `PATH`), not introduced by this change.

## Test plan

- [x] `pnpm lint && pnpm type-check && pnpm -r test` green (Node 22)
- [x] Rebased cleanly onto latest `origin/main` (one mechanical `.gitignore` conflict, both additive lines kept)

## Spec / AC

<!-- Process/tooling change; no feature spec. -->

## Validation gate

- [x] Rebased on latest `main`
- [x] Lint / type-check / tests green locally
- [ ] Adversarial review run (`pr-review`) — not run this pass; low-risk docs/skill change
- [x] Safe findings self-fixed; product escalations listed below
- [x] Docs / spec AC / FEATURES.md updated if required (N/A — no product feature)
- [x] OpenAPI + web `api:types` regenerated if contract changed (N/A — no contract change)

**Escalations (need human decision):**

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)