### PR TITLE
feat(lint,web): add stylelint token-discipline gate

### DIFF
--- a/apps/web/src/app/styles/activity-history.css
+++ b/apps/web/src/app/styles/activity-history.css
@@ -1,15 +1,4 @@
 .hh {
-  --hh-maint: oklch(46% 0.1 150);
-  --hh-maint-bg: oklch(95% 0.03 150);
-  --hh-added: oklch(49% 0.11 292);
-  --hh-added-bg: oklch(95% 0.03 292);
-  --hh-scheduled: oklch(49% 0.11 252);
-  --hh-scheduled-bg: oklch(95% 0.03 252);
-  --hh-completed: oklch(50% 0.09 196);
-  --hh-completed-bg: oklch(95% 0.03 196);
-  --hh-deleted: oklch(54% 0.13 28);
-  --hh-deleted-bg: oklch(96% 0.028 28);
-  --hh-spine: oklch(89% 0.006 80);
   --hh-node: 44px;
   --hh-gap: 16px;
 }
@@ -25,12 +14,13 @@
   padding: 0 10px;
   background: var(--hf-surface);
   border: 1px solid var(--hf-line);
-  border-radius: 8px;
+  border-radius: var(--hf-r);
   color: var(--hf-ink-faint);
 }
 
 .hh-search:focus-within {
-  border-color: oklch(80% 0.01 80);
+  border-color: var(--hf-line-strong);
+  /* stylelint-disable-next-line function-disallowed-list -- one-off focus-ring glow, no repeated focus-ring token exists yet */
   box-shadow: 0 0 0 3px oklch(92% 0.01 80);
 }
 
@@ -52,7 +42,7 @@
   height: 32px;
   padding: 0 30px 0 11px;
   border: 1px solid var(--hf-line);
-  border-radius: 8px;
+  border-radius: var(--hf-r);
   background: var(--hf-surface)
     url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='%238a857a' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E")
     no-repeat right 9px center;
@@ -65,7 +55,7 @@
 }
 
 .hh-select:hover {
-  border-color: oklch(85% 0.008 80);
+  border-color: var(--hf-line-strong);
 }
 
 .hh-grid {
@@ -136,7 +126,7 @@
   top: 0;
   bottom: 0;
   width: 1px;
-  background: var(--hh-spine);
+  background: var(--hf-line);
 }
 
 .hh-daygroup:last-child .hh-event:last-child::before {
@@ -159,33 +149,33 @@
 }
 
 .hh-node[data-type="maintenance_logged"] {
-  background: var(--hh-maint-bg);
-  color: var(--hh-maint);
-  border-color: oklch(88% 0.04 150);
+  background: var(--hf-evt-maint-bg);
+  color: var(--hf-evt-maint);
+  border-color: var(--hf-ok-border);
 }
 
 .hh-node[data-type="asset_added"] {
-  background: var(--hh-added-bg);
-  color: var(--hh-added);
-  border-color: oklch(88% 0.04 292);
+  background: var(--hf-evt-added-bg);
+  color: var(--hf-evt-added);
+  border-color: var(--hf-evt-added-border);
 }
 
 .hh-node[data-type="task_scheduled"] {
-  background: var(--hh-scheduled-bg);
-  color: var(--hh-scheduled);
-  border-color: oklch(88% 0.04 252);
+  background: var(--hf-evt-scheduled-bg);
+  color: var(--hf-evt-scheduled);
+  border-color: var(--hf-evt-scheduled-border);
 }
 
 .hh-node[data-type="task_completed"] {
-  background: var(--hh-completed-bg);
-  color: var(--hh-completed);
-  border-color: oklch(88% 0.04 196);
+  background: var(--hf-evt-completed-bg);
+  color: var(--hf-evt-completed);
+  border-color: var(--hf-evt-completed-border);
 }
 
 .hh-node[data-type="task_deleted"] {
-  background: var(--hh-deleted-bg);
-  color: var(--hh-deleted);
-  border-color: oklch(88% 0.05 28);
+  background: var(--hf-bad-bg);
+  color: var(--hf-evt-deleted);
+  border-color: var(--hf-bad-border);
 }
 
 .hh-card {
@@ -201,7 +191,7 @@
 }
 
 .hh-card:hover {
-  border-color: oklch(86% 0.008 80);
+  border-color: var(--hf-line-strong);
   box-shadow: var(--hf-shadow-2);
 }
 
@@ -231,23 +221,23 @@
 }
 
 .hh-verb[data-type="maintenance_logged"] {
-  color: var(--hh-maint);
+  color: var(--hf-evt-maint);
 }
 
 .hh-verb[data-type="asset_added"] {
-  color: var(--hh-added);
+  color: var(--hf-evt-added);
 }
 
 .hh-verb[data-type="task_scheduled"] {
-  color: var(--hh-scheduled);
+  color: var(--hf-evt-scheduled);
 }
 
 .hh-verb[data-type="task_completed"] {
-  color: var(--hh-completed);
+  color: var(--hf-evt-completed);
 }
 
 .hh-verb[data-type="task_deleted"] {
-  color: var(--hh-deleted);
+  color: var(--hf-evt-deleted);
 }
 
 .hh-title {
@@ -306,14 +296,14 @@
   padding: 5px 10px 5px 5px;
   background: var(--hf-surface-2);
   border: 1px solid var(--hf-line-soft);
-  border-radius: 999px;
+  border-radius: var(--hf-r-full);
   font-size: 12px;
   color: var(--hf-ink-soft);
   text-decoration: none;
 }
 
 a.hh-asset-chip:hover {
-  border-color: oklch(85% 0.008 80);
+  border-color: var(--hf-line-strong);
   color: var(--hf-ink);
 }
 
