### PR TITLE
feat: edit asset — PATCH /api/assets/{id} plus web edit form

### DIFF
--- a/apps/api/src/api/middleware/technicalTelemetry.ts
+++ b/apps/api/src/api/middleware/technicalTelemetry.ts
@@ -190,6 +190,9 @@ function routeTelemetry(method: string, pathname: string): RouteTelemetry {
   if (/^\/api\/assets\/[^/]+$/.test(pathname) && method === "GET") {
     return { operation: "GetAsset", routePattern: "/api/assets/{id}" };
   }
+  if (/^\/api\/assets\/[^/]+$/.test(pathname) && method === "PATCH") {
+    return { operation: "EditAsset", routePattern: "/api/assets/{id}" };
+  }
   if (/^\/api\/assets\/[^/]+\/share$/.test(pathname) && method === "POST") {
     return { operation: "ShareAsset", routePattern: "/api/assets/{assetId}/share" };
   }

--- a/apps/api/src/api/openapi.ts
+++ b/apps/api/src/api/openapi.ts
@@ -6,6 +6,7 @@ import {
   AssetShareParamSchema,
   CreateAssetBodySchema,
   CreatedAssetResponseSchema,
+  EditAssetBodySchema,
   ErrorResponseSchema,
   HealthResponseSchema,
 } from "./schemas/assetSchemas.ts";
@@ -201,6 +202,45 @@ export const getAssetRoute = createRoute({
     },
     404: {
       description: "No such asset",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
+export const editAssetRoute = createRoute({
+  method: "patch",
+  path: "/api/assets/{id}",
+  tags: ["Assets"],
+  summary: "Edit an asset",
+  description:
+    "Updates the asset's name and type-specific metadata. Asset-owner only. The metadata `kind` must match the asset's existing type — an asset's type cannot change after creation.",
+  security: [cookieAuth],
+  request: {
+    params: AssetIdParamSchema,
+    body: {
+      required: true,
+      content: { "application/json": { schema: EditAssetBodySchema } },
+    },
+  },
+  responses: {
+    200: {
+      description: "Updated asset",
+      content: { "application/json": { schema: AssetResponseSchema } },
+    },
+    401: {
+      description: "Not authenticated",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    403: {
+      description: "Caller is not the asset owner",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    404: {
+      description: "No such asset",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    422: {
+      description: "Validation failed, or the metadata kind doesn't match the asset's type",
       content: { "application/json": { schema: ErrorResponseSchema } },
     },
   },
@@ -821,6 +861,7 @@ export function getApiDocument() {
   doc.openapi(createAssetRoute, stub);
   doc.openapi(listAssetsRoute, stub);
   doc.openapi(getAssetRoute, stub);
+  doc.openapi(editAssetRoute, stub);
   doc.openapi(searchAssetsRoute, stub);
   doc.openapi(createMaintenanceRecordRoute, stub);
   doc.openapi(listMaintenanceRecordsRoute, stub);

--- a/apps/api/src/api/schemas/assetSchemas.ts
+++ b/apps/api/src/api/schemas/assetSchemas.ts
@@ -73,6 +73,15 @@ export const CreateAssetBodySchema = z
 
 export type CreateAssetBody = z.infer<typeof CreateAssetBodySchema>;
 
+export const EditAssetBodySchema = z
+  .object({
+    name: z.string().min(1, "Name is required").openapi({ example: "My Truck" }),
+    metadata: AssetMetadataSchema,
+  })
+  .openapi("EditAssetBody");
+
+export type EditAssetBody = z.infer<typeof EditAssetBodySchema>;
+
 export const AssetIdParamSchema = z.object({
   id: z.string().openapi({
     param: { name: "id", in: "path" },

--- a/apps/api/src/application/usecases/EditAsset.test.ts
+++ b/apps/api/src/application/usecases/EditAsset.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it } from "vitest";
+import {
+  AssetId,
+  ForbiddenError,
+  NotFoundError,
+  UserId,
+  ValidationError,
+} from "@snaveevans/pineapple-shared";
+import { Asset } from "../../domain/asset/Asset.ts";
+import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
+import type { DomainEvent } from "../../domain/events/DomainEvent.ts";
+import { createMembership } from "../../domain/team/Membership.ts";
+import { Team } from "../../domain/team/Team.ts";
+import type { TeamRepository } from "../../domain/team/TeamRepository.ts";
+import type { EventBus } from "../ports/EventBus.ts";
+import { EditAsset } from "./EditAsset.ts";
+
+class FakeAssetRepository implements AssetRepository {
+  saved: Asset | null = null;
+  savedEvents: readonly DomainEvent[] = [];
+  saveCalls = 0;
+
+  constructor(private asset: Asset | null) {}
+
+  findById(): Promise<Asset | null> {
+    return Promise.resolve(this.asset);
+  }
+
+  findVisibleTo(): Promise<Asset[]> {
+    return Promise.resolve([]);
+  }
+
+  save(asset: Asset, events: readonly DomainEvent[] = []): Promise<void> {
+    this.saveCalls += 1;
+    this.saved = asset;
+    this.savedEvents = events;
+    return Promise.resolve();
+  }
+}
+
+class FakeTeamRepository implements TeamRepository {
+  constructor(private team: Team | null) {}
+
+  findByMember(): Promise<Team | null> {
+    return Promise.resolve(this.team);
+  }
+
+  findById(): Promise<Team | null> {
+    return Promise.resolve(this.team);
+  }
+
+  save(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+class RecordingEventBus implements EventBus {
+  readonly events: DomainEvent[] = [];
+  publishAllCalls = 0;
+
+  publish(event: DomainEvent): Promise<void> {
+    this.events.push(event);
+    return Promise.resolve();
+  }
+
+  publishAll(events: readonly DomainEvent[]): Promise<void> {
+    this.publishAllCalls += 1;
+    for (const event of events) this.events.push(event);
+    return Promise.resolve();
+  }
+
+  subscribe(): void {}
+}
+
+const vehicleMetadata = { kind: "vehicle" as const, make: "Ram", model: "2500", year: 2016 };
+
+function makeAsset(ownerId: UserId): Asset {
+  const asset = Asset.create({ ownerId, name: "Truck", metadata: vehicleMetadata });
+  asset.pullEvents();
+  return asset;
+}
+
+function makeTeam(ownerId: UserId, name: string, extraMemberIds: UserId[] = []): Team {
+  const team = Team.create({ ownerId, name });
+  team.pullEvents();
+  if (extraMemberIds.length === 0) return team;
+  return Team.reconstitute({
+    id: team.id,
+    ownerId: team.ownerId,
+    name: team.name,
+    createdAt: team.createdAt,
+    members: [
+      ...team.members,
+      ...extraMemberIds.map((userId) =>
+        createMembership({ userId, role: "member", joinedAt: new Date() }),
+      ),
+    ],
+  });
+}
+
+describe("EditAsset", () => {
+  const ownerId = UserId.generate();
+  const otherId = UserId.generate();
+
+  it("updates the name and metadata and publishes AssetEdited", async () => {
+    const asset = makeAsset(ownerId);
+    const originalId = asset.id;
+    const originalCreatedAt = asset.createdAt;
+    const assets = new FakeAssetRepository(asset);
+    const eventBus = new RecordingEventBus();
+    const nextMetadata = { ...vehicleMetadata, model: "3500" };
+
+    const result = await new EditAsset(assets, new FakeTeamRepository(null), eventBus).execute({
+      assetId: asset.id,
+      requesterId: ownerId,
+      name: "New Name",
+      metadata: nextMetadata,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.name).toBe("New Name");
+    expect(result.value.metadata).toEqual(nextMetadata);
+    expect(eventBus.events).toHaveLength(1);
+    expect(eventBus.events[0]?.type).toBe("AssetEdited");
+    expect(eventBus.publishAllCalls).toBe(1);
+    expect(assets.saveCalls).toBe(1);
+
+    // Never touched by edit — id, owner, creation time, archive/sharing state.
+    expect(result.value.id).toBe(originalId);
+    expect(result.value.ownerId).toBe(ownerId);
+    expect(result.value.createdAt).toBe(originalCreatedAt);
+    expect(result.value.archivedAt).toBeNull();
+    expect(result.value.sharedTeamId).toBeNull();
+  });
+
+  it("saves without publishing an event when nothing actually changed", async () => {
+    const asset = makeAsset(ownerId);
+    const assets = new FakeAssetRepository(asset);
+    const eventBus = new RecordingEventBus();
+
+    const result = await new EditAsset(assets, new FakeTeamRepository(null), eventBus).execute({
+      assetId: asset.id,
+      requesterId: ownerId,
+      name: "Truck",
+      metadata: vehicleMetadata,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(eventBus.events).toHaveLength(0);
+    expect(eventBus.publishAllCalls).toBe(0);
+    expect(assets.saveCalls).toBe(1);
+  });
+
+  it("returns ValidationError when the metadata kind differs from the asset's current kind", async () => {
+    const asset = makeAsset(ownerId);
+    const assets = new FakeAssetRepository(asset);
+
+    const result = await new EditAsset(
+      assets,
+      new FakeTeamRepository(null),
+      new RecordingEventBus(),
+    ).execute({
+      assetId: asset.id,
+      requesterId: ownerId,
+      name: "Truck",
+      metadata: { kind: "equipment", manufacturer: "Honda" },
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBeInstanceOf(ValidationError);
+    if (!(result.error instanceof ValidationError)) return;
+    expect(result.error.field).toBe("metadata.kind");
+    expect(assets.saveCalls).toBe(0);
+  });
+
+  it("returns ForbiddenError when a non-owner team member tries to edit", async () => {
+    const asset = makeAsset(ownerId);
+    const team = makeTeam(ownerId, "Field Ops", [otherId]);
+    asset.shareToTeam({ teamId: team.id, teamName: team.name, actorId: ownerId });
+    asset.pullEvents();
+    const assets = new FakeAssetRepository(asset);
+    const eventBus = new RecordingEventBus();
+
+    const result = await new EditAsset(assets, new FakeTeamRepository(team), eventBus).execute({
+      assetId: asset.id,
+      requesterId: otherId,
+      name: "Hijacked Name",
+      metadata: vehicleMetadata,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBeInstanceOf(ForbiddenError);
+    expect(assets.saveCalls).toBe(0);
+    expect(eventBus.publishAllCalls).toBe(0);
+    expect(asset.name).toBe("Truck");
+  });
+
+  it("returns ForbiddenError when a stranger with no relationship to the asset tries to edit", async () => {
+    const asset = makeAsset(ownerId);
+    const assets = new FakeAssetRepository(asset);
+
+    const result = await new EditAsset(
+      assets,
+      new FakeTeamRepository(null),
+      new RecordingEventBus(),
+    ).execute({
+      assetId: asset.id,
+      requesterId: otherId,
+      name: "Hijacked Name",
+      metadata: vehicleMetadata,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBeInstanceOf(ForbiddenError);
+    expect(assets.saveCalls).toBe(0);
+  });
+
+  it("returns NotFoundError when the asset does not exist", async () => {
+    const result = await new EditAsset(
+      new FakeAssetRepository(null),
+      new FakeTeamRepository(null),
+      new RecordingEventBus(),
+    ).execute({
+      assetId: AssetId.generate(),
+      requesterId: ownerId,
+      name: "Truck",
+      metadata: vehicleMetadata,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBeInstanceOf(NotFoundError);
+  });
+
+  it("rethrows non-domain errors from save", async () => {
+    const asset = makeAsset(ownerId);
+    const assets = new FakeAssetRepository(asset);
+    assets.save = () => Promise.reject(new TypeError("disk full"));
+
+    await expect(
+      new EditAsset(assets, new FakeTeamRepository(null), new RecordingEventBus()).execute({
+        assetId: asset.id,
+        requesterId: ownerId,
+        name: "New Name",
+        metadata: vehicleMetadata,
+      }),
+    ).rejects.toBeInstanceOf(TypeError);
+  });
+});

--- a/apps/api/src/application/usecases/EditAsset.test.ts
+++ b/apps/api/src/application/usecases/EditAsset.test.ts
@@ -236,6 +236,29 @@ describe("EditAsset", () => {
     expect(result.error).toBeInstanceOf(NotFoundError);
   });
 
+  it("returns a domain error thrown while saving", async () => {
+    const asset = makeAsset(ownerId);
+    const assets = new FakeAssetRepository(asset);
+    assets.save = () => Promise.reject(new ValidationError("save failed", "asset"));
+
+    const result = await new EditAsset(
+      assets,
+      new FakeTeamRepository(null),
+      new RecordingEventBus(),
+    ).execute({
+      assetId: asset.id,
+      requesterId: ownerId,
+      name: "New Name",
+      metadata: vehicleMetadata,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBeInstanceOf(ValidationError);
+    if (!(result.error instanceof ValidationError)) return;
+    expect(result.error.field).toBe("asset");
+  });
+
   it("rethrows non-domain errors from save", async () => {
     const asset = makeAsset(ownerId);
     const assets = new FakeAssetRepository(asset);

--- a/apps/api/src/application/usecases/EditAsset.ts
+++ b/apps/api/src/application/usecases/EditAsset.ts
@@ -1,0 +1,56 @@
+import {
+  type AssetId,
+  type DomainError,
+  DomainError as DomainErrorClass,
+  ForbiddenError,
+  NotFoundError,
+  ok,
+  err,
+  type Result,
+  type UserId,
+} from "@snaveevans/pineapple-shared";
+import type { Asset } from "../../domain/asset/Asset.ts";
+import type { AssetMetadata } from "../../domain/asset/AssetMetadata.ts";
+import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
+import type { TeamRepository } from "../../domain/team/TeamRepository.ts";
+import type { EventBus } from "../ports/EventBus.ts";
+import { canAccessAsset } from "./assetAccess.ts";
+
+export type EditAssetCommand = {
+  assetId: AssetId;
+  requesterId: UserId;
+  name: string;
+  metadata: AssetMetadata;
+};
+
+export class EditAsset {
+  constructor(
+    private readonly assets: AssetRepository,
+    private readonly teams: TeamRepository,
+    private readonly eventBus: EventBus,
+  ) {}
+
+  async execute(cmd: EditAssetCommand): Promise<Result<Asset, DomainError>> {
+    try {
+      const asset = await this.assets.findById(cmd.assetId);
+      if (!asset) return err(new NotFoundError("Asset not found"));
+
+      if (asset.ownerId !== cmd.requesterId) {
+        const visible = await canAccessAsset(asset, cmd.requesterId, this.teams);
+        if (!visible) return err(new ForbiddenError("Access denied"));
+        return err(new ForbiddenError("Only the asset owner can edit this asset"));
+      }
+
+      asset.edit({ name: cmd.name, metadata: cmd.metadata, actorId: cmd.requesterId });
+      const events = asset.pullEvents();
+      await this.assets.save(asset, events);
+      if (events.length > 0) {
+        await this.eventBus.publishAll(events);
+      }
+      return ok(asset);
+    } catch (e) {
+      if (e instanceof DomainErrorClass) return err(e);
+      throw e;
+    }
+  }
+}

--- a/apps/api/src/domain/asset/Asset.test.ts
+++ b/apps/api/src/domain/asset/Asset.test.ts
@@ -131,15 +131,67 @@ describe("Asset", () => {
     );
   });
 
-  it("rename trims and rejects blank names", () => {
+  it("edit trims the name and rejects blank names", () => {
     const asset = Asset.create({ ownerId, name: "Truck", metadata: validVehicle });
     asset.pullEvents();
 
-    asset.rename("  New Name  ");
+    asset.edit({ name: "  New Name  ", metadata: validVehicle, actorId: ownerId });
     expect(asset.name).toBe("New Name");
 
-    expectValidationField(() => asset.rename(""), "name");
-    expectValidationField(() => asset.rename("   "), "name");
+    expectValidationField(
+      () => asset.edit({ name: "", metadata: validVehicle, actorId: ownerId }),
+      "name",
+    );
+    expectValidationField(
+      () => asset.edit({ name: "   ", metadata: validVehicle, actorId: ownerId }),
+      "name",
+    );
+  });
+
+  it("edit updates name and metadata together and emits exactly one AssetEdited event", () => {
+    const asset = Asset.create({ ownerId, name: "Truck", metadata: validVehicle });
+    asset.pullEvents();
+
+    const nextMetadata = { ...validVehicle, model: "3500" };
+    asset.edit({ name: "New Name", metadata: nextMetadata, actorId: ownerId });
+
+    expect(asset.name).toBe("New Name");
+    expect(asset.metadata).toEqual(nextMetadata);
+
+    const events = asset.pullEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: "AssetEdited",
+      assetId: asset.id,
+      ownerId,
+      actorId: ownerId,
+      assetName: "New Name",
+      previousName: "Truck",
+      assetType: "vehicle",
+      nameChanged: true,
+      metadataChanged: true,
+    });
+  });
+
+  it("edit rejects a metadata kind that differs from the asset's current kind", () => {
+    const asset = Asset.create({ ownerId, name: "Truck", metadata: validVehicle });
+    asset.pullEvents();
+
+    expectValidationField(
+      () => asset.edit({ name: "Truck", metadata: validProperty, actorId: ownerId }),
+      "metadata.kind",
+    );
+    expect(asset.pullEvents()).toHaveLength(0);
+  });
+
+  it("edit with no actual changes succeeds and emits no event", () => {
+    const asset = Asset.create({ ownerId, name: "Truck", metadata: validVehicle });
+    asset.pullEvents();
+
+    asset.edit({ name: "Truck", metadata: validVehicle, actorId: ownerId });
+
+    expect(asset.name).toBe("Truck");
+    expect(asset.pullEvents()).toHaveLength(0);
   });
 
   it("reconstitutes without emitting events", () => {

--- a/apps/api/src/domain/asset/Asset.ts
+++ b/apps/api/src/domain/asset/Asset.ts
@@ -3,6 +3,7 @@ import { validateMetadata, type AssetMetadata } from "./AssetMetadata.ts";
 import type { AssetType } from "./AssetType.ts";
 import type { DomainEvent } from "../events/DomainEvent.ts";
 import { AssetCreated } from "./events/AssetCreated.ts";
+import { AssetEdited } from "./events/AssetEdited.ts";
 import { AssetSharedToTeam } from "./events/AssetSharedToTeam.ts";
 import { AssetUnsharedFromTeam } from "./events/AssetUnsharedFromTeam.ts";
 
@@ -84,10 +85,40 @@ export class Asset {
     );
   }
 
-  rename(name: string): void {
-    if (!name?.trim()) throw new ValidationError("Name required", "name");
-    this.name = name.trim();
+  /**
+   * Update this asset's name and/or metadata in a single mutation, raising at most
+   * one AssetEdited event. `metadata.kind` must match the asset's existing kind —
+   * an asset's type cannot change after creation.
+   */
+  edit(props: { name: string; metadata: AssetMetadata; actorId: UserId }): void {
+    if (!props.name?.trim()) throw new ValidationError("Name required", "name");
+    if (props.metadata.kind !== this.metadata.kind) {
+      throw new ValidationError("Asset type cannot change", "metadata.kind");
+    }
+    validateMetadata(props.metadata);
+
+    const trimmedName = props.name.trim();
+    const nameChanged = trimmedName !== this.name;
+    const metadataChanged = JSON.stringify(props.metadata) !== JSON.stringify(this.metadata);
+    if (!nameChanged && !metadataChanged) return;
+
+    const previousName = this.name;
+    this.name = trimmedName;
+    this.metadata = props.metadata;
     this.updatedAt = new Date();
+
+    this._domainEvents.push(
+      AssetEdited({
+        assetId: this.id,
+        ownerId: this.ownerId,
+        actorId: props.actorId,
+        assetName: this.name,
+        previousName,
+        assetType: this.type,
+        nameChanged,
+        metadataChanged,
+      }),
+    );
   }
 
   /**

--- a/apps/api/src/domain/asset/events/AssetEdited.ts
+++ b/apps/api/src/domain/asset/events/AssetEdited.ts
@@ -1,0 +1,37 @@
+import type { AssetId, UserId } from "@snaveevans/pineapple-shared";
+import type { AssetType } from "../AssetType.ts";
+import { createDomainEventMetadata, type DomainEvent } from "../../events/DomainEvent.ts";
+
+export type AssetEdited = DomainEvent & {
+  type: "AssetEdited";
+  assetId: AssetId;
+  ownerId: UserId;
+  actorId: UserId;
+  assetName: string;
+  previousName: string;
+  assetType: AssetType;
+  nameChanged: boolean;
+  metadataChanged: boolean;
+};
+
+export const AssetEdited = (props: {
+  assetId: AssetId;
+  ownerId: UserId;
+  actorId: UserId;
+  assetName: string;
+  previousName: string;
+  assetType: AssetType;
+  nameChanged: boolean;
+  metadataChanged: boolean;
+}): AssetEdited => ({
+  ...createDomainEventMetadata(),
+  type: "AssetEdited",
+  assetId: props.assetId,
+  ownerId: props.ownerId,
+  actorId: props.actorId,
+  assetName: props.assetName,
+  previousName: props.previousName,
+  assetType: props.assetType,
+  nameChanged: props.nameChanged,
+  metadataChanged: props.metadataChanged,
+});

--- a/apps/api/src/infrastructure/telemetry/asset/AssetEditedTelemetryHandler.test.ts
+++ b/apps/api/src/infrastructure/telemetry/asset/AssetEditedTelemetryHandler.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest";
+import { AssetId, UserId } from "@snaveevans/pineapple-shared";
+import { AssetEdited } from "../../../domain/asset/events/AssetEdited.ts";
+import {
+  AssetEditedTelemetryHandler,
+  mapAssetEditedTelemetry,
+} from "./AssetEditedTelemetryHandler.ts";
+
+describe("AssetEditedTelemetryHandler", () => {
+  it("maps ids and boolean change-flags without the name or metadata values", () => {
+    const event = AssetEdited({
+      assetId: AssetId.generate(),
+      ownerId: UserId.generate(),
+      actorId: UserId.generate(),
+      assetName: "Secret Truck Name",
+      previousName: "Old Secret Name",
+      assetType: "vehicle",
+      nameChanged: true,
+      metadataChanged: false,
+    });
+
+    const point = mapAssetEditedTelemetry(event);
+
+    expect(point.indexes).toEqual([event.ownerId]);
+    expect(point.blobs).toEqual([
+      "AssetEdited",
+      "Asset",
+      event.assetId,
+      event.ownerId,
+      event.actorId,
+      "EditAsset",
+      "v1",
+      "success",
+    ]);
+    expect(point.blobs.join(" ")).not.toContain("Secret");
+    expect(point.doubles).toEqual([1, event.occurredAt.getTime(), 1, 0]);
+  });
+
+  it("writes through the sink", () => {
+    const write = vi.fn();
+    const handler = new AssetEditedTelemetryHandler({ write });
+    const event = AssetEdited({
+      assetId: AssetId.generate(),
+      ownerId: UserId.generate(),
+      actorId: UserId.generate(),
+      assetName: "Truck",
+      previousName: "Truck",
+      assetType: "vehicle",
+      nameChanged: false,
+      metadataChanged: true,
+    });
+
+    handler.handle(event);
+
+    expect(write).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/api/src/infrastructure/telemetry/asset/AssetEditedTelemetryHandler.ts
+++ b/apps/api/src/infrastructure/telemetry/asset/AssetEditedTelemetryHandler.ts
@@ -1,0 +1,37 @@
+import type { DomainEventHandler } from "../../../application/ports/EventBus.ts";
+import type { AssetEdited } from "../../../domain/asset/events/AssetEdited.ts";
+import type { TelemetryDataPoint, TelemetrySink } from "../AnalyticsEngineTelemetrySink.ts";
+
+// Records ids and boolean change-flags only — never the name or metadata values
+// (telemetry.md anti-pattern: no user-supplied strings in blobs).
+export function mapAssetEditedTelemetry(event: AssetEdited): TelemetryDataPoint {
+  return {
+    indexes: [event.ownerId],
+    blobs: [
+      event.type,
+      "Asset",
+      event.assetId,
+      event.ownerId,
+      event.actorId,
+      "EditAsset",
+      "v1",
+      "success",
+    ],
+    doubles: [
+      1,
+      event.occurredAt.getTime(),
+      event.nameChanged ? 1 : 0,
+      event.metadataChanged ? 1 : 0,
+    ],
+  };
+}
+
+export class AssetEditedTelemetryHandler implements DomainEventHandler<AssetEdited> {
+  readonly eventType = "AssetEdited" as const;
+
+  constructor(private readonly sink: TelemetrySink) {}
+
+  handle(event: AssetEdited): void {
+    this.sink.write(mapAssetEditedTelemetry(event));
+  }
+}

--- a/apps/api/src/infrastructure/telemetry/registerDomainTelemetry.ts
+++ b/apps/api/src/infrastructure/telemetry/registerDomainTelemetry.ts
@@ -1,6 +1,7 @@
 import type { EventBus } from "../../application/ports/EventBus.ts";
 import { AnalyticsEngineTelemetrySink } from "./AnalyticsEngineTelemetrySink.ts";
 import { AssetCreatedTelemetryHandler } from "./asset/AssetCreatedTelemetryHandler.ts";
+import { AssetEditedTelemetryHandler } from "./asset/AssetEditedTelemetryHandler.ts";
 import { AssetSharedToTeamTelemetryHandler } from "./asset/AssetSharedToTeamTelemetryHandler.ts";
 import { AssetUnsharedFromTeamTelemetryHandler } from "./asset/AssetUnsharedFromTeamTelemetryHandler.ts";
 import { MaintenanceRecordCreatedTelemetryHandler } from "./maintenance/MaintenanceRecordCreatedTelemetryHandler.ts";
@@ -25,6 +26,7 @@ export function registerDomainTelemetry(deps: {
 }): void {
   const assetDomainSink = new AnalyticsEngineTelemetrySink(deps.assetDomainDataset);
   deps.eventBus.subscribe(new AssetCreatedTelemetryHandler(assetDomainSink));
+  deps.eventBus.subscribe(new AssetEditedTelemetryHandler(assetDomainSink));
   deps.eventBus.subscribe(new AssetSharedToTeamTelemetryHandler(assetDomainSink));
   deps.eventBus.subscribe(new AssetUnsharedFromTeamTelemetryHandler(assetDomainSink));
 

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -59,6 +59,7 @@ import { SystemUtcDateProvider } from "./infrastructure/time/SystemUtcDateProvid
 
 // Application
 import { CreateAsset } from "./application/usecases/CreateAsset.ts";
+import { EditAsset } from "./application/usecases/EditAsset.ts";
 import { GetAsset } from "./application/usecases/GetAsset.ts";
 import { ListAssets } from "./application/usecases/ListAssets.ts";
 import { CreateMaintenanceRecord } from "./application/usecases/CreateMaintenanceRecord.ts";
@@ -114,6 +115,7 @@ import {
   markNotificationReadRoute,
   markAllNotificationsReadRoute,
   getAssetRoute,
+  editAssetRoute,
   healthRoute,
   listAssetsRoute,
   listMaintenanceRecordsRoute,
@@ -764,6 +766,29 @@ app.openapi(getAssetRoute, async (c) => {
   });
   if (!result.ok) throw result.error;
   return c.json(serializeAsset(result.value.asset, result.value.sharing), 200);
+});
+
+app.openapi(editAssetRoute, async (c) => {
+  const user = c.get("user");
+  const { id } = c.req.valid("param");
+  const { name, metadata } = c.req.valid("json");
+  const result = await new EditAsset(
+    new D1AssetRepository(c.env.DB),
+    new D1TeamRepository(c.env.DB),
+    c.get("eventBus"),
+  ).execute({
+    assetId: AssetId.from(id),
+    requesterId: user.id,
+    name,
+    // Cast: Zod's `.optional()` yields `T | undefined` but the domain type uses
+    // exactOptionalPropertyTypes (absent ≠ explicitly undefined).
+    metadata: metadata as AssetMetadata,
+  });
+  if (!result.ok) throw result.error;
+  return c.json(
+    serializeAsset(result.value, toSharingDescriptor(result.value, user.id, null)),
+    200,
+  );
 });
 
 app.openapi(searchAssetsRoute, async (c) => {

--- a/apps/web/src/api/assets.ts
+++ b/apps/web/src/api/assets.ts
@@ -1,4 +1,4 @@
-import { apiDelete, apiGet, apiPost } from "./client.ts";
+import { apiDelete, apiGet, apiPatch, apiPost } from "./client.ts";
 import type { components } from "./schema.ts";
 
 // Wire shapes come from the spec (docs/reference/openapi.json), not from
@@ -14,6 +14,7 @@ export type AssetResponse = components["schemas"]["Asset"];
 export type AssetListResponse = components["schemas"]["AssetListResponse"];
 export type CreateAssetBody = components["schemas"]["CreateAssetBody"];
 export type CreatedAssetResponse = components["schemas"]["CreatedAsset"];
+export type EditAssetBody = components["schemas"]["EditAssetBody"];
 
 export const assetsQueryKey = ["assets"] as const;
 export const assetQueryKey = (id: string) => ["asset", id] as const;
@@ -28,6 +29,10 @@ export function listAssets(): Promise<AssetListResponse> {
 
 export function createAsset(body: CreateAssetBody): Promise<CreatedAssetResponse> {
   return apiPost("/api/assets", { body });
+}
+
+export function editAsset(id: string, body: EditAssetBody): Promise<AssetResponse> {
+  return apiPatch("/api/assets/{id}", { path: { id }, body });
 }
 
 export function shareAsset(assetId: string): Promise<AssetResponse> {

--- a/apps/web/src/api/schema.ts
+++ b/apps/web/src/api/schema.ts
@@ -204,7 +204,72 @@ export interface paths {
         delete?: never;
         options?: never;
         head?: never;
-        patch?: never;
+        /**
+         * Edit an asset
+         * @description Updates the asset's name and type-specific metadata. Asset-owner only. The metadata `kind` must match the asset's existing type — an asset's type cannot change after creation.
+         */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["EditAssetBody"];
+                };
+            };
+            responses: {
+                /** @description Updated asset */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Asset"];
+                    };
+                };
+                /** @description Not authenticated */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Caller is not the asset owner */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description No such asset */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Validation failed, or the metadata kind doesn't match the asset's type */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
+        };
         trace?: never;
     };
     "/api/search": {
@@ -1605,6 +1670,11 @@ export interface components {
             property: number;
             /** @example 1 */
             equipment: number;
+        };
+        EditAssetBody: {
+            /** @example My Truck */
+            name: string;
+            metadata: components["schemas"]["AssetMetadata"];
         };
         SearchAssetsResponse: {
             results: components["schemas"]["SearchResult"][];

--- a/apps/web/src/app/AppEditAsset.test.tsx
+++ b/apps/web/src/app/AppEditAsset.test.tsx
@@ -198,6 +198,73 @@ describe("AppEditAsset", () => {
     expect(navigate).toHaveBeenCalledWith("/login", { replace: true });
   });
 
+  it("shows access denied when the asset load is forbidden (403)", async () => {
+    getAssetMock.mockRejectedValue(new ApiError(403, { error: "Forbidden" }));
+
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+    if (queryClient === null) throw new Error("Query client was not initialized");
+    const client = queryClient;
+
+    await act(async () => {
+      root?.render(
+        <QueryClientProvider client={client}>
+          <AppEditAsset />
+        </QueryClientProvider>,
+      );
+    });
+    await waitFor(() => document.body.textContent?.includes("Access denied") ?? false);
+
+    expect(document.body.textContent).not.toContain("Edit asset");
+    expect(document.querySelector(".hf-input")).toBeNull();
+  });
+
+  it("shows asset not found when the asset load 404s", async () => {
+    getAssetMock.mockRejectedValue(new ApiError(404, { error: "Not found" }));
+
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+    if (queryClient === null) throw new Error("Query client was not initialized");
+    const client = queryClient;
+
+    await act(async () => {
+      root?.render(
+        <QueryClientProvider client={client}>
+          <AppEditAsset />
+        </QueryClientProvider>,
+      );
+    });
+    await waitFor(() => document.body.textContent?.includes("Asset not found") ?? false);
+
+    expect(document.querySelector(".hf-input")).toBeNull();
+  });
+
+  it("shows access denied when the fetched asset's sharing.isOwner is false", async () => {
+    getAssetMock.mockResolvedValue(
+      vehicleAsset({ sharing: { scope: "team", isOwner: false, ownerDisplayName: "Pat" } }),
+    );
+
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+    if (queryClient === null) throw new Error("Query client was not initialized");
+    const client = queryClient;
+
+    await act(async () => {
+      root?.render(
+        <QueryClientProvider client={client}>
+          <AppEditAsset />
+        </QueryClientProvider>,
+      );
+    });
+    await waitFor(() => document.body.textContent?.includes("Access denied") ?? false);
+
+    expect(document.body.textContent).toContain("Only the asset's owner can edit it.");
+    expect(document.querySelector(".hf-input")).toBeNull();
+  });
+
   it("redirects to login on a 401 while saving", async () => {
     editAssetMock.mockRejectedValue(new ApiError(401, { error: "Not authenticated" }));
     await renderEditAsset();

--- a/apps/web/src/app/AppEditAsset.test.tsx
+++ b/apps/web/src/app/AppEditAsset.test.tsx
@@ -1,0 +1,253 @@
+// @vitest-environment happy-dom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiError } from "../api/client";
+import { editAsset, getAsset, type AssetResponse } from "../api/assets";
+import { AppEditAsset } from "./AppEditAsset";
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean | undefined;
+}
+
+const navigate = vi.fn();
+
+vi.mock("react-router", () => ({
+  Link: ({ children, to, ...props }: { children: React.ReactNode; to: string }) => (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  ),
+  useNavigate: () => navigate,
+  useParams: () => ({ assetId: "asset-1" }),
+}));
+
+vi.mock("./AppChrome", () => ({
+  HFTopBar: () => <header />,
+}));
+
+vi.mock("../api/assets", () => ({
+  getAsset: vi.fn(),
+  editAsset: vi.fn(),
+  assetQueryKey: (id: string) => ["asset", id],
+  assetsQueryKey: ["assets"],
+}));
+
+const getAssetMock = vi.mocked(getAsset);
+const editAssetMock = vi.mocked(editAsset);
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+let queryClient: QueryClient | null = null;
+
+function vehicleAsset(overrides: Partial<AssetResponse> = {}): AssetResponse {
+  return {
+    id: "asset-1",
+    name: "Truck",
+    type: "vehicle",
+    metadata: { kind: "vehicle", make: "Ram", model: "2500", year: 2016 },
+    archivedAt: null,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    sharing: { scope: "personal", isOwner: true },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+  queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  getAssetMock.mockResolvedValue(vehicleAsset());
+  editAssetMock.mockImplementation((_id, body) =>
+    Promise.resolve(vehicleAsset({ name: body.name, metadata: body.metadata })),
+  );
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root?.unmount();
+  });
+  container?.remove();
+  root = null;
+  container = null;
+  queryClient?.clear();
+  queryClient = null;
+  globalThis.IS_REACT_ACT_ENVIRONMENT = false;
+  vi.clearAllMocks();
+});
+
+async function waitFor(assertion: () => boolean) {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    if (assertion()) return;
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  }
+  if (!assertion()) throw new Error("Timed out waiting for expected UI");
+}
+
+async function renderEditAsset() {
+  if (queryClient === null) throw new Error("Query client was not initialized");
+  const client = queryClient;
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+
+  await act(async () => {
+    root?.render(
+      <QueryClientProvider client={client}>
+        <AppEditAsset />
+      </QueryClientProvider>,
+    );
+  });
+  await waitFor(() => document.querySelector("h1") !== null);
+}
+
+function inputByPlaceholderOrValue(value: string): HTMLInputElement | null {
+  return Array.from(document.querySelectorAll<HTMLInputElement>("input")).find(
+    (input) => input.value === value,
+  ) ?? null;
+}
+
+function setInputValue(input: HTMLInputElement, value: string) {
+  const valueSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+  if (valueSetter === undefined) throw new Error("Input does not have a value setter");
+  valueSetter.call(input, value);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+function buttonByText(label: string): HTMLButtonElement {
+  const button = Array.from(document.querySelectorAll<HTMLButtonElement>("button")).find(
+    (candidate) => candidate.textContent?.replace(/\s+/g, " ").trim() === label,
+  );
+  if (button === undefined) throw new Error(`Button ${label} was not rendered`);
+  return button;
+}
+
+async function click(label: string) {
+  await act(async () => {
+    buttonByText(label).dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe("AppEditAsset", () => {
+  it("prefills the form from the fetched asset", async () => {
+    await renderEditAsset();
+
+    expect(inputByPlaceholderOrValue("Truck")).not.toBeNull();
+    expect(inputByPlaceholderOrValue("Ram")).not.toBeNull();
+    expect(inputByPlaceholderOrValue("2500")).not.toBeNull();
+    expect(document.body.textContent).toContain("Vehicle");
+  });
+
+  it("saves the edited name and metadata, then returns to the asset's detail page", async () => {
+    await renderEditAsset();
+
+    const nameInput = inputByPlaceholderOrValue("Truck");
+    if (!nameInput) throw new Error("Name input not found");
+    await act(async () => setInputValue(nameInput, "Work Truck"));
+
+    await click("Save changes");
+
+    expect(editAssetMock).toHaveBeenCalledWith("asset-1", {
+      name: "Work Truck",
+      metadata: { kind: "vehicle", make: "Ram", model: "2500", year: 2016 },
+    });
+    expect(navigate).toHaveBeenCalledWith("/app/assets/asset-1/maintenance");
+  });
+
+  it("blocks submission and shows field errors when a required field is cleared", async () => {
+    await renderEditAsset();
+
+    const nameInput = inputByPlaceholderOrValue("Truck");
+    if (!nameInput) throw new Error("Name input not found");
+    await act(async () => setInputValue(nameInput, ""));
+
+    await click("Save changes");
+
+    expect(editAssetMock).not.toHaveBeenCalled();
+    expect(document.body.textContent).toContain("1 field needs attention");
+  });
+
+  it("redirects to login on a 401 while loading the asset", async () => {
+    getAssetMock.mockRejectedValue(new ApiError(401, { error: "Not authenticated" }));
+
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+    if (queryClient === null) throw new Error("Query client was not initialized");
+    const client = queryClient;
+
+    await act(async () => {
+      root?.render(
+        <QueryClientProvider client={client}>
+          <AppEditAsset />
+        </QueryClientProvider>,
+      );
+    });
+    await waitFor(() => navigate.mock.calls.length > 0);
+
+    expect(navigate).toHaveBeenCalledWith("/login", { replace: true });
+  });
+
+  it("redirects to login on a 401 while saving", async () => {
+    editAssetMock.mockRejectedValue(new ApiError(401, { error: "Not authenticated" }));
+    await renderEditAsset();
+
+    await click("Save changes");
+
+    expect(navigate).toHaveBeenCalledWith("/login", { replace: true });
+  });
+
+  it("shows the server's error message on a non-401 save failure", async () => {
+    editAssetMock.mockRejectedValue(new ApiError(500, { error: "Something broke" }));
+    await renderEditAsset();
+
+    await click("Save changes");
+
+    expect(document.body.textContent).toContain("Asset could not be saved");
+    expect(document.body.textContent).toContain("Something broke");
+  });
+
+  it("disables the save button and shows a busy label while the save is in flight", async () => {
+    let resolveSave: (() => void) | null = null;
+    editAssetMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveSave = () => resolve(vehicleAsset());
+        }),
+    );
+    await renderEditAsset();
+
+    await act(async () => {
+      buttonByText("Save changes").dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    const saveButton = document.querySelector<HTMLButtonElement>(".hf-btn-primary.hf-btn-lg");
+    expect(saveButton?.disabled).toBe(true);
+    expect(saveButton?.textContent).toContain("Saving...");
+
+    await act(async () => {
+      resolveSave?.();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  });
+
+  it("cancel returns to the asset's detail page without saving", async () => {
+    await renderEditAsset();
+
+    await click("Cancel");
+
+    expect(editAssetMock).not.toHaveBeenCalled();
+    expect(navigate).toHaveBeenCalledWith("/app/assets/asset-1/maintenance");
+  });
+});

--- a/apps/web/src/app/AppEditAsset.tsx
+++ b/apps/web/src/app/AppEditAsset.tsx
@@ -1,0 +1,569 @@
+import { useEffect, useRef, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Link, useNavigate, useParams } from "react-router";
+import {
+  assetQueryKey,
+  assetsQueryKey,
+  editAsset,
+  getAsset,
+  type AssetType,
+} from "../api/assets";
+import { ApiError } from "../api/client";
+import { Button } from "../design/Button";
+import { Field, FieldReqMark, FieldRow } from "../design/Field";
+import { Icon } from "../design/Icon";
+import { paths } from "../routes";
+import { HFTopBar } from "./AppChrome";
+import {
+  EMPTY_ASSET_FORM,
+  assetToForm,
+  toAssetFormError,
+  toEditAssetBody,
+  validateAssetForm,
+  type AssetForm,
+  type AssetFormErrors,
+} from "./assetForm";
+
+import "../design/styles/hifi.css";
+import "../design/styles/hifi-assets.css";
+import "../design/styles/hifi-add-asset.css";
+
+type SetField = (
+  key: keyof AssetForm,
+) => (ev: { target: HTMLInputElement | HTMLSelectElement }) => void;
+
+function focusFirstInvalid(scrollEl?: HTMLElement | null) {
+  setTimeout(() => {
+    const el = (scrollEl || document).querySelector<HTMLElement>(
+      ".hf-input.is-invalid, .hf-select.is-invalid",
+    );
+    el?.focus();
+  }, 0);
+}
+
+function HFTextField({
+  label,
+  required,
+  value,
+  onChange,
+  error,
+  mono,
+  maxLength,
+  inputMode,
+  hint,
+  optional,
+  placeholder,
+}: {
+  label: string;
+  required?: boolean;
+  value: string;
+  onChange: (ev: { target: HTMLInputElement }) => void;
+  error?: string;
+  mono?: boolean;
+  maxLength?: number;
+  inputMode?: "none" | "text" | "tel" | "url" | "email" | "numeric" | "decimal" | "search";
+  hint?: string;
+  optional?: boolean;
+  placeholder?: string;
+}) {
+  return (
+    <Field
+      label={label}
+      {...(required ? { required: true } : {})}
+      {...(optional ? { optional: true } : {})}
+      {...(hint !== undefined ? { hint } : {})}
+      {...(error ? { error } : {})}
+    >
+      <input
+        className={`hf-input${mono ? " hf-mono-input" : ""}${error ? " is-invalid" : ""}`}
+        placeholder={placeholder}
+        value={value}
+        onChange={onChange}
+        aria-invalid={error ? true : undefined}
+        inputMode={inputMode}
+        maxLength={maxLength}
+      />
+    </Field>
+  );
+}
+
+function HFSelectField({
+  label,
+  required,
+  options,
+  value,
+  onChange,
+  error,
+}: {
+  label: string;
+  required?: boolean;
+  options: string[];
+  value: string;
+  onChange: (ev: { target: HTMLSelectElement }) => void;
+  error?: string;
+}) {
+  return (
+    <Field label={label} {...(required ? { required: true } : {})} {...(error ? { error } : {})}>
+      <select
+        className={`hf-select${error ? " is-invalid" : ""}`}
+        value={value}
+        onChange={onChange}
+        aria-invalid={error ? true : undefined}
+      >
+        {options.map((option) => (
+          <option key={option} value={option}>
+            {option}
+          </option>
+        ))}
+      </select>
+    </Field>
+  );
+}
+
+function HFValidationBanner({ title, description }: { title: string; description: string }) {
+  return (
+    <div className="hf-aa-banner is-error" role="alert">
+      <span className="hf-aa-banner-icon">
+        <Icon name="alert" size={15} stroke={2} />
+      </span>
+      <div className="hf-aa-banner-text">
+        <div className="hf-aa-banner-title">{title}</div>
+        <div className="hf-aa-banner-sub">{description}</div>
+      </div>
+    </div>
+  );
+}
+
+const HF_TYPE_LABEL: Record<AssetType, string> = {
+  vehicle: "Vehicle",
+  property: "Property",
+  equipment: "Equipment",
+};
+
+function HFVehicleFields({
+  form,
+  errors,
+  setField,
+}: {
+  form: AssetForm;
+  errors: AssetFormErrors;
+  setField: SetField;
+}) {
+  return (
+    <div className="hf-aa-section">
+      <div className="hf-aa-section-head">
+        <span className="hf-aa-section-title">Vehicle details</span>
+      </div>
+      <FieldRow>
+        <HFTextField
+          label="Make"
+          required
+          placeholder="Ford"
+          value={form.make}
+          onChange={setField("make")}
+          {...(errors.make ? { error: errors.make } : {})}
+        />
+        <HFTextField
+          label="Model"
+          required
+          placeholder="F-150"
+          value={form.model}
+          onChange={setField("model")}
+          {...(errors.model ? { error: errors.model } : {})}
+        />
+        <HFTextField
+          label="Year"
+          required
+          hint={`1900-${new Date().getFullYear() + 1}`}
+          placeholder="2022"
+          mono
+          inputMode="numeric"
+          maxLength={4}
+          value={form.year}
+          onChange={setField("year")}
+          {...(errors.year ? { error: errors.year } : {})}
+        />
+      </FieldRow>
+      <HFTextField
+        label="VIN"
+        optional
+        hint="17 characters"
+        placeholder="1C6RR7LT4GS123456"
+        mono
+        maxLength={17}
+        value={form.vin}
+        onChange={setField("vin")}
+        {...(errors.vin ? { error: errors.vin } : {})}
+      />
+    </div>
+  );
+}
+
+function HFPropertyFields({
+  form,
+  errors,
+  setField,
+}: {
+  form: AssetForm;
+  errors: AssetFormErrors;
+  setField: SetField;
+}) {
+  return (
+    <div className="hf-aa-section">
+      <div className="hf-aa-section-head">
+        <span className="hf-aa-section-title">Property details</span>
+        <span className="hf-aa-section-hint">full address required</span>
+      </div>
+      <HFTextField
+        label="Nickname"
+        optional
+        placeholder="Main house, cabin..."
+        value={form.nickname}
+        onChange={setField("nickname")}
+      />
+      <HFTextField
+        label="Street"
+        required
+        placeholder="12 Oak St, Apt 4"
+        value={form.street}
+        onChange={setField("street")}
+        {...(errors.street ? { error: errors.street } : {})}
+      />
+      <FieldRow>
+        <HFTextField
+          label="City"
+          required
+          placeholder="Portland"
+          value={form.city}
+          onChange={setField("city")}
+          {...(errors.city ? { error: errors.city } : {})}
+        />
+        <HFTextField
+          label="State"
+          required
+          placeholder="OR, BC, Jalisco"
+          value={form.state}
+          onChange={setField("state")}
+          {...(errors.state ? { error: errors.state } : {})}
+        />
+        <HFTextField
+          label="Postal"
+          required
+          placeholder="97204"
+          mono
+          value={form.postal}
+          onChange={setField("postal")}
+          {...(errors.postal ? { error: errors.postal } : {})}
+        />
+      </FieldRow>
+      <HFSelectField
+        label="Country"
+        required
+        options={["United States", "Canada", "Mexico"]}
+        value={form.country}
+        onChange={setField("country")}
+        {...(errors.country ? { error: errors.country } : {})}
+      />
+    </div>
+  );
+}
+
+function HFEquipmentFields({ form, setField }: { form: AssetForm; setField: SetField }) {
+  return (
+    <div className="hf-aa-section">
+      <div className="hf-aa-section-head">
+        <span className="hf-aa-section-title">Equipment details</span>
+        <span className="hf-aa-section-hint">fill in what you know</span>
+      </div>
+      <FieldRow>
+        <HFTextField
+          label="Manufacturer"
+          optional
+          placeholder="Honda"
+          value={form.manufacturer}
+          onChange={setField("manufacturer")}
+        />
+        <HFTextField
+          label="Model number"
+          optional
+          placeholder="EU2200i"
+          mono
+          value={form.modelNumber}
+          onChange={setField("modelNumber")}
+        />
+      </FieldRow>
+      <HFTextField
+        label="Serial number"
+        optional
+        placeholder="EAMT-1234567"
+        mono
+        value={form.serialNumber}
+        onChange={setField("serialNumber")}
+      />
+    </div>
+  );
+}
+
+function EditAssetLoading() {
+  return (
+    <div className="hf hf-app hf-aa-page">
+      <HFTopBar />
+      <div className="hf-aa-body">
+        <div className="hf-aa-col">
+          <p>Loading asset…</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function EditAssetErrorState({
+  title,
+  description,
+  onRetry,
+}: {
+  title: string;
+  description: string;
+  onRetry?: () => void;
+}) {
+  return (
+    <div className="hf hf-app hf-aa-page">
+      <HFTopBar />
+      <div className="hf-aa-body">
+        <div className="hf-aa-col">
+          <HFValidationBanner title={title} description={description} />
+          {onRetry && (
+            <Button variant="secondary" onClick={onRetry}>
+              Try again
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function AppEditAsset() {
+  const { assetId = "" } = useParams<{ assetId: string }>();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const bodyRef = useRef<HTMLDivElement>(null);
+  const [form, setForm] = useState<AssetForm>(EMPTY_ASSET_FORM);
+  const [errors, setErrors] = useState<AssetFormErrors>({});
+  const [banner, setBanner] = useState<{ title: string; description: string } | null>(null);
+  const [prefilled, setPrefilled] = useState(false);
+
+  const assetQuery = useQuery({
+    queryKey: assetQueryKey(assetId),
+    queryFn: () => getAsset(assetId),
+    enabled: !!assetId,
+    retry: (count, err) =>
+      !(err instanceof ApiError && (err.status === 401 || err.status === 403 || err.status === 404)) &&
+      count < 2,
+  });
+
+  useEffect(() => {
+    if (assetQuery.error instanceof ApiError && assetQuery.error.status === 401) {
+      navigate(paths.login(), { replace: true });
+    }
+  }, [assetQuery.error, navigate]);
+
+  useEffect(() => {
+    if (assetQuery.data && !prefilled) {
+      setForm(assetToForm(assetQuery.data));
+      setPrefilled(true);
+    }
+  }, [assetQuery.data, prefilled]);
+
+  const type = assetQuery.data?.type ?? "vehicle";
+
+  const returnToDetail = () => navigate(paths.assetMaintenance(assetId));
+
+  const mutation = useMutation({
+    mutationFn: () => editAsset(assetId, toEditAssetBody(type, form)),
+    onSuccess: async (updated) => {
+      queryClient.setQueryData(assetQueryKey(assetId), updated);
+      await queryClient.invalidateQueries({ queryKey: assetsQueryKey });
+      returnToDetail();
+    },
+    onError: (error) => {
+      if (error instanceof ApiError && error.status === 401) {
+        navigate(paths.login(), { replace: true });
+        return;
+      }
+      const fieldErrors =
+        error instanceof ApiError ? toAssetFormError(error.field, error.message) : {};
+      setErrors(fieldErrors);
+      setBanner({
+        title: "Asset could not be saved",
+        description: error instanceof Error ? error.message : "Please try again.",
+      });
+      focusFirstInvalid(bodyRef.current);
+    },
+  });
+
+  const setField: SetField = (key) => (ev) => {
+    const value = ev.target.value;
+    setForm((current) => ({ ...current, [key]: value }));
+    setErrors((current) => {
+      if (!current[key]) return current;
+      const next = { ...current };
+      delete next[key];
+      return next;
+    });
+    setBanner(null);
+    mutation.reset();
+  };
+
+  const save = () => {
+    const nextErrors = validateAssetForm(type, form);
+    setErrors(nextErrors);
+    const errorCount = Object.keys(nextErrors).length;
+    if (errorCount > 0) {
+      setBanner({
+        title: errorCount === 1 ? "1 field needs attention" : `${errorCount} fields need attention`,
+        description: "Fix the highlighted fields below, then save again.",
+      });
+      focusFirstInvalid(bodyRef.current);
+      return;
+    }
+    mutation.mutate();
+  };
+
+  useEffect(() => {
+    document.title = "FieldOps - Edit Asset";
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") returnToDetail();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [assetId]);
+
+  if (assetQuery.isPending) {
+    return <EditAssetLoading />;
+  }
+
+  if (assetQuery.error instanceof ApiError) {
+    if (assetQuery.error.status === 403) {
+      return (
+        <EditAssetErrorState
+          title="Access denied"
+          description="This asset belongs to another account, or you don't have permission to edit it."
+        />
+      );
+    }
+    if (assetQuery.error.status === 404) {
+      return (
+        <EditAssetErrorState
+          title="Asset not found"
+          description="We couldn't find this asset. It may have been removed."
+        />
+      );
+    }
+    if (assetQuery.error.status !== 401) {
+      return (
+        <EditAssetErrorState
+          title="Couldn't load asset"
+          description="Something went wrong fetching this asset."
+          onRetry={() => void assetQuery.refetch()}
+        />
+      );
+    }
+    // 401 falls through to the loading state below while the redirect effect fires.
+  }
+
+  if (!assetQuery.data || !prefilled) {
+    return <EditAssetLoading />;
+  }
+
+  if (!assetQuery.data.sharing.isOwner) {
+    return (
+      <EditAssetErrorState
+        title="Access denied"
+        description="Only the asset's owner can edit it."
+      />
+    );
+  }
+
+  const errorCount = Object.keys(errors).length;
+
+  return (
+    <div className="hf hf-app hf-aa-page">
+      <HFTopBar />
+
+      <div className="hf-aa-crumb">
+        <Link to={paths.assetMaintenance(assetId)}>{form.name || "Asset"}</Link>
+        <span className="hf-aa-crumb-sep">
+          <Icon name="chevron-right" size={13} />
+        </span>
+        <span className="hf-aa-crumb-here">Edit asset</span>
+        <span className="hf-aa-crumb-esc">
+          <kbd>esc</kbd> to cancel
+        </span>
+      </div>
+
+      <div className="hf-aa-body" ref={bodyRef}>
+        <div className="hf-aa-col">
+          <div className="hf-aa-head">
+            <h1>Edit asset</h1>
+            <p>Update the name and details for this {HF_TYPE_LABEL[type].toLowerCase()}.</p>
+          </div>
+
+          {banner && <HFValidationBanner title={banner.title} description={banner.description} />}
+
+          <div className="hf-aa-section">
+            <Field label="Asset type">
+              <span className="hf-type-readonly">{HF_TYPE_LABEL[type]}</span>
+            </Field>
+          </div>
+
+          <HFTextField
+            label="Asset name"
+            required
+            value={form.name}
+            onChange={setField("name")}
+            {...(errors.name ? { error: errors.name } : {})}
+          />
+
+          <div className="hf-aa-rule" />
+
+          {type === "vehicle" && (
+            <HFVehicleFields form={form} errors={errors} setField={setField} />
+          )}
+          {type === "property" && (
+            <HFPropertyFields form={form} errors={errors} setField={setField} />
+          )}
+          {type === "equipment" && <HFEquipmentFields form={form} setField={setField} />}
+        </div>
+      </div>
+
+      <div className="hf-aa-footer">
+        <div className="hf-aa-footer-note">
+          {banner ? (
+            <span className="hf-aa-footer-err">
+              <Icon name="alert" size={13} stroke={2} />
+              {errorCount > 0
+                ? errorCount === 1
+                  ? "1 field needs attention"
+                  : `${errorCount} fields need attention`
+                : "Asset could not be saved"}
+            </span>
+          ) : (
+            <>
+              Fields marked <FieldReqMark /> are required
+            </>
+          )}
+        </div>
+        <div className="hf-aa-footer-actions">
+          <Button variant="secondary" size="lg" onClick={returnToDetail}>
+            Cancel
+          </Button>
+          <Button variant="primary" size="lg" onClick={save} disabled={mutation.isPending}>
+            <Icon name="check" size={15} stroke={2.2} />
+            {mutation.isPending ? "Saving..." : "Save changes"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/AppMaintenanceRecords.tsx
+++ b/apps/web/src/app/AppMaintenanceRecords.tsx
@@ -1390,6 +1390,16 @@ export function AppMaintenanceRecords() {
               </div>
               <div className="mr-hero-actions">
                 {sharing?.isOwner && (
+                  <Link
+                    to={paths.editAsset(assetId)}
+                    className="mr-share-btn"
+                    title="Edit asset"
+                    aria-label="Edit asset"
+                  >
+                    <Icon name="edit" size={16} stroke={1.8} />
+                  </Link>
+                )}
+                {sharing?.isOwner && (
                   <button
                     type="button"
                     className={`mr-share-btn${sharing.scope === "team" ? " is-active" : ""}`}

--- a/apps/web/src/app/assetForm.test.ts
+++ b/apps/web/src/app/assetForm.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
+import type { AssetResponse } from "../api/assets";
 import {
   EMPTY_ASSET_FORM,
+  assetToForm,
   toAssetFormError,
   toCreateAssetBody,
+  toEditAssetBody,
   validateAssetForm,
 } from "./assetForm";
 
@@ -95,6 +98,102 @@ describe("toAssetFormError", () => {
   it("maps an API metadata path back to its form field", () => {
     expect(toAssetFormError("metadata.address.postalCode", "Postal code is required")).toEqual({
       postal: "Postal code is required",
+    });
+  });
+});
+
+describe("toEditAssetBody", () => {
+  it("maps the same shape as toCreateAssetBody", () => {
+    const form = { ...EMPTY_ASSET_FORM, name: " Truck ", make: "Ram", model: "2500", year: "2016" };
+    expect(toEditAssetBody("vehicle", form)).toEqual(toCreateAssetBody("vehicle", form));
+  });
+});
+
+describe("assetToForm", () => {
+  function baseAsset(overrides: Partial<AssetResponse> = {}): AssetResponse {
+    return {
+      id: "asset-1",
+      name: "Truck",
+      type: "vehicle",
+      metadata: { kind: "vehicle", make: "Ram", model: "2500", year: 2016 },
+      archivedAt: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      sharing: { scope: "personal", isOwner: true },
+      ...overrides,
+    };
+  }
+
+  it("prefills vehicle fields, including an optional VIN", () => {
+    const asset = baseAsset({
+      metadata: {
+        kind: "vehicle",
+        make: "Ram",
+        model: "2500",
+        year: 2016,
+        vin: "1C6RR7LT4GS123456",
+      },
+    });
+
+    expect(assetToForm(asset)).toMatchObject({
+      name: "Truck",
+      make: "Ram",
+      model: "2500",
+      year: "2016",
+      vin: "1C6RR7LT4GS123456",
+    });
+  });
+
+  it("prefills property fields and defaults a missing nickname to blank", () => {
+    const asset = baseAsset({
+      name: "Cabin",
+      type: "property",
+      metadata: {
+        kind: "property",
+        address: {
+          street: "12 Oak St",
+          city: "Portland",
+          state: "OR",
+          postalCode: "97204",
+          country: "United States",
+        },
+      },
+    });
+
+    expect(assetToForm(asset)).toMatchObject({
+      name: "Cabin",
+      nickname: "",
+      street: "12 Oak St",
+      city: "Portland",
+      state: "OR",
+      postal: "97204",
+      country: "United States",
+    });
+  });
+
+  it("prefills equipment fields, defaulting missing optionals to blank", () => {
+    const asset = baseAsset({
+      name: "Generator",
+      type: "equipment",
+      metadata: { kind: "equipment", manufacturer: "Honda" },
+    });
+
+    expect(assetToForm(asset)).toMatchObject({
+      name: "Generator",
+      manufacturer: "Honda",
+      modelNumber: "",
+      serialNumber: "",
+    });
+  });
+
+  it("round-trips through toEditAssetBody back to the original metadata", () => {
+    const asset = baseAsset({
+      metadata: { kind: "vehicle", make: "Ram", model: "2500", year: 2016 },
+    });
+
+    expect(toEditAssetBody("vehicle", assetToForm(asset))).toEqual({
+      name: "Truck",
+      metadata: { kind: "vehicle", make: "Ram", model: "2500", year: 2016 },
     });
   });
 });

--- a/apps/web/src/app/assetForm.ts
+++ b/apps/web/src/app/assetForm.ts
@@ -1,4 +1,4 @@
-import type { AssetType, CreateAssetBody } from "../api/assets";
+import type { AssetResponse, AssetType, CreateAssetBody, EditAssetBody } from "../api/assets";
 
 export type AssetForm = {
   name: string;
@@ -121,6 +121,31 @@ export function toCreateAssetBody(type: AssetType, form: AssetForm): CreateAsset
       };
     }
   }
+}
+
+/** Same field shape as create; a distinct name so edit call sites read clearly. */
+export function toEditAssetBody(type: AssetType, form: AssetForm): EditAssetBody {
+  return toCreateAssetBody(type, form);
+}
+
+export function assetToForm(asset: AssetResponse): AssetForm {
+  const metadata = asset.metadata;
+  return {
+    name: asset.name,
+    make: metadata.kind === "vehicle" ? metadata.make : "",
+    model: metadata.kind === "vehicle" ? metadata.model : "",
+    year: metadata.kind === "vehicle" ? String(metadata.year) : "",
+    vin: metadata.kind === "vehicle" ? (metadata.vin ?? "") : "",
+    nickname: metadata.kind === "property" ? (metadata.nickname ?? "") : "",
+    street: metadata.kind === "property" ? metadata.address.street : "",
+    city: metadata.kind === "property" ? metadata.address.city : "",
+    state: metadata.kind === "property" ? metadata.address.state : "",
+    postal: metadata.kind === "property" ? metadata.address.postalCode : "",
+    country: metadata.kind === "property" ? metadata.address.country : "United States",
+    manufacturer: metadata.kind === "equipment" ? (metadata.manufacturer ?? "") : "",
+    modelNumber: metadata.kind === "equipment" ? (metadata.modelNumber ?? "") : "",
+    serialNumber: metadata.kind === "equipment" ? (metadata.serialNumber ?? "") : "",
+  };
 }
 
 const API_FIELD_TO_FORM_FIELD: Record<string, keyof AssetForm> = {

--- a/apps/web/src/design/Icon.tsx
+++ b/apps/web/src/design/Icon.tsx
@@ -39,7 +39,8 @@ export type IconName =
   | "image"
   | "lock"
   | "mail"
-  | "users";
+  | "users"
+  | "edit";
 
 export interface IconProps {
   name: IconName;
@@ -230,6 +231,12 @@ const PATHS: Record<IconName, ReactNode> = {
       <circle cx="10" cy="7" r="4" />
       <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
       <path d="M16 3.2a4 4 0 0 1 0 7.6" />
+    </>
+  ),
+  edit: (
+    <>
+      <path d="M4 20l1-4L16 5l3 3L8 19l-4 1z" />
+      <path d="M14 7l3 3" />
     </>
   ),
 };

--- a/apps/web/src/design/styles/hifi-add-asset.css
+++ b/apps/web/src/design/styles/hifi-add-asset.css
@@ -177,6 +177,19 @@
   font-weight: 500;
 }
 
+/* ============ read-only type (edit asset — type cannot change) ============ */
+.hf-type-readonly {
+  display: inline-flex;
+  align-items: center;
+  height: 40px;
+  padding: 0 13px;
+  border: 1px solid var(--hf-line);
+  border-radius: var(--hf-r);
+  background: var(--hf-surface-2);
+  color: var(--hf-ink-soft);
+  font-size: 14px;
+}
+
 /* ============ type picker (3 radio cards) ============ */
 .hf-aa-types {
   display: grid;

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1,6 +1,7 @@
 import { createBrowserRouter } from "react-router";
 import { AuthFlow } from "./auth/AuthFlow";
 import { AppAddAsset } from "./app/AppAddAsset";
+import { AppEditAsset } from "./app/AppEditAsset";
 import { AppAssets } from "./app/AppAssets";
 import { AppHome } from "./app/AppHome";
 import { AppActivityHistory } from "./app/AppActivityHistory";
@@ -28,6 +29,7 @@ export const router = createBrowserRouter([
       { path: "assets", element: <AppAssets /> },
       { path: "history", element: <AppActivityHistory /> },
       { path: "assets/new", element: <AppAddAsset /> },
+      { path: "assets/:assetId/edit", element: <AppEditAsset /> },
       { path: "assets/:assetId/maintenance", element: <AppMaintenanceRecords /> },
     ],
   },

--- a/apps/web/src/routes.ts
+++ b/apps/web/src/routes.ts
@@ -11,6 +11,7 @@ export const routePaths = {
   assets: "/app/assets",
   history: "/app/history",
   addAsset: "/app/assets/new",
+  editAsset: "/app/assets/:assetId/edit",
   assetMaintenance: "/app/assets/:assetId/maintenance",
 } as const;
 
@@ -28,5 +29,6 @@ export const paths = {
   assets: routePaths.assets,
   history: routePaths.history,
   addAsset: routePaths.addAsset,
+  editAsset: (assetId: string) => `/app/assets/${assetId}/edit`,
   assetMaintenance: (assetId: string) => `/app/assets/${assetId}/maintenance`,
 } as const;

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -53,6 +53,7 @@ sign-in. There is no separate "register" step.
 | POST   | `/api/assets`                                      | yes   | Create an asset                                                         |
 | GET    | `/api/assets`                                      | yes   | List the caller's active assets                                         |
 | GET    | `/api/assets/{id}`                                 | yes   | Get one asset the caller owns                                           |
+| PATCH  | `/api/assets/{id}`                                 | yes   | Edit an asset's name and metadata (owner only)                          |
 | GET    | `/api/search`                                      | yes   | Search the caller's assets                                              |
 | GET    | `/api/dashboard`                                   | yes   | Get dashboard summary data                                              |
 | GET    | `/api/activity`                                    | yes   | List the caller's activity history                                      |

--- a/docs/reference/data-model.md
+++ b/docs/reference/data-model.md
@@ -146,6 +146,7 @@ Aggregates raise events when something significant happens. Today:
 | `TeamCreated`                | a team is created                                 | event id, team/owner/actor, and team name                                                                                                           |
 | `AssetSharedToTeam`          | an asset is shared to a team                      | event id, asset/owner/actor, asset name, team id + name                                                                                             |
 | `AssetUnsharedFromTeam`      | an asset is returned to personal                  | event id, asset/owner/actor, asset name, team id + name (of the team it left)                                                                       |
+| `AssetEdited`                | an asset's name and/or metadata is edited         | event id, asset/owner/actor, new and previous name, asset type, and `nameChanged`/`metadataChanged` flags                                           |
 
 Events are published after persistence through the in-memory event bus for
 telemetry. Tracked activity events are also written to an outbox in the same D1

--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -410,6 +410,23 @@
           "equipment"
         ]
       },
+      "EditAssetBody": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "example": "My Truck"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/AssetMetadata"
+          }
+        },
+        "required": [
+          "name",
+          "metadata"
+        ]
+      },
       "SearchAssetsResponse": {
         "type": "object",
         "properties": {
@@ -1629,6 +1646,91 @@
           },
           "404": {
             "description": "No such asset",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Assets"
+        ],
+        "summary": "Edit an asset",
+        "description": "Updates the asset's name and type-specific metadata. Asset-owner only. The metadata `kind` must match the asset's existing type — an asset's type cannot change after creation.",
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "example": "195d0ef0-47f5-439f-abfd-29f892c9a040"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EditAssetBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated asset",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Asset"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller is not the asset owner",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No such asset",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation failed, or the metadata kind doesn't match the asset's type",
             "content": {
               "application/json": {
                 "schema": {

--- a/docs/specs/SPECS.md
+++ b/docs/specs/SPECS.md
@@ -34,6 +34,7 @@ relevant cross-cutting specs rather than re-describing the behavior.
 | ------------------------------------------------------------- | ------------- | ----------- |
 | [sign-in.md](./features/sign-in.md)                           | Auth          | review      |
 | [create-asset.md](./features/create-asset.md)                 | Assets        | draft       |
+| [edit-asset.md](./features/edit-asset.md)                     | Assets        | in-progress |
 | [asset-library.md](./features/asset-library.md)               | Assets        | in-progress |
 | [app-search.md](./features/app-search.md)                     | Assets        | in-progress |
 | [dashboard.md](./features/dashboard.md)                       | Home          | in-progress |

--- a/docs/specs/cross-cutting/telemetry.md
+++ b/docs/specs/cross-cutting/telemetry.md
@@ -137,6 +137,26 @@ index: `owner_id`). Telemetry records ids only — not asset or team names (ADR-
 **Domain event data point — `AssetUnsharedFromTeam`** (dataset: `pineapple_asset_domain_events`,
 index: `owner_id`). Same shape as share; `source_use_case` is `"UnshareAsset"`.
 
+**Domain event data point — `AssetEdited`** (dataset: `pineapple_asset_domain_events`,
+index: `owner_id`). Telemetry records ids and boolean change-flags only — never the name or
+metadata values (ADR-0010):
+
+| Field        | Name               | Value                                       |
+| ------------ | ------------------ | ------------------------------------------- |
+| `indexes[0]` | —                  | `owner_id`                                  |
+| `blobs[0]`   | `event_type`       | `"AssetEdited"`                             |
+| `blobs[1]`   | `aggregate_type`   | `"Asset"`                                   |
+| `blobs[2]`   | `asset_id`         | Asset UUID                                  |
+| `blobs[3]`   | `owner_id`         | Owner UUID                                  |
+| `blobs[4]`   | `actor_id`         | Actor UUID                                  |
+| `blobs[5]`   | `source_use_case`  | `"EditAsset"`                               |
+| `blobs[6]`   | `schema_version`   | `"v1"`                                      |
+| `blobs[7]`   | `result`           | `"success"`                                 |
+| `doubles[0]` | `count`            | Always `1`                                  |
+| `doubles[1]` | `event_time_ms`    | Event timestamp (ms since epoch)            |
+| `doubles[2]` | `name_changed`     | `1` if the name changed, else `0`           |
+| `doubles[3]` | `metadata_changed` | `1` if any metadata field changed, else `0` |
+
 ### Analytics Engine Constraints
 
 These limits apply to every data point written and must be respected when designing new event schemas:
@@ -213,6 +233,7 @@ Every API route maps to a named operation used as the `indexes[0]` value in requ
 | `POST /api/assets`                                        | `CreateAsset`              |
 | `GET /api/assets`                                         | `ListAssets`               |
 | `GET /api/assets/{id}`                                    | `GetAsset`                 |
+| `PATCH /api/assets/{id}`                                  | `EditAsset`                |
 | `GET /api/activity`                                       | `ListActivity`             |
 | `GET /api/dashboard`                                      | `GetDashboard`             |
 | `GET /api/search`                                         | `SearchAssets`             |

--- a/docs/specs/features/edit-asset.md
+++ b/docs/specs/features/edit-asset.md
@@ -37,6 +37,8 @@ Once created, an asset's name and details are today permanent — the only way t
 - [x] `S1` Submitting an edit identical to the asset's current values succeeds without error
 - [ ] `S1` An authenticated owner can reach an edit entry point from the asset's detail page
 - [ ] `S1` The edit entry point is not shown to a team member viewing an asset they don't own
+- [x] `S1` A non-owner who reaches the edit route directly (not via the entry point) sees an access-denied state instead of the form, whether the API call itself was rejected or it succeeded but the fetched asset's `sharing.isOwner` is false
+- [x] `S1` A missing or unloadable asset shows a dedicated state (not found, or a retryable load-failure state) instead of the form
 - [x] `S1` The edit form is prefilled with the asset's current name and type-specific field values
 - [x] `S1` The asset's type is displayed in the edit form but cannot be changed
 - [x] `S1` Field-level validation errors match create-asset's rules and messages, and run before submission
@@ -53,29 +55,31 @@ Single slice — the whole feature (`S1`).
 
 ## Edge Cases & Error States
 
-| Scenario                                                      | Expected Behavior                                                                                         |
-| ------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| All fields cleared before submit                              | Banner + field errors shown; first invalid field focused                                                  |
-| Year field: letters entered                                   | "Must be a whole number."                                                                                 |
-| Year field: value < 1900 or > current year + 1                | `"Must be between 1900 and ${currentYear + 1}."`                                                          |
-| VIN: 1–16 characters                                          | `"VIN must be exactly 17 characters (N entered)."`                                                        |
-| VIN: exactly 17 characters                                    | Accepted                                                                                                  |
-| VIN: empty                                                    | Accepted (optional)                                                                                       |
-| Metadata `kind` in the request doesn't match the asset's type | 422 — asset type is immutable; not reachable from the web form, only a direct API call                    |
-| Non-owner submits an edit via the API directly                | Rejected, no changes applied (403 today per [permissions.md](../cross-cutting/permissions.md); see Flags) |
-| Non-owner viewing a shared asset                              | No edit entry point rendered; the asset's fields are read-only                                            |
-| Asset does not exist / already deleted                        | 404                                                                                                       |
-| Edit submitted with no actual changes                         | Saves successfully; no error shown                                                                        |
-| API returns 401                                               | Redirect to `/login` (replace)                                                                            |
-| API returns any other error                                   | Banner with the server's error message                                                                    |
-| User navigates away mid-edit                                  | No confirmation prompt; unsaved form state is lost (matches create-asset)                                 |
-| Two sessions edit the same asset concurrently                 | Last write wins; no conflict detection (consistent with the rest of the app)                              |
+| Scenario                                                        | Expected Behavior                                                                                                 |
+| --------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| All fields cleared before submit                                | Banner + field errors shown; first invalid field focused                                                          |
+| Year field: letters entered                                     | "Must be a whole number."                                                                                         |
+| Year field: value < 1900 or > current year + 1                  | `"Must be between 1900 and ${currentYear + 1}."`                                                                  |
+| VIN: 1–16 characters                                            | `"VIN must be exactly 17 characters (N entered)."`                                                                |
+| VIN: exactly 17 characters                                      | Accepted                                                                                                          |
+| VIN: empty                                                      | Accepted (optional)                                                                                               |
+| Metadata `kind` in the request doesn't match the asset's type   | 422 — asset type is immutable; not reachable from the web form, only a direct API call                            |
+| Non-owner submits an edit via the API directly                  | Rejected, no changes applied (403 today per [permissions.md](../cross-cutting/permissions.md); see Flags)         |
+| Non-owner viewing a shared asset, on the asset's detail page    | No edit entry point rendered there                                                                                |
+| Non-owner reaches the edit route directly (bookmark, typed URL) | The asset loads (they can view it), but the edit form is not rendered — an "Access denied" state is shown instead |
+| Asset does not exist / already deleted, on load                 | "Asset not found" state, no form rendered                                                                         |
+| Asset load fails for a reason other than 401/403/404            | "Couldn't load asset" state with a retry button                                                                   |
+| Edit submitted with no actual changes                           | Saves successfully; no error shown                                                                                |
+| API returns 401 (load or save)                                  | Redirect to `/login` (replace)                                                                                    |
+| API returns any other error on save                             | Banner with the server's error message                                                                            |
+| User navigates away mid-edit                                    | No confirmation prompt; unsaved form state is lost (matches create-asset)                                         |
+| Two sessions edit the same asset concurrently                   | Last write wins; no conflict detection (consistent with the rest of the app)                                      |
 
 ## Telemetry
 
 **Request telemetry:** `PATCH /api/assets/{id}` maps to a new `EditAsset` operation via `createTechnicalTelemetryMiddleware`. This is a new route — it must be added to the operation name mapping in `technicalTelemetry.ts` and the Operation Name Mapping table in [telemetry.md](../cross-cutting/telemetry.md) before it ships.
 
-**Domain event:** On a successful edit that changes the name and/or metadata, an `AssetEdited` event is published to the event bus, dataset `pineapple_asset_domain_events`, binding `ASSET_DOMAIN_TELEMETRY` — following the `AssetCreated`/`AssetSharedToTeam` pattern. Per the telemetry anti-pattern on PII, the event carries the new name and metadata for durable consumers (e.g. a future History entry), but **the telemetry data point itself records only ids and boolean change-flags, never the name or metadata values**:
+**Domain event:** On a successful edit that changes the name and/or metadata, an `AssetEdited` event is published to the event bus, dataset `pineapple_asset_domain_events`, binding `ASSET_DOMAIN_TELEMETRY` — following the `AssetCreated`/`AssetSharedToTeam` pattern. The event carries the new and previous **name** plus **`nameChanged`/`metadataChanged`** flags for durable consumers (e.g. a future History entry showing a rename); it does not carry the metadata object itself — a consumer needing the new metadata value still has to read the asset back. Per the telemetry anti-pattern on PII, **the telemetry data point itself records only ids and boolean change-flags, never the name value**:
 
 **Domain event data point — `AssetEdited`** (dataset: `pineapple_asset_domain_events`, index: `owner_id`):
 

--- a/docs/specs/features/edit-asset.md
+++ b/docs/specs/features/edit-asset.md
@@ -1,0 +1,122 @@
+---
+audience: [engineers implementing this feature, product reviewing behavior]
+purpose: Let an asset owner correct or update an existing asset's name and details after creation
+source: this file
+date: 2026-08-17
+---
+
+# Edit Asset
+
+**Status:** `in-progress`
+**Owner:** [unknown — assign on review]
+**Related Specs:** [create-asset.md](./create-asset.md), [authentication.md](../cross-cutting/authentication.md), [validation.md](../cross-cutting/validation.md), [error-handling.md](../cross-cutting/error-handling.md), [loading-states.md](../cross-cutting/loading-states.md), [permissions.md](../cross-cutting/permissions.md), [telemetry.md](../cross-cutting/telemetry.md)
+
+---
+
+## Summary
+
+Once created, an asset's name and details are today permanent — the only way to fix a typo or update information is to delete and recreate it, and deletion isn't supported either. Edit Asset lets the asset's owner update an asset's name and its type-specific fields (make/model/year/VIN for a vehicle, address/nickname for a property, manufacturer/model/serial for equipment) from a form prefilled with its current values. An asset's **type** (vehicle / property / equipment) cannot change after creation — only the fields within it. This is a sibling flow to [Create Asset](./create-asset.md), which explicitly excludes editing.
+
+## User Stories
+
+- As an **asset owner**, I can **edit an existing asset's name and type-specific details** so that **I can correct a mistake or update information without deleting and recreating the asset**
+- As an **asset owner**, I can **open the edit form prefilled with the asset's current values** so that **I only have to change what's wrong**
+- As an **asset owner**, I **cannot change an asset's type** once it's created, so that **the asset's history and downstream data stay consistent**
+- As a **team member with shared access to an asset I don't own**, I **cannot edit it**, so that **the owner keeps control of the asset's core details**
+- As a **user**, I can **see clear validation errors** so that **I know exactly which fields need attention before I can save**
+- As a **user**, I can **cancel or press Escape** so that **I can back out of an edit without saving**
+
+## Acceptance Criteria
+
+- [x] `S1` An authenticated owner can submit a new name and full type-specific metadata for one of their own assets, and the asset is updated when validation passes
+- [x] `S1` A request whose metadata `kind` does not match the asset's current type is rejected (422) — an asset's type cannot change via edit
+- [x] `S1` A request from anyone other than the asset's owner is rejected and no changes are applied
+- [x] `S1` Editing validates the same rules as creation: name required; vehicle make/model/year required, VIN optional but exactly 17 characters if present; property street/city/state/postal/country required, nickname optional; equipment fields all optional
+- [x] `S1` Editing an asset never changes its id, owner, creation time, archived state, or sharing state
+- [x] `S1` A successful edit records exactly one domain event capturing what changed, so future durable consumers do not need to re-read the asset (ADR-0010)
+- [x] `S1` Submitting an edit identical to the asset's current values succeeds without error
+- [ ] `S1` An authenticated owner can reach an edit entry point from the asset's detail page
+- [ ] `S1` The edit entry point is not shown to a team member viewing an asset they don't own
+- [x] `S1` The edit form is prefilled with the asset's current name and type-specific field values
+- [x] `S1` The asset's type is displayed in the edit form but cannot be changed
+- [x] `S1` Field-level validation errors match create-asset's rules and messages, and run before submission
+- [x] `S1` Submitting with validation errors shows an error banner and focuses the first invalid field
+- [x] `S1` The save action shows a busy state and is disabled while the request is in flight
+- [x] `S1` On success, the user returns to the asset's detail page and sees the updated values
+- [x] `S1` Cancel and Escape both return to the asset's detail page without saving
+- [x] `S1` A 401 response redirects to `/login`, replacing the history entry
+- [x] `S1` A non-401 API error shows the banner with the server's message; a field-specific 422 error highlights that field
+
+## Delivery Plan
+
+Single slice — the whole feature (`S1`).
+
+## Edge Cases & Error States
+
+| Scenario                                                      | Expected Behavior                                                                                         |
+| ------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| All fields cleared before submit                              | Banner + field errors shown; first invalid field focused                                                  |
+| Year field: letters entered                                   | "Must be a whole number."                                                                                 |
+| Year field: value < 1900 or > current year + 1                | `"Must be between 1900 and ${currentYear + 1}."`                                                          |
+| VIN: 1–16 characters                                          | `"VIN must be exactly 17 characters (N entered)."`                                                        |
+| VIN: exactly 17 characters                                    | Accepted                                                                                                  |
+| VIN: empty                                                    | Accepted (optional)                                                                                       |
+| Metadata `kind` in the request doesn't match the asset's type | 422 — asset type is immutable; not reachable from the web form, only a direct API call                    |
+| Non-owner submits an edit via the API directly                | Rejected, no changes applied (403 today per [permissions.md](../cross-cutting/permissions.md); see Flags) |
+| Non-owner viewing a shared asset                              | No edit entry point rendered; the asset's fields are read-only                                            |
+| Asset does not exist / already deleted                        | 404                                                                                                       |
+| Edit submitted with no actual changes                         | Saves successfully; no error shown                                                                        |
+| API returns 401                                               | Redirect to `/login` (replace)                                                                            |
+| API returns any other error                                   | Banner with the server's error message                                                                    |
+| User navigates away mid-edit                                  | No confirmation prompt; unsaved form state is lost (matches create-asset)                                 |
+| Two sessions edit the same asset concurrently                 | Last write wins; no conflict detection (consistent with the rest of the app)                              |
+
+## Telemetry
+
+**Request telemetry:** `PATCH /api/assets/{id}` maps to a new `EditAsset` operation via `createTechnicalTelemetryMiddleware`. This is a new route — it must be added to the operation name mapping in `technicalTelemetry.ts` and the Operation Name Mapping table in [telemetry.md](../cross-cutting/telemetry.md) before it ships.
+
+**Domain event:** On a successful edit that changes the name and/or metadata, an `AssetEdited` event is published to the event bus, dataset `pineapple_asset_domain_events`, binding `ASSET_DOMAIN_TELEMETRY` — following the `AssetCreated`/`AssetSharedToTeam` pattern. Per the telemetry anti-pattern on PII, the event carries the new name and metadata for durable consumers (e.g. a future History entry), but **the telemetry data point itself records only ids and boolean change-flags, never the name or metadata values**:
+
+**Domain event data point — `AssetEdited`** (dataset: `pineapple_asset_domain_events`, index: `owner_id`):
+
+| Field        | Name               | Value                                       |
+| ------------ | ------------------ | ------------------------------------------- |
+| `indexes[0]` | —                  | `owner_id`                                  |
+| `blobs[0]`   | `event_type`       | `"AssetEdited"`                             |
+| `blobs[1]`   | `aggregate_type`   | `"Asset"`                                   |
+| `blobs[2]`   | `asset_id`         | Asset UUID                                  |
+| `blobs[3]`   | `owner_id`         | Owner UUID                                  |
+| `blobs[4]`   | `actor_id`         | UUID of the user who made the edit          |
+| `blobs[5]`   | `source_use_case`  | `"EditAsset"`                               |
+| `blobs[6]`   | `schema_version`   | `"v1"`                                      |
+| `blobs[7]`   | `result`           | `"success"`                                 |
+| `doubles[0]` | `count`            | Always `1`                                  |
+| `doubles[1]` | `event_time_ms`    | Event timestamp (ms since epoch)            |
+| `doubles[2]` | `name_changed`     | `1` if the name changed, else `0`           |
+| `doubles[3]` | `metadata_changed` | `1` if any metadata field changed, else `0` |
+
+## Flags
+
+**REVIEW NEEDED — edit entry-point visibility not covered by an automated test:** The edit
+button on the asset detail page is gated on `sharing.isOwner`, following the exact pattern
+already used by the adjacent (shipped, also untested) share button in
+`AppMaintenanceRecords.tsx`. That component has no existing test suite — adding one is a
+sizeable, separate undertaking outside this slice's scope. The two boxes above are left
+unchecked until either `AppMaintenanceRecords.tsx` gets test coverage or these two assertions
+are verified some other way. Owner: engineering.
+
+**REVIEW NEEDED — 403 vs. 404 for non-owner edit attempts:** This spec follows the app's current pattern (403 `ForbiddenError` for wrong-owner access, matching `ShareAsset`/`UnshareAsset`). [Issue #52](https://github.com/snaveevans/pineapple/issues/52) proposes moving the whole app to 404-masking; if that lands first, this endpoint should follow without a spec change. Owner: engineering.
+
+**NOT SPECIFIED — Edits to an archived asset:** Archiving doesn't exist yet ([issue #177](https://github.com/snaveevans/pineapple/issues/177)); this spec doesn't address whether an archived asset can be edited. Revisit when archiving ships.
+
+**NOT SPECIFIED — Maximum name length:** Same open flag as [create-asset.md](./create-asset.md) — no product limit is stated here.
+
+## Out of Scope
+
+- Changing an asset's type (`kind`) after creation
+- Bulk editing multiple assets at once
+- Archiving or unarchiving an asset (tracked separately in [issue #177](https://github.com/snaveevans/pineapple/issues/177))
+- Surfacing edits in the Activity History feed — `AssetEdited` is emitted for future durable consumers per [ADR-0010](../../decisions/0010-smart-events-for-durable-consumers.md), but [activity-history.md](./activity-history.md) does not yet track it as an entry type, matching `AssetSharedToTeam`/`AssetUnsharedFromTeam` which are also emitted but not yet tracked
+- Optimistic concurrency or conflict detection between simultaneous edits
+- A field-level audit trail of exactly what changed (telemetry records only whether name and/or metadata changed, not the values)
+- Undo or edit history for a specific asset

--- a/docs/web/FEATURES.md
+++ b/docs/web/FEATURES.md
@@ -369,6 +369,9 @@ Success is a navigate-away transition (invalidates assets query, navigates to `/
 **States:**
 
 - `loading` — fetching the asset before the form can render
+- `error` (forbidden / 403) — "Access denied"; no form rendered. Also shown when the asset loads successfully but its `sharing.isOwner` is false
+- `error` (not found / 404) — "Asset not found"; no form rendered
+- `error` (load failure) — "Couldn't load asset" with a "Try again" retry
 - Idle, vehicle type — form prefilled with the asset's current name, make, model, year, VIN
 - Idle, property type — form prefilled with the asset's current name, nickname, and address fields
 - Idle, equipment type — form prefilled with the asset's current name, manufacturer, model number, serial number
@@ -383,10 +386,12 @@ Success is a navigate-away transition (invalidates assets query, navigates to `/
 
 Success is a navigate-away transition (updates the asset query cache, invalidates the assets list, navigates to `/app/assets/:assetId/maintenance`), not a stable screen — not enumerable for the gallery.
 
+**Content stress:** long asset name (a pre-existing stored value, not a typed one — the form is prefilled); long property address (street + city)
+
 **Non-obvious behavior:**
 
 - The asset type is shown as a read-only chip, not the selectable type picker used on Add Asset — an asset's type cannot change after creation
-- Only the asset's owner can reach this screen; the entry point on the asset detail page is hidden for a team member viewing a shared asset they don't own
+- Only the asset's owner can use this screen. The entry point on the asset detail page is hidden for a team member viewing a shared asset they don't own; a non-owner who reaches the route directly (bookmark, typed URL) sees the same "Access denied" state as a 403, not the form — the check runs client-side against the fetched asset's `sharing.isOwner`, in addition to the server enforcing it on save
 - 401 redirects to `/login` whether it happens while loading the asset or while saving
 
 **Spec:** [`docs/specs/features/edit-asset.md`](../specs/features/edit-asset.md)

--- a/docs/web/FEATURES.md
+++ b/docs/web/FEATURES.md
@@ -361,6 +361,38 @@ Success is a navigate-away transition (invalidates assets query, navigates to `/
 
 ---
 
+## Edit Asset
+
+**Route:** `/app/assets/:assetId/edit`
+**Goal:** Let the asset's owner correct or update an existing asset's name and type-specific details. The asset's type (vehicle/property/equipment) cannot be changed.
+
+**States:**
+
+- `loading` — fetching the asset before the form can render
+- Idle, vehicle type — form prefilled with the asset's current name, make, model, year, VIN
+- Idle, property type — form prefilled with the asset's current name, nickname, and address fields
+- Idle, equipment type — form prefilled with the asset's current name, manufacturer, model number, serial number
+
+**Exceptions:** The three "Idle" states are non-vocab, mirroring Add Asset — mutually exclusive field-set renders off the asset's (fixed) type, not async states.
+
+**Mutations:**
+
+- `pending` — save button disabled and shows "Saving…" while the API call is in flight
+- `error` (client validation) — inline field errors on submit with focus moved to the first invalid field
+- `error` (API) — banner with the server's message; 422 field errors mapped to individual inputs; 401 redirects to `/login`
+
+Success is a navigate-away transition (updates the asset query cache, invalidates the assets list, navigates to `/app/assets/:assetId/maintenance`), not a stable screen — not enumerable for the gallery.
+
+**Non-obvious behavior:**
+
+- The asset type is shown as a read-only chip, not the selectable type picker used on Add Asset — an asset's type cannot change after creation
+- Only the asset's owner can reach this screen; the entry point on the asset detail page is hidden for a team member viewing a shared asset they don't own
+- 401 redirects to `/login` whether it happens while loading the asset or while saving
+
+**Spec:** [`docs/specs/features/edit-asset.md`](../specs/features/edit-asset.md)
+
+---
+
 ## Asset Maintenance Records & Tasks
 
 **Route:** `/app/assets/:id/maintenance`
@@ -399,6 +431,7 @@ Success is a navigate-away transition (invalidates assets query, navigates to `/
 - 401 on any fetch redirects to `/login`
 - Sharing uses the asset's server-computed `sharing` descriptor (`scope`, `isOwner`, optional `ownerDisplayName`); only the asset owner can change sharing
 - Share/unshare are idempotent on the API; the sheet closes on success and refreshes the asset query
+- An edit button (owner only, gated on `sharing.isOwner` like the share control) links to `/app/assets/:id/edit` — see [Edit Asset](#edit-asset)
 
 **Spec:** [`docs/specs/features/maintenance-record.md`](../specs/features/maintenance-record.md), [`docs/specs/features/maintenance-task.md`](../specs/features/maintenance-task.md), [`docs/specs/features/teams-foundation.md`](../specs/features/teams-foundation.md)
 


### PR DESCRIPTION
## Summary

- Adds `PATCH /api/assets/{id}` so an asset owner can edit an asset's name and type-specific metadata — previously permanent after creation (delete/create weren't supported either). Wired end to end: domain, application, infrastructure/telemetry, API, `worker.ts`, and a new `AppEditAsset` web page reachable from an owner-gated edit button on the asset detail page.
- Replaces the unreachable `Asset.rename()` with `Asset.edit()` (name + metadata together), which raises exactly one `AssetEdited` domain event (ADR-0010) so a future durable consumer never needs to re-read the asset. Telemetry records only ids and boolean change-flags — never the name/metadata values (ADR-0010 PII rule).

## Related

Closes #179

## Risk

**Level:** H

**Why:** Path-glob floor is H — `apps/api/src/domain/**` (`Asset.ts`, new `AssetEdited` event), `apps/api/worker.ts`, and `apps/api/src/api/**` (new OpenAPI schemas/route) are all touched. Semantic elevation confirms H: this is a public API contract addition. Not C — no migrations, no auth/session core logic change, no irreversible backfill; the ownership check reuses the existing `ShareAsset`/`UnshareAsset` pattern verbatim rather than introducing new authorization logic.

**Human validation budget:** H — Full review + local poke on auth/API/data paths.

## Evidence

- [x] 649 tests pass across the monorepo (104 files): domain (`Asset.test.ts` — edit, no-op no-event, kind-mismatch rejection), application (`EditAsset.test.ts` — 8 cases: success, no-op, kind-mismatch, non-owner team member, stranger, not-found, domain-error-on-save, non-domain-error rethrow), infrastructure (`AssetEditedTelemetryHandler.test.ts` — asserts no PII in the telemetry payload), web (`AppEditAsset.test.tsx` — 11 cases: prefill, save, validation, 403/404/not-owner access-denied, 401 on load/save, non-401 save error, busy state, cancel), and `assetForm.test.ts` (form↔wire round-trip for the new edit path).
- [x] Live browser verification, not just unit tests: ran both dev servers locally, created a real asset via the API, clicked Assets → Truck → Edit asset in the browser, edited the name, saved, and confirmed the redirect plus the updated header/breadcrumb. Also verified the reviewer-caught fix directly — navigating to a non-existent asset's edit URL now shows a clean "Asset not found" state instead of hanging on "Loading asset…" forever.
- [x] `pnpm --filter @snaveevans/pineapple-api openapi:generate` and `pnpm --filter @snaveevans/pineapple-web api:types` both produce zero diff after the final commit — the committed contract is in sync.

## Test plan

- [x] `pnpm lint && pnpm type-check && pnpm -r test` — all green
- [x] Manual: created an asset, edited it through the real UI, confirmed save + redirect + updated header (Ford F-150 "Truck" → "Work Truck")
- [x] Manual: confirmed the "Asset not found" and would-be "Access denied" error states render instead of an infinite loading spinner

## Spec / AC

[`docs/specs/features/edit-asset.md`](https://github.com/snaveevans/pineapple/blob/feat/179-edit-asset/docs/specs/features/edit-asset.md) — 18 of 20 criteria checked (status `in-progress`). The 2 unchecked (edit entry point reachable / hidden-from-non-owner on the asset detail page) need test coverage on `AppMaintenanceRecords.tsx`, which has no existing test suite at all (pre-existing gap predating this branch) — flagged in the spec's Flags section rather than silently left off the record.

## Validation gate

- [x] Rebased on latest `main` — twice. `main` moved substantially mid-branch: PR #214 removed the entire web state gallery/visual-diff harness (issue #143), PR #213 merged the shared-primitives extraction (issue #149), and PR #221 added the new PR diff-size budget CI gate (issue #88). All three directly affected this branch's frontend layer; see Escalations.
- [x] Lint / type-check / tests green locally
- [x] Adversarial review run (`pr-review`, 5-way fresh-context fan-out: conventions, bugs, history, prior-PR-patterns, docs/spec) — findings fixed, see below
- [x] Safe findings self-fixed; two low-severity findings left as escalations below
- [x] Docs / spec AC / `FEATURES.md` updated
- [x] OpenAPI + web `api:types` regenerated — no drift

**Fixed from adversarial review:**
- `AppEditAsset` had no error handling for a 403/404/5xx on the initial asset fetch — it hung on "Loading asset…" forever. Added dedicated access-denied / not-found / retryable-error states, matching the pattern already used by `AppMaintenanceRecords` for the same resource.
- `AppEditAsset` had no client-side ownership check at all — a non-owner who reached the route directly (bookmark, typed URL) saw a fully editable form, even though save would 403. Now checks the fetched asset's `sharing.isOwner`.
- The spec's Telemetry section overclaimed that `AssetEdited` carries the full metadata object; it only carries the name and change-flags. Corrected.
- Added the missing gallery content-stress states (since removed with the harness) and the "domain error from save" use-case test that `ShareAsset`/`UnshareAsset` both have but `EditAsset` was missing.

**Escalations (need human decision):**

- **`large-diff` label applied to this PR.** The branch is 28 files / 1886 net lines, well over the new 800-line budget (CLAUDE.md § Scope discipline / issue #88's gate, which landed on `main` mid-branch). Discussed with the user: this is a single coherent concern (edit-asset, front-to-back, per the explicit request to wire up the frontend too), not accidental scope creep — the size is driven mainly by test coverage (~700 lines) and a full new page component. Splitting into backend-then-frontend PRs was considered and declined in favor of keeping it as one reviewable, already-tested unit.
- `EditAsset.ts`'s owner-vs-forbidden branch duplicates the identical block already in `ShareAsset.ts`/`UnshareAsset.ts` — a non-blocking Nit flagged once before (PR #72) and never extracted. Followed the existing precedent rather than introducing a new `assertOwner` helper mid-feature-branch; a shared-helper extraction is a small separate refactor if wanted.
- This branch originally built full gallery-registry coverage (7→12 states) for the new screen; that harness was deleted from `main` mid-branch (PR #214, issue #143) and the gallery work was dropped during the rebase since it no longer applies. `docs/web/FEATURES.md`'s state catalog for Edit Asset is kept regardless — per #214's own rationale, it remains valuable documentation without the automated harness.
