### PR TITLE
refactor(web): consolidate design tokens into a single source

### DIFF
--- a/apps/web/src/app/styles/activity-history.css
+++ b/apps/web/src/app/styles/activity-history.css
@@ -332,7 +332,7 @@ a.hh-asset-chip:hover {
 .hh-asset-chip .hf-asset-icon {
   width: 22px;
   height: 22px;
-  border-radius: 6px;
+  border-radius: var(--hf-r-sm);
 }
 
 .hh-asset-chip-name {

--- a/apps/web/src/app/styles/app-search.css
+++ b/apps/web/src/app/styles/app-search.css
@@ -1,23 +1,7 @@
+/* Rendered via createPortal onto document.body, so it isn't a descendant of
+   .hf — it consumes the --hf-* tokens from tokens.css (imported globally via
+   index.css) directly rather than through cascade from an .hf ancestor. */
 .hfs-root {
-  --hf-surface: oklch(100% 0 0);
-  --hf-surface-2: oklch(97% 0.005 85);
-  --hf-ink: oklch(22% 0.015 70);
-  --hf-ink-soft: oklch(45% 0.012 75);
-  --hf-ink-faint: oklch(60% 0.008 80);
-  --hf-line: oklch(91% 0.006 80);
-  --hf-line-soft: oklch(94% 0.005 80);
-  --hf-brand: oklch(45% 0.1 150);
-  --hf-brand-2: oklch(38% 0.1 150);
-  --hf-brand-bg: oklch(95% 0.025 150);
-  --hf-bad: oklch(52% 0.18 28);
-  --hf-bad-bg: oklch(96% 0.025 28);
-  --hf-tint-vehicle: oklch(94% 0.025 240);
-  --hf-tint-equip: oklch(94% 0.035 55);
-  --hf-tint-prop: oklch(94% 0.025 295);
-  --hf-mono: "JetBrains Mono", ui-monospace, "SFMono-Regular", Menlo, monospace;
-  --hf-sans:
-    "Inter", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
-
   color: var(--hf-ink);
   font-family: var(--hf-sans);
   font-size: 14px;
@@ -62,7 +46,7 @@
   background: transparent;
   cursor: pointer;
   padding: 9px 14px;
-  border-radius: 10px;
+  border-radius: var(--hf-r);
   color: var(--hf-ink);
   scroll-margin: 8px;
 }
@@ -92,7 +76,7 @@
 
 .hfs-result-icon[data-type="vehicle"] {
   background: var(--hf-tint-vehicle);
-  color: oklch(40% 0.1 240);
+  color: var(--hf-cat-vehicle-fg);
 }
 
 .hfs-result-icon[data-type="equipment"] {
@@ -209,9 +193,9 @@
 .hfs-shimmer {
   background: linear-gradient(
     100deg,
-    oklch(94% 0.005 80) 30%,
+    var(--hf-line-soft) 30%,
     oklch(97% 0.004 80) 50%,
-    oklch(94% 0.005 80) 70%
+    var(--hf-line-soft) 70%
   );
   background-size: 200% 100%;
   animation: hfs-shimmer 1.1s ease-in-out infinite;

--- a/apps/web/src/app/styles/profile-edit.css
+++ b/apps/web/src/app/styles/profile-edit.css
@@ -11,11 +11,11 @@
 }
 
 .pe-hint-warn {
-  color: oklch(60% 0.13 75) !important;
+  color: var(--hf-warn) !important;
 }
 
 .pe-hint-bad {
-  color: oklch(52% 0.18 28) !important;
+  color: var(--hf-bad) !important;
 }
 
 .pe-identity {

--- a/apps/web/src/app/styles/team.css
+++ b/apps/web/src/app/styles/team.css
@@ -22,7 +22,7 @@
 .tm-empty-icon {
   width: 52px;
   height: 52px;
-  border-radius: 14px;
+  border-radius: var(--hf-r-lg);
   background: var(--hf-brand-bg);
   color: var(--hf-brand-2);
   display: flex;

--- a/apps/web/src/auth/styles/auth.css
+++ b/apps/web/src/auth/styles/auth.css
@@ -1,48 +1,10 @@
 /* FieldOps — Auth (log in / sign up) flow.
    Google-first (Better Auth, phase 1). Split layout: brand panel + auth card.
-   Built on the .hf tokens; token block mirrored onto .au so reused .hf-*
-   collage components resolve their variables. */
+   Built on the --hf-* tokens from tokens.css (imported globally via
+   index.css) so reused .hf-* collage components resolve their variables
+   even though .au isn't nested under a .hf ancestor. */
 
 .au {
-  --hf-bg: oklch(98% 0.005 85);
-  --hf-surface: oklch(100% 0 0);
-  --hf-surface-2: oklch(97% 0.005 85);
-  --hf-ink: oklch(22% 0.015 70);
-  --hf-ink-soft: oklch(45% 0.012 75);
-  --hf-ink-faint: oklch(60% 0.008 80);
-  --hf-line: oklch(91% 0.006 80);
-  --hf-line-soft: oklch(94% 0.005 80);
-  --hf-brand: oklch(45% 0.1 150);
-  --hf-brand-2: oklch(38% 0.1 150);
-  --hf-brand-bg: oklch(95% 0.025 150);
-  --hf-ok: oklch(50% 0.1 150);
-  --hf-ok-bg: oklch(96% 0.025 150);
-  --hf-warn: oklch(60% 0.13 75);
-  --hf-warn-bg: oklch(96% 0.045 80);
-  --hf-bad: oklch(52% 0.18 28);
-  --hf-bad-bg: oklch(96% 0.025 28);
-  --hf-tint-vehicle: oklch(94% 0.025 240);
-  --hf-tint-equip: oklch(94% 0.035 55);
-  --hf-tint-prop: oklch(94% 0.025 295);
-  --hf-tint-lawn: oklch(94% 0.03 145);
-  --hf-cat-vehicle-bg: oklch(96% 0.025 240);
-  --hf-cat-vehicle-fg: oklch(40% 0.1 240);
-  --hf-cat-property-bg: oklch(95% 0.03 295);
-  --hf-cat-property-fg: oklch(38% 0.1 295);
-  --hf-cat-equipment-bg: oklch(95% 0.035 60);
-  --hf-cat-equipment-fg: oklch(40% 0.1 60);
-  --hf-cat-lawn-bg: oklch(95% 0.04 145);
-  --hf-cat-lawn-fg: oklch(38% 0.1 145);
-  --hf-r-sm: 6px;
-  --hf-r: 10px;
-  --hf-r-lg: 14px;
-  --hf-shadow-1: 0 1px 2px rgba(20, 18, 14, 0.04), 0 1px 0 rgba(20, 18, 14, 0.03);
-  --hf-shadow-2: 0 4px 12px rgba(20, 18, 14, 0.06), 0 1px 0 rgba(20, 18, 14, 0.03);
-  --hf-shadow-3: 0 18px 50px -12px rgba(20, 18, 14, 0.22), 0 6px 16px -8px rgba(20, 18, 14, 0.12);
-  --hf-sans:
-    "Inter", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
-  --hf-mono: "JetBrains Mono", ui-monospace, "SFMono-Regular", Menlo, monospace;
-
   background: var(--hf-bg);
   color: var(--hf-ink);
   font-family: var(--hf-sans);

--- a/apps/web/src/design/styles/hifi-assets.css
+++ b/apps/web/src/design/styles/hifi-assets.css
@@ -1,19 +1,9 @@
 /* FieldOps — Hi-Fi Assets styles
-   Extends the .hf design tokens from hifi.css. Adds asset-grid + asset-row
-   + toolbar + add-card. Same container-query contract — desktop card grid
-   collapses to horizontal rows at the mobile breakpoint. */
-
-/* tints per category (used by the thumb background) */
-.hf {
-  --hf-cat-vehicle-bg: oklch(96% 0.025 240);
-  --hf-cat-vehicle-fg: oklch(40% 0.1 240);
-  --hf-cat-equipment-bg: oklch(95% 0.035 60);
-  --hf-cat-equipment-fg: oklch(40% 0.1 60);
-  --hf-cat-property-bg: oklch(95% 0.03 295);
-  --hf-cat-property-fg: oklch(38% 0.1 295);
-  --hf-cat-lawn-bg: oklch(95% 0.04 145);
-  --hf-cat-lawn-fg: oklch(38% 0.1 145);
-}
+   Extends the .hf design tokens from hifi.css (the --hf-cat-* category
+   swatches used for the thumb background live in tokens.css). Adds
+   asset-grid + asset-row + toolbar + add-card. Same container-query
+   contract — desktop card grid collapses to horizontal rows at the mobile
+   breakpoint. */
 
 /* ============ Assets page chrome ============ */
 .hf-assets-page .hf-greeting .hf-h1 {
@@ -57,7 +47,7 @@
   justify-content: center;
   border: 0;
   background: transparent;
-  border-radius: 6px;
+  border-radius: var(--hf-r-sm);
   color: var(--hf-ink-soft);
 }
 .hf-view-btn:hover {

--- a/apps/web/src/design/styles/hifi.css
+++ b/apps/web/src/design/styles/hifi.css
@@ -1,49 +1,11 @@
 /* FieldOps — Hi-Fi Master/Detail styles
    Everything scoped under .hf so it doesn't bleed into the sketchy wireframes.
    Same container-query contract: container-name "hfapp" on the root,
-   "hfmd" on the master-detail shell. */
+   "hfmd" on the master-detail shell.
+   Consumes the --hf-* tokens declared once in tokens.css (imported globally
+   via index.css) rather than declaring its own copy. */
 
 .hf {
-  --hf-bg: oklch(98% 0.005 85); /* warm off-white app bg */
-  --hf-surface: oklch(100% 0 0); /* pure white card */
-  --hf-surface-2: oklch(97% 0.005 85); /* faint warm */
-  --hf-ink: oklch(22% 0.015 70); /* darkest text */
-  --hf-ink-soft: oklch(45% 0.012 75);
-  --hf-ink-faint: oklch(60% 0.008 80);
-  --hf-line: oklch(91% 0.006 80); /* hairline borders */
-  --hf-line-soft: oklch(94% 0.005 80);
-
-  /* brand: deep forest green — signals service/health */
-  --hf-brand: oklch(45% 0.1 150);
-  --hf-brand-2: oklch(38% 0.1 150);
-  --hf-brand-bg: oklch(95% 0.025 150);
-
-  /* status */
-  --hf-ok: oklch(50% 0.1 150);
-  --hf-ok-bg: oklch(96% 0.025 150);
-  --hf-warn: oklch(60% 0.13 75);
-  --hf-warn-bg: oklch(96% 0.045 80);
-  --hf-bad: oklch(52% 0.18 28);
-  --hf-bad-bg: oklch(96% 0.025 28);
-
-  /* asset tints */
-  --hf-tint-vehicle: oklch(94% 0.025 240);
-  --hf-tint-equip: oklch(94% 0.035 55);
-  --hf-tint-prop: oklch(94% 0.025 295);
-  --hf-tint-lawn: oklch(94% 0.03 145);
-
-  /* radii / shadows */
-  --hf-r-sm: 6px;
-  --hf-r: 10px;
-  --hf-r-lg: 14px;
-  --hf-shadow-1: 0 1px 2px rgba(20, 18, 14, 0.04), 0 1px 0 rgba(20, 18, 14, 0.03);
-  --hf-shadow-2: 0 4px 12px rgba(20, 18, 14, 0.06), 0 1px 0 rgba(20, 18, 14, 0.03);
-
-  /* fonts */
-  --hf-sans:
-    "Inter", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
-  --hf-mono: "JetBrains Mono", ui-monospace, "SFMono-Regular", Menlo, monospace;
-
   background: var(--hf-bg);
   color: var(--hf-ink);
   font-family: var(--hf-sans);

--- a/apps/web/src/design/styles/mr.css
+++ b/apps/web/src/design/styles/mr.css
@@ -11,7 +11,7 @@
 .mr-root { position: relative; }
 .mr-scroll { overflow-y: auto; overflow-x: hidden; }
 .mr-scroll::-webkit-scrollbar { width: 10px; }
-.mr-scroll::-webkit-scrollbar-thumb { background: var(--hf-line); border-radius: 6px; border: 3px solid transparent; background-clip: content-box; }
+.mr-scroll::-webkit-scrollbar-thumb { background: var(--hf-line); border-radius: var(--hf-r-sm); border: 3px solid transparent; background-clip: content-box; }
 
 /* ============ buttons (local, FieldOps flavour) ============ */
 .mr-btn {
@@ -50,7 +50,7 @@
 .mr-rail-list { flex: 1; min-height: 0; overflow-y: auto; padding: 0 10px 14px; display: flex; flex-direction: column; gap: 2px; }
 .mr-rail-row {
   display: flex; align-items: center; gap: 11px; width: 100%; text-align: left;
-  padding: 9px 10px; border-radius: 10px; border: 1px solid transparent; background: none;
+  padding: 9px 10px; border-radius: var(--hf-r); border: 1px solid transparent; background: none;
 }
 .mr-rail-row:hover { background: var(--hf-surface-2); }
 .mr-rail-row.active { background: var(--hf-brand-bg); }
@@ -110,7 +110,7 @@
   background: var(--hf-surface-2); color: var(--hf-ink-soft); border-color: var(--hf-line);
 }
 .mr-share-btn {
-  flex-shrink: 0; width: 38px; height: 38px; border-radius: 10px;
+  flex-shrink: 0; width: 38px; height: 38px; border-radius: var(--hf-r);
   border: 1px solid var(--hf-line); background: var(--hf-surface);
   color: var(--hf-ink-soft); display: flex; align-items: center; justify-content: center;
 }
@@ -129,7 +129,7 @@
 }
 
 .mr-shr-tile {
-  width: 52px; height: 52px; border-radius: 14px;
+  width: 52px; height: 52px; border-radius: var(--hf-r-lg);
   background: var(--hf-brand-bg); color: var(--hf-brand-2);
   display: flex; align-items: center; justify-content: center;
   margin: 2px auto 0;
@@ -143,7 +143,7 @@
   background: var(--hf-surface-2);
 }
 .mr-shr-team-mark {
-  width: 36px; height: 36px; border-radius: 10px;
+  width: 36px; height: 36px; border-radius: var(--hf-r);
   background: var(--hf-surface); border: 1px solid var(--hf-line); color: var(--hf-brand-2);
   display: flex; align-items: center; justify-content: center; flex-shrink: 0;
 }
@@ -192,7 +192,7 @@
 .mr-hist-meta { font-family: var(--hf-mono); font-size: 11.5px; color: var(--hf-ink-faint); }
 .mr-density { display: flex; gap: 2px; background: var(--hf-surface-2); border: 1px solid var(--hf-line); border-radius: 9px; padding: 3px; }
 .mr-density button {
-  display: inline-flex; align-items: center; gap: 6px; padding: 5px 11px; border-radius: 6px;
+  display: inline-flex; align-items: center; gap: 6px; padding: 5px 11px; border-radius: var(--hf-r-sm);
   border: none; background: none; font-size: 12.5px; font-weight: 500; color: var(--hf-ink-soft);
 }
 .mr-density button.active { background: var(--hf-surface); color: var(--hf-ink); font-weight: 600; box-shadow: var(--hf-shadow-1); }
@@ -259,7 +259,7 @@
 
 /* ============ LOADING SKELETON ============ */
 @keyframes mr-shimmer { 0% { background-position: -200px 0; } 100% { background-position: 320px 0; } }
-.mr-skel { display: block; height: 12px; border-radius: 6px; background: linear-gradient(90deg, var(--hf-line-soft) 0px, var(--hf-line) 40px, var(--hf-line-soft) 80px); background-size: 320px 100%; animation: mr-shimmer 1.1s linear infinite; }
+.mr-skel { display: block; height: 12px; border-radius: var(--hf-r-sm); background: linear-gradient(90deg, var(--hf-line-soft) 0px, var(--hf-line) 40px, var(--hf-line-soft) 80px); background-size: 320px 100%; animation: mr-shimmer 1.1s linear infinite; }
 .mr-skel-w40 { width: 40%; } .mr-skel-w50 { width: 50%; } .mr-skel-w70 { width: 70%; } .mr-skel-w75 { width: 75%; } .mr-skel-w80 { width: 80%; } .mr-skel-w90 { width: 90%; }
 .mr-skel-block { width: 100%; height: 34px; border-radius: 8px; }
 .mr-skel-tl { display: flex; flex-direction: column; gap: 22px; }
@@ -512,7 +512,7 @@
 }
 .mr-unit-btn {
   flex: 1; display: inline-flex; align-items: center; justify-content: center;
-  padding: 6px 4px; border-radius: 6px; border: none; background: none;
+  padding: 6px 4px; border-radius: var(--hf-r-sm); border: none; background: none;
   font-size: 12.5px; font-weight: 500; color: var(--hf-ink-soft);
 }
 .mr-unit-btn.active { background: var(--hf-surface); color: var(--hf-ink); font-weight: 600; box-shadow: var(--hf-shadow-1); }

--- a/apps/web/src/design/styles/tokens.css
+++ b/apps/web/src/design/styles/tokens.css
@@ -1,0 +1,59 @@
+/* FieldOps — design tokens, single source of truth.
+   Declared once at :root so every scope (.hf, .au, .mk, .hfs-root, portalled
+   content) consumes the same values instead of re-declaring them. Imported
+   once, from index.css, so it's available globally regardless of which
+   scoped stylesheet a given screen pulls in. */
+
+:root {
+  /* surfaces / ink */
+  --hf-bg: oklch(98% 0.005 85); /* warm off-white app bg */
+  --hf-surface: oklch(100% 0 0); /* pure white card */
+  --hf-surface-2: oklch(97% 0.005 85); /* faint warm */
+  --hf-ink: oklch(22% 0.015 70); /* darkest text */
+  --hf-ink-soft: oklch(45% 0.012 75);
+  --hf-ink-faint: oklch(60% 0.008 80);
+  --hf-line: oklch(91% 0.006 80); /* hairline borders */
+  --hf-line-soft: oklch(94% 0.005 80);
+
+  /* brand: deep forest green — signals service/health */
+  --hf-brand: oklch(45% 0.1 150);
+  --hf-brand-2: oklch(38% 0.1 150);
+  --hf-brand-bg: oklch(95% 0.025 150);
+
+  /* status */
+  --hf-ok: oklch(50% 0.1 150);
+  --hf-ok-bg: oklch(96% 0.025 150);
+  --hf-warn: oklch(60% 0.13 75);
+  --hf-warn-bg: oklch(96% 0.045 80);
+  --hf-bad: oklch(52% 0.18 28);
+  --hf-bad-bg: oklch(96% 0.025 28);
+
+  /* asset tints (dashboard / library thumbs) */
+  --hf-tint-vehicle: oklch(94% 0.025 240);
+  --hf-tint-equip: oklch(94% 0.035 55);
+  --hf-tint-prop: oklch(94% 0.025 295);
+  --hf-tint-lawn: oklch(94% 0.03 145);
+
+  /* asset category swatches (bg + fg pairs) */
+  --hf-cat-vehicle-bg: oklch(96% 0.025 240);
+  --hf-cat-vehicle-fg: oklch(40% 0.1 240);
+  --hf-cat-equipment-bg: oklch(95% 0.035 60);
+  --hf-cat-equipment-fg: oklch(40% 0.1 60);
+  --hf-cat-property-bg: oklch(95% 0.03 295);
+  --hf-cat-property-fg: oklch(38% 0.1 295);
+  --hf-cat-lawn-bg: oklch(95% 0.04 145);
+  --hf-cat-lawn-fg: oklch(38% 0.1 145);
+
+  /* radii / shadows */
+  --hf-r-sm: 6px;
+  --hf-r: 10px;
+  --hf-r-lg: 14px;
+  --hf-shadow-1: 0 1px 2px rgba(20, 18, 14, 0.04), 0 1px 0 rgba(20, 18, 14, 0.03);
+  --hf-shadow-2: 0 4px 12px rgba(20, 18, 14, 0.06), 0 1px 0 rgba(20, 18, 14, 0.03);
+  --hf-shadow-3: 0 18px 50px -12px rgba(20, 18, 14, 0.22), 0 6px 16px -8px rgba(20, 18, 14, 0.12);
+
+  /* fonts */
+  --hf-sans:
+    "Inter", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
+  --hf-mono: "JetBrains Mono", ui-monospace, "SFMono-Regular", Menlo, monospace;
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1,10 +1,12 @@
+@import "./design/styles/tokens.css";
+
 /* Global reset for the marketing page. The warm off-white matches the .mk /
    .hf design-system background token so there's no flash before paint. */
 html,
 body {
   margin: 0;
   padding: 0;
-  background: oklch(98% 0.005 85);
+  background: var(--hf-bg);
 }
 
 /* Full-height chain so the .hf app shell (/app) can size to the viewport and

--- a/apps/web/src/marketing/styles/marketing.css
+++ b/apps/web/src/marketing/styles/marketing.css
@@ -1,43 +1,9 @@
 /* FieldOps — Marketing (logged-out) home page.
-   Built on the .hf design tokens for visual continuity with the app.
-   Token block is mirrored onto .mk so reused .hf-* components (asset cards,
-   status pills) resolve their variables outside the app shell. */
+   Built on the --hf-* tokens from tokens.css (imported globally via
+   index.css) for visual continuity with the app, so reused .hf-* components
+   (asset cards, status pills) resolve their variables outside the app shell. */
 
 .mk {
-  --hf-bg: oklch(98% 0.005 85);
-  --hf-surface: oklch(100% 0 0);
-  --hf-surface-2: oklch(97% 0.005 85);
-  --hf-ink: oklch(22% 0.015 70);
-  --hf-ink-soft: oklch(45% 0.012 75);
-  --hf-ink-faint: oklch(60% 0.008 80);
-  --hf-line: oklch(91% 0.006 80);
-  --hf-line-soft: oklch(94% 0.005 80);
-  --hf-brand: oklch(45% 0.1 150);
-  --hf-brand-2: oklch(38% 0.1 150);
-  --hf-brand-bg: oklch(95% 0.025 150);
-  --hf-ok: oklch(50% 0.1 150);
-  --hf-ok-bg: oklch(96% 0.025 150);
-  --hf-warn: oklch(60% 0.13 75);
-  --hf-warn-bg: oklch(96% 0.045 80);
-  --hf-bad: oklch(52% 0.18 28);
-  --hf-bad-bg: oklch(96% 0.025 28);
-  --hf-tint-vehicle: oklch(94% 0.025 240);
-  --hf-tint-equip: oklch(94% 0.035 55);
-  --hf-tint-prop: oklch(94% 0.025 295);
-  --hf-tint-lawn: oklch(94% 0.03 145);
-  --hf-cat-vehicle-fg: oklch(40% 0.1 240);
-  --hf-cat-property-fg: oklch(38% 0.1 295);
-  --hf-cat-equipment-fg: oklch(40% 0.1 60);
-  --hf-r-sm: 6px;
-  --hf-r: 10px;
-  --hf-r-lg: 14px;
-  --hf-shadow-1: 0 1px 2px rgba(20, 18, 14, 0.04), 0 1px 0 rgba(20, 18, 14, 0.03);
-  --hf-shadow-2: 0 4px 12px rgba(20, 18, 14, 0.06), 0 1px 0 rgba(20, 18, 14, 0.03);
-  --hf-shadow-3: 0 18px 50px -12px rgba(20, 18, 14, 0.22), 0 6px 16px -8px rgba(20, 18, 14, 0.12);
-  --hf-sans:
-    "Inter", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
-  --hf-mono: "JetBrains Mono", ui-monospace, "SFMono-Regular", Menlo, monospace;
-
   background: var(--hf-bg);
   color: var(--hf-ink);
   font-family: var(--hf-sans);
@@ -123,7 +89,7 @@
   white-space: nowrap;
   height: 44px;
   padding: 0 20px;
-  border-radius: 10px;
+  border-radius: var(--hf-r);
   font-size: 15px;
   font-weight: 600;
   font-family: inherit;

--- a/apps/web/src/onboarding/styles/onboarding.css
+++ b/apps/web/src/onboarding/styles/onboarding.css
@@ -195,8 +195,8 @@
   justify-content: center;
 }
 .ob-mini-thumb-lawn {
-  background: oklch(95% 0.04 145);
-  color: oklch(38% 0.1 145);
+  background: var(--hf-cat-lawn-bg);
+  color: var(--hf-cat-lawn-fg);
 }
 .ob-mini-body {
   padding: 10px 12px 12px;
@@ -226,8 +226,8 @@
   width: 38px;
   height: 38px;
   border-radius: 8px;
-  background: oklch(96% 0.025 240);
-  color: oklch(40% 0.1 240);
+  background: var(--hf-cat-vehicle-bg);
+  color: var(--hf-cat-vehicle-fg);
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Summary

- Adds `apps/web/src/design/styles/tokens.css`, declaring every `--hf-*` token once at `:root`, imported once from `index.css` so it's globally available regardless of which scoped stylesheet a screen pulls in.
- `.hf` (hifi.css), `.au` (auth.css), `.mk` (marketing.css), `.hfs-root` (app-search.css), and the reopened `.hf` block in hifi-assets.css now consume the shared tokens instead of each re-declaring their own copy.
- Replaces raw literals that exactly matched an existing token's value (10 `oklch()` colors, 13 `border-radius` pixel values) with `var()` references.

## Related

Closes #147

## Value-difference reconciliation

Every token that was duplicated across scopes had **exactly one value** everywhere it appeared — checked mechanically across all declaration sites, not just spot-checked. There was no actual drift to reconcile beyond *presence*: `--hf-shadow-3` and the `--hf-cat-*` family were declared in `auth.css`, `marketing.css`, and `hifi-assets.css` but were missing from `hifi.css` itself. `tokens.css` now declares them once, matching the value every existing site already agreed on.

`mr.css`'s `.mr-root.brand-*` rules still declare `--hf-brand` / `--hf-brand-2` / `--hf-brand-bg`. These are intentional per-instance theme-preview overrides (a brand-color switcher for the maintenance-records mockup), not copies of the source of truth — restructuring `mr.css` is explicitly out of scope per the issue's notes, so these were left as-is.

Literals that were *close* to but not identical to a token (e.g. `app-search.css`'s equipment icon tint at `oklch(42% 0.1 60)` vs. the token's `oklch(40% 0.1 60)`) were left as raw literals rather than silently snapped to the token value, per the issue's instruction not to pre-emptively invent/merge values — that's a product call for a follow-up, not this refactor.

## Risk

**Level:** L

**Why:** CSS-only change (no `.ts`/`.tsx` touched), purely mechanical token consolidation and exact-value literal substitution, 12 files / net -75 lines. No logic, routing, or data-flow change.

**Human validation budget:** Glance evidence. Do not read the diff line-by-line — the visual diff below is the proof.

## Evidence

- [x] `pnpm lint && pnpm type-check && pnpm -r test` — all green (642 tests passed)
- [x] Local gallery visual diff (`scripts/gallery-diff-local.sh`) against merge-base: **0 changed states** across all 236 rendered screen/state/viewport triples. This is local evidence from the `gallery-visual-diff` skill, not a CI gate result (Phase A of #146 is non-blocking) — but it's the same merge-base-vs-HEAD pixel diff CI will run.
- [x] `grep -rn '\-\-hf-[a-z0-9-]*:' apps/web/src` confirms exactly one declaration site per token (plus `mr.css`'s intentional overrides, discussed above).

## Test plan

- [x] `pnpm lint`
- [x] `pnpm type-check`
- [x] `pnpm -r test`
- [x] Local gallery visual diff — 0 changed states

## Spec / AC

No spec — this is a behavior-preserving refactor per the issue (`Refactor / no behavior change` triage: skip spec, per `CLAUDE.md` → Scope discipline).

Issue #147 acceptance criteria:
- [x] Exactly one declaration site per token
- [x] No scoped stylesheet declares a `--hf-*` token (except `mr.css`'s intentional theme-override mechanism, noted above)
- [x] Value differences between former copies are resolved, and each choice is stated in this PR body (see "Value-difference reconciliation")
- [x] The visual diff from #146 reports zero changed regions


---
_Generated by [Claude Code](https://claude.ai/code/session_01QGNUbfXjW3LVgr67tUeiFk)_