### PR TITLE
feat: local gallery visual-diff wrapper + skill

### DIFF
--- a/.claude/skills/gallery-visual-diff/SKILL.md
+++ b/.claude/skills/gallery-visual-diff/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: gallery-visual-diff
+description: Run the web state gallery's visual diff locally against the merge-base before pushing a frontend change. Use after editing anything that can alter the rendered web app — CSS, a stylesheet, a design token, a component under apps/web/src, layout, or a UX/visual refactor. Do NOT use for test-only edits, docs-only changes, or apps/api work — nothing in this skill applies there.
+---
+
+Prove a frontend change is visually clean **while you still have context**, instead of
+pushing and reading a CI comment cold. This is the same merge-base-vs-HEAD pixel diff
+CI runs (`docs/specs/cross-cutting/testing.md`, "Visual diff against the base branch
+(#146)"), wrapped for local use.
+
+**Say the cost up front.** A cold run is ~8-12 minutes (two production builds, two
+~150s Playwright renders, one `pnpm install` in a throwaway worktree). Every later run
+against the same merge-base reuses the cached baseline and only rebuilds/re-renders
+HEAD — seconds, not minutes. Decide with the user (or just note it) whether to run now
+or after you finish iterating on the change; don't block a fast edit-loop on a cold run.
+
+## Run it
+
+```bash
+scripts/gallery-diff-local.sh              # normal run
+scripts/gallery-diff-local.sh --refresh-base   # force-discard the cached baseline
+```
+
+The script does the mechanics — relevance gate, merge-base worktree, caching, render,
+diff. Don't re-derive that logic inline; read `scripts/gallery-diff-local.sh` if you
+need to know exactly what it does. This skill is about **reading the result**.
+
+If it prints "No changes under apps/web/src/\*\* or apps/web/gallery/\*\* since
+merge-base — visual diff skipped" and exits 0, there's nothing to diff — the edit
+didn't touch a rendered surface. That's a normal, correct outcome, not a skip you
+need to force past.
+
+## Reading the result
+
+**Zero changed states** → the change is visually clean. Say so plainly in the PR body
+(e.g. "Local gallery diff: 0 changed states"). This is a real, checkable claim — the
+script just proved it, not just claimed it.
+
+**Any changed states** → classify **every one** as INTENDED or REGRESSION before
+writing the PR body. Don't just paste the count.
+
+- For a change that's supposed to alter appearance (new component, restyle), a
+  changed state that matches the intended area is INTENDED — name it and why.
+- For a **behavior-preserving refactor** (the #147 / #149 pattern — renaming,
+  extracting, reorganizing without an intended visual change), treat every changed
+  state as a REGRESSION until you've looked at the diff PNG and can explain why it's
+  actually fine. "The refactor shouldn't have touched pixels" is not proof that it
+  didn't — open `<diff dir>/diff/<file>.png` and look.
+- The PR body must name and justify each changed triple, not just report the total.
+
+The script prints the diff directory path and the changed screen/state/viewport
+triples; `base/`, `head/`, and `diff/` subfolders hold the actual PNGs plus
+`summary.json`.
+
+## Known flake — do not chase it
+
+`asset-library/populated-filtered` at the **mobile** viewport has flapped between
+`unchanged` and a ~78px `changed` result across otherwise-identical runs, with no
+`apps/web/src` changes in play (recorded in `testing.md`, PR #209 — sub-pixel glyph
+interior rendering noise inside one asset card's icon, not a token or layout shift).
+
+If that state is the **only** one that shows a small change, **re-run before
+believing it**. Do not spend time investigating it as a real regression, and do not
+"fix" it by touching product code or the harness.
+
+## Hard rule: never tune the threshold
+
+If you see what looks like a false positive (a change that shouldn't be there,
+happening consistently — not the known flake above), **record it as a finding** in
+`docs/specs/cross-cutting/testing.md` the same way PR #209's finding is recorded.
+**Never raise the `pixelmatch` threshold to make a diff go green.** "Make the diff
+pass" is not the goal here — "know whether the change is visually clean" is. Loosening
+the threshold answers a different, wrong question.
+
+## This is not a CI gate — yet
+
+Phase A of the visual diff is **non-blocking** in CI today: diff findings never fail
+the check (Phase B — promotion to required — is still an open checkbox on #146). So a
+clean local run doesn't make CI red-or-green either way. The value of this skill is
+purely **getting the answer while you still have the context to fix it**, rather than
+finding out from a PR comment after the fact. Don't imply in a PR body that a clean
+local run is a gate passing — say what it actually is: local evidence the author
+checked and the result was clean (or that the changes were classified as intended).

--- a/.claude/skills/gallery-visual-diff/SKILL.md
+++ b/.claude/skills/gallery-visual-diff/SKILL.md
@@ -10,9 +10,11 @@ CI runs (`docs/specs/cross-cutting/testing.md`, "Visual diff against the base br
 
 **Say the cost up front.** A cold run is ~8-12 minutes (two production builds, two
 ~150s Playwright renders, one `pnpm install` in a throwaway worktree). Every later run
-against the same merge-base reuses the cached baseline and only rebuilds/re-renders
-HEAD — seconds, not minutes. Decide with the user (or just note it) whether to run now
-or after you finish iterating on the change; don't block a fast edit-loop on a cold run.
+against the same merge-base reuses the cached baseline, skipping the base-side
+install/build/render — but HEAD still gets a full production build and its own ~150s
+render every time, cache hit or not. A warm-cache run is **~2-3 minutes, not seconds**.
+Decide with the user (or just note it) whether to run now or after you finish iterating
+on the change; don't block a fast edit-loop on a run that's still minutes long.
 
 ## Run it
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,43 +215,29 @@ jobs:
         if: steps.gallery-scope.outputs.run == 'true'
         run: pnpm --filter @snaveevans/pineapple-web exec playwright install chromium --with-deps
 
-      - name: Build web (HEAD, production)
+      # Build+render is shared with local usage via scripts/gallery-build-render.sh
+      # (scripts/gallery-diff-local.sh, docs/specs/cross-cutting/testing.md).
+      - name: Build and render state gallery (HEAD)
         if: steps.gallery-scope.outputs.run == 'true'
-        run: pnpm --filter @snaveevans/pineapple-web build
-
-      - name: Render state gallery (HEAD)
-        if: steps.gallery-scope.outputs.run == 'true'
-        env:
-          TZ: UTC
-        run: pnpm --filter @snaveevans/pineapple-web gallery:render -- --out apps/web/gallery/out-head
+        run: bash scripts/gallery-build-render.sh apps/web/gallery/out-head
 
       # Dual render + pixel diff only on pull_request (Phase A of #146).
+      # Worktree mechanics are shared with local usage via
+      # scripts/gallery-render-at-ref.sh — see that script's header and
+      # scripts/gallery-diff-local.sh, which renders the same merge-base
+      # baseline (cached) before a push.
       - name: Render state gallery (merge-base)
         if: steps.gallery-scope.outputs.run == 'true' && steps.gallery-scope.outputs.diff == 'true'
         id: base-render
-        env:
-          TZ: UTC
-          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
         run: |
           set -euo pipefail
           MERGE_BASE="$(git merge-base HEAD "origin/${GITHUB_BASE_REF}")"
           echo "merge_base=${MERGE_BASE}" >> "$GITHUB_OUTPUT"
           echo "Rendering gallery at merge-base ${MERGE_BASE}"
-
-          # Detached worktree keeps HEAD checkout + out-head intact.
-          BASE_WT="${RUNNER_TEMP}/gallery-merge-base"
-          git worktree add --detach "$BASE_WT" "$MERGE_BASE"
-
-          # Reuse the runner's Chromium; install deps for the base tree.
-          cd "$BASE_WT"
-          pnpm install --frozen-lockfile
-          pnpm --filter @snaveevans/pineapple-web build
-          # Write into the HEAD workspace so the diff step sees both trees.
-          pnpm --filter @snaveevans/pineapple-web gallery:render -- \
-            --out "${GITHUB_WORKSPACE}/apps/web/gallery/out-base"
-
-          cd "${GITHUB_WORKSPACE}"
-          git worktree remove --force "$BASE_WT"
+          bash scripts/gallery-render-at-ref.sh \
+            "$MERGE_BASE" \
+            "${GITHUB_WORKSPACE}/apps/web/gallery/out-base" \
+            "${RUNNER_TEMP}/gallery-merge-base"
 
       - name: Pixel-diff gallery (merge-base vs HEAD)
         if: steps.gallery-scope.outputs.run == 'true' && steps.gallery-scope.outputs.diff == 'true'

--- a/docs/specs/cross-cutting/testing.md
+++ b/docs/specs/cross-cutting/testing.md
@@ -297,6 +297,50 @@ the PR comment can inline them as markdown.
 - Same-repo PRs get a sticky PR comment (`<!-- pineapple-web-visual-diff -->`) with the summary and
   inline images, legible at phone width.
 
+#### Running it locally
+
+CI's dual render is the only place this used to run. `scripts/gallery-diff-local.sh`
+wraps the same two CLIs so an agent (or a human) can get the merge-base-vs-HEAD
+verdict **before** pushing, while still holding the context needed to fix a
+regression. Interpretation guidance (how to read a changed state, the known flake,
+the no-tuning rule) lives in `.claude/skills/gallery-visual-diff/SKILL.md` — this
+section documents the mechanics only.
+
+- **Ordering problem it solves:** rendering a baseline before editing needs foresight
+  and goes stale on every pull/rebase; re-rendering the merge-base after every edit is
+  correct but pays the ~150s render cost on every iteration. The script always derives
+  the baseline from `git merge-base HEAD origin/main` in a **detached `git worktree`**
+  (never `git checkout` — HEAD's working tree, branch, and `node_modules` are never
+  touched) and **caches the rendered baseline keyed on the merge-base SHA**
+  (`~/.cache/pineapple-gallery/<sha>/out`). First run against a given merge-base pays
+  for the base render; every later iteration on that branch reuses the cache and only
+  rebuilds/re-renders HEAD. The cache self-invalidates the moment the merge-base moves
+  (a rebase or a `main` merge changes the SHA, which changes the cache key).
+- **Relevance gate first.** Before doing anything expensive, the script diffs
+  `apps/web/src` and `apps/web/gallery` against the merge-base; if neither changed, it
+  prints that and exits 0 immediately rather than spending ~8-12 minutes on a PR that
+  touches no rendered surface.
+- **Cost:** ~8-12 minutes cold (two production builds, two ~150s renders, one
+  `pnpm install` in the throwaway worktree). A cache hit only pays the HEAD side —
+  seconds, not minutes.
+- **Exit code:** 0 whenever the run completes, whether or not visual changes were
+  found — a changed state is information, not a script failure. Non-zero is reserved
+  for genuine failures (build, render, or worktree setup broke).
+- Output (`~/.cache/pineapple-gallery/runs/latest/`) lives outside the repo, same as
+  CI's artifact-only posture — no gallery PNG is ever committed, locally or in CI.
+- `--refresh-base` force-discards the cached baseline and re-renders it.
+- **The worktree/build/render mechanics are not duplicated between CI and local.**
+  `scripts/gallery-build-render.sh` (build + `gallery:render`) and
+  `scripts/gallery-render-at-ref.sh` (detached-worktree render at an arbitrary ref) are
+  the shared implementation; `gallery-diff-local.sh` and the CI `gallery` job's HEAD and
+  merge-base render steps all call into them rather than each spelling out the same
+  bash independently.
+
+```bash
+scripts/gallery-diff-local.sh
+scripts/gallery-diff-local.sh --refresh-base
+```
+
 #### Acceptance criteria (#146)
 
 - [x] A PR with no visual change reports zero changed regions and uploads no images. `S1`

--- a/docs/specs/cross-cutting/testing.md
+++ b/docs/specs/cross-cutting/testing.md
@@ -266,6 +266,20 @@ antialiased edge pixels, not antialiased _glyph interior_ pixels). Recorded per 
 rather than silently retuning `threshold`; revisit if this or other states start flapping
 regularly once Phase B is on the table.
 
+**Recurrence (2026-08-11, PR #210):** Same state, same viewport, same 78px magnitude, on a PR
+whose merge-base **is** #209's post-merge `main` and whose diff touches zero files under
+`apps/web/src` — so #210's "base" render is byte-for-byte the same source #209's "head" was.
+Confirms this is genuine cross-run Chromium rendering nondeterminism, not something either PR's
+code caused. A same-source local reproduction attempt did _not_ flake (base and a fresh HEAD
+render came back byte-identical), consistent with the original finding's "flipped between" framing
+— it's intermittent, not a steady offset. The `truck` icon (`apps/web/src/design/Icon.tsx`) is an
+inline SVG built from two `<circle>` wheels and short diagonal `<path>` strokes at 1.75px stroke
+width — exactly the shape (curves plus thin diagonals at sub-pixel widths) most sensitive to
+frame-to-frame anti-aliasing drift when its container's layout rounds by a fraction of a pixel
+differently between two separate browser process launches. This is the second occurrence — per
+the note above, that's the trigger to revisit once Phase B is on the table, not a threshold change
+now.
+
 #### What the job reports
 
 - Count of changed states (screen / state / viewport triples).
@@ -321,8 +335,10 @@ section documents the mechanics only.
   prints that and exits 0 immediately rather than spending ~8-12 minutes on a PR that
   touches no rendered surface.
 - **Cost:** ~8-12 minutes cold (two production builds, two ~150s renders, one
-  `pnpm install` in the throwaway worktree). A cache hit only pays the HEAD side —
-  seconds, not minutes.
+  `pnpm install` in the throwaway worktree). A cache hit skips the base-side install,
+  build, and render entirely, but HEAD is always rebuilt and re-rendered from scratch —
+  a warm-cache run is ~2-3 minutes, not seconds (measured: 2m40s in this PR's evidence,
+  versus 5m13s cold).
 - **Exit code:** 0 whenever the run completes, whether or not visual changes were
   found — a changed state is information, not a script failure. Non-zero is reserved
   for genuine failures (build, render, or worktree setup broke).

--- a/scripts/gallery-build-render.sh
+++ b/scripts/gallery-build-render.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Build the web app for production and render the state gallery into a dir.
+#
+# The one place "build + render" is spelled out — shared by CI
+# (.github/workflows/ci.yml, HEAD side) and the local tooling
+# (scripts/gallery-diff-local.sh, scripts/gallery-render-at-ref.sh) so the
+# two commands don't drift out of sync across callers.
+#
+#   scripts/gallery-build-render.sh <out-dir>
+#
+# <out-dir> is passed straight to `gallery:render -- --out`; render.ts
+# resolves a relative path against the repo root regardless of cwd, and
+# takes an absolute path unchanged — pass whichever the caller has.
+set -euo pipefail
+
+OUT_DIR="${1:?usage: gallery-build-render.sh <out-dir>}"
+
+pnpm --filter @snaveevans/pineapple-web build
+TZ=UTC pnpm --filter @snaveevans/pineapple-web gallery:render -- --out "$OUT_DIR"

--- a/scripts/gallery-diff-local.sh
+++ b/scripts/gallery-diff-local.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Local visual diff for the web state gallery — merge-base vs HEAD.
+#
+# Wraps the two existing gallery CLIs (gallery:render, gallery:diff) so a
+# frontend change can be proven visually clean before pushing, without
+# waiting on CI. See docs/specs/cross-cutting/testing.md, "Visual diff
+# against the base branch (#146)" for the threshold/reporting contract this
+# mirrors, and .claude/skills/gallery-visual-diff/SKILL.md for how to read
+# the output.
+#
+# The baseline render shares its worktree mechanics with CI's merge-base
+# step via scripts/gallery-render-at-ref.sh; both it and the HEAD side here
+# share the actual build+render pair via scripts/gallery-build-render.sh.
+#
+#   scripts/gallery-diff-local.sh [--refresh-base]
+#
+# Cost: ~8-12 minutes cold (two production builds + two ~150s renders + a
+# pnpm install in a throwaway merge-base worktree). Every later run against
+# the same merge-base reuses the cached baseline render and only rebuilds
+# and re-renders HEAD — seconds, not minutes.
+#
+# Exit 0 whenever the run completed, whether or not visual changes were
+# found — a changed state is information, not a script failure. Non-zero
+# means a genuine failure: relevance-gate git plumbing, build, render, or
+# worktree setup broke.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+REFRESH_BASE=0
+for arg in "$@"; do
+  case "$arg" in
+    --refresh-base)
+      REFRESH_BASE=1
+      ;;
+    -h | --help)
+      echo "Usage: scripts/gallery-diff-local.sh [--refresh-base]"
+      echo "  --refresh-base   discard the cached merge-base render and rebuild it"
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+CACHE_ROOT="${XDG_CACHE_HOME:-$HOME/.cache}/pineapple-gallery"
+RUN_DIR="$CACHE_ROOT/runs/latest"
+HEAD_OUT="$RUN_DIR/head"
+DIFF_OUT="$RUN_DIR/diff"
+
+log() { echo "==> $*"; }
+
+log "Fetching origin/main..."
+if ! git fetch --quiet origin main; then
+  echo "warning: could not fetch origin/main — using local ref, merge-base may be stale" >&2
+fi
+
+MERGE_BASE="$(git merge-base HEAD origin/main)"
+log "merge-base: $MERGE_BASE"
+
+# Relevance gate FIRST — a full run is ~8-12 minutes; never spend that on a
+# PR that touches no rendered surface.
+if git diff --quiet "$MERGE_BASE" -- apps/web/src apps/web/gallery; then
+  log "No changes under apps/web/src/** or apps/web/gallery/** since merge-base — visual diff skipped."
+  exit 0
+fi
+
+log "apps/web/src or apps/web/gallery changed since merge-base — running visual diff."
+
+BASE_CACHE_DIR="$CACHE_ROOT/$MERGE_BASE"
+BASE_OUT="$BASE_CACHE_DIR/out"
+
+if [ "$REFRESH_BASE" -eq 1 ] && [ -d "$BASE_CACHE_DIR" ]; then
+  log "--refresh-base: discarding cached baseline at $BASE_CACHE_DIR"
+  rm -rf "$BASE_CACHE_DIR"
+fi
+
+if [ -d "$BASE_OUT" ] && [ -f "$BASE_OUT/manifest.json" ]; then
+  log "Baseline cache HIT for $MERGE_BASE — reusing $BASE_OUT"
+  BASE_TIMING="cached"
+else
+  log "Baseline cache MISS for $MERGE_BASE — rendering into a detached worktree"
+  T_BASE_START=$(date +%s)
+  # Never `git checkout` — this leaves HEAD's working tree, branch, and
+  # node_modules untouched. Worktree path is deterministic (keyed on the
+  # merge-base) so a killed run's residue is easy to spot and is cleared on
+  # the next attempt regardless.
+  bash "$REPO_ROOT/scripts/gallery-render-at-ref.sh" \
+    "$MERGE_BASE" "$BASE_OUT" "$CACHE_ROOT/worktrees/$MERGE_BASE"
+  BASE_TIMING="$(($(date +%s) - T_BASE_START))s"
+fi
+
+log "Building and rendering HEAD (production)..."
+T_HEAD_START=$(date +%s)
+mkdir -p "$RUN_DIR"
+bash "$REPO_ROOT/scripts/gallery-build-render.sh" "$HEAD_OUT"
+HEAD_TIMING="$(($(date +%s) - T_HEAD_START))s"
+
+log "Diffing merge-base vs HEAD..."
+T_DIFF_START=$(date +%s)
+pnpm --filter @snaveevans/pineapple-web gallery:diff -- \
+  --base "$BASE_OUT" \
+  --head "$HEAD_OUT" \
+  --out "$DIFF_OUT"
+DIFF_TIMING="$(($(date +%s) - T_DIFF_START))s"
+
+SUMMARY_JSON="$DIFF_OUT/summary.json" node --input-type=module -e '
+import { readFileSync } from "node:fs";
+const s = JSON.parse(readFileSync(process.env.SUMMARY_JSON, "utf8"));
+const changed = s.entries.filter((e) => e.status !== "unchanged");
+console.log("");
+console.log("== gallery-diff-local summary ==");
+console.log(
+  `compared=${s.totalCompared} changed=${s.changedCount} added=${s.addedCount} ` +
+  `removed=${s.removedCount} resized=${s.resizedCount} unchanged=${s.unchangedCount}`,
+);
+if (changed.length === 0) {
+  console.log("No visually changed states.");
+} else {
+  console.log("");
+  console.log("Changed screen/state/viewport triples:");
+  for (const e of changed) {
+    console.log(`  ${e.status}\t${e.diffPixels}px\t${e.id}\t${e.viewport}`);
+  }
+}
+'
+
+echo ""
+log "Diff PNGs: $DIFF_OUT (base/ head/ diff/ subfolders, summary.json)"
+log "timing: base=${BASE_TIMING} head=${HEAD_TIMING} diff=${DIFF_TIMING}"

--- a/scripts/gallery-render-at-ref.sh
+++ b/scripts/gallery-render-at-ref.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Render the state gallery at an arbitrary git ref without disturbing the
+# current working tree, branch, or node_modules.
+#
+# Checks the ref out into a detached `git worktree` (never `git checkout`),
+# installs its dependencies, and builds+renders via gallery-build-render.sh.
+# Shared by CI's merge-base render step and scripts/gallery-diff-local.sh's
+# cached baseline render, so the worktree mechanics live in exactly one
+# place instead of two copies drifting apart.
+#
+#   scripts/gallery-render-at-ref.sh <ref> <out-dir> [<worktree-dir>]
+#
+# <out-dir> must be an absolute path: it's written to *after* cd-ing into
+# the worktree, so a relative path would resolve inside the throwaway tree
+# and vanish with it on cleanup.
+# <worktree-dir> defaults to a fresh temp dir. If given, any existing
+# content at that path is discarded first — callers that pass one (e.g. a
+# cache-keyed path) own that path and expect a clean checkout, not a reused
+# stale one. The worktree is always removed on exit — success, error, or
+# interrupt — so no run leaves one behind.
+set -euo pipefail
+
+REF="${1:?usage: gallery-render-at-ref.sh <ref> <out-dir> [<worktree-dir>]}"
+OUT_DIR="${2:?usage: gallery-render-at-ref.sh <ref> <out-dir> [<worktree-dir>]}"
+CUSTOM_WORKTREE_DIR="${3:-}"
+
+case "$OUT_DIR" in
+  /*) ;;
+  *)
+    echo "gallery-render-at-ref.sh: <out-dir> must be absolute, got: $OUT_DIR" >&2
+    exit 2
+    ;;
+esac
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Residue from a prior run killed hard enough to skip the trap below.
+git worktree prune >/dev/null 2>&1 || true
+
+if [ -n "$CUSTOM_WORKTREE_DIR" ]; then
+  WORKTREE_DIR="$CUSTOM_WORKTREE_DIR"
+  rm -rf "$WORKTREE_DIR"
+  mkdir -p "$(dirname "$WORKTREE_DIR")"
+else
+  WORKTREE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/pineapple-gallery-ref.XXXXXX")"
+  rmdir "$WORKTREE_DIR" # git worktree add wants a path that doesn't exist yet
+fi
+
+cleanup() {
+  if [ -d "$WORKTREE_DIR" ]; then
+    git -C "$REPO_ROOT" worktree remove --force "$WORKTREE_DIR" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+git worktree add --detach "$WORKTREE_DIR" "$REF"
+
+(
+  cd "$WORKTREE_DIR"
+  # Skip the postinstall Chromium fetch — the browser cache is shared by
+  # path (PLAYWRIGHT_BROWSERS_PATH, or Playwright's default user cache),
+  # not per-worktree, and is already populated from the main checkout.
+  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 pnpm install --frozen-lockfile
+  bash "$REPO_ROOT/scripts/gallery-build-render.sh" "$OUT_DIR"
+)


### PR DESCRIPTION
## Summary

- `scripts/gallery-diff-local.sh` runs the web state gallery's merge-base-vs-HEAD visual diff (#146) locally, so a frontend change can be proven visually clean before pushing instead of finding out from a CI comment cold.
- Solves the baseline-freshness/re-render-cost tradeoff by always deriving the baseline from a detached `git worktree` at `git merge-base HEAD origin/main` (never `git checkout`), cached on disk keyed by the merge-base SHA — first run pays for the base render, later iterations only rebuild/re-render HEAD.
- `.claude/skills/gallery-visual-diff/SKILL.md` carries the interpretation guidance: when to trigger, how to classify a changed state (intended vs. regression — every change is a regression until justified for a behavior-preserving refactor), the recorded `asset-library/populated-filtered` mobile flake (testing.md, PR #209) with a re-run-before-trusting instruction, and a hard rule against tuning the pixelmatch threshold to force green.
- The worktree/build/render mechanics are shared, not duplicated, between CI and local: `scripts/gallery-build-render.sh` and `scripts/gallery-render-at-ref.sh` are the one implementation, and `.github/workflows/ci.yml`'s `gallery` job now calls into them instead of spelling the same bash out inline for its HEAD and merge-base render steps.
- `docs/specs/cross-cutting/testing.md` documents the local workflow under the existing "Visual diff against the base branch (#146)" section.

## Risk

**Level:** H

**Why:** Path-glob floor from `.github/workflows/ci.yml` (H per the repo's risk rubric). The change to that file is mechanical — replacing inline worktree/build/render bash with calls to the newly-extracted scripts that reproduce the exact same commands/env — but it touches the gallery job that gates every web PR, so it gets full review rather than a down-override.

**Human validation budget:** Full review + local poke on the affected path (here: confirm the `gallery` CI job still runs correctly on the next PR that touches `apps/web`, since this branch itself doesn't touch `apps/web/src` and so the job's relevance gate will skip it).

## Evidence

- [x] `pnpm lint && pnpm type-check && pnpm -r test` green locally (642 tests, 104 files) and again via the repo's pre-push hook.
- [x] **Zero-changed-states run** (cold cache, temporary no-op comment added under `apps/web/src` to pass the relevance gate, then reverted before committing):
  ```
  ==> merge-base: b60a293901c053ef8fadd6c4fa54adb96463be1b
  ==> Baseline cache MISS for b60a29... — rendering into a detached worktree
  ==> Building and rendering HEAD (production)...
  ==> Diffing merge-base vs HEAD...
  diff: total=236 changed=0 added=0 removed=0 resized=0 unchanged=236 threshold=0.1
  phase A: no visual change
  ==> timing: base=155s head=142s diff=15s
  ```
  Wall clock: **5m13s**.
- [x] **Caught-change + cache-reuse run** (same merge-base, deliberately shifted the `--hf-brand` design token in `apps/web/src/design/styles/hifi.css`, reverted before committing):
  ```
  ==> merge-base: b60a293901c053ef8fadd6c4fa54adb96463be1b
  ==> Baseline cache HIT for b60a29... — reusing .../out
  ==> Building and rendering HEAD (production)...
  ==> Diffing merge-base vs HEAD...
  diff: total=236 changed=100 added=0 removed=0 resized=0 unchanged=136 threshold=0.1
  phase A: 100 visual change(s) reported (non-blocking)
  ==> timing: base=cached head=139s diff=21s
  ```
  Wall clock: **2m40s** — base render skipped entirely (`base=cached`) versus the 155s it cost cold, demonstrating the caching win the ordering-problem design targets.
- [x] Working tree is clean of both temporary test changes (`git status --porcelain` confirmed empty for `apps/web/src/**` before committing) — no product code shipped in this PR.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm type-check`
- [x] `pnpm -r test`
- [x] `scripts/gallery-diff-local.sh` — zero-change run (above)
- [x] `scripts/gallery-diff-local.sh` — deliberate-change + cache-reuse run (above)

## Spec / AC

- Extends `docs/specs/cross-cutting/testing.md` § "Visual diff against the base branch (#146)" with a "Running it locally" subsection. No AC boxes flip — #146's Phase B checkbox (promotion to required check) is unrelated to this change; Phase A remains non-blocking, which the skill explicitly calls out so a clean local run isn't mistaken for a CI gate that doesn't exist yet.

## Validation gate

<!-- Not run via the validation-gate skill; verified manually per Evidence above. -->


---
_Generated by [Claude Code](https://claude.ai/code/session_016mMpGMu4w916w27MHzYVsz)_