@@ -351,7 +341,7 @@ a.hh-asset-chip:hover {
   padding: 4px 9px;
   background: var(--hf-surface-2);
   border: 1px solid var(--hf-line-soft);
-  border-radius: 7px;
+  border-radius: var(--hf-r-sm);
   font-size: 12px;
   color: var(--hf-ink-soft);
   white-space: nowrap;
@@ -385,7 +375,7 @@ a.hh-asset-chip:hover {
   padding: 0 16px;
   background: var(--hf-surface);
   border: 1px solid var(--hf-line);
-  border-radius: 999px;
+  border-radius: var(--hf-r-full);
   font: inherit;
   font-size: 12.5px;
   font-weight: 600;
@@ -397,7 +387,7 @@ a.hh-asset-chip:hover {
 }
 
 .hh-loadmore-btn:hover:not(:disabled) {
-  border-color: oklch(82% 0.01 80);
+  border-color: var(--hf-line-strong);
   color: var(--hf-ink);
 }
 
@@ -472,6 +462,7 @@ a.hh-asset-chip:hover {
 .hh-bd-swatch {
   width: 9px;
   height: 9px;
+  /* stylelint-disable-next-line declaration-property-value-disallowed-list -- keep as a rounded square, not --hf-r-sm's circle: on a 9px box, CSS caps radius at half the side (4.5px), so 6px renders as a full circle */
   border-radius: 3px;
   flex-shrink: 0;
 }
@@ -486,14 +477,14 @@ a.hh-asset-chip:hover {
 .hh-bd-track {
   grid-column: 1 / -1;
   height: 5px;
-  border-radius: 3px;
+  border-radius: var(--hf-r-sm);
   background: var(--hf-surface-2);
   overflow: hidden;
 }
 
 .hh-bd-fill {
   height: 100%;
-  border-radius: 3px;
+  border-radius: var(--hf-r-sm);
 }
 
 .hh-active-asset {

--- a/apps/web/src/app/styles/app-search.css
+++ b/apps/web/src/app/styles/app-search.css
@@ -61,13 +61,13 @@
 
 .hfs-result.sel {
   background: var(--hf-brand-bg);
-  box-shadow: inset 0 0 0 1px oklch(82% 0.05 150);
+  box-shadow: inset 0 0 0 1px var(--hf-ok-border);
 }
 
 .hfs-result-icon {
   width: 38px;
   height: 38px;
-  border-radius: 9px;
+  border-radius: var(--hf-r);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -81,12 +81,12 @@
 
 .hfs-result-icon[data-type="equipment"] {
   background: var(--hf-tint-equip);
-  color: oklch(42% 0.1 60);
+  color: var(--hf-cat-equipment-fg);
 }
 
 .hfs-result-icon[data-type="property"] {
   background: var(--hf-tint-prop);
-  color: oklch(40% 0.1 295);
+  color: var(--hf-cat-property-fg);
 }
 
 .hfs-result-main {
@@ -128,7 +128,7 @@
   letter-spacing: 0.06em;
   color: var(--hf-ink-soft);
   padding: 3px 8px;
-  border-radius: 999px;
+  border-radius: var(--hf-r-full);
   border: 1px solid var(--hf-line);
   background: var(--hf-surface);
   flex-shrink: 0;
@@ -146,9 +146,10 @@
 }
 
 .hfs-mark {
+  /* stylelint-disable-next-line function-disallowed-list -- one-off search-match highlight yellow, not part of the status/tint scale */
   background: oklch(88% 0.13 95);
   color: inherit;
-  border-radius: 3px;
+  border-radius: var(--hf-r-sm);
   padding: 0 1px;
   font-weight: 700;
 }
@@ -168,7 +169,7 @@
 .hfs-skel-icon {
   width: 38px;
   height: 38px;
-  border-radius: 9px;
+  border-radius: var(--hf-r);
 }
 
 .hfs-skel-lines {
@@ -179,7 +180,7 @@
 
 .hfs-skel-bar {
   height: 9px;
-  border-radius: 5px;
+  border-radius: var(--hf-r-sm);
 }
 
 .hfs-skel-bar.w1 {
@@ -191,12 +192,14 @@
 }
 
 .hfs-shimmer {
+  /* stylelint-disable function-disallowed-list -- one-off shimmer highlight stop, brighter than --hf-line-soft by design */
   background: linear-gradient(
     100deg,
     var(--hf-line-soft) 30%,
     oklch(97% 0.004 80) 50%,
     var(--hf-line-soft) 70%
   );
+  /* stylelint-enable function-disallowed-list */
   background-size: 200% 100%;
   animation: hfs-shimmer 1.1s ease-in-out infinite;
 }
@@ -223,7 +226,7 @@
 .hfs-state-icon {
   width: 46px;
   height: 46px;
-  border-radius: 12px;
+  border-radius: var(--hf-r);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -272,7 +275,7 @@
   position: fixed;
   inset: 0;
   z-index: 1000;
-  background: oklch(22% 0.015 70 / 0.42);
+  background: var(--hf-scrim);
   backdrop-filter: blur(3px);
   -webkit-backdrop-filter: blur(3px);
   display: flex;
@@ -295,10 +298,12 @@
   width: min(640px, calc(100% - 48px));
   background: var(--hf-surface);
   border: 1px solid var(--hf-line);
-  border-radius: 16px;
+  border-radius: var(--hf-r-lg);
+  /* stylelint-disable function-disallowed-list -- one-off 2-layer overlay-panel shadow, distinct from the single-layer --hf-shadow-modal */
   box-shadow:
     0 24px 60px rgba(20, 18, 14, 0.28),
     0 2px 8px rgba(20, 18, 14, 0.1);
+  /* stylelint-enable function-disallowed-list */
   overflow: hidden;
   display: flex;
   flex-direction: column;
@@ -364,7 +369,7 @@
   font-size: 10px;
   color: var(--hf-ink-faint);
   border: 1px solid var(--hf-line);
-  border-radius: 5px;
+  border-radius: var(--hf-r-sm);
   padding: 3px 7px;
   background: var(--hf-surface-2);
   flex-shrink: 0;
@@ -429,7 +434,7 @@
   justify-content: center;
   background: var(--hf-surface);
   border: 1px solid var(--hf-line);
-  border-radius: 5px;
+  border-radius: var(--hf-r-sm);
   color: var(--hf-ink-soft);
 }
 
@@ -483,7 +488,7 @@
   padding: 0 12px;
   background: var(--hf-surface-2);
   border: 1px solid var(--hf-line);
-  border-radius: 11px;
+  border-radius: var(--hf-r);
 }
 
 .hfs-sheet-field:focus-within {
@@ -531,7 +536,7 @@
 .hfs-sheet .hfs-result-icon {
   width: 44px;
   height: 44px;
-  border-radius: 11px;
+  border-radius: var(--hf-r);
 }
 
 .hfs-sheet .hfs-result-name {

--- a/apps/web/src/app/styles/notifications.css
+++ b/apps/web/src/app/styles/notifications.css
@@ -35,7 +35,7 @@
   color: var(--hf-brand-2);
   background: var(--hf-brand-bg);
   padding: 2px 8px;
-  border-radius: 999px;
+  border-radius: var(--hf-r-full);
   white-space: nowrap;
 }
 
@@ -163,7 +163,7 @@
 
 .nt-skel-line {
   height: 9px;
-  border-radius: 4px;
+  border-radius: var(--hf-r-sm);
   background: var(--hf-surface-2);
 }
 

--- a/apps/web/src/app/styles/profile-edit.css
+++ b/apps/web/src/app/styles/profile-edit.css
@@ -98,7 +98,7 @@
   align-items: center;
   gap: 5px;
   padding: 3px 9px 3px 7px;
-  border-radius: 999px;
+  border-radius: var(--hf-r-full);
   font-size: 11px;
   font-weight: 600;
   letter-spacing: 0;
@@ -110,10 +110,12 @@
   color: var(--hf-ok);
 }
 
+/* stylelint-disable function-disallowed-list -- one-off "unverified" amber tint, close to but distinct from --hf-warn-bg (different hue/chroma) */
 .pe-verify-badge.is-unverified {
   background: oklch(95% 0.035 75);
   color: oklch(52% 0.14 70);
 }
+/* stylelint-enable function-disallowed-list */
 
 .pe-email-row {
   display: flex;

--- a/apps/web/src/app/styles/team.css
+++ b/apps/web/src/app/styles/team.css
@@ -23,7 +23,7 @@
 .tm-team-mark {
   width: 46px;
   height: 46px;
-  border-radius: 12px;
+  border-radius: var(--hf-r);
   background: var(--hf-brand-bg);
   color: var(--hf-brand-2);
   display: flex;
@@ -99,12 +99,12 @@
   display: inline-flex;
   align-items: center;
   padding: 4px 10px;
-  border-radius: 999px;
+  border-radius: var(--hf-r-full);
   font-size: 11px;
   font-weight: 600;
   background: var(--hf-ok-bg);
   color: var(--hf-ok);
-  border: 1px solid oklch(88% 0.04 150);
+  border: 1px solid var(--hf-ok-border);
   flex-shrink: 0;
 }
 
@@ -145,7 +145,7 @@
   color: var(--hf-ink-faint);
   background: var(--hf-surface);
   border: 1px solid var(--hf-line);
-  border-radius: 999px;
+  border-radius: var(--hf-r-full);
   padding: 3px 8px;
   flex-shrink: 0;
 }
@@ -171,13 +171,13 @@
 
 .hf-aa-banner.is-error {
   background: var(--hf-bad-bg);
-  border-color: oklch(88% 0.04 28);
+  border-color: var(--hf-bad-border);
   border-left: 3px solid var(--hf-bad);
 }
 
 .hf-aa-banner.is-error .hf-aa-banner-icon {
   color: var(--hf-bad);
-  border: 1px solid oklch(88% 0.04 28);
+  border: 1px solid var(--hf-bad-border);
 }
 
 .hf-aa-banner.is-error .hf-aa-banner-title {

--- a/apps/web/src/auth/styles/auth.css
+++ b/apps/web/src/auth/styles/auth.css
@@ -47,7 +47,7 @@
   background: repeating-linear-gradient(
     135deg,
     transparent 0 22px,
-    rgba(20, 18, 14, 0.012) 22px 23px
+    var(--hf-texture-line-subtle) 22px 23px
   );
 }
 .au-brand-logo {
@@ -62,7 +62,7 @@
 .au-brand-mark {
   width: 30px;
   height: 30px;
-  border-radius: 8px;
+  border-radius: var(--hf-r);
   background: var(--hf-ink);
   display: flex;
   align-items: center;
@@ -117,7 +117,7 @@
   flex-shrink: 0;
   margin-top: 1px;
   background: var(--hf-brand);
-  color: #fff;
+  color: var(--hf-on-brand);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -196,7 +196,7 @@
 .au-google {
   width: 100%;
   height: 50px;
-  border-radius: 11px;
+  border-radius: var(--hf-r);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -217,7 +217,7 @@
 }
 .au-google:hover {
   background: var(--hf-surface-2);
-  border-color: oklch(82% 0.012 80);
+  border-color: var(--hf-line-strong);
   box-shadow: var(--hf-shadow-2);
 }
 .au-google:active {
@@ -315,7 +315,7 @@
 .au-redirect-badge {
   width: 72px;
   height: 72px;
-  border-radius: 20px;
+  border-radius: var(--hf-r-xl);
   background: var(--hf-surface);
   border: 1px solid var(--hf-line);
   box-shadow: var(--hf-shadow-2);
@@ -328,7 +328,7 @@
 .au-spinner {
   position: absolute;
   inset: -9px;
-  border-radius: 24px;
+  border-radius: var(--hf-r-xl);
   border: 2.5px solid var(--hf-brand-bg);
   border-top-color: var(--hf-brand);
   animation: au-spin 0.8s linear infinite;
@@ -375,9 +375,9 @@
 .au-fail-badge {
   width: 72px;
   height: 72px;
-  border-radius: 20px;
+  border-radius: var(--hf-r-xl);
   background: var(--hf-bad-bg);
-  border: 1px solid oklch(88% 0.045 28);
+  border: 1px solid var(--hf-bad-border);
   color: var(--hf-bad);
   display: flex;
   align-items: center;
@@ -414,14 +414,14 @@
 .au-btn-primary {
   width: 100%;
   height: 50px;
-  border-radius: 11px;
+  border-radius: var(--hf-r);
   display: flex;
   align-items: center;
   justify-content: center;
   gap: 9px;
   background: var(--hf-brand);
   border: 1px solid var(--hf-brand-2);
-  color: #fff;
+  color: var(--hf-on-brand);
   font-family: inherit;
   font-size: 15.5px;
   font-weight: 600;
@@ -478,7 +478,7 @@
   right: 30px;
   transform: rotate(3deg);
   padding: 9px 13px;
-  border-radius: 999px;
+  border-radius: var(--hf-r-full);
   display: flex;
   align-items: center;
   gap: 8px;

--- a/apps/web/src/design/styles/hifi-add-asset.css
+++ b/apps/web/src/design/styles/hifi-add-asset.css
@@ -44,7 +44,7 @@
   padding: 2px 6px;
   background: var(--hf-surface-2);
   border: 1px solid var(--hf-line);
-  border-radius: 4px;
+  border-radius: var(--hf-r-sm);
   color: var(--hf-ink-faint);
 }
 
@@ -122,18 +122,18 @@
 }
 .hf-aa-banner.is-error {
   background: var(--hf-bad-bg);
-  border-color: oklch(85% 0.05 28);
+  border-color: var(--hf-bad-border);
   border-left: 3px solid var(--hf-bad);
 }
 .hf-aa-banner.is-ok {
   background: var(--hf-ok-bg);
-  border-color: oklch(88% 0.04 150);
+  border-color: var(--hf-ok-border);
   border-left: 3px solid var(--hf-ok);
 }
 .hf-aa-banner-icon {
   width: 26px;
   height: 26px;
-  border-radius: 7px;
+  border-radius: var(--hf-r-sm);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -142,11 +142,11 @@
 }
 .hf-aa-banner.is-error .hf-aa-banner-icon {
   color: var(--hf-bad);
-  border: 1px solid oklch(85% 0.05 28);
+  border: 1px solid var(--hf-bad-border);
 }
 .hf-aa-banner.is-ok .hf-aa-banner-icon {
   color: var(--hf-ok);
-  border: 1px solid oklch(88% 0.04 150);
+  border: 1px solid var(--hf-ok-border);
 }
 .hf-aa-banner-text {
   min-width: 0;
@@ -200,7 +200,7 @@
     background 100ms;
 }
 .hf-type-card:hover {
-  border-color: oklch(82% 0.012 80);
+  border-color: var(--hf-line-strong);
   box-shadow: var(--hf-shadow-1);
 }
 .hf-type-card.selected {
@@ -233,7 +233,7 @@
 .hf-type-icon {
   width: 34px;
   height: 34px;
-  border-radius: 8px;
+  border-radius: var(--hf-r);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -281,7 +281,7 @@
   gap: 6px;
   padding: 7px 12px;
   border: 1px solid var(--hf-line);
-  border-radius: 999px;
+  border-radius: var(--hf-r-full);
   background: var(--hf-surface);
   color: var(--hf-ink-soft);
   font-size: 12.5px;
@@ -293,7 +293,7 @@
     color 100ms;
 }
 .hf-subchip:hover {
-  border-color: oklch(82% 0.012 80);
+  border-color: var(--hf-line-strong);
   color: var(--hf-ink);
 }
 .hf-subchip.selected {
@@ -336,7 +336,7 @@
   border: 1.5px dashed var(--hf-ink-faint);
   border-radius: var(--hf-r);
   background:
-    repeating-linear-gradient(135deg, transparent 0 16px, rgba(20, 18, 14, 0.02) 16px 17px),
+    repeating-linear-gradient(135deg, transparent 0 16px, var(--hf-texture-line) 16px 17px),
     var(--hf-surface-2);
   display: flex;
   flex-direction: column;
@@ -391,9 +391,9 @@
 .hf-aa-next-icon {
   width: 34px;
   height: 34px;
-  border-radius: 8px;
+  border-radius: var(--hf-r);
   background: var(--hf-surface);
-  border: 1px solid oklch(88% 0.04 150);
+  border: 1px solid var(--hf-ok-border);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -470,7 +470,7 @@
 .hf-sheet-dim {
   position: absolute;
   inset: 0;
-  background: rgba(20, 18, 14, 0.28);
+  background: var(--hf-scrim);
 }
 
 .hf-sheet {
@@ -480,9 +480,9 @@
   bottom: 0;
   height: 93%;
   background: var(--hf-surface);
-  border-top-left-radius: 20px;
-  border-top-right-radius: 20px;
-  box-shadow: 0 -8px 30px rgba(20, 18, 14, 0.18);
+  border-top-left-radius: var(--hf-r-xl);
+  border-top-right-radius: var(--hf-r-xl);
+  box-shadow: var(--hf-shadow-sheet);
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -495,7 +495,7 @@
 .hf-sheet-grab span {
   width: 38px;
   height: 4px;
-  border-radius: 2px;
+  border-radius: var(--hf-r-full);
   background: var(--hf-line);
 }
 .hf-sheet-head {

--- a/apps/web/src/design/styles/hifi-add-service.css
+++ b/apps/web/src/design/styles/hifi-add-service.css
@@ -1,14 +1,14 @@
 /* FieldOps — "Add a service" modal (dashboard). */
 
 .hf-svc-overlay { position: fixed; inset: 0; z-index: 60; overflow: hidden; }
-.hf-svc-scrim { position: absolute; inset: 0; background: rgba(20, 18, 14, 0.34); animation: hf-svc-fade 240ms ease-out; }
+.hf-svc-scrim { position: absolute; inset: 0; background: var(--hf-scrim); animation: hf-svc-fade 240ms ease-out; }
 @keyframes hf-svc-fade { from { opacity: 0; } }
 
 .hf-svc-drawer {
   position: absolute; top: 0; right: 0; bottom: 0;
   width: min(440px, 100%);
   background: var(--hf-bg);
-  box-shadow: -12px 0 50px rgba(20, 18, 14, 0.2);
+  box-shadow: var(--hf-shadow-drawer);
   display: flex; flex-direction: column;
   will-change: transform;
   animation: hf-svc-slide-r 360ms cubic-bezier(0.32, 0.72, 0, 1);
@@ -65,10 +65,10 @@
   transition: border-color 100ms, box-shadow 100ms;
 }
 .hf-svc-body .hf-input::placeholder { color: var(--hf-ink-faint); }
-.hf-svc-body .hf-input:hover { border-color: oklch(85% 0.008 80); }
+.hf-svc-body .hf-input:hover { border-color: var(--hf-line-strong); }
 .hf-svc-body .hf-input:focus { outline: none; border-color: var(--hf-brand); box-shadow: 0 0 0 3px var(--hf-brand-bg); }
 .hf-svc-body .hf-input.is-invalid { border-color: var(--hf-bad); background: var(--hf-bad-bg); }
-.hf-svc-body .hf-input.is-invalid:focus { box-shadow: 0 0 0 3px oklch(52% 0.18 28 / 0.16); }
+.hf-svc-body .hf-input.is-invalid:focus { box-shadow: 0 0 0 3px var(--hf-bad-a16); }
 .hf-svc-body .hf-mono-input { font-family: var(--hf-mono); font-size: 13px; }
 .hf-svc-field-err {
   display: flex; align-items: center; gap: 5px;
@@ -85,7 +85,7 @@
   cursor: pointer; text-align: left;
   transition: border-color 100ms, background 100ms;
 }
-.hf-svc-asset:hover:not(:disabled) { border-color: oklch(85% 0.008 80); background: var(--hf-surface-2); }
+.hf-svc-asset:hover:not(:disabled) { border-color: var(--hf-line-strong); background: var(--hf-surface-2); }
 .hf-svc-asset:disabled { opacity: 0.6; cursor: not-allowed; }
 .hf-svc-picker-row:disabled { opacity: 0.6; cursor: not-allowed; }
 .hf-svc-asset-text { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 2px; }
@@ -133,7 +133,7 @@
 .hf-seg-btn {
   flex: 1; height: 32px;
   border: none; background: transparent; cursor: pointer;
-  border-radius: 7px;
+  border-radius: var(--hf-r-sm);
   font-family: var(--hf-sans); font-size: 12.5px; font-weight: 500;
   color: var(--hf-ink-soft);
   transition: background 100ms, color 100ms;
@@ -148,7 +148,7 @@
   display: flex; align-items: center; gap: 10px;
   padding: 11px 13px;
   background: var(--hf-brand-bg);
-  border: 1px solid oklch(88% 0.04 150);
+  border: 1px solid var(--hf-ok-border);
   border-radius: var(--hf-r);
   color: var(--hf-brand-2);
 }
@@ -157,7 +157,7 @@
 
 .hf-svc-spinner {
   width: 14px; height: 14px; border-radius: 50%;
-  border: 2px solid oklch(100% 0 0 / 0.4); border-top-color: white;
+  border: 2px solid var(--hf-spinner-track); border-top-color: var(--hf-on-brand);
   animation: hf-svc-spin 600ms linear infinite;
 }
 @keyframes hf-svc-spin { to { transform: rotate(360deg); } }
@@ -179,7 +179,7 @@
   padding: 10px 12px;
   border-radius: var(--hf-r);
   background: var(--hf-bad-bg);
-  border: 1px solid oklch(88% 0.06 28);
+  border: 1px solid var(--hf-bad-border);
   color: var(--hf-bad);
   font-size: 12.5px;
 }

--- a/apps/web/src/design/styles/hifi-assets.css
+++ b/apps/web/src/design/styles/hifi-assets.css
@@ -35,7 +35,7 @@
   padding: 3px;
   background: var(--hf-surface);
   border: 1px solid var(--hf-line);
-  border-radius: 8px;
+  border-radius: var(--hf-r);
   gap: 2px;
 }
 .hf-view-btn {
@@ -100,7 +100,7 @@
   box-shadow: var(--hf-shadow-1);
 }
 .hf-asset-card:hover {
-  border-color: oklch(80% 0.012 80);
+  border-color: var(--hf-line-strong);
   box-shadow: var(--hf-shadow-2);
   transform: translateY(-1px);
 }
@@ -119,7 +119,7 @@
 
 /* overdue accent: left edge stripe + tinted thumb fade */
 .hf-asset-card[data-status="overdue"] {
-  border-color: oklch(85% 0.05 28);
+  border-color: var(--hf-bad-border);
 }
 .hf-asset-card[data-status="overdue"]::before {
   /* the stripe is rendered inside the thumb instead — keep card border subtle */
@@ -133,6 +133,7 @@
   align-items: center;
   justify-content: center;
   /* warm pattern background so empty-photo state feels intentional */
+  /* stylelint-disable-next-line function-disallowed-list -- one-off texture tint, rgb black rather than the warm --hf-texture-line tone, used nowhere else */
   background: repeating-linear-gradient(135deg, transparent 0 18px, rgba(0, 0, 0, 0.012) 18px 19px);
 }
 .hf-asset-thumb[data-cat="vehicle"] {
@@ -170,9 +171,10 @@
   top: 10px;
   left: 10px;
   padding: 3px 8px;
+  /* stylelint-disable-next-line function-disallowed-list -- one-off near-opaque scrim behind a badge sitting on a photo thumbnail, not a --hf-surface card */
   background: rgba(255, 255, 255, 0.85);
   border: 1px solid var(--hf-line);
-  border-radius: 999px;
+  border-radius: var(--hf-r-full);
   font-family: var(--hf-mono);
   font-size: 10px;
   text-transform: uppercase;
@@ -266,7 +268,7 @@
 /* ============ Add-asset ghost card ============ */
 .hf-add-card {
   background:
-    repeating-linear-gradient(135deg, transparent 0 16px, rgba(20, 18, 14, 0.025) 16px 17px),
+    repeating-linear-gradient(135deg, transparent 0 16px, var(--hf-texture-line) 16px 17px),
     var(--hf-surface);
   border-style: dashed;
   box-shadow: none;
@@ -279,7 +281,7 @@
 }
 .hf-add-card:hover .hf-add-card-plus {
   background: var(--hf-brand);
-  color: white;
+  color: var(--hf-on-brand);
   border-color: var(--hf-brand);
 }
 .hf-add-card-inner {
@@ -333,7 +335,7 @@
     box-shadow 120ms;
 }
 .hf-asset-row:hover {
-  border-color: oklch(80% 0.012 80);
+  border-color: var(--hf-line-strong);
 }
 .hf-asset-row-static {
   cursor: default;
@@ -342,12 +344,12 @@
   border-color: var(--hf-line);
 }
 .hf-asset-row[data-status="overdue"] {
-  border-color: oklch(85% 0.05 28);
+  border-color: var(--hf-bad-border);
 }
 .hf-asset-row .hf-asset-thumb {
   width: 84px;
   height: 84px;
-  border-radius: 8px;
+  border-radius: var(--hf-r);
   flex-shrink: 0;
 }
 .hf-asset-row .hf-asset-cat-badge {

--- a/apps/web/src/design/styles/hifi.css
+++ b/apps/web/src/design/styles/hifi.css
@@ -55,7 +55,7 @@
 .hf-logo-mark {
   width: 26px;
   height: 26px;
-  border-radius: 7px;
+  border-radius: var(--hf-r-sm);
   background: var(--hf-ink);
   display: flex;
   align-items: center;
@@ -78,7 +78,7 @@
   align-items: center;
   gap: 7px;
   padding: 7px 11px;
-  border-radius: 7px;
+  border-radius: var(--hf-r-sm);
   color: var(--hf-ink-soft);
   font-size: 13.5px;
   font-weight: 500;
@@ -105,7 +105,7 @@
 .hf-icon-btn {
   width: 32px;
   height: 32px;
-  border-radius: 7px;
+  border-radius: var(--hf-r-sm);
   border: 1px solid transparent;
   background: transparent;
   color: var(--hf-ink-soft);
@@ -126,8 +126,8 @@
   height: 14px;
   padding: 0 3px;
   background: var(--hf-bad);
-  color: white;
-  border-radius: 7px;
+  color: var(--hf-on-brand);
+  border-radius: var(--hf-r-sm);
   font-size: 9px;
   font-weight: 700;
   line-height: 14px;
@@ -224,21 +224,21 @@
 }
 .hf-stat-bad {
   background: var(--hf-bad-bg);
-  border-color: oklch(85% 0.04 28);
+  border-color: var(--hf-bad-border);
 }
 .hf-stat-bad .hf-stat-val {
   color: var(--hf-bad);
 }
 .hf-stat-warn {
   background: var(--hf-warn-bg);
-  border-color: oklch(88% 0.045 75);
+  border-color: var(--hf-warn-border);
 }
 .hf-stat-warn .hf-stat-val {
-  color: oklch(48% 0.13 75);
+  color: var(--hf-warn-ink);
 }
 .hf-stat-ok {
   background: var(--hf-ok-bg);
-  border-color: oklch(88% 0.04 150);
+  border-color: var(--hf-ok-border);
 }
 .hf-stat-ok .hf-stat-val {
   color: var(--hf-ok);
@@ -263,7 +263,7 @@
   gap: 6px;
   padding: 6px 11px;
   border: 1px solid var(--hf-line);
-  border-radius: 999px;
+  border-radius: var(--hf-r-full);
   background: var(--hf-surface);
   color: var(--hf-ink-soft);
   font-size: 12.5px;
@@ -271,7 +271,7 @@
 }
 .hf-chip:hover {
   color: var(--hf-ink);
-  border-color: oklch(85% 0.008 80);
+  border-color: var(--hf-line-strong);
 }
 .hf-chip.active {
   background: var(--hf-ink);
@@ -279,6 +279,7 @@
   border-color: var(--hf-ink);
 }
 .hf-chip.active .hf-chip-count {
+  /* stylelint-disable-next-line function-disallowed-list -- one-off muted count text readable against the dark .hf-chip.active background */
   color: oklch(75% 0.008 80);
 }
 .hf-chip-count {
@@ -305,10 +306,12 @@
   position: sticky;
   top: 0;
 }
+/* stylelint-disable function-disallowed-list -- one-off overdue-card tint/gradient, not part of the --hf-bad-* status scale (bg is too saturated for a full-card wash) */
 .hf-detail-card[data-status="overdue"] {
   border-color: oklch(82% 0.06 28);
   background: linear-gradient(to bottom, oklch(98% 0.015 28) 0%, var(--hf-surface) 60%);
 }
+/* stylelint-enable function-disallowed-list */
 
 .hf-detail-body {
   display: flex;
@@ -506,7 +509,7 @@
   overflow: hidden;
 }
 .hf-row:hover {
-  border-color: oklch(85% 0.008 80);
+  border-color: var(--hf-line-strong);
 }
 .hf-row.selected {
   border-color: var(--hf-ink);
@@ -559,7 +562,7 @@
   gap: 4px;
   max-width: 100%;
   padding: 2px 8px 2px 6px;
-  border-radius: 999px;
+  border-radius: var(--hf-r-full);
   border: 1px solid transparent;
   font-size: 11px;
   font-weight: 600;
@@ -577,7 +580,7 @@
 .hf-share-badge.is-owner {
   background: var(--hf-brand-bg);
   color: var(--hf-brand-2);
-  border-color: oklch(88% 0.04 150);
+  border-color: var(--hf-ok-border);
 }
 .hf-share-badge.is-member {
   background: var(--hf-surface-2);
@@ -625,7 +628,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: 8px;
+  border-radius: var(--hf-r);
   color: var(--hf-ink);
   flex-shrink: 0;
 }
@@ -636,7 +639,7 @@
   align-items: center;
   gap: 5px;
   padding: 4px 9px;
-  border-radius: 999px;
+  border-radius: var(--hf-r-full);
   font-size: 11.5px;
   font-weight: 500;
   border: 1px solid transparent;
@@ -646,17 +649,17 @@
 .hf-pill-bad {
   background: var(--hf-bad-bg);
   color: var(--hf-bad);
-  border-color: oklch(88% 0.045 28);
+  border-color: var(--hf-bad-border);
 }
 .hf-pill-warn {
   background: var(--hf-warn-bg);
-  color: oklch(45% 0.13 75);
-  border-color: oklch(88% 0.06 75);
+  color: var(--hf-warn-ink);
+  border-color: var(--hf-warn-border);
 }
 .hf-pill-ok {
   background: var(--hf-ok-bg);
   color: var(--hf-ok);
-  border-color: oklch(88% 0.045 150);
+  border-color: var(--hf-ok-border);
 }
 
 /* ============ BOTTOM NAV (mobile only) ============ */

--- a/apps/web/src/design/styles/mr.css
+++ b/apps/web/src/design/styles/mr.css
@@ -3,11 +3,6 @@
    Breakpoints use the same container contract: @container hfapp.
    Phones <=600 · tablet 601–1000 · desktop >1000. */
 
-/* ============ brand accent (Tweaks) ============ */
-.mr-root.brand-green { --hf-brand: oklch(45% 0.10 150); --hf-brand-2: oklch(38% 0.10 150); --hf-brand-bg: oklch(95% 0.025 150); }
-.mr-root.brand-blue  { --hf-brand: oklch(52% 0.13 245); --hf-brand-2: oklch(44% 0.13 245); --hf-brand-bg: oklch(95% 0.03 245); }
-.mr-root.brand-slate { --hf-brand: oklch(42% 0.03 260); --hf-brand-2: oklch(34% 0.03 260); --hf-brand-bg: oklch(95% 0.012 260); }
-
 .mr-root { position: relative; }
 .mr-scroll { overflow-y: auto; overflow-x: hidden; }
 .mr-scroll::-webkit-scrollbar { width: 10px; }
@@ -81,7 +76,7 @@
 /* ============ sharing (hero badge + action + sheet) ============ */
 .mr-share-badge {
   margin-top: 8px; display: inline-flex; align-items: center; gap: 5px;
-  padding: 3px 9px 3px 7px; border-radius: 999px; border: 1px solid transparent;
+  padding: 3px 9px 3px 7px; border-radius: var(--hf-r-full); border: 1px solid transparent;
   font-size: 11px; font-weight: 600; letter-spacing: -0.005em;
   max-width: 100%; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
   font-family: var(--hf-sans); background: none;
@@ -89,7 +84,7 @@
 .mr-share-badge span { overflow: hidden; text-overflow: ellipsis; }
 .mr-share-badge.is-owner {
   background: var(--hf-brand-bg); color: var(--hf-brand-2);
-  border-color: oklch(88% 0.04 150);
+  border-color: var(--hf-ok-border);
   cursor: pointer;
 }
 .mr-share-badge.is-member {
@@ -102,7 +97,7 @@
 }
 .mr-share-btn:hover { color: var(--hf-ink); border-color: var(--hf-ink-faint); }
 .mr-share-btn.is-active {
-  background: var(--hf-brand-bg); border-color: oklch(88% 0.04 150); color: var(--hf-brand-2);
+  background: var(--hf-brand-bg); border-color: var(--hf-ok-border); color: var(--hf-brand-2);
 }
 .mr-share-btn:disabled { opacity: 0.55; cursor: not-allowed; }
 
@@ -141,7 +136,7 @@
   font-size: 12px; color: var(--hf-ink-soft); line-height: 1.5;
 }
 .mr-shr-unshare-btn {
-  width: 100%; padding: 13px; border-radius: 12px;
+  width: 100%; padding: 13px; border-radius: var(--hf-r);
   background: var(--hf-surface); border: 1.5px solid var(--hf-bad); color: var(--hf-bad);
   font-size: 14.5px; font-weight: 600;
 }
@@ -166,8 +161,8 @@
 }
 .mr-tab:hover { color: var(--hf-ink); }
 .mr-tab.active { color: var(--hf-ink); font-weight: 600; }
-.mr-tab.active::after { content: ""; position: absolute; left: 0; right: 0; bottom: -1px; height: 2px; background: var(--hf-brand); border-radius: 2px; }
-.mr-tab-count { font-family: var(--hf-mono); font-size: 11px; color: var(--hf-ink-faint); background: var(--hf-surface-2); border: 1px solid var(--hf-line); padding: 1px 6px; border-radius: 999px; }
+.mr-tab.active::after { content: ""; position: absolute; left: 0; right: 0; bottom: -1px; height: 2px; background: var(--hf-brand); border-radius: var(--hf-r-full); }
+.mr-tab-count { font-family: var(--hf-mono); font-size: 11px; color: var(--hf-ink-faint); background: var(--hf-surface-2); border: 1px solid var(--hf-line); padding: 1px 6px; border-radius: var(--hf-r-full); }
 .mr-tab.active .mr-tab-count { color: var(--hf-brand-2); }
 
 /* ============ history head ============ */
@@ -176,7 +171,7 @@
 .mr-hist-head-txt { display: flex; align-items: baseline; gap: 10px; }
 .mr-hist-title { font-size: 14px; font-weight: 700; color: var(--hf-ink); letter-spacing: -0.01em; }
 .mr-hist-meta { font-family: var(--hf-mono); font-size: 11.5px; color: var(--hf-ink-faint); }
-.mr-density { display: flex; gap: 2px; background: var(--hf-surface-2); border: 1px solid var(--hf-line); border-radius: 9px; padding: 3px; }
+.mr-density { display: flex; gap: 2px; background: var(--hf-surface-2); border: 1px solid var(--hf-line); border-radius: var(--hf-r); padding: 3px; }
 .mr-density button {
   display: inline-flex; align-items: center; gap: 6px; padding: 5px 11px; border-radius: var(--hf-r-sm);
   border: none; background: none; font-size: 12.5px; font-weight: 500; color: var(--hf-ink-soft);
@@ -204,7 +199,7 @@
 .mr-tl-ago-inline { color: var(--hf-ink-faint); }
 .mr-tl-title { font-size: 16px; font-weight: 600; color: var(--hf-ink); letter-spacing: -0.014em; line-height: 1.25; display: flex; align-items: center; gap: 9px; flex-wrap: wrap; }
 .mr-tl-notes { margin: 8px 0 0; padding: 10px 13px; background: var(--hf-surface); border: 1px solid var(--hf-line-soft); border-left: 3px solid var(--hf-brand); border-radius: var(--hf-r-sm); font-size: 13.5px; color: var(--hf-ink-soft); line-height: 1.5; text-wrap: pretty; }
-.mr-tl-sameday { display: inline-flex; align-items: center; white-space: nowrap; padding: 1px 8px; border-radius: 999px; background: var(--hf-brand-bg); color: var(--hf-brand-2); font-family: var(--hf-sans); font-size: 10px; font-weight: 600; letter-spacing: 0.01em; }
+.mr-tl-sameday { display: inline-flex; align-items: center; white-space: nowrap; padding: 1px 8px; border-radius: var(--hf-r-full); background: var(--hf-brand-bg); color: var(--hf-brand-2); font-family: var(--hf-sans); font-size: 10px; font-weight: 600; letter-spacing: 0.01em; }
 .mr-tl-sameday-wide { display: inline-flex; }
 .mr-tl-date-inline .mr-tl-sameday { text-transform: none; }
 
@@ -232,8 +227,8 @@
 
 /* ============ ERROR / 403 / 404 ============ */
 .mr-error { display: flex; flex-direction: column; align-items: center; justify-content: center; text-align: center; gap: 11px; padding: 52px 24px; }
-.mr-error-art { width: 60px; height: 60px; border-radius: 16px; display: flex; align-items: center; justify-content: center; background: var(--hf-surface-2); border: 1px solid var(--hf-line); color: var(--hf-ink-soft); }
-.mr-error-error .mr-error-art, .mr-error-forbidden .mr-error-art { background: var(--hf-bad-bg); border-color: oklch(88% 0.045 28); color: var(--hf-bad); }
+.mr-error-art { width: 60px; height: 60px; border-radius: var(--hf-r-lg); display: flex; align-items: center; justify-content: center; background: var(--hf-surface-2); border: 1px solid var(--hf-line); color: var(--hf-ink-soft); }
+.mr-error-error .mr-error-art, .mr-error-forbidden .mr-error-art { background: var(--hf-bad-bg); border-color: var(--hf-bad-border); color: var(--hf-bad); }
 .mr-error-title { font-size: 18px; font-weight: 700; color: var(--hf-ink); letter-spacing: -0.02em; }
 .mr-error-sub { font-size: 13.5px; color: var(--hf-ink-soft); line-height: 1.55; max-width: 340px; }
 .mr-error .hf-btn { margin-top: 4px; }
@@ -242,7 +237,7 @@
 @keyframes mr-shimmer { 0% { background-position: -200px 0; } 100% { background-position: 320px 0; } }
 .mr-skel { display: block; height: 12px; border-radius: var(--hf-r-sm); background: linear-gradient(90deg, var(--hf-line-soft) 0px, var(--hf-line) 40px, var(--hf-line-soft) 80px); background-size: 320px 100%; animation: mr-shimmer 1.1s linear infinite; }
 .mr-skel-w40 { width: 40%; } .mr-skel-w50 { width: 50%; } .mr-skel-w70 { width: 70%; } .mr-skel-w75 { width: 75%; } .mr-skel-w80 { width: 80%; } .mr-skel-w90 { width: 90%; }
-.mr-skel-block { width: 100%; height: 34px; border-radius: 8px; }
+.mr-skel-block { width: 100%; height: 34px; border-radius: var(--hf-r); }
 .mr-skel-tl { display: flex; flex-direction: column; gap: 22px; }
 .mr-skel-item { display: grid; grid-template-columns: 18px 1fr; gap: 14px; }
 .mr-skel-dot { width: 13px; height: 13px; border-radius: 50%; background: var(--hf-line); margin-top: 3px; }
@@ -262,7 +257,7 @@
 .mr-form-actions { display: flex; gap: 10px; justify-content: flex-end; padding: 14px 20px; border-top: 1px solid var(--hf-line); flex-shrink: 0; }
 .mr-form-actions .mr-btn-save { min-width: 130px; }
 
-.mr-banner { display: flex; align-items: center; gap: 9px; padding: 10px 12px; border-radius: var(--hf-r); background: var(--hf-bad-bg); border: 1px solid oklch(88% 0.045 28); color: var(--hf-bad); font-size: 13px; font-weight: 500; }
+.mr-banner { display: flex; align-items: center; gap: 9px; padding: 10px 12px; border-radius: var(--hf-r); background: var(--hf-bad-bg); border: 1px solid var(--hf-bad-border); color: var(--hf-bad); font-size: 13px; font-weight: 500; }
 
 /* Field component inside MR forms keeps former label weight */
 .mr-form .hf-field-label,
@@ -300,14 +295,8 @@
 .mr-textarea { min-height: 88px; line-height: 1.5; resize: vertical; }
 .mr-field-hint { font-size: 11.5px; color: var(--hf-ink-faint); line-height: 1.4; }
 .mr-field-err { display: flex; align-items: center; gap: 5px; font-size: 11.5px; color: var(--hf-bad); font-weight: 500; }
-.mr-spinner {
-  width: 14px;
-  height: 14px;
-  border-radius: 50%;
-  border: 2px solid rgba(255, 255, 255, 0.4);
-  border-top-color: #fff;
-  animation: mr-spin 0.7s linear infinite;
-}
+
+.mr-spinner { width: 14px; height: 14px; border-radius: 50%; border: 2px solid var(--hf-spinner-track); border-top-color: var(--hf-on-brand); animation: mr-spin 0.7s linear infinite; }
 @keyframes mr-spin { to { transform: rotate(360deg); } }
 
 /* inline form (two-pane side) */
@@ -335,21 +324,21 @@
 
 /* ============ overlays ============ */
 .mr-overlay { position: absolute; inset: 0; z-index: 60; overflow: hidden; }
-.mr-scrim { position: absolute; inset: 0; background: rgba(20,18,14,0.34); animation: mr-fade 240ms ease-out; }
+.mr-scrim { position: absolute; inset: 0; background: var(--hf-scrim); animation: mr-fade 240ms ease-out; }
 @keyframes mr-fade { from { opacity: 0; } }
 
 /* modal */
-.mr-overlay-panel-modal { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); width: min(480px, calc(100% - 40px)); max-height: calc(100% - 48px); background: var(--hf-bg); border-radius: 18px; box-shadow: 0 24px 70px rgba(20,18,14,0.28); overflow: hidden; display: flex; flex-direction: column; animation: mr-pop 160ms cubic-bezier(.3,.7,.4,1); }
+.mr-overlay-panel-modal { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); width: min(480px, calc(100% - 40px)); max-height: calc(100% - 48px); background: var(--hf-bg); border-radius: var(--hf-r-xl); box-shadow: var(--hf-shadow-modal); overflow: hidden; display: flex; flex-direction: column; animation: mr-pop 160ms cubic-bezier(.3,.7,.4,1); }
 @keyframes mr-pop { from { opacity: 0; transform: translate(-50%, -46%) scale(0.97); } }
 
 /* drawer */
-.mr-overlay-panel-drawer { position: absolute; top: 0; right: 0; bottom: 0; width: min(440px, 100%); background: var(--hf-bg); box-shadow: -12px 0 50px rgba(20,18,14,0.2); display: flex; flex-direction: column; will-change: transform; animation: mr-slide-r 360ms cubic-bezier(0.32, 0.72, 0, 1); }
+.mr-overlay-panel-drawer { position: absolute; top: 0; right: 0; bottom: 0; width: min(440px, 100%); background: var(--hf-bg); box-shadow: var(--hf-shadow-drawer); display: flex; flex-direction: column; will-change: transform; animation: mr-slide-r 360ms cubic-bezier(0.32, 0.72, 0, 1); }
 @keyframes mr-slide-r { from { transform: translateX(100%); } }
 
 /* sheet (mobile) */
-.mr-overlay-panel-sheet { position: absolute; left: 0; right: 0; bottom: 0; max-height: 92%; background: var(--hf-bg); border-radius: 22px 22px 0 0; box-shadow: 0 -8px 40px rgba(20,18,14,0.18); display: flex; flex-direction: column; will-change: transform; animation: mr-slide-u 380ms cubic-bezier(0.32, 0.72, 0, 1); }
+.mr-overlay-panel-sheet { position: absolute; left: 0; right: 0; bottom: 0; max-height: 92%; background: var(--hf-bg); border-radius: var(--hf-r-xl) var(--hf-r-xl) 0 0; box-shadow: var(--hf-shadow-sheet); display: flex; flex-direction: column; will-change: transform; animation: mr-slide-u 380ms cubic-bezier(0.32, 0.72, 0, 1); }
 @keyframes mr-slide-u { from { transform: translateY(100%); } }
-.mr-sheet-grab { width: 38px; height: 5px; border-radius: 999px; background: var(--hf-line); margin: 9px auto 0; flex-shrink: 0; }
+.mr-sheet-grab { width: 38px; height: 5px; border-radius: var(--hf-r-full); background: var(--hf-line); margin: 9px auto 0; flex-shrink: 0; }
 
 /* =====================================================================
    OVERVIEW TAB
@@ -361,18 +350,18 @@
 .mr-health-row { display: flex; flex-wrap: wrap; gap: 8px; }
 .mr-health-chip {
   display: inline-flex; align-items: center; gap: 7px;
-  padding: 7px 13px; border-radius: 999px;
+  padding: 7px 13px; border-radius: var(--hf-r-full);
   font-size: 13px; border: 1px solid transparent;
 }
 .mr-health-chip-dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
 .mr-health-chip-val { font-weight: 700; }
 .mr-health-chip-lbl { opacity: 0.85; }
 
-.mr-health-chip-overdue { background: var(--hf-bad-bg);  color: var(--hf-bad);          border-color: oklch(88% 0.045 28); }
+.mr-health-chip-overdue { background: var(--hf-bad-bg);  color: var(--hf-bad);          border-color: var(--hf-bad-border); }
 .mr-health-chip-overdue .mr-health-chip-dot { background: var(--hf-bad); }
-.mr-health-chip-soon    { background: var(--hf-warn-bg); color: oklch(45% 0.13 75);      border-color: oklch(88% 0.06 75); }
-.mr-health-chip-soon    .mr-health-chip-dot { background: oklch(65% 0.18 75); }
-.mr-health-chip-ok      { background: var(--hf-ok-bg);   color: var(--hf-ok);            border-color: oklch(88% 0.045 150); }
+.mr-health-chip-soon    { background: var(--hf-warn-bg); color: var(--hf-warn-ink);      border-color: var(--hf-warn-border); }
+.mr-health-chip-soon    .mr-health-chip-dot { background: var(--hf-warn); }
+.mr-health-chip-ok      { background: var(--hf-ok-bg);   color: var(--hf-ok);            border-color: var(--hf-ok-border); }
 .mr-health-chip-ok      .mr-health-chip-dot { background: var(--hf-ok); }
 
 /* recent activity */
@@ -428,14 +417,14 @@
   background: var(--hf-surface); border: 1px solid var(--hf-line);
   transition: border-color 100ms;
 }
-.mr-task-card:hover { border-color: oklch(85% 0.008 80); }
+.mr-task-card:hover { border-color: var(--hf-line-strong); }
 .mr-task-card[data-status="overdue"] {
   background: linear-gradient(to right, var(--hf-bad-bg) 0%, var(--hf-bad-bg) 3px, var(--hf-surface) 3px);
-  border-color: oklch(88% 0.04 28);
+  border-color: var(--hf-bad-border);
 }
 .mr-task-card[data-status="soon"] {
   background: linear-gradient(to right, var(--hf-warn-bg) 0%, var(--hf-warn-bg) 3px, var(--hf-surface) 3px);
-  border-color: oklch(88% 0.055 75);
+  border-color: var(--hf-warn-border);
 }
 
 .mr-task-card-main { display: flex; align-items: center; gap: 11px; min-width: 0; flex: 1; }
@@ -456,30 +445,30 @@
 /* due badge */
 .mr-due-badge {
   display: inline-flex; align-items: center; gap: 5px;
-  padding: 4px 9px; border-radius: 999px;
+  padding: 4px 9px; border-radius: var(--hf-r-full);
   font-size: 11.5px; font-weight: 500; white-space: nowrap;
   border: 1px solid transparent;
 }
-.mr-due-badge-overdue { background: var(--hf-bad-bg);  color: var(--hf-bad);             border-color: oklch(88% 0.045 28); }
-.mr-due-badge-soon    { background: var(--hf-warn-bg); color: oklch(45% 0.13 75);         border-color: oklch(88% 0.06 75);  }
-.mr-due-badge-ok      { background: var(--hf-ok-bg);   color: var(--hf-ok);               border-color: oklch(88% 0.045 150);}
+.mr-due-badge-overdue { background: var(--hf-bad-bg);  color: var(--hf-bad);             border-color: var(--hf-bad-border); }
+.mr-due-badge-soon    { background: var(--hf-warn-bg); color: var(--hf-warn-ink);         border-color: var(--hf-warn-border);  }
+.mr-due-badge-ok      { background: var(--hf-ok-bg);   color: var(--hf-ok);               border-color: var(--hf-ok-border);}
 
 /* task actions */
 .mr-task-actions { display: flex; align-items: center; gap: 6px; }
 .mr-task-log-btn { padding: 7px 12px; font-size: 12.5px; font-weight: 600; }
 .mr-task-del-btn {
-  width: 28px; height: 28px; border-radius: 7px; flex-shrink: 0;
+  width: 28px; height: 28px; border-radius: var(--hf-r-sm); flex-shrink: 0;
   background: none; border: 1px solid transparent;
   display: flex; align-items: center; justify-content: center;
   color: var(--hf-ink-faint);
 }
-.mr-task-del-btn:hover { background: var(--hf-bad-bg); border-color: oklch(88% 0.045 28); color: var(--hf-bad); }
+.mr-task-del-btn:hover { background: var(--hf-bad-bg); border-color: var(--hf-bad-border); color: var(--hf-bad); }
 
 /* delete confirm */
 .mr-task-confirm { display: flex; align-items: center; gap: 7px; }
 .mr-task-confirm-txt { font-size: 12.5px; font-weight: 500; color: var(--hf-ink); white-space: nowrap; }
-.mr-task-confirm-yes { padding: 6px 11px; font-size: 12.5px; background: var(--hf-bad); color: #fff; border-color: var(--hf-bad); font-weight: 600; }
-.mr-task-confirm-yes:hover { background: oklch(44% 0.18 28); border-color: oklch(44% 0.18 28); }
+.mr-task-confirm-yes { padding: 6px 11px; font-size: 12.5px; background: var(--hf-bad); color: var(--hf-on-brand); border-color: var(--hf-bad); font-weight: 600; }
+.mr-task-confirm-yes:hover { background: var(--hf-bad-2); border-color: var(--hf-bad-2); }
 .mr-task-confirm-no { padding: 6px 11px; font-size: 12.5px; }
 
 /* task empty state */
@@ -505,7 +494,7 @@
 /* task badge on timeline / table records */
 .mr-tl-task-badge {
   display: inline-flex; align-items: center; gap: 4px;
-  padding: 1px 7px; border-radius: 999px;
+  padding: 1px 7px; border-radius: var(--hf-r-full);
   background: var(--hf-brand-bg); color: var(--hf-brand-2);
   font-size: 10.5px; font-weight: 600; white-space: nowrap;
   font-family: var(--hf-sans);
@@ -516,7 +505,7 @@
 .mr-interval-num { width: 76px; flex-shrink: 0; text-align: center; font-family: var(--hf-mono); }
 .mr-unit-seg {
   flex: 1; display: flex; gap: 2px; background: var(--hf-surface-2);
-  border: 1px solid var(--hf-line); border-radius: 9px; padding: 3px;
+  border: 1px solid var(--hf-line); border-radius: var(--hf-r); padding: 3px;
 }
 .mr-unit-btn {
   flex: 1; display: inline-flex; align-items: center; justify-content: center;

--- a/apps/web/src/design/styles/primitives.css
+++ b/apps/web/src/design/styles/primitives.css
@@ -7,7 +7,7 @@
   align-items: center;
   gap: 6px;
   padding: 8px 13px;
-  border-radius: 8px;
+  border-radius: var(--hf-r);
   font-size: 13px;
   font-weight: 500;
   border: 1px solid var(--hf-line);
@@ -31,7 +31,7 @@
   border-color: var(--hf-ink);
 }
 .hf-btn-primary:hover {
-  background: oklch(28% 0.015 70);
+  background: var(--hf-ink-2);
 }
 .hf-btn-secondary {
   background: var(--hf-surface);
@@ -49,8 +49,9 @@
 /* Brand-filled primary — lifted from former .mr-btn-primary */
 .hf-btn-brand {
   background: var(--hf-brand);
-  color: #fff;
+  color: var(--hf-on-brand);
   border-color: var(--hf-brand);
+  /* stylelint-disable-next-line function-disallowed-list -- one-off primary-button lift, not part of the --hf-shadow-* elevation scale */
   box-shadow: 0 1px 2px rgba(20, 18, 14, 0.12);
 }
 .hf-btn-brand:hover {
@@ -64,6 +65,7 @@
   justify-content: center;
   gap: 7px;
   padding: 9px 14px;
+  /* stylelint-disable-next-line declaration-property-value-disallowed-list -- keep the exact former .mr-btn radius (see comment above); 10px would be a real, if subtle, geometry change */
   border-radius: 9px;
   font-size: 13.5px;
   font-weight: 600;
@@ -94,12 +96,13 @@
   width: 14px;
   height: 14px;
   border-radius: 50%;
-  border: 2px solid rgba(255, 255, 255, 0.3);
-  border-top-color: #fff;
+  border: 2px solid var(--hf-spinner-track);
+  border-top-color: var(--hf-on-brand);
   animation: hf-btn-spin 0.7s linear infinite;
   flex-shrink: 0;
 }
 .hf-btn-spinner-dark {
+  /* stylelint-disable-next-line function-disallowed-list -- one-off: needs to read against a dark button, not the default --hf-line-strong hover tone */
   border-color: oklch(80% 0.008 80);
   border-top-color: var(--hf-ink-soft);
 }
@@ -140,9 +143,9 @@
   flex-shrink: 0;
 }
 .hf-empty-icon[data-tone="bad"] {
-  background: oklch(96% 0.04 28);
+  background: var(--hf-bad-bg);
   color: var(--hf-bad);
-  border-color: oklch(88% 0.05 28);
+  border-color: var(--hf-bad-border);
 }
 .hf-empty-icon[data-tone="brand"] {
   border-radius: var(--hf-r-lg);
@@ -201,7 +204,7 @@
   border: 1px dashed var(--hf-line);
   border-radius: var(--hf-r-lg);
   background:
-    repeating-linear-gradient(135deg, transparent 0 16px, rgba(20, 18, 14, 0.02) 16px 17px),
+    repeating-linear-gradient(135deg, transparent 0 16px, var(--hf-texture-line) 16px 17px),
     var(--hf-surface);
 }
 
@@ -264,7 +267,7 @@
 .hf-empty--history .hf-empty-icon {
   width: 48px;
   height: 48px;
-  border-radius: 12px;
+  border-radius: var(--hf-r);
   margin-bottom: 4px;
   color: var(--hf-ink-faint);
   border: none;
@@ -286,7 +289,7 @@
 .hf-empty--hero .hf-empty-icon {
   width: 72px;
   height: 72px;
-  border-radius: 20px;
+  border-radius: var(--hf-r-xl);
   margin-bottom: 0;
   border: none;
 }
@@ -345,7 +348,7 @@
   height: 40px;
   padding: 0 12px;
   border: 1px solid var(--hf-line);
-  border-radius: 8px;
+  border-radius: var(--hf-r);
   background: var(--hf-surface);
   color: var(--hf-ink);
   font: inherit;
@@ -360,7 +363,7 @@
 }
 .hf-input:hover,
 .hf-select:hover {
-  border-color: oklch(85% 0.008 80);
+  border-color: var(--hf-line-strong);
 }
 .hf-input:focus,
 .hf-select:focus {
@@ -399,7 +402,7 @@
 .hf-input.is-invalid:focus,
 .hf-select.is-invalid:focus {
   border-color: var(--hf-bad);
-  box-shadow: 0 0 0 3px oklch(52% 0.18 28 / 0.16);
+  box-shadow: 0 0 0 3px var(--hf-bad-a16);
 }
 .hf-field-error {
   display: flex;

--- a/apps/web/src/design/styles/tokens.css
+++ b/apps/web/src/design/styles/tokens.css
@@ -10,6 +10,7 @@
   --hf-surface: oklch(100% 0 0); /* pure white card */
   --hf-surface-2: oklch(97% 0.005 85); /* faint warm */
   --hf-ink: oklch(22% 0.015 70); /* darkest text */
+  --hf-ink-2: oklch(28% 0.015 70); /* lighter/hover variant, mirrors --hf-brand-2 */
   --hf-ink-soft: oklch(45% 0.012 75);
   --hf-ink-faint: oklch(60% 0.008 80);
   --hf-line: oklch(91% 0.006 80); /* hairline borders */
@@ -26,6 +27,8 @@
   --hf-warn: oklch(60% 0.13 75);
   --hf-warn-bg: oklch(96% 0.045 80);
   --hf-bad: oklch(52% 0.18 28);
+  --hf-bad-2: oklch(44% 0.18 28); /* darker/hover variant, mirrors --hf-brand-2 */
+  --hf-bad-a16: oklch(52% 0.18 28 / 0.16); /* invalid-field focus ring */
   --hf-bad-bg: oklch(96% 0.025 28);
 
   /* asset tints (dashboard / library thumbs) */
@@ -48,9 +51,54 @@
   --hf-r-sm: 6px;
   --hf-r: 10px;
   --hf-r-lg: 14px;
+  --hf-r-xl: 20px; /* large hero icons, modal/sheet panel corners */
+  --hf-r-full: 999px; /* pill / circle chrome */
   --hf-shadow-1: 0 1px 2px rgba(20, 18, 14, 0.04), 0 1px 0 rgba(20, 18, 14, 0.03);
   --hf-shadow-2: 0 4px 12px rgba(20, 18, 14, 0.06), 0 1px 0 rgba(20, 18, 14, 0.03);
   --hf-shadow-3: 0 18px 50px -12px rgba(20, 18, 14, 0.22), 0 6px 16px -8px rgba(20, 18, 14, 0.12);
+
+  /* overlay elevation (modal / drawer / bottom-sheet panels + their scrim) */
+  --hf-scrim: rgba(20, 18, 14, 0.34);
+  --hf-shadow-modal: 0 24px 70px rgba(20, 18, 14, 0.28);
+  --hf-shadow-drawer: -12px 0 50px rgba(20, 18, 14, 0.2);
+  --hf-shadow-sheet: 0 -8px 40px rgba(20, 18, 14, 0.18);
+  --hf-texture-line: rgba(
+    20,
+    18,
+    14,
+    0.02
+  ); /* subtle diagonal hatch on dashed empty-state panels */
+  --hf-texture-line-subtle: rgba(
+    20,
+    18,
+    14,
+    0.012
+  ); /* fainter hatch, wider 22px spacing (auth / marketing decorative panels) */
+
+  /* status border tints (paired with the -bg/-fg pairs above, used on chips/badges/cards) */
+  --hf-ok-border: oklch(88% 0.04 150);
+  --hf-bad-border: oklch(88% 0.045 28);
+  --hf-warn-border: oklch(88% 0.06 75);
+  --hf-warn-ink: oklch(45% 0.13 75); /* darker warn text, e.g. on a warn-bg pill */
+
+  /* activity/event type swatches (History timeline) */
+  --hf-evt-maint: oklch(46% 0.1 150);
+  --hf-evt-maint-bg: oklch(95% 0.03 150);
+  --hf-evt-added: oklch(49% 0.11 292);
+  --hf-evt-added-bg: oklch(95% 0.03 292);
+  --hf-evt-scheduled: oklch(49% 0.11 252);
+  --hf-evt-scheduled-bg: oklch(95% 0.03 252);
+  --hf-evt-completed: oklch(50% 0.09 196);
+  --hf-evt-completed-bg: oklch(95% 0.03 196);
+  --hf-evt-deleted: oklch(54% 0.13 28);
+  --hf-evt-added-border: oklch(88% 0.04 292);
+  --hf-evt-scheduled-border: oklch(88% 0.04 252);
+  --hf-evt-completed-border: oklch(88% 0.04 196);
+
+  /* interaction */
+  --hf-line-strong: oklch(85% 0.008 80); /* hover/focus border, darker than --hf-line */
+  --hf-spinner-track: oklch(100% 0 0 / 0.35); /* spinner ring on a colored/dark button */
+  --hf-on-brand: oklch(100% 0 0); /* white foreground on a saturated/dark background */
 
   /* fonts */
   --hf-sans:

--- a/apps/web/src/marketing/styles/marketing.css
+++ b/apps/web/src/marketing/styles/marketing.css
@@ -27,6 +27,7 @@
   position: sticky;
   top: 0;
   z-index: 40;
+  /* stylelint-disable-next-line function-disallowed-list -- one-off translucent header glass, alpha variant of --hf-bg with no repeat elsewhere */
   background: oklch(98% 0.005 85 / 0.82);
   backdrop-filter: blur(10px);
   border-bottom: 1px solid var(--hf-line);
@@ -47,7 +48,7 @@
 .mk-logo-mark {
   width: 30px;
   height: 30px;
-  border-radius: 8px;
+  border-radius: var(--hf-r);
   background: var(--hf-ink);
   display: flex;
   align-items: center;
@@ -65,7 +66,7 @@
 }
 .mk-nav-link {
   padding: 8px 12px;
-  border-radius: 8px;
+  border-radius: var(--hf-r);
   text-decoration: none;
   color: var(--hf-ink-soft);
   font-size: 14.5px;
@@ -107,7 +108,8 @@
 }
 .mk-btn-primary {
   background: var(--hf-brand);
-  color: #fff;
+  color: var(--hf-on-brand);
+  /* stylelint-disable-next-line function-disallowed-list -- one-off button hairline lift, not part of the --hf-shadow-* elevation scale */
   box-shadow: 0 1px 0 rgba(20, 18, 14, 0.06);
 }
 .mk-btn-primary:hover {
@@ -120,19 +122,19 @@
 }
 .mk-btn-ghost:hover {
   background: var(--hf-surface);
-  border-color: oklch(82% 0.012 80);
+  border-color: var(--hf-line-strong);
 }
 .mk-btn-sm {
   height: 38px;
   padding: 0 15px;
   font-size: 14px;
-  border-radius: 9px;
+  border-radius: var(--hf-r);
 }
 .mk-btn-lg {
   height: 50px;
   padding: 0 26px;
   font-size: 16px;
-  border-radius: 11px;
+  border-radius: var(--hf-r);
 }
 .mk-link-quiet {
   color: var(--hf-ink-soft);
@@ -166,8 +168,8 @@
   letter-spacing: 0.1em;
   color: var(--hf-brand-2);
   padding: 6px 12px;
-  border: 1px solid oklch(88% 0.04 150);
-  border-radius: 999px;
+  border: 1px solid var(--hf-ok-border);
+  border-radius: var(--hf-r-full);
   background: var(--hf-brand-bg);
 }
 .mk-h1 {
@@ -228,7 +230,7 @@
     radial-gradient(90% 80% at 15% 90%, var(--hf-tint-vehicle) 0%, transparent 50%),
     var(--hf-surface-2);
   border: 1px solid var(--hf-line);
-  border-radius: 22px;
+  border-radius: var(--hf-r-xl);
   overflow: hidden;
 }
 .mk-collage-panel::after {
@@ -238,7 +240,7 @@
   background: repeating-linear-gradient(
     135deg,
     transparent 0 22px,
-    rgba(20, 18, 14, 0.012) 22px 23px
+    var(--hf-texture-line-subtle) 22px 23px
   );
 }
 .mk-float {
@@ -267,7 +269,7 @@
   right: 54px;
   transform: rotate(3deg);
   padding: 9px 13px;
-  border-radius: 999px;
+  border-radius: var(--hf-r-full);
   display: flex;
   align-items: center;
   gap: 8px;
@@ -396,12 +398,12 @@
 .mk-feature:hover {
   box-shadow: var(--hf-shadow-2);
   transform: translateY(-2px);
-  border-color: oklch(85% 0.01 80);
+  border-color: var(--hf-line-strong);
 }
 .mk-feature-icon {
   width: 46px;
   height: 46px;
-  border-radius: 12px;
+  border-radius: var(--hf-r);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -413,7 +415,7 @@
 }
 .mk-feature-icon[data-tone="warn"] {
   background: var(--hf-warn-bg);
-  color: oklch(45% 0.13 75);
+  color: var(--hf-warn-ink);
 }
 .mk-feature-icon[data-tone="bad"] {
   background: var(--hf-bad-bg);
@@ -456,7 +458,7 @@
   height: 40px;
   border-radius: 50%;
   background: var(--hf-ink);
-  color: #fff;
+  color: var(--hf-on-brand);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -496,7 +498,7 @@
 .mk-cta-box {
   background:
     radial-gradient(120% 140% at 85% 0%, var(--hf-brand-bg) 0%, transparent 55%), var(--hf-ink);
-  border-radius: 24px;
+  border-radius: var(--hf-r-xl);
   padding: 56px 56px;
   text-align: center;
   position: relative;
@@ -508,13 +510,14 @@
   line-height: 1.1;
   font-weight: 700;
   letter-spacing: -0.03em;
-  color: #fff;
+  color: var(--hf-on-brand);
   text-wrap: balance;
 }
 .mk-cta-box p {
   margin: 14px auto 0;
   max-width: 30em;
   font-size: 17px;
+  /* stylelint-disable-next-line function-disallowed-list -- one-off CTA-box copy tone on a dark background, no repeat elsewhere */
   color: oklch(86% 0.01 85);
   line-height: 1.5;
 }
@@ -522,15 +525,17 @@
   justify-content: center;
   margin-top: 30px;
 }
+/* stylelint-disable function-disallowed-list -- one-off glass-button treatment on the CTA hero, matches the issue's documented "marketing hero collage" precedent for genuine one-offs */
 .mk-cta-box .mk-btn-ghost {
   background: transparent;
-  color: #fff;
+  color: var(--hf-on-brand);
   border-color: oklch(100% 0 0 / 0.28);
 }
 .mk-cta-box .mk-btn-ghost:hover {
   background: oklch(100% 0 0 / 0.08);
   border-color: oklch(100% 0 0 / 0.5);
 }
+/* stylelint-enable function-disallowed-list */
 
 /* ============ footer ============ */
 .mk-footer {

--- a/apps/web/src/onboarding/styles/onboarding.css
+++ b/apps/web/src/onboarding/styles/onboarding.css
@@ -79,7 +79,7 @@
   height: 50px;
   padding: 0 14px;
   border: 1.5px solid var(--hf-line);
-  border-radius: 11px;
+  border-radius: var(--hf-r);
   font-family: var(--hf-sans);
   font-size: 15.5px;
   color: var(--hf-ink);
@@ -95,10 +95,12 @@
 }
 .ob-input:focus {
   border-color: var(--hf-ink);
+  /* stylelint-disable-next-line function-disallowed-list -- one-off focus-ring glow, no repeated focus-ring token exists yet */
   box-shadow: 0 0 0 3px oklch(22% 0.015 70 / 0.08);
 }
 .ob-input.ob-input-error {
   border-color: var(--hf-bad);
+  /* stylelint-disable-next-line function-disallowed-list -- one-off, lighter than --hf-bad-a16 (0.1 vs 0.16 alpha) by design for this field's error ring */
   box-shadow: 0 0 0 3px oklch(52% 0.18 28 / 0.1);
 }
 .ob-input:disabled {
@@ -120,14 +122,15 @@
 .ob-submit {
   width: 100%;
   height: 50px;
-  border-radius: 11px;
+  border-radius: var(--hf-r);
   display: flex;
   align-items: center;
   justify-content: center;
   gap: 9px;
   background: var(--hf-ink);
+  /* stylelint-disable-next-line function-disallowed-list -- one-off, darker than --hf-ink for contrast against the solid ink button fill */
   border: 1px solid oklch(18% 0.015 70);
-  color: #fff;
+  color: var(--hf-on-brand);
   font-family: var(--hf-sans);
   font-size: 15.5px;
   font-weight: 600;
@@ -140,7 +143,7 @@
   letter-spacing: -0.01em;
 }
 .ob-submit:hover:not(:disabled) {
-  background: oklch(28% 0.015 70);
+  background: var(--hf-ink-2);
   box-shadow: var(--hf-shadow-2);
 }
 .ob-submit:active:not(:disabled) {
@@ -155,8 +158,8 @@
   width: 16px;
   height: 16px;
   border-radius: 50%;
-  border: 2px solid rgba(255, 255, 255, 0.3);
-  border-top-color: white;
+  border: 2px solid var(--hf-spinner-track);
+  border-top-color: var(--hf-on-brand);
   animation: ob-spin 0.7s linear infinite;
   flex-shrink: 0;
 }
@@ -218,14 +221,14 @@
 
 .ob-pill-warn {
   background: var(--hf-warn-bg);
-  color: oklch(45% 0.13 75);
-  border-color: oklch(88% 0.06 75);
+  color: var(--hf-warn-ink);
+  border-color: var(--hf-warn-border);
 }
 
 .ob-asset-icon-vehicle {
   width: 38px;
   height: 38px;
-  border-radius: 8px;
+  border-radius: var(--hf-r);
   background: var(--hf-cat-vehicle-bg);
   color: var(--hf-cat-vehicle-fg);
   display: flex;

--- a/docs/specs/SPECS.md
+++ b/docs/specs/SPECS.md
@@ -17,16 +17,16 @@ generate or sync specs from code and PRs.
 Concerns that apply to every feature. When writing a feature spec, reference the
 relevant cross-cutting specs rather than re-describing the behavior.
 
-| Spec                                                         | Concern                          | Status |
-| ------------------------------------------------------------ | -------------------------------- | ------ |
-| [authentication.md](./cross-cutting/authentication.md)       | Auth, sessions, identity         | active |
-| [error-handling.md](./cross-cutting/error-handling.md)       | Error states and user messaging  | active |
-| [permissions.md](./cross-cutting/permissions.md)             | Role-based access control        | active |
-| [validation.md](./cross-cutting/validation.md)               | Input validation patterns        | active |
-| [loading-states.md](./cross-cutting/loading-states.md)       | Async UI states                  | active |
-| [telemetry.md](./cross-cutting/telemetry.md)                 | Telemetry and observability      | active |
-| [testing.md](./cross-cutting/testing.md)                     | Test verification, mutation gate | active |
-| [schema-migrations.md](./cross-cutting/schema-migrations.md) | D1 schema change and rollout     | review |
+| Spec                                                         | Concern                                          | Status |
+| ------------------------------------------------------------ | ------------------------------------------------ | ------ |
+| [authentication.md](./cross-cutting/authentication.md)       | Auth, sessions, identity                         | active |
+| [error-handling.md](./cross-cutting/error-handling.md)       | Error states and user messaging                  | active |
+| [permissions.md](./cross-cutting/permissions.md)             | Role-based access control                        | active |
+| [validation.md](./cross-cutting/validation.md)               | Input validation patterns                        | active |
+| [loading-states.md](./cross-cutting/loading-states.md)       | Async UI states                                  | active |
+| [telemetry.md](./cross-cutting/telemetry.md)                 | Telemetry and observability                      | active |
+| [testing.md](./cross-cutting/testing.md)                     | Test verification, mutation gate, CSS token lint | active |
+| [schema-migrations.md](./cross-cutting/schema-migrations.md) | D1 schema change and rollout                     | review |
 
 ## Feature Specs
 

--- a/docs/specs/cross-cutting/testing.md
+++ b/docs/specs/cross-cutting/testing.md
@@ -1,6 +1,6 @@
 ---
 audience: all contributors
-purpose: canonical verification contract — mutation gate (API)
+purpose: canonical verification contract — mutation gate (API), CSS token lint gate (web)
 source: this file
 date: 2026-08-15
 ---
@@ -9,12 +9,19 @@ date: 2026-08-15
 
 **Status:** `active`
 **Owner:** engineering
-**Applies To:** API logic in `apps/api/src/domain/**` and `apps/api/src/application/**` (mutation gate)
+**Applies To:** API logic in `apps/api/src/domain/**` and `apps/api/src/application/**` (mutation gate); stylesheets in `apps/web/src/**/*.css` (CSS token lint gate)
 
 > The mutation gate is the `Mutation` workflow (`.github/workflows/mutation.yml`), with `mutation`
 > a required status check on `main`. Tracked by [#86](https://github.com/snaveevans/pineapple/issues/86).
 > The decision behind it is
 > [ADR-0016](../../decisions/0016-mutation-testing-as-the-ci-trust-boundary.md).
+>
+> The CSS token lint gate runs as `lint:css` inside the root `pnpm lint` script (part of the `verify`
+> job's required `Lint` step — no separate CI job). Tracked by
+> [#148](https://github.com/snaveevans/pineapple/issues/148) (epic
+> [#143](https://github.com/snaveevans/pineapple/issues/143)). No ADR: the issue itself already
+> fixed the tool (stylelint, the only real choice for linting plain CSS) and the banned patterns —
+> there was no live alternative to weigh.
 
 ---
 
@@ -174,3 +181,174 @@ Every feature that adds or changes logic in `domain/**` or `application/**` must
 - **Run time grows with the codebase.** The baseline run was ~80s for 1518 mutants at
   `concurrency: 4`. If the blocking path becomes a drag on iteration, ADR-0016's revisit trigger
   applies.
+
+---
+
+## CSS token lint gate
+
+**Status:** `active`
+**Tracked by:** [#148](https://github.com/snaveevans/pineapple/issues/148) (epic
+[#143](https://github.com/snaveevans/pineapple/issues/143))
+**Depends on:** [#147](https://github.com/snaveevans/pineapple/issues/147) — token consolidation
+into `apps/web/src/design/styles/tokens.css` (merged; there was nothing to enforce against before
+it)
+
+`--hf-brand`, `--hf-r`, and the rest of `tokens.css` are the branded types of the frontend:
+`UserId.from()` exists so a raw string can't slip into a `UserId` field; the token file exists so
+`oklch(45% 0.1 150)` can't slip into a component stylesheet as a shadow copy of the brand color.
+Before this gate, that discipline was documentation only. `main` auto-merges on green CI with zero
+required reviewers, so an unenforced convention drifts back the moment a fast model (or a human in
+a hurry) reaches for a literal instead of a token — exactly what #147 measured and fixed once
+already.
+
+### What it is
+
+- **Tool:** `stylelint`, config at repo-root `stylelint.config.js`, scoped to
+  `apps/web/src/**/*.css`. `apps/api` has no stylesheets and is untouched.
+- **Three rules, not a general style ruleset.** This gate does not adopt
+  `stylelint-config-standard` or any formatting/quality rule set — only the token-discipline rules
+  below. Broader CSS style linting is out of scope for #148 and would be its own decision.
+  - `color-no-hex: true` — bans `#fff`-style literals.
+  - `function-disallowed-list: ["oklch", "rgb", "rgba", "hsl", "hsla"]` — bans every raw color
+    function. Only `oklch`/`rgb`/`rgba` had live usage at merge; `hsl`/`hsla` are banned
+    pre-emptively so a future contributor can't route around the other four through the one
+    unlisted function name.
+  - `declaration-property-value-disallowed-list` on `border-radius` and its four per-corner
+    longhand properties, against `/^(?=.*px)(0|\d+(\.\d+)?px)(\s+(0|\d+(\.\d+)?px)){0,3}$/` — bans
+    any 1-4-value shorthand built from bare px lengths and unitless `0` (catches both
+    `border-radius: 8px` and `border-radius: 22px 22px 0 0`), but requires at least one `px`
+    component so a plain `border-radius: 0` reset isn't forced through a token — there's no radius
+    scale concept for "no rounding." `50%` (circles) never matches (no `px`) and needs no carve-out.
+    `999px`-style pill radii do match and are tokenized (`--hf-r-full`) where they recur.
+- **`tokens.css` is exempt**, via a stylelint `overrides` block scoped to that one file path — it
+  is the declaration site, so the rules that ban literals everywhere else would be
+  self-contradictory there.
+- **Wired into `pnpm lint`** (root `lint` script runs `eslint .` then `lint:css`) and into
+  `lint-staged` (`apps/web/src/**/*.css` → `stylelint`). No separate CI job: it rides the
+  existing required `Lint` step in the `verify` job, the same way ESLint does.
+- **No `prettier --write` in the CSS `lint-staged` entry, deliberately.** Two hand-authored
+  files (`mr.css`, `hifi-add-service.css`) predate any Prettier run against `apps/web`'s CSS and
+  use a denser multi-declaration-per-line style; Prettier's canonical CSS output is always one
+  declaration per line, so running `--write` on either explodes the whole file (~3x line count)
+  on the first touch — confirmed by bisecting down to `.mr-root { position: relative; }` alone
+  reformatting to 3 lines. CI has never enforced CSS formatting (no `format:check` step touches
+  `apps/web/src/**/*.css`), so adding `prettier --write` here would be scope creep unrelated to
+  token discipline, landing as an unreviewable full-file diff on whichever PR happens to touch
+  one of those two files next. If CSS formatting enforcement is wanted, that's a separate,
+  deliberate decision — not a side effect of this gate.
+
+### The escape hatch
+
+A genuine one-off stays a literal, guarded by a reason (real example, `marketing.css`):
+
+```css
+/* stylelint-disable function-disallowed-list -- one-off glass-button treatment on the CTA hero, matches the issue's documented "marketing hero collage" precedent for genuine one-offs */
+.mk-cta-box .mk-btn-ghost {
+  background: transparent;
+  color: var(--hf-on-brand);
+  border-color: oklch(100% 0 0 / 0.28);
+}
+.mk-cta-box .mk-btn-ghost:hover {
+  background: oklch(100% 0 0 / 0.08);
+  border-color: oklch(100% 0 0 / 0.5);
+}
+/* stylelint-enable function-disallowed-list */
+```
+
+A block `stylelint-disable`/`stylelint-enable` pair is needed whenever the violation isn't on the
+line immediately after the comment (e.g. inside a multi-line `box-shadow` or `background`) —
+`stylelint-disable-next-line` only covers the literal next line, so a comment placed one line too
+early silently disables nothing and `reportNeedlessDisables` catches it.
+
+- **`reportDescriptionlessDisables: true`** — a `stylelint-disable` comment with no `-- reason`
+  is itself a lint error. The escape hatch cannot be used silently.
+- **`reportNeedlessDisables: true`** — a disable comment covering a rule that wasn't actually
+  going to fire is also an error, so a stale disable (left behind after a later edit removed the
+  violation) doesn't survive unnoticed.
+- **`reportInvalidScopeDisables: true`** — a disable comment naming a rule this config doesn't
+  configure is an error, catching a typo'd rule name that would otherwise silently disable
+  nothing.
+
+### Anti-patterns
+
+- **Adding a new `--hf-*` token for a value used exactly once.** That's what the disable comment
+  is for. A token earns its place by being a real repeated value in the design system, not by
+  being the fix-of-least-resistance for one lint error (mirrors the mutation gate's "shaping
+  production code to satisfy a check" anti-pattern above).
+- **Widening the config to `stylelint-config-standard` (or any formatting rule set) to "finish
+  the job."** Out of scope for this gate — a separate decision with its own violation count and
+  its own PR.
+- **Silencing a violation by broadening the regex or dropping a function from the disallowed
+  list.** Same act as lowering the mutation `thresholds.break` — gaming the gate rather than
+  fixing the CSS. If the rule is genuinely wrong for a case, that's a disable comment with a
+  reason, decided site by site, not a config change that opens the gate for everyone.
+- **Leaving the rules disabled with a cleanup TODO.** If the violation count makes a clean
+  landing impractical in one PR, split the cleanup by directory and land the rules enabled on the
+  final slice — never merge with the gate off.
+
+### Acceptance criteria (#148)
+
+- [x] `pnpm lint` fails when a raw color (`oklch()`/hex/`rgb()`/`rgba()`) is added to a feature
+      stylesheet outside `tokens.css`. `S1`
+- [x] `pnpm lint` fails on a bare pixel `border-radius` outside `tokens.css`. `S1`
+- [x] Zero violations at merge — every literal outside `tokens.css` is either tokenized or carries
+      a justified inline disable. `S1`
+      Baseline (measured with this branch's `stylelint.config.js` against `origin/main`'s CSS as
+      it stood right after #149's primitives extraction, 14 stylesheets): **272 violations**.
+      Resolved into: - **30 new `--hf-*` tokens** in `tokens.css` — status border tints (`--hf-ok/bad/warn-border`),
+      a darker `--hf-bad-2`/`--hf-ink-2` hover pair (mirrors the existing `--hf-brand-2`),
+      activity/event swatches (12 tokens promoted from `activity-history.css`'s local `--hh-*`
+      custom properties, which #147 didn't reach since they aren't `--hf-*`-prefixed), overlay
+      elevation (`--hf-scrim`, three `--hf-shadow-*`), a `--hf-r-full` pill radius and a
+      `--hf-r-xl` tier for large hero icons/panel corners (20px — 16-24px raw values that don't
+      cleanly collapse into the issue's three named tiers), spinner track, on-brand foreground,
+      and two hatch-texture tints. Each is backed by 2+ real repeated sites. - **Near-duplicate values reconciled into one canonical token**, each a deliberate call,
+      listed in full (not just "e.g."): four slightly-drifted "bad-border" reds → one
+      `--hf-bad-border`; three modal/drawer/sheet shadow blur radii → three `--hf-shadow-*`
+      tokens; `--hh-spine` (89% L) and `activity-history.css`'s bad-tone icon background (0.04
+      chroma) folded into the existing `--hf-line` (91% L) and `--hf-bad-bg` (0.025 chroma);
+      four scrim alphas (0.28/0.34×2/0.42) → one `--hf-scrim` (0.34, the majority value); four
+      spinner-track alphas (0.3×2/0.4×2) → one `--hf-spinner-track` (0.35, splitting the
+      difference — no majority existed to prefer). **Also resolves the specific case #147/#211
+      named and deliberately left raw** ("close to but not identical to a token" — the
+      `app-search.css` equipment-icon tint at `oklch(42% 0.1 60)` vs. the token's
+      `oklch(40% 0.1 60)`) — snapped to `var(--hf-cat-equipment-fg)`, and the adjacent
+      property-icon tint (`oklch(40% 0.1 295)` vs. the token's `oklch(38% 0.1 295)`) to
+      `var(--hf-cat-property-fg)`, both a ≤2-point lightness nudge, both spot-checked live
+      (no visible difference at that magnitude). - **Border-radius scale-snapping** — the issue's Scope section requires only
+      `--hf-r-sm`/`--hf-r`/`--hf-r-lg` (plus the pill/xl additions above), so dozens of
+      non-matching raw px values were snapped to the nearest tier. Two sites were kept as
+      literals instead, because snapping would have been a real, not cosmetic, shape change:
+      `primitives.css`'s `.mr-root .hf-btn` (a comment two lines above explicitly promises
+      "exact former `.mr-btn` metrics" — 9px stays 9px, not `--hf-r` 10px) and
+      `activity-history.css`'s `.hh-bd-swatch` (9×9px legend dot at 3px — CSS caps
+      `border-radius` at half the box side, so `--hf-r-sm`'s 6px would round it to a full
+      circle instead of the intended rounded square). - **17 justified inline disables** for genuine one-offs (decorative textures, the marketing
+      CTA glass effect, single-use focus rings, the two geometry exceptions above). - **3 fully dead rules deleted outright** (`mr.css`'s unused `.brand-green`/`.brand-blue`/
+      `.brand-slate` theme overrides — confirmed unreferenced by any component via `git grep`
+      across all of `apps/web/src`, both `.tsx` and `.css`). Note: #147's PR body characterized
+      these same rules as "an intentional per-instance theme switcher, not copies of the
+      source," and declined to touch them as out of scope for that refactor. No open issue
+      references a planned theme-switcher feature, and the dead-code check is unambiguous
+      (`git log -S` shows the classes were added once, in the original responsive-UI commit,
+      and never referenced by any component since) — deleting them here, rather than leaving
+      unenforceable raw literals in place, is the correct call for a token-_enforcement_ gate,
+      but the tension with #147's framing is worth a reviewer's eyes. - **Visual verification:** the Playwright-based gallery/visual-diff harness (see Known
+      Issues above — "removed as low-value and flaky") was removed from `main` mid-implementation
+      and is not available on this branch. Spot-checked live instead — full marketing home page
+      and the `/login` screen rendered via `vite dev`, console clean, no visual regressions —
+      rather than a systematic per-state diff. `S1`
+- [x] The rules run in `lint-staged` as well as CI (via `pnpm lint`). `S1`
+
+### Delivery plan
+
+| Slice | Scope                                                                                                                                                                         | Issue | Depends on |
+| ----- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- | ---------- |
+| `S1`  | stylelint added, three rules configured, `tokens.css` exempted, wired into `lint`/`lint-staged`, justified-disable escape hatch, existing codebase brought to zero violations | #148  | #147, #149 |
+
+### Commands
+
+```bash
+pnpm lint:css              # stylelint apps/web/src/**/*.css only
+pnpm lint                  # eslint . && lint:css — what CI's required Lint step runs
+```

--- a/docs/specs/cross-cutting/testing.md
+++ b/docs/specs/cross-cutting/testing.md
@@ -293,51 +293,39 @@ early silently disables nothing and `reportNeedlessDisables` catches it.
 - [x] `pnpm lint` fails on a bare pixel `border-radius` outside `tokens.css`. `S1`
 - [x] Zero violations at merge — every literal outside `tokens.css` is either tokenized or carries
       a justified inline disable. `S1`
-      Baseline (measured with this branch's `stylelint.config.js` against `origin/main`'s CSS as
-      it stood right after #149's primitives extraction, 14 stylesheets): **272 violations**.
-      Resolved into: - **30 new `--hf-*` tokens** in `tokens.css` — status border tints (`--hf-ok/bad/warn-border`),
-      a darker `--hf-bad-2`/`--hf-ink-2` hover pair (mirrors the existing `--hf-brand-2`),
-      activity/event swatches (12 tokens promoted from `activity-history.css`'s local `--hh-*`
-      custom properties, which #147 didn't reach since they aren't `--hf-*`-prefixed), overlay
-      elevation (`--hf-scrim`, three `--hf-shadow-*`), a `--hf-r-full` pill radius and a
-      `--hf-r-xl` tier for large hero icons/panel corners (20px — 16-24px raw values that don't
-      cleanly collapse into the issue's three named tiers), spinner track, on-brand foreground,
-      and two hatch-texture tints. Each is backed by 2+ real repeated sites. - **Near-duplicate values reconciled into one canonical token**, each a deliberate call,
-      listed in full (not just "e.g."): four slightly-drifted "bad-border" reds → one
-      `--hf-bad-border`; three modal/drawer/sheet shadow blur radii → three `--hf-shadow-*`
-      tokens; `--hh-spine` (89% L) and `activity-history.css`'s bad-tone icon background (0.04
-      chroma) folded into the existing `--hf-line` (91% L) and `--hf-bad-bg` (0.025 chroma);
-      four scrim alphas (0.28/0.34×2/0.42) → one `--hf-scrim` (0.34, the majority value); four
-      spinner-track alphas (0.3×2/0.4×2) → one `--hf-spinner-track` (0.35, splitting the
-      difference — no majority existed to prefer). **Also resolves the specific case #147/#211
-      named and deliberately left raw** ("close to but not identical to a token" — the
-      `app-search.css` equipment-icon tint at `oklch(42% 0.1 60)` vs. the token's
-      `oklch(40% 0.1 60)`) — snapped to `var(--hf-cat-equipment-fg)`, and the adjacent
-      property-icon tint (`oklch(40% 0.1 295)` vs. the token's `oklch(38% 0.1 295)`) to
-      `var(--hf-cat-property-fg)`, both a ≤2-point lightness nudge, both spot-checked live
-      (no visible difference at that magnitude). - **Border-radius scale-snapping** — the issue's Scope section requires only
-      `--hf-r-sm`/`--hf-r`/`--hf-r-lg` (plus the pill/xl additions above), so dozens of
-      non-matching raw px values were snapped to the nearest tier. Two sites were kept as
-      literals instead, because snapping would have been a real, not cosmetic, shape change:
-      `primitives.css`'s `.mr-root .hf-btn` (a comment two lines above explicitly promises
-      "exact former `.mr-btn` metrics" — 9px stays 9px, not `--hf-r` 10px) and
-      `activity-history.css`'s `.hh-bd-swatch` (9×9px legend dot at 3px — CSS caps
-      `border-radius` at half the box side, so `--hf-r-sm`'s 6px would round it to a full
-      circle instead of the intended rounded square). - **17 justified inline disables** for genuine one-offs (decorative textures, the marketing
-      CTA glass effect, single-use focus rings, the two geometry exceptions above). - **3 fully dead rules deleted outright** (`mr.css`'s unused `.brand-green`/`.brand-blue`/
-      `.brand-slate` theme overrides — confirmed unreferenced by any component via `git grep`
-      across all of `apps/web/src`, both `.tsx` and `.css`). Note: #147's PR body characterized
-      these same rules as "an intentional per-instance theme switcher, not copies of the
-      source," and declined to touch them as out of scope for that refactor. No open issue
-      references a planned theme-switcher feature, and the dead-code check is unambiguous
-      (`git log -S` shows the classes were added once, in the original responsive-UI commit,
-      and never referenced by any component since) — deleting them here, rather than leaving
-      unenforceable raw literals in place, is the correct call for a token-_enforcement_ gate,
-      but the tension with #147's framing is worth a reviewer's eyes. - **Visual verification:** the Playwright-based gallery/visual-diff harness (see Known
-      Issues above — "removed as low-value and flaky") was removed from `main` mid-implementation
-      and is not available on this branch. Spot-checked live instead — full marketing home page
-      and the `/login` screen rendered via `vite dev`, console clean, no visual regressions —
-      rather than a systematic per-state diff. `S1`
+
+      Baseline (this branch's `stylelint.config.js` against `origin/main`'s CSS right after #149's
+              primitives extraction, 14 stylesheets): **272 violations**, resolved via:
+
+  - **30 new `--hf-*` tokens** in `tokens.css` (status border tints, a `--hf-bad-2`/`--hf-ink-2`
+    hover pair mirroring `--hf-brand-2`, 12 activity/event swatches promoted from
+    `activity-history.css`'s local — non-`--hf-*` — `--hh-*` properties #147 didn't reach, overlay
+    elevation, a `--hf-r-full` pill and a `--hf-r-xl` (20px) tier for hero icons/panel corners
+    outside the issue's three named tiers, spinner track, on-brand foreground, two hatch
+    textures), each backed by 2+ real repeated sites.
+  - **Near-duplicates reconciled into one canonical token**, each disclosed: four drifted
+    "bad-border" reds → `--hf-bad-border`; three shadow blur radii → three `--hf-shadow-*`;
+    `--hh-spine`/a bad-tone icon bg folded into `--hf-line`/`--hf-bad-bg`; four scrim alphas →
+    `--hf-scrim` (majority value); four spinner alphas → `--hf-spinner-track` (split, no
+    majority). Also resolves the case #147/#211 explicitly left raw ("close to but not identical
+    to a token") — `app-search.css`'s two category-icon tints, each a ≤2-point lightness nudge
+    onto the existing token, spot-checked live.
+  - **Border-radius scale-snapping** onto the issue's 3 named tiers (plus pill/xl), except two
+    sites kept as literals where snapping would be a real shape change:
+    `.mr-root .hf-btn` (a comment promises "exact former `.mr-btn` metrics") and
+    `.hh-bd-swatch` (a 9×9px dot at 3px — `--hf-r-sm`'s 6px hits CSS's half-side radius cap and
+    renders as a circle, not a rounded square).
+  - **17 justified inline disables** (decorative textures, the marketing CTA glass effect,
+    single-use focus rings, the two geometry exceptions above).
+  - **3 dead rules deleted** (`mr.css`'s unreferenced `.brand-green`/`.brand-blue`/`.brand-slate`
+    — confirmed via `git grep`/`git log -S`). #147's PR body called these same rules "an
+    intentional theme switcher" and left them alone; no issue references that feature, so
+    deleting unenforceable dead literals is correct here, but the differing framing is worth a
+    reviewer's eyes.
+  - **Visual verification:** the Playwright gallery/visual-diff harness (Known Issues, above) was
+    removed from `main` mid-implementation. Spot-checked live instead (marketing home, `/login`
+    via `vite dev`, console clean) rather than a systematic per-state diff. `S1`
+
 - [x] The rules run in `lint-staged` as well as CI (via `pnpm lint`). `S1`
 
 ### Delivery plan

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "kill-ports": "lsof -ti:8787,5173,9229,9230 | xargs kill -9 2>/dev/null || true",
     "dev": "pnpm -r --parallel --filter @snaveevans/pineapple-api --filter @snaveevans/pineapple-web run dev",
-    "lint": "eslint .",
+    "lint": "eslint . && pnpm run lint:css",
+    "lint:css": "stylelint \"apps/web/src/**/*.css\"",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "type-check": "pnpm -r --if-present run type-check",
@@ -24,6 +25,9 @@
     ],
     "**/*.{json,yaml,md,cjs,mjs}": [
       "prettier --write"
+    ],
+    "apps/web/src/**/*.css": [
+      "stylelint"
     ]
   },
   "devDependencies": {
@@ -37,6 +41,7 @@
     "husky": "^9.1.7",
     "lint-staged": "^17.3.0",
     "prettier": "^3.9.6",
+    "stylelint": "^17.14.1",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.66.0",
     "vitest": "^4.1.10"

--- a/pitfalls.md
+++ b/pitfalls.md
@@ -46,3 +46,48 @@ post-merge.
 - PR #176, review comment: https://github.com/snaveevans/pineapple/pull/176#issuecomment-5209057744
 - Fix commit: `eeca7e9` on branch `chore/125-automated-dependency-updates`
 - Schema: https://json.schemastore.org/dependabot-2.0.json (`additionalProperties: false` on update entries)
+
+## 2026-08-17 — Flaky `AppAssets.test.tsx` only under the root `pnpm test` / pre-push hook
+
+### Symptom
+
+`git push` failed via the `pre-push` husky hook (`pnpm type-check && pnpm test`,
+where root `test` is a bare `vitest run` across the whole workspace in one process)
+with `TypeError: Cannot read properties of undefined (reading 'clear')` at
+`window.localStorage.clear()` in `apps/web/src/app/AppAssets.test.tsx`'s
+`beforeEach`, failing all 5 tests in that file. The diff being pushed touched zero
+`.ts`/`.tsx` files (CSS-only change), and `pnpm --filter @snaveevans/pineapple-web
+test` (the per-package run, using `apps/web`'s own `vitest.config.ts`) passed
+108/108 every time. Re-running the identical root-level `vitest run` command
+repeatedly on the identical committed tree passed twice, failed once, passed
+again — confirmed non-deterministic, not content-driven (also reproduced,
+inconsistently, on a clean `origin/main` checkout).
+
+### Cause
+
+Not fully root-caused. Likely a `window.localStorage` initialization race specific
+to running the full ~101-file / 620-test suite in one Vitest process from the
+repo root (root `vitest.config.ts` has no explicit `environment`/`setupFiles` —
+it only excludes `.claude/**` worktrees), vs. the per-package config that always
+passed. Only ever seen in this one file/suite combination.
+
+### Fix
+
+Retried the push (`git push`) without changing any code — passed on the next
+attempt. Did **not** use `--no-verify`.
+
+### How to avoid next time
+
+If `pnpm push` / the pre-push hook fails specifically in `AppAssets.test.tsx`
+with a `window.localStorage` `TypeError`, and your diff doesn't touch any
+`.ts`/`.tsx` files, don't chase it as a real regression — confirm via
+`pnpm --filter @snaveevans/pineapple-web test` (should pass), then retry the
+push once or twice. If it's still red after 2-3 tries, treat it as a genuine
+regression and investigate further; this entry is about the known-flaky case,
+not a blanket license to retry-until-green.
+
+### Evidence
+
+- Branch `stylelint` (issue #148), local session: root `vitest run` outcomes on
+  the same commit, in order: fail (5/5 `AppAssets.test.tsx` tests) → pass
+  (101/101) → pass (101/101) → fail (same 5 tests) → pass (101/101, pushed).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       prettier:
         specifier: ^3.9.6
         version: 3.9.6
+      stylelint:
+        specifier: ^17.14.1
+        version: 17.14.1(typescript@6.0.3)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -385,6 +388,12 @@ packages:
     resolution: {integrity: sha512-ikqee8669yp2I+uLG67T5P5BSbe+y4NqW5Mk+7tYa+Ydzhpmh0pDyMaH9918J2Ll36ZqYKDb4g4QBeMpWg7VDg==}
     engines: {node: '>=18.18'}
 
+  '@cacheable/memory@2.2.0':
+    resolution: {integrity: sha512-CTLKqLItRCEixEAewD3/j9DB3/o96gpTPD4eJ1v+DGOlxZRZncRQkGYqqnAGCscYd6RNeXfGeiuCphsPtqyIfQ==}
+
+  '@cacheable/utils@2.5.0':
+    resolution: {integrity: sha512-buipgOVDkkPXNR5+xBpDw7Zk2n1EvU7qBJCNUcL7rhQ//kfpOXPAvQ511Os0vpLYJ1pZnvudNytkQt2hst3wqA==}
+
   '@cloudflare/kv-asset-handler@0.5.0':
     resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
     engines: {node: '>=22.0.0'}
@@ -441,6 +450,50 @@ packages:
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
+
+  '@csstools/css-calc@3.3.0':
+    resolution: {integrity: sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.8':
+    resolution: {integrity: sha512-CpMLjAvwQg3BL5S0IeqsZNMH7EQrEWi0kLKOC13ZBF0ZwERiLWlibNPJr8G1kdU3Ms/r2KiNrF81pUh2HwAHdg==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/media-query-list-parser@5.0.0':
+    resolution: {integrity: sha512-T9lXmZOfnam3eMERPsszjY5NK0jX8RmThmmm99FZ8b7z8yMaFZWKwLWGZuTwdO3ddRY5fy13GmmEYZXB4I98Eg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/selector-resolve-nested@4.0.1':
+    resolution: {integrity: sha512-j3vdQu0XwLME5qOTWxm8cnmvsf423R2YL6DbKklCHZwkDm7UdKNu6RPlw4REIJhSlKBICY3B70/7QZdicLqZgg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      postcss-selector-parser: ^7.1.1
+
+  '@csstools/selector-specificity@6.0.0':
+    resolution: {integrity: sha512-4sSgl78OtOXEX/2d++8A83zHNTgwCJMaR24FvsYL7Uf/VS8HZk9PTwR51elTbGqMuwH3szLvvOXEaVnqn0Z3zA==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      postcss-selector-parser: ^7.1.1
 
   '@emnapi/runtime@1.11.3':
     resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
@@ -1144,6 +1197,15 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
+  '@keyv/bigmap@1.3.1':
+    resolution: {integrity: sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      keyv: ^5.6.0
+
+  '@keyv/serialize@1.1.1':
+    resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
+
   '@noble/ciphers@2.3.0':
     resolution: {integrity: sha512-Clu/xdfgVTf9o7ngLOURaxePwR0j8sjclKEtVij10/jGulwFsPWCvvRgG/XjUVf8Nei+jLG6uwyXzUTGY1DQrw==}
     engines: {node: '>= 20.19.0'}
@@ -1151,6 +1213,18 @@ packages:
   '@noble/hashes@2.3.0':
     resolution: {integrity: sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==}
     engines: {node: '>= 20.19.0'}
+
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
 
   '@opentelemetry/semantic-conventions@1.43.0':
     resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
@@ -1559,6 +1633,14 @@ packages:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.3.0:
+    resolution: {integrity: sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==}
+    engines: {node: '>=12'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
@@ -1569,6 +1651,10 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  astral-regex@2.0.0:
+    resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
+    engines: {node: '>=8'}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -1686,6 +1772,9 @@ packages:
     resolution: {integrity: sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==}
     engines: {node: '>=4.0'}
 
+  cacheable@2.5.0:
+    resolution: {integrity: sha512-60cyAOytib/OzBw1JNSoSV/boK1AtHryDIjvVBk7XbN4ugfkM3+Sry7fEjNgPMGgOjuaZPAp8ruZ0Cxafwyq9g==}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -1693,6 +1782,10 @@ packages:
   call-bound@1.0.4:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
+
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
 
   caniuse-lite@1.0.30001793:
     resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
@@ -1726,6 +1819,9 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  colord@2.9.3:
+    resolution: {integrity: sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==}
+
   colorette@1.4.0:
     resolution: {integrity: sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==}
 
@@ -1743,9 +1839,31 @@ packages:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
 
+  cosmiconfig@9.0.2:
+    resolution: {integrity: sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=4.9.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  css-functions-list@3.3.3:
+    resolution: {integrity: sha512-8HFEBPKhOpJPEPu70wJJetjKta86Gw9+CCyCnB3sui2qQfOvRyqBy4IKLKKAwdMpWb2lHXWk9Wb4Z6AmaUT1Pg==}
+    engines: {node: '>=12'}
+
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  cssesc@3.0.0:
+    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
+    engines: {node: '>=4'}
+    hasBin: true
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -1885,6 +2003,9 @@ packages:
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
   enhanced-resolve@5.24.5:
     resolution: {integrity: sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==}
     engines: {node: '>=10.13.0'}
@@ -1892,6 +2013,13 @@ packages:
   entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
+
+  env-paths@2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
+
+  error-ex@1.3.4:
+    resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
   error-stack-parser-es@1.0.5:
     resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
@@ -2046,6 +2174,10 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
@@ -2064,6 +2196,13 @@ packages:
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
 
+  fastest-levenshtein@1.0.16:
+    resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
+    engines: {node: '>= 4.9.1'}
+
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -2076,6 +2215,9 @@ packages:
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
     engines: {node: '>=18'}
+
+  file-entry-cache@11.1.5:
+    resolution: {integrity: sha512-+PFTHITI08JIGhnNpGNI8T8inUpgZfk3GNEqfT9R2zZV2iFXg3CvqzSl/uEhs7TSGujYRELEANyDvS8Fj7+S7Q==}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -2093,6 +2235,9 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
+  flat-cache@6.1.23:
+    resolution: {integrity: sha512-f++BY9pTk+983xK1FLzlLpmM0i0z+jHmx3QESGkURMXujQZz1k5wzwX6hjnQ8goaD0B+sYnDK1yZ6MTyZfUaqA==}
+
   flatted@3.4.4:
     resolution: {integrity: sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==}
 
@@ -2107,6 +2252,10 @@ packages:
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
+
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
 
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
@@ -2123,13 +2272,32 @@ packages:
   get-tsconfig@4.14.2:
     resolution: {integrity: sha512-XpwZALwwl/BaKTAyC6+c5T8y6kCg2jk+XGqOVrKIQmW49pNypYLMRjCUXqa28tQgJlhS2RlzP7sc+Rx7W6qsfw==}
 
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
+  global-modules@2.0.0:
+    resolution: {integrity: sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==}
+    engines: {node: '>=6'}
+
+  global-prefix@3.0.0:
+    resolution: {integrity: sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==}
+    engines: {node: '>=6'}
+
   globals@15.15.0:
     resolution: {integrity: sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==}
     engines: {node: '>=18'}
+
+  globby@16.2.3:
+    resolution: {integrity: sha512-VZX7TV7jmd/pn71vdnLKtgwy1IWqc3KjI9x1/UtPkwoKk5fKrNLY30ltDe3cAM5xruIN7YuuaulFt133jRrKZg==}
+    engines: {node: '>=20'}
+
+  globjoin@0.1.4:
+    resolution: {integrity: sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==}
 
   globrex@0.1.2:
     resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
@@ -2154,9 +2322,17 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  has-flag@5.0.1:
+    resolution: {integrity: sha512-CsNUt5x9LUdx6hnk/E2SZLsDyvfqANZSUq4+D3D8RzDJ2M+HDTIkF60ibS1vHaK55vzgiZw1bEPFG9yH7l33wA==}
+    engines: {node: '>=12'}
+
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
+
+  hashery@1.5.1:
+    resolution: {integrity: sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==}
+    engines: {node: '>=20'}
 
   hasown@2.0.4:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
@@ -2165,6 +2341,16 @@ packages:
   hono@4.13.1:
     resolution: {integrity: sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==}
     engines: {node: '>=16.9.0'}
+
+  hookified@1.15.1:
+    resolution: {integrity: sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==}
+
+  hookified@2.2.0:
+    resolution: {integrity: sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==}
+
+  html-tags@5.1.0:
+    resolution: {integrity: sha512-n6l5uca7/y5joxZ3LUePhzmBFUJ+U2YWzhMa8XUTecSeSlQiZdF5XAd/Q3/WUl0VsXgUwWi8I7CNIwdI5WN1SQ==}
+    engines: {node: '>=20.10'}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -2191,6 +2377,13 @@ packages:
     resolution: {integrity: sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==}
     engines: {node: '>= 4'}
 
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
+  import-meta-resolve@4.2.0:
+    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
+
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
@@ -2201,6 +2394,12 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
+  is-arrayish@0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
   is-core-module@2.16.1:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
@@ -2214,6 +2413,10 @@ packages:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
 
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
@@ -2221,6 +2424,10 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-path-inside@4.0.0:
+    resolution: {integrity: sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==}
+    engines: {node: '>=12'}
 
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
@@ -2262,6 +2469,9 @@ packages:
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
+  json-parse-even-better-errors@2.3.1:
+    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+
   json-rpc-2.0@1.7.1:
     resolution: {integrity: sha512-JqZjhjAanbpkXIzFE7u8mE/iFblawwlXtONaCvRqI+pyABVz7B4M1EUNpyVW+dZjqgQ2L5HFmZCmOCgUKm00hg==}
 
@@ -2281,6 +2491,13 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  keyv@5.6.0:
+    resolution: {integrity: sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==}
+
+  kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
+    engines: {node: '>=0.10.0'}
 
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
@@ -2368,6 +2585,9 @@ packages:
     resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
     engines: {node: '>= 12.0.0'}
 
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
   lint-staged@17.3.0:
     resolution: {integrity: sha512-woZS3vNe3UKqBaLPvbLOtKRY4tLANpWQhom12MGWqC8Mh1lCOO+WgSwmX2amjJAqTY9BkXYW87fCUH5H9Ph6xw==}
     engines: {node: '>=22.22.1'}
@@ -2380,6 +2600,9 @@ packages:
   lodash.groupby@4.6.0:
     resolution: {integrity: sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==}
 
+  lodash.truncate@4.4.2:
+    resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -2389,6 +2612,20 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mathml-tag-names@4.0.0:
+    resolution: {integrity: sha512-aa6AU2Pcx0VP/XWnh8IGL0SYSgQHDT6Ucror2j2mXeFAlN3ahaNs8EZtG1YiticMkSLj3Gt6VPFfZogt7G5iFQ==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  meow@14.1.0:
+    resolution: {integrity: sha512-EDYo6VlmtnumlcBCbh1gLJ//9jvM/ndXHfVXIFrZVr6fGcwTUyCTFNTLCKuY3ffbK8L/+3Mzqnd58RojiZqHVw==}
+    engines: {node: '>=20'}
+
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -2465,6 +2702,10 @@ packages:
     resolution: {integrity: sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==}
     engines: {node: '>=18'}
 
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+
   npm-run-path@6.0.0:
     resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
     engines: {node: '>=18'}
@@ -2497,6 +2738,14 @@ packages:
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
+
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
+  parse-json@5.2.0:
+    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
+    engines: {node: '>=8'}
 
   parse-json@8.3.0:
     resolution: {integrity: sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==}
@@ -2542,6 +2791,19 @@ packages:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
 
+  postcss-safe-parser@7.0.1:
+    resolution: {integrity: sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==}
+    engines: {node: '>=18.0'}
+    peerDependencies:
+      postcss: ^8.4.31
+
+  postcss-selector-parser@7.1.5:
+    resolution: {integrity: sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==}
+    engines: {node: '>=4'}
+
+  postcss-value-parser@4.2.0:
+    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
+
   postcss@8.5.26:
     resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
@@ -2567,9 +2829,16 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  qified@0.10.1:
+    resolution: {integrity: sha512-+Owyggi9IxT1ePKGafcI87ubSmxol6smwJ+RAHDQlx9+9cPwFWDiKFFCPuWhr9ignlGpZ9vDQLw67N4dcTVFEA==}
+    engines: {node: '>=20'}
+
   qs@6.15.1:
     resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
     engines: {node: '>=0.6'}
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
   react-dom@19.2.8:
     resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
@@ -2594,6 +2863,10 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
@@ -2602,6 +2875,10 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
   rolldown@1.2.4:
     resolution: {integrity: sha512-rSr7irW0K7QRWzjdJXqZowkcRdDtjRduh43rBltnVKd0VFq839l1lJoDvGJb6gl7+4rTTCrPWu+YfujUL8Ug7w==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2609,6 +2886,9 @@ packages:
 
   rou3@0.9.2:
     resolution: {integrity: sha512-3SOzvaAg8rkHrXtRjpCvCvbyO5to9oOO27Z/XqHEYXfMRVSw/qMIVdmaOk9W2lcRLtR6dlqTjo9hDeJk70QBYQ==}
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
@@ -2676,6 +2956,14 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  slash@5.1.0:
+    resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
+    engines: {node: '>=14.16'}
+
+  slice-ansi@4.0.0:
+    resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
+    engines: {node: '>=10'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -2698,9 +2986,30 @@ packages:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
     engines: {node: '>=0.6.19'}
 
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@8.2.2:
+    resolution: {integrity: sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==}
+    engines: {node: '>=20'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
+
   strip-final-newline@4.0.0:
     resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
     engines: {node: '>=18'}
+
+  stylelint@17.14.1:
+    resolution: {integrity: sha512-xVQwyiuxALUBNB2fBe0tmNemg9KqLtdj3T64mioFDar79B2cU8LIyz+3KL6LdiHs9NkeNfwxpKSaIVOY8f112g==}
+    engines: {node: '>=20.19.0'}
+    hasBin: true
 
   supports-color@10.2.2:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
@@ -2710,9 +3019,20 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  supports-hyperlinks@4.5.0:
+    resolution: {integrity: sha512-ZW2OvfeCXrNTbLakPUzjQG922EeGCOteFSVoek5DKStTh898wf7zgtuFlzQN8HfZCxC3Eh02yJVrRW51hADf+w==}
+    engines: {node: '>=20'}
+
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  svg-tags@1.0.0:
+    resolution: {integrity: sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==}
+
+  table@6.9.0:
+    resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==}
+    engines: {node: '>=10.0.0'}
 
   tagged-tag@1.0.0:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
@@ -2817,6 +3137,10 @@ packages:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
     engines: {node: '>=18'}
 
+  unicorn-magic@0.4.0:
+    resolution: {integrity: sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==}
+    engines: {node: '>=20'}
+
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
@@ -2828,6 +3152,9 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   vite@8.2.1:
     resolution: {integrity: sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==}
@@ -2920,6 +3247,10 @@ packages:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
     engines: {node: '>=12'}
 
+  which@1.3.1:
+    resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
+    hasBin: true
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -2951,6 +3282,10 @@ packages:
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
+
+  write-file-atomic@7.0.1:
+    resolution: {integrity: sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   ws@8.21.0:
     resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
@@ -3304,6 +3639,18 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
+  '@cacheable/memory@2.2.0':
+    dependencies:
+      '@cacheable/utils': 2.5.0
+      '@keyv/bigmap': 1.3.1(keyv@5.6.0)
+      hookified: 1.15.1
+      keyv: 5.6.0
+
+  '@cacheable/utils@2.5.0':
+    dependencies:
+      hashery: 1.5.1
+      keyv: 5.6.0
+
   '@cloudflare/kv-asset-handler@0.5.0': {}
 
   '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260801.1)':
@@ -3345,6 +3692,34 @@ snapshots:
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
+
+  '@csstools/css-calc@3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.8(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
+
+  '@csstools/media-query-list-parser@5.0.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/selector-resolve-nested@4.0.1(postcss-selector-parser@7.1.5)':
+    dependencies:
+      postcss-selector-parser: 7.1.5
+
+  '@csstools/selector-specificity@6.0.0(postcss-selector-parser@7.1.5)':
+    dependencies:
+      postcss-selector-parser: 7.1.5
 
   '@emnapi/runtime@1.11.3':
     dependencies:
@@ -3819,9 +4194,29 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@keyv/bigmap@1.3.1(keyv@5.6.0)':
+    dependencies:
+      hashery: 1.5.1
+      hookified: 1.15.1
+      keyv: 5.6.0
+
+  '@keyv/serialize@1.1.1': {}
+
   '@noble/ciphers@2.3.0': {}
 
   '@noble/hashes@2.3.0': {}
+
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.20.1
 
   '@opentelemetry/semantic-conventions@1.43.0': {}
 
@@ -4274,6 +4669,10 @@ snapshots:
 
   ansi-colors@4.1.3: {}
 
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.3.0: {}
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
@@ -4281,6 +4680,8 @@ snapshots:
   argparse@2.0.1: {}
 
   assertion-error@2.0.1: {}
+
+  astral-regex@2.0.0: {}
 
   balanced-match@1.0.2: {}
 
@@ -4393,6 +4794,14 @@ snapshots:
     dependencies:
       '@types/node': 26.2.0
 
+  cacheable@2.5.0:
+    dependencies:
+      '@cacheable/memory': 2.2.0
+      '@cacheable/utils': 2.5.0
+      hookified: 1.15.1
+      keyv: 5.6.0
+      qified: 0.10.1
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -4402,6 +4811,8 @@ snapshots:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
+
+  callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001793: {}
 
@@ -4426,6 +4837,8 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  colord@2.9.3: {}
+
   colorette@1.4.0: {}
 
   commander@14.0.3: {}
@@ -4436,11 +4849,29 @@ snapshots:
 
   cookie@1.1.1: {}
 
+  cosmiconfig@9.0.2(typescript@6.0.3):
+    dependencies:
+      env-paths: 2.2.1
+      import-fresh: 3.3.1
+      js-yaml: 4.2.0
+      parse-json: 5.2.0
+    optionalDependencies:
+      typescript: 6.0.3
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  css-functions-list@3.3.3: {}
+
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
+  cssesc@3.0.0: {}
 
   csstype@3.2.3: {}
 
@@ -4482,12 +4913,20 @@ snapshots:
 
   emoji-regex@10.6.0: {}
 
+  emoji-regex@8.0.0: {}
+
   enhanced-resolve@5.24.5:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
 
   entities@7.0.1: {}
+
+  env-paths@2.2.1: {}
+
+  error-ex@1.3.4:
+    dependencies:
+      is-arrayish: 0.2.1
 
   error-stack-parser-es@1.0.5: {}
 
@@ -4713,6 +5152,14 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
@@ -4729,6 +5176,12 @@ snapshots:
     dependencies:
       fast-string-width: 3.0.2
 
+  fastest-levenshtein@1.0.16: {}
+
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
+
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
       picomatch: 4.0.5
@@ -4736,6 +5189,10 @@ snapshots:
   figures@6.1.0:
     dependencies:
       is-unicode-supported: 2.1.0
+
+  file-entry-cache@11.1.5:
+    dependencies:
+      flat-cache: 6.1.23
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -4755,6 +5212,12 @@ snapshots:
       flatted: 3.4.4
       keyv: 4.5.4
 
+  flat-cache@6.1.23:
+    dependencies:
+      cacheable: 2.5.0
+      flatted: 3.4.4
+      hookified: 1.15.1
+
   flatted@3.4.4: {}
 
   fsevents@2.3.3:
@@ -4763,6 +5226,8 @@ snapshots:
   function-bind@1.1.2: {}
 
   gensync@1.0.0-beta.2: {}
+
+  get-east-asian-width@1.6.0: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -4791,11 +5256,36 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
+
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
 
+  global-modules@2.0.0:
+    dependencies:
+      global-prefix: 3.0.0
+
+  global-prefix@3.0.0:
+    dependencies:
+      ini: 1.3.8
+      kind-of: 6.0.3
+      which: 1.3.1
+
   globals@15.15.0: {}
+
+  globby@16.2.3:
+    dependencies:
+      '@sindresorhus/merge-streams': 4.0.0
+      fast-glob: 3.3.3
+      ignore: 7.0.6
+      is-path-inside: 4.0.0
+      slash: 5.1.0
+      unicorn-magic: 0.4.0
+
+  globjoin@0.1.4: {}
 
   globrex@0.1.2: {}
 
@@ -4827,13 +5317,25 @@ snapshots:
 
   has-flag@4.0.0: {}
 
+  has-flag@5.0.1: {}
+
   has-symbols@1.1.0: {}
+
+  hashery@1.5.1:
+    dependencies:
+      hookified: 1.15.1
 
   hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
 
   hono@4.13.1: {}
+
+  hookified@1.15.1: {}
+
+  hookified@2.2.0: {}
+
+  html-tags@5.1.0: {}
 
   https-proxy-agent@7.0.6(supports-color@10.2.2):
     dependencies:
@@ -4854,11 +5356,22 @@ snapshots:
 
   ignore@7.0.6: {}
 
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
+  import-meta-resolve@4.2.0: {}
+
   imurmurhash@0.1.4: {}
 
   index-to-position@1.2.0: {}
 
   inherits@2.0.4: {}
+
+  ini@1.3.8: {}
+
+  is-arrayish@0.2.1: {}
 
   is-core-module@2.16.1:
     dependencies:
@@ -4870,11 +5383,15 @@ snapshots:
 
   is-extglob@2.1.1: {}
 
+  is-fullwidth-code-point@3.0.0: {}
+
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
 
   is-number@7.0.0: {}
+
+  is-path-inside@4.0.0: {}
 
   is-plain-obj@4.1.0: {}
 
@@ -4900,6 +5417,8 @@ snapshots:
 
   json-buffer@3.0.1: {}
 
+  json-parse-even-better-errors@2.3.1: {}
+
   json-rpc-2.0@1.7.1: {}
 
   json-schema-traverse@0.4.1: {}
@@ -4913,6 +5432,12 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  keyv@5.6.0:
+    dependencies:
+      '@keyv/serialize': 1.1.1
+
+  kind-of@6.0.3: {}
 
   kleur@4.1.5: {}
 
@@ -4972,6 +5497,8 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.33.0
       lightningcss-win32-x64-msvc: 1.33.0
 
+  lines-and-columns@1.2.4: {}
+
   lint-staged@17.3.0:
     dependencies:
       picomatch: 4.0.5
@@ -4986,6 +5513,8 @@ snapshots:
 
   lodash.groupby@4.6.0: {}
 
+  lodash.truncate@4.4.2: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -4995,6 +5524,14 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   math-intrinsics@1.1.0: {}
+
+  mathml-tag-names@4.0.0: {}
+
+  mdn-data@2.27.1: {}
+
+  meow@14.1.0: {}
+
+  merge2@1.4.1: {}
 
   micromatch@4.0.8:
     dependencies:
@@ -5059,6 +5596,8 @@ snapshots:
 
   node-releases@2.0.46: {}
 
+  normalize-path@3.0.0: {}
+
   npm-run-path@6.0.0:
     dependencies:
       path-key: 4.0.0
@@ -5099,6 +5638,17 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
+  parse-json@5.2.0:
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      error-ex: 1.3.4
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.2.4
+
   parse-json@8.3.0:
     dependencies:
       '@babel/code-frame': 7.29.7
@@ -5127,6 +5677,17 @@ snapshots:
 
   pluralize@8.0.0: {}
 
+  postcss-safe-parser@7.0.1(postcss@8.5.26):
+    dependencies:
+      postcss: 8.5.26
+
+  postcss-selector-parser@7.1.5:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+
+  postcss-value-parser@4.2.0: {}
+
   postcss@8.5.26:
     dependencies:
       nanoid: 3.3.18
@@ -5145,9 +5706,15 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  qified@0.10.1:
+    dependencies:
+      hookified: 2.2.0
+
   qs@6.15.1:
     dependencies:
       side-channel: 1.1.1
+
+  queue-microtask@1.2.3: {}
 
   react-dom@19.2.8(react@19.2.8):
     dependencies:
@@ -5165,6 +5732,8 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  resolve-from@4.0.0: {}
+
   resolve-pkg-maps@1.0.0: {}
 
   resolve@1.22.12:
@@ -5173,6 +5742,8 @@ snapshots:
       is-core-module: 2.16.2
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+
+  reusify@1.1.0: {}
 
   rolldown@1.2.4:
     dependencies:
@@ -5195,6 +5766,10 @@ snapshots:
       '@rolldown/binding-win32-x64-msvc': 1.2.4
 
   rou3@0.9.2: {}
+
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
 
   rxjs@7.8.2:
     dependencies:
@@ -5284,6 +5859,14 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  slash@5.1.0: {}
+
+  slice-ansi@4.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      astral-regex: 2.0.0
+      is-fullwidth-code-point: 3.0.0
+
   source-map-js@1.2.1: {}
 
   source-map@0.6.1: {}
@@ -5296,7 +5879,67 @@ snapshots:
 
   string-argv@0.3.2: {}
 
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@8.2.2:
+    dependencies:
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.3.0
+
   strip-final-newline@4.0.0: {}
+
+  stylelint@17.14.1(typescript@6.0.3):
+    dependencies:
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-syntax-patches-for-csstree': 1.1.8(css-tree@3.2.1)
+      '@csstools/css-tokenizer': 4.0.0
+      '@csstools/media-query-list-parser': 5.0.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/selector-resolve-nested': 4.0.1(postcss-selector-parser@7.1.5)
+      '@csstools/selector-specificity': 6.0.0(postcss-selector-parser@7.1.5)
+      colord: 2.9.3
+      cosmiconfig: 9.0.2(typescript@6.0.3)
+      css-functions-list: 3.3.3
+      css-tree: 3.2.1
+      debug: 4.4.3(supports-color@10.2.2)
+      fast-glob: 3.3.3
+      fastest-levenshtein: 1.0.16
+      file-entry-cache: 11.1.5
+      global-modules: 2.0.0
+      globby: 16.2.3
+      globjoin: 0.1.4
+      html-tags: 5.1.0
+      ignore: 7.0.6
+      import-meta-resolve: 4.2.0
+      mathml-tag-names: 4.0.0
+      meow: 14.1.0
+      micromatch: 4.0.8
+      normalize-path: 3.0.0
+      picocolors: 1.1.1
+      postcss: 8.5.26
+      postcss-safe-parser: 7.0.1(postcss@8.5.26)
+      postcss-selector-parser: 7.1.5
+      postcss-value-parser: 4.2.0
+      string-width: 8.2.2
+      supports-hyperlinks: 4.5.0
+      svg-tags: 1.0.0
+      table: 6.9.0
+      write-file-atomic: 7.0.1
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   supports-color@10.2.2: {}
 
@@ -5304,7 +5947,22 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  supports-hyperlinks@4.5.0:
+    dependencies:
+      has-flag: 5.0.1
+      supports-color: 10.2.2
+
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  svg-tags@1.0.0: {}
+
+  table@6.9.0:
+    dependencies:
+      ajv: 8.18.0
+      lodash.truncate: 4.4.2
+      slice-ansi: 4.0.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
 
   tagged-tag@1.0.0: {}
 
@@ -5389,6 +6047,8 @@ snapshots:
 
   unicorn-magic@0.3.0: {}
 
+  unicorn-magic@0.4.0: {}
+
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
       browserslist: 4.28.2
@@ -5400,6 +6060,8 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  util-deprecate@1.0.2: {}
 
   vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(tsx@4.23.12)(yaml@2.9.0):
     dependencies:
@@ -5447,6 +6109,10 @@ snapshots:
 
   whatwg-mimetype@3.0.0: {}
 
+  which@1.3.1:
+    dependencies:
+      isexe: 2.0.0
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -5484,6 +6150,10 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  write-file-atomic@7.0.1:
+    dependencies:
+      signal-exit: 4.1.0
 
   ws@8.21.0: {}
 

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -1,0 +1,49 @@
+// Enforces design-token usage in apps/web CSS (issue #148). `tokens.css` is
+// the single declaration site (#147); every other stylesheet must consume
+// `--hf-*` custom properties instead of raw color/radius literals. A
+// justified escape hatch exists for genuine one-offs — see the reportDescriptionless*
+// options below and docs/specs/cross-cutting/testing.md.
+
+/** @type {import('stylelint').Config} */
+export default {
+  // A `stylelint-disable` comment with no `-- reason` is itself a lint error,
+  // an unnecessary one is flagged, and disabling a rule that doesn't exist
+  // (e.g. a typo) is flagged too. Together these make the escape hatch an
+  // explicit, reviewable exception rather than a silent bypass.
+  reportDescriptionlessDisables: true,
+  reportInvalidScopeDisables: true,
+  reportNeedlessDisables: true,
+  rules: {
+    "color-no-hex": true,
+    // Named colors ("white", "black") are exactly as raw as a hex/oklch
+    // literal — the codebase's few uses (button text, spinner rings) are
+    // all a plain white foreground on a colored/dark background, now
+    // tokenized via --hf-on-brand.
+    "color-named": "never",
+    // oklch/rgba had live usage at merge; rgb/hsl/hsla had none but are
+    // banned pre-emptively — the Why here is "no raw color literal outside
+    // tokens.css", not just the functions the issue happened to measure.
+    "function-disallowed-list": ["oklch", "rgb", "rgba", "hsl", "hsla"],
+    "declaration-property-value-disallowed-list": {
+      // Matches border-radius and its four longhand corners. Requires at
+      // least one bare `Npx` component so a plain `0` reset (no scale
+      // concept applies to "no rounding") isn't forced through a token.
+      "/^border(-(top|bottom)-(left|right))?-radius$/": [
+        /^(?=.*px)(0|\d+(?:\.\d+)?px)(?:\s+(?:0|\d+(?:\.\d+)?px)){0,3}$/,
+      ],
+    },
+  },
+  overrides: [
+    {
+      // The token source itself declares the raw values everything else
+      // must reference.
+      files: ["apps/web/src/design/styles/tokens.css"],
+      rules: {
+        "color-no-hex": null,
+        "color-named": null,
+        "function-disallowed-list": null,
+        "declaration-property-value-disallowed-list": null,
+      },
+    },
+  ],
+};


### PR DESCRIPTION
## Summary

- Adds a stylelint gate (`stylelint.config.js`) banning raw color literals (`oklch()`/hex/`rgb()`/`rgba()`/`hsl()`/`hsla()`/named colors) and bare-pixel `border-radius` outside `apps/web/src/design/styles/tokens.css`, with a justified-disable escape hatch (`reportDescriptionlessDisables`/`NeedlessDisables`/`InvalidScopeDisables`). Wired into `pnpm lint` and `lint-staged`.
- Brings the existing `apps/web` codebase (272-violation baseline, measured against `origin/main`'s CSS after #149's primitives extraction) to zero violations: 30 new `--hf-*` tokens backed by real repeated usage (or promoted from `activity-history.css`'s local `--hh-*` properties), disclosed near-duplicate reconciliations, a new `--hf-r-xl` tier for large hero/panel corners, 17 justified inline disables, and deletion of 3 confirmed-dead theme-override rules in `mr.css`. Full accounting in `docs/specs/cross-cutting/testing.md`'s new "CSS token lint gate" section.
- Records a pre-existing, non-deterministic `AppAssets.test.tsx` flake hit under the root `pnpm test` (unrelated to this diff — no `.tsx` touched) in `pitfalls.md`.

## Related

Closes #148

## Risk

**Level:** M

**Why:** Path-glob baseline is M (`apps/web/src/**`, non-trivial — a large CSS token-substitution diff across the design system). No H/C path or semantic elevation applies: no `apps/api` domain/application/API-contract, no auth/permissions/sharing logic, no migrations, no `.github/workflows/**`. Two escalations below are worth a human glance but don't raise the floor.

**Human validation budget:** Evidence + escalations; spot-check 1–2 hot files.

## Evidence

- `pnpm lint && pnpm type-check && pnpm -r test` green locally (apps/api 512/512, apps/web 108/108) under the pinned Node version (`.tool-versions`, 22.21.1 — a Homebrew Node on `PATH` reproduces the known `apps/web` Cloudflare Vite plugin failure documented in `CLAUDE.md`).
- Fresh `stylelint "apps/web/src/**/*.css"` run: exit 0, zero violations.
- Live visual spot-check via `vite dev` + browser: marketing home page (hero, CTA glass buttons, collage panel at the new `--hf-r-xl` radius) and `/login` — console clean, no visual regressions. The Playwright gallery/visual-diff harness this repo used to have was removed from `main` mid-implementation (unrelated PR), so this is a manual spot-check rather than a systematic per-state diff — see Escalations.
- 5-agent adversarial review (`pr-review` pattern: conventions, bugs, history/blame, prior-PR precedent, docs-consistency) run against the diff; every actionable finding fixed before this push (see Escalations for the ones that needed a product-owner glance rather than a pure bug fix).

## Test plan

- [x] `pnpm lint` — stylelint fails on a reintroduced raw color/radius outside `tokens.css` (verified during development on multiple real violations before fixing each)
- [x] `pnpm type-check`
- [x] `pnpm -r test`
- [x] Manual: `pnpm --filter @snaveevans/pineapple-web dev`, visually inspected marketing home + `/login`

## Spec / AC

`docs/specs/cross-cutting/testing.md` — "CSS token lint gate" section, all `S1` acceptance criteria checked (spec status now `active`). `docs/specs/SPECS.md` index row updated to match.

## Validation gate

- [x] Rebased on latest `main` (merged #213 extract-primitives and #220 Node-version-pin mid-implementation to avoid duplicating their in-flight work, then rebased onto both)
- [x] Lint / type-check / tests green locally
- [x] Adversarial review run (5-agent `pr-review` fan-out: conventions, bugs, history, prior-PR precedent, docs-consistency)
- [x] Safe findings self-fixed; product escalations listed below
- [x] Docs / spec AC updated (testing.md, SPECS.md)
- [x] No OpenAPI/contract change — regen not applicable

**Escalations (need human decision):**

- **`mr.css`'s dead `.brand-green`/`.brand-blue`/`.brand-slate` deletion.** Confirmed unreferenced by any component (`git grep`/`git log -S` across all of `apps/web/src`), but #147's own PR body characterized these same rules as "an intentional per-instance theme switcher... out of scope" and declined to touch them. No open issue references a planned theme-switcher feature. Deleting them here (rather than leaving unenforceable raw literals) is the right call for a token-*enforcement* gate, but the differing framing between the two PRs is worth a glance.
- **New `--hf-r-xl: 20px` token.** The issue's Scope section names only `--hf-r-sm`/`--hf-r`/`--hf-r-lg`. Ten sites (spinner rings, badges, modal/sheet corners, a marketing collage panel) originally used 16–24px raw radii; forcing them onto the 14px `--hf-r-lg` tier would have been a real (up to ~42%) size reduction, so I added one more tier instead of silently shrinking them. Spot-checked live (marketing collage panel, `.au-*` badges) — looks intentional, not broken — but it's a genuine 4th tier beyond what the issue named, worth a design-system-owner's yes/no.
- **No systematic visual-diff evidence.** The gallery/visual-diff harness was removed from `main` (separate PR, mid-implementation here) — this PR's "no visual regression" claim rests on a manual spot-check of 2 pages plus per-site reasoning during the token/radius substitution work, not an automated per-state screenshot diff like #147/#149 had available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)