### PR TITLE
docs: specify maintenance task edit delivery

### DIFF
--- a/docs/specs/features/maintenance-task.md
+++ b/docs/specs/features/maintenance-task.md
@@ -9,8 +9,8 @@ metadata:
 
 **Status:** active
 **Owner:** product and engineering
-**Last Updated:** 2026-07-02
-**Related Specs:** [authentication.md](../cross-cutting/authentication.md), [validation.md](../cross-cutting/validation.md), [error-handling.md](../cross-cutting/error-handling.md), [loading-states.md](../cross-cutting/loading-states.md), [permissions.md](../cross-cutting/permissions.md), [telemetry.md](../cross-cutting/telemetry.md), [maintenance-record.md](./maintenance-record.md), [dashboard.md](./dashboard.md)
+**Last Updated:** 2026-08-17
+**Related Specs:** [authentication.md](../cross-cutting/authentication.md), [validation.md](../cross-cutting/validation.md), [error-handling.md](../cross-cutting/error-handling.md), [loading-states.md](../cross-cutting/loading-states.md), [permissions.md](../cross-cutting/permissions.md), [telemetry.md](../cross-cutting/telemetry.md), [maintenance-record.md](./maintenance-record.md), [dashboard.md](./dashboard.md), [activity-history.md](./activity-history.md)
 
 ---
 
@@ -28,98 +28,151 @@ The Maintenance Task feature lets an authenticated owner-operator define schedul
 - As **DIYer Dale**, I can **use a task's dedicated "Log maintenance" flow** so that **the record is pre-linked to the task without extra steps**
 - As an **authenticated owner-operator**, I can **delete a maintenance task** so that **stale or incorrect tasks don't clutter my asset**
 - As a **user who deletes a task**, my **existing maintenance records are preserved** so that **my historical maintenance log is not lost**
+- As an **authenticated owner-operator**, I can **edit a task's title or interval** so that **I can correct a mistake without losing `lastCompletedDate` or churning the task's history the way delete-and-recreate does**
 
 ## Acceptance Criteria
 
+<!-- These boxes are the live implementation checklist: check a box (`- [x]`) only when the
+behavior is implemented AND covered by a test on `main`. Every criterion carries exactly one
+slice tag (`S1`…) from the Delivery Plan below — so each box has a home and "slice done = its
+tagged boxes are all `[x]`." See docs/specs/SPECS.md. -->
+
 ### Task creation
 
-- [ ] A maintenance task is always tied to an existing asset owned by the authenticated user
-- [ ] `POST /api/assets/{assetId}/maintenance-tasks` accepts `{ title, intervalValue, intervalUnit, lastCompletedDate? }` and returns the full created task with status 201
-- [ ] `ownerId` is never accepted in the request body; it is derived from the authenticated session
-- [ ] `title` is required and limited to 100 characters
-- [ ] `intervalValue` is required and must be a positive integer (≥ 1)
-- [ ] `intervalUnit` is required and must be one of `"day" | "week" | "month" | "year"`
-- [ ] `lastCompletedDate` is optional; when provided it must be a valid YYYY-MM-DD date that is today or earlier
-- [ ] When `lastCompletedDate` is provided, `nextDue = lastCompletedDate + interval` (calendar-based arithmetic)
-- [ ] When `lastCompletedDate` is omitted, `nextDue = today (UTC calendar date) + interval`
-- [ ] Creating a task for an archived asset returns 409
-- [ ] The create use case checks that the target asset exists and belongs to the authenticated user before creating the task
+- [x] `S1` A maintenance task is always tied to an existing asset owned by the authenticated user
+- [x] `S1` `POST /api/assets/{assetId}/maintenance-tasks` accepts `{ title, intervalValue, intervalUnit, lastCompletedDate? }` and returns the full created task with status 201
+- [x] `S1` `ownerId` is never accepted in the request body; it is derived from the authenticated session
+- [x] `S1` `title` is required and limited to 100 characters
+- [x] `S1` `intervalValue` is required and must be a positive integer (≥ 1)
+- [x] `S1` `intervalUnit` is required and must be one of `"day" | "week" | "month" | "year"`
+- [x] `S1` `lastCompletedDate` is optional; when provided it must be a valid YYYY-MM-DD date that is today or earlier
+- [x] `S1` When `lastCompletedDate` is provided, `nextDue = lastCompletedDate + interval` (calendar-based arithmetic)
+- [x] `S1` When `lastCompletedDate` is omitted, `nextDue = today (UTC calendar date) + interval`
+- [x] `S1` Creating a task for an archived asset returns 409
+- [x] `S1` The create use case checks that the target asset exists and belongs to the authenticated user before creating the task
 
 ### Task list
 
-- [ ] `GET /api/assets/{assetId}/maintenance-tasks` returns `{ maintenanceTasks: [...] }` with status 200
-- [ ] The list use case returns only tasks for an asset owned by the authenticated user
-- [ ] Each task in the response includes `id`, `assetId`, `title`, `intervalValue`, `intervalUnit`, `lastCompletedDate` (nullable), `nextDue`, and `createdAt`; `ownerId` is never exposed
-- [ ] Tasks are returned in ascending `nextDue` order (soonest due first)
-- [ ] The dashboard's cross-asset queue is exposed through [dashboard.md](./dashboard.md), not by requiring the web app to call this asset-scoped endpoint once per asset
+- [x] `S1` `GET /api/assets/{assetId}/maintenance-tasks` returns `{ maintenanceTasks: [...] }` with status 200
+- [x] `S1` The list use case returns only tasks for an asset owned by the authenticated user
+- [x] `S1` Each task in the response includes `id`, `assetId`, `title`, `intervalValue`, `intervalUnit`, `lastCompletedDate` (nullable), `nextDue`, and `createdAt`; `ownerId` is never exposed
+- [x] `S1` Tasks are returned in ascending `nextDue` order (soonest due first)
+- [x] `S1` The dashboard's cross-asset queue is exposed through [dashboard.md](./dashboard.md), not by requiring the web app to call this asset-scoped endpoint once per asset
 
 ### Task deletion
 
-- [ ] `DELETE /api/assets/{assetId}/maintenance-tasks/{taskId}` returns 204 on success
-- [ ] Deleting a task that doesn't exist returns 404
-- [ ] Deleting a task that belongs to another user returns 403
-- [ ] Existing maintenance records previously linked to the deleted task are preserved with their `taskId` set to null
+- [x] `S1` `DELETE /api/assets/{assetId}/maintenance-tasks/{taskId}` returns 204 on success
+- [x] `S1` Deleting a task that doesn't exist returns 404
+- [x] `S1` Deleting a task that belongs to another user returns 403
+- [x] `S1` Existing maintenance records previously linked to the deleted task are preserved with their `taskId` set to null
+
+### Task edit
+
+- [ ] `S2` `PATCH /api/assets/{assetId}/maintenance-tasks/{taskId}` accepts `{ title?, intervalValue?, intervalUnit? }` and returns the full updated task with status 200
+- [ ] `S2` At least one of `title`, `intervalValue`, `intervalUnit` must be present in the request body; a body with none of them returns 422
+- [ ] `S2` `lastCompletedDate` and `nextDue` are not fields on this endpoint's request schema; the endpoint never accepts a direct override of either — `nextDue` is always derived (see recompute rule below)
+- [ ] `S2` `ownerId` is never accepted in the request body; it is derived from the authenticated session
+- [ ] `S2` When provided, `title` follows the same validation as task creation (non-empty after trim, ≤100 characters)
+- [ ] `S2` When provided, `intervalValue` follows the same validation as task creation (positive integer ≥ 1)
+- [ ] `S2` When provided, `intervalUnit` follows the same validation as task creation (one of `day | week | month | year`)
+- [ ] `S2` A field omitted from the request body keeps its current stored value
+- [ ] `S2` When the resulting `intervalValue` and/or `intervalUnit` differ from the task's current stored values, `nextDue` is recomputed as `(lastCompletedDate ?? todayUtc) + interval`, using the resulting `intervalValue`/`intervalUnit` and the same calendar arithmetic as task creation
+- [ ] `S2` When the resulting `intervalValue` and `intervalUnit` are unchanged from the task's current stored values — whether omitted from the request or resent unchanged — `lastCompletedDate` and `nextDue` are left unchanged; this holds even for a title-only edit on a task with no `lastCompletedDate`, where recomputing from `todayUtc` would otherwise silently push the schedule out
+- [ ] `S2` When the requested `title`, `intervalValue`, and `intervalUnit` (after applying only the provided fields) are identical to the task's current stored values, the edit is a no-op: the task is returned unchanged with status 200, and no `MaintenanceTaskUpdated` event is published
+- [ ] `S2` Editing a task on an archived asset is permitted — asset archival blocks new maintenance activity (creating tasks or records), not correction of an existing task's metadata
+- [ ] `S2` Editing a task that doesn't exist returns 404
+- [ ] `S2` Editing a task that exists but belongs to a different asset than the path `assetId` returns 404
+- [ ] `S2` Editing a task whose asset the requester cannot access returns 403
+- [ ] `S2` The update use case checks that the target asset exists and the requester can access it before applying the edit, following the same task-then-asset-then-access order as task deletion (task lookup and asset-mismatch check first, then asset lookup, then the access check)
+- [ ] `S2` A successful edit that changes `title`, `intervalValue`, or `intervalUnit` publishes a `MaintenanceTaskUpdated` domain event carrying the resulting `nextDue` as a producer-owned conclusion (ADR-0010), so the notifications scheduler reschedules the pending reminder via its existing supersede path without reading task storage back
+- [ ] `S3` An editable task exposes an edit action that opens a form prefilled with its title and interval; the form never offers `lastCompletedDate` or `nextDue`
+- [ ] `S3` Saving the task submits the edit endpoint, updates the displayed task in place, and shows the existing access-denied / not-found treatment for 403/404 responses
 
 ### Record-task linking (change to existing maintenance-record endpoint)
 
-- [ ] `POST /api/assets/{assetId}/maintenance-records` accepts an optional `taskId` field in the request body
-- [ ] When `taskId` is provided, it must reference a maintenance task belonging to the same asset; a task from a different asset returns 422
-- [ ] When `taskId` references a task owned by a different user, 404 is returned (existence is not revealed)
-- [ ] Maintenance record responses include a nullable `taskId` field
-- [ ] When a linked record's `performedAt` is strictly greater than the task's current `lastCompletedDate` (or the task has no `lastCompletedDate`), the task's `lastCompletedDate` updates to `record.performedAt` and `nextDue` advances accordingly
-- [ ] When a linked record's `performedAt` is earlier than the task's current `lastCompletedDate`, `lastCompletedDate` and `nextDue` are unchanged — linking an older record never regresses the next-due date
-- [ ] Linking a record to a task for an archived asset returns 409 (the existing archived-asset rule for record creation applies)
+- [x] `S1` `POST /api/assets/{assetId}/maintenance-records` accepts an optional `taskId` field in the request body
+- [x] `S1` When `taskId` is provided, it must reference a maintenance task belonging to the same asset; a task from a different asset returns 422
+- [x] `S1` When `taskId` references a task owned by a different user, 404 is returned (existence is not revealed)
+- [x] `S1` Maintenance record responses include a nullable `taskId` field
+- [x] `S1` When a linked record's `performedAt` is strictly greater than the task's current `lastCompletedDate` (or the task has no `lastCompletedDate`), the task's `lastCompletedDate` updates to `record.performedAt` and `nextDue` advances accordingly
+- [x] `S1` When a linked record's `performedAt` is earlier than the task's current `lastCompletedDate`, `lastCompletedDate` and `nextDue` are unchanged — linking an older record never regresses the next-due date
+- [x] `S1` Linking a record to a task for an archived asset returns 409 (the existing archived-asset rule for record creation applies)
 
 ### General
 
-- [ ] A 401 response from the API redirects to `/login` through the API client layer
-- [ ] A 403 response from asset or task ownership checks is shown as an access-denied error
-- [ ] A 404 response is shown as a not-found error when the asset or task does not exist
+- [x] `S1` A 401 response from the API redirects to `/login` through the API client layer
+- [x] `S1` A 403 response from asset or task ownership checks is shown as an access-denied error
+- [x] `S1` A 404 response is shown as a not-found error when the asset or task does not exist
+- [ ] `S3` A 403/404 response from a task edit is shown using the same access-denied / not-found treatment as the rest of this feature
+
+## Delivery Plan
+
+| Slice | Scope                                                                                                                              | Issue | Depends on |
+| ----- | ---------------------------------------------------------------------------------------------------------------------------------- | ----- | ---------- |
+| `S1`  | Task creation, listing, deletion, and record-task linking (already shipped)                                                        | —     | —          |
+| `S2`  | Task-edit backend: `PATCH` for `title`/`intervalValue`/`intervalUnit`, recomputed `nextDue`, and a `MaintenanceTaskUpdated` Smart Event | #180 | `S1` |
+| `S3`  | Task-edit UI: prefilled title/interval form that updates the task in place without exposing schedule baselines | #180 | `S2` |
 
 ## Validation & Ownership
 
 **Authentication:** This feature is available only to authenticated users. API requests use the resolved `User.id` as `ownerId`.
 
-**Permissions:** Tasks are owned through the asset they belong to. A user can create, list, and delete tasks only for assets they own. The client cannot supply `ownerId`.
+**Permissions:** Tasks are owned through the asset they belong to. A user can create, list, delete, and edit tasks only for assets they own or that are shared with their team (same access rule as create/delete — see `canAccessAsset`). The client cannot supply `ownerId`.
 
-**HTTP validation:** Inputs are validated at the Zod HTTP edge in `apps/api/src/api/schemas/maintenanceTaskSchemas.ts`. Required fields: `title` (string, max 100 chars), `intervalValue` (positive integer), `intervalUnit` (enum: `day | week | month | year`). Optional: `lastCompletedDate` (YYYY-MM-DD, today or earlier). For maintenance record creation, `taskId` is optional (UUID).
+**HTTP validation:** Inputs are validated at the Zod HTTP edge in `apps/api/src/api/schemas/maintenanceTaskSchemas.ts`. Required fields (create): `title` (string, max 100 chars), `intervalValue` (positive integer), `intervalUnit` (enum: `day | week | month | year`). Optional (create): `lastCompletedDate` (YYYY-MM-DD, today or earlier). For maintenance record creation, `taskId` is optional (UUID). The edit (`PATCH`) schema makes `title`, `intervalValue`, and `intervalUnit` all optional but validated with the same per-field rules as create when present, and refines that at least one of the three must be supplied; it declares no `lastCompletedDate` or `nextDue` field at all, so either key in a request body is silently stripped by Zod's default unknown-key handling rather than rejected or applied.
 
-**Domain validation:** Domain construction trims title and preserves these invariants: non-empty title of at most 100 characters; positive integer interval value; valid interval unit; date-only `lastCompletedDate` of today or earlier when provided; `nextDue` always present and derived from `lastCompletedDate` (or today's UTC calendar date) + interval.
+**Domain validation:** Domain construction trims title and preserves these invariants: non-empty title of at most 100 characters; positive integer interval value; valid interval unit; date-only `lastCompletedDate` of today or earlier when provided; `nextDue` always present and derived from `lastCompletedDate` (or today's UTC calendar date) + interval. Editing reuses the same invariants — an edit cannot leave the task in a state creation itself couldn't produce.
 
-**Next-due arithmetic:** Interval arithmetic is calendar-based. "2 months from 2026-01-31" yields "2026-03-31"; if the resulting day exceeds the month length, clamp to the last day of that month. The implementation must not parse date strings through `Date` for calendar arithmetic; use manual calendar math or a WinterCG-compatible date library.
+**Next-due arithmetic:** Interval arithmetic is calendar-based. "2 months from 2026-01-31" yields "2026-03-31"; if the resulting day exceeds the month length, clamp to the last day of that month. The implementation must not parse date strings through `Date` for calendar arithmetic; use manual calendar math or a WinterCG-compatible date library. Editing must reuse this same `addInterval` implementation, not a second one.
 
-**Date-only mitigation:** Same convention as [maintenance-record.md](./maintenance-record.md). `lastCompletedDate` and `nextDue` are timezone-free YYYY-MM-DD strings across the API, domain, and D1 persistence. Today's UTC calendar date is authoritative for seeding and comparisons.
+**Edit recompute rule:** An edit whose resulting `intervalValue`/`intervalUnit` differ from the task's current stored values recomputes `nextDue = addInterval(lastCompletedDate ?? todayUtc, resultingIntervalValue, resultingIntervalUnit)` — the identical formula task creation uses, just with the task's current `lastCompletedDate` (if any) as the baseline instead of a client-supplied one. The recompute is gated on the _resulting_ value actually differing from what's stored, not merely on whether the request includes the field — a client that resends the current interval alongside a title change (e.g. a form that always submits its full state) must not shift `nextDue` as a side effect. This matters most for a task with no `lastCompletedDate`, where the baseline would otherwise silently move from the task's original creation date to "today."
+
+**Date-only mitigation:** Same convention as [maintenance-record.md](./maintenance-record.md). `lastCompletedDate` and `nextDue` are timezone-free YYYY-MM-DD strings across the API, domain, and D1 persistence. Today's UTC calendar date is authoritative for seeding, comparisons, and edit recomputation.
 
 **Field errors:** Validation errors map back to `title`, `intervalValue`, `intervalUnit`, and `lastCompletedDate` when the backend includes a known `field` value.
 
 ## Edge Cases & Error States
 
-| Scenario                                                               | Expected Behavior                                                    |
-| ---------------------------------------------------------------------- | -------------------------------------------------------------------- |
-| Asset has no maintenance tasks                                         | List returns `{ maintenanceTasks: [] }`                              |
-| `title` is empty                                                       | 422; title field shows required-field error                          |
-| `title` is over 100 characters                                         | 422; title field shows max-length error                              |
-| `intervalValue` is 0 or negative                                       | 422; intervalValue field shows must-be-positive error                |
-| `intervalValue` is not an integer                                      | 422; intervalValue field shows type error                            |
-| `intervalUnit` is not a valid enum value                               | 422; intervalUnit field shows invalid-value error                    |
-| `lastCompletedDate` is in the future                                   | 422; lastCompletedDate field shows "must be today or earlier" error  |
-| `lastCompletedDate` is malformed                                       | 422; lastCompletedDate field shows format error                      |
-| `lastCompletedDate` omitted                                            | `nextDue` seeded as today (UTC calendar date) + interval             |
-| Asset is archived; task creation attempted                             | 409                                                                  |
-| Asset is archived; task list requested                                 | Existing task list is returned normally                              |
-| Asset is archived; record with `taskId` provided                       | 409 (archived-asset rule on record creation applies)                 |
-| Linked record's `performedAt` equals task's `lastCompletedDate`        | `lastCompletedDate` and `nextDue` unchanged                          |
-| Linked record's `performedAt` is older than task's `lastCompletedDate` | `lastCompletedDate` and `nextDue` unchanged                          |
-| `taskId` in record creation belongs to a different asset (same user)   | 422; taskId field shows "task does not belong to this asset"         |
-| `taskId` in record creation belongs to another user's task             | 404                                                                  |
-| `taskId` in record creation references a non-existent task             | 404                                                                  |
-| Task is deleted while it has linked records                            | 204; linked records preserved with `taskId` set to null              |
-| Deleting a task that doesn't exist                                     | 404                                                                  |
-| Deleting another user's task                                           | 403                                                                  |
-| User lists tasks for another user's asset                              | 403                                                                  |
-| User lists tasks for a non-existent asset                              | 404                                                                  |
-| 422 response with a known field name                                   | Banner shown; server error message pinned to the matching form field |
-| 422 response without a field name                                      | Banner shown; no field highlighted                                   |
+| Scenario                                                                       | Expected Behavior                                                                            |
+| ------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------- |
+| Asset has no maintenance tasks                                                 | List returns `{ maintenanceTasks: [] }`                                                      |
+| `title` is empty                                                               | 422; title field shows required-field error                                                  |
+| `title` is over 100 characters                                                 | 422; title field shows max-length error                                                      |
+| `intervalValue` is 0 or negative                                               | 422; intervalValue field shows must-be-positive error                                        |
+| `intervalValue` is not an integer                                              | 422; intervalValue field shows type error                                                    |
+| `intervalUnit` is not a valid enum value                                       | 422; intervalUnit field shows invalid-value error                                            |
+| `lastCompletedDate` is in the future                                           | 422; lastCompletedDate field shows "must be today or earlier" error                          |
+| `lastCompletedDate` is malformed                                               | 422; lastCompletedDate field shows format error                                              |
+| `lastCompletedDate` omitted                                                    | `nextDue` seeded as today (UTC calendar date) + interval                                     |
+| Asset is archived; task creation attempted                                     | 409                                                                                          |
+| Asset is archived; task list requested                                         | Existing task list is returned normally                                                      |
+| Asset is archived; record with `taskId` provided                               | 409 (archived-asset rule on record creation applies)                                         |
+| Linked record's `performedAt` equals task's `lastCompletedDate`                | `lastCompletedDate` and `nextDue` unchanged                                                  |
+| Linked record's `performedAt` is older than task's `lastCompletedDate`         | `lastCompletedDate` and `nextDue` unchanged                                                  |
+| `taskId` in record creation belongs to a different asset (same user)           | 422; taskId field shows "task does not belong to this asset"                                 |
+| `taskId` in record creation belongs to another user's task                     | 404                                                                                          |
+| `taskId` in record creation references a non-existent task                     | 404                                                                                          |
+| Task is deleted while it has linked records                                    | 204; linked records preserved with `taskId` set to null                                      |
+| Deleting a task that doesn't exist                                             | 404                                                                                          |
+| Deleting another user's task                                                   | 403                                                                                          |
+| User lists tasks for another user's asset                                      | 403                                                                                          |
+| User lists tasks for a non-existent asset                                      | 404                                                                                          |
+| PATCH body has none of `title`, `intervalValue`, `intervalUnit`                | 422; banner shown, no field highlighted                                                      |
+| PATCH `title` present but empty/whitespace-only                                | 422; title field shows required-field error                                                  |
+| PATCH `title` exceeds 100 characters                                           | 422; title field shows max-length error                                                      |
+| PATCH `intervalValue` is 0, negative, or non-integer                           | 422; intervalValue field shows validation error                                              |
+| PATCH `intervalUnit` is not `day`/`week`/`month`/`year`                        | 422; intervalUnit field shows invalid-value error                                            |
+| PATCH body includes `lastCompletedDate` or `nextDue`                           | Silently ignored (not part of the schema); `nextDue` is still derived per the recompute rule |
+| Edit changes only `title`                                                      | `lastCompletedDate` and `nextDue` unchanged; `MaintenanceTaskUpdated` published              |
+| Edit changes `intervalValue`/`intervalUnit`, task has a `lastCompletedDate`    | `nextDue` recomputed from `lastCompletedDate` + resulting interval                           |
+| Edit changes `intervalValue`/`intervalUnit`, task has no `lastCompletedDate`   | `nextDue` recomputed from today's UTC date + resulting interval                              |
+| Edit request's resulting values exactly match the task's current stored values | 200 with unchanged task; no `MaintenanceTaskUpdated` event published                         |
+| Editing a task that doesn't exist                                              | 404                                                                                          |
+| Editing a task that belongs to a different asset than the path `assetId`       | 404                                                                                          |
+| Editing a task whose asset the requester cannot access                         | 403                                                                                          |
+| Editing a task on an archived asset                                            | Permitted; 200                                                                               |
+| 422 response with a known field name                                           | Banner shown; server error message pinned to the matching form field                         |
+| 422 response without a field name                                              | Banner shown; no field highlighted                                                           |
 
 ## Telemetry
 
@@ -128,12 +181,13 @@ The Maintenance Task feature lets an authenticated owner-operator define schedul
 - `POST /api/assets/{assetId}/maintenance-tasks` → `CreateMaintenanceTask` operation
 - `GET /api/assets/{assetId}/maintenance-tasks` → `ListMaintenanceTasks` operation
 - `DELETE /api/assets/{assetId}/maintenance-tasks/{taskId}` → `DeleteMaintenanceTask` operation
+- `PATCH /api/assets/{assetId}/maintenance-tasks/{taskId}` → `UpdateMaintenanceTask` operation
 
-All three route patterns must be added to the operation name mapping in `technicalTelemetry.ts`. See [telemetry.md](../cross-cutting/telemetry.md) for the full request data point shape. The existing `POST /api/assets/{assetId}/maintenance-records` operation name (`CreateMaintenanceRecord`) is unchanged when `taskId` is added to the body.
+All four route patterns must be added to the operation name mapping in `technicalTelemetry.ts`. See [telemetry.md](../cross-cutting/telemetry.md) for the full request data point shape. The existing `POST /api/assets/{assetId}/maintenance-records` operation name (`CreateMaintenanceRecord`) is unchanged when `taskId` is added to the body.
 
-**Domain events:** Three events are published to dataset `pineapple_maintenance_task_domain_events` (binding: `MAINTENANCE_TASK_DOMAIN_TELEMETRY`). None may include user-entered title text in telemetry blobs.
+**Domain events:** Four events are published to dataset `pineapple_maintenance_task_domain_events` (binding: `MAINTENANCE_TASK_DOMAIN_TELEMETRY`). None may include user-entered title text in telemetry blobs.
 
-**Enriched event payload vs. telemetry blobs (Smart Events, [ADR-0010](../../decisions/0010-smart-events-for-durable-consumers.md)):** The blob tables below are the _thin telemetry projection_ written to Analytics Engine (IDs and enums only, no PII). The _event payload_ carried on the bus/queue to durable consumers is richer — it additionally carries the asset snapshot (`name`, `type`), the task `title`, the History `activityEntryType` conclusion, and, for `MaintenanceTaskCreated` and `MaintenanceTaskAdvanced`, the resulting **`nextDue`** as a producer-owned conclusion. `nextDue` is required so the [notifications](./notifications.md) durable scheduler can schedule/reschedule a reminder **without reading maintenance-task storage back** (ADR-0010); `MaintenanceTaskDeleted` needs no `nextDue` (its consumer cancels). These payload fields are **not** added to the telemetry blobs, which stay PII-free. The full payload contract lives in [data-model.md](../../reference/data-model.md) (domain-events table). Implementation must populate `nextDue` where these events are constructed in the application layer, using the task's `nextDue` after creation or advancement.
+**Enriched event payload vs. telemetry blobs (Smart Events, [ADR-0010](../../decisions/0010-smart-events-for-durable-consumers.md)):** The blob tables below are the _thin telemetry projection_ written to Analytics Engine (IDs and enums only, no PII). The _event payload_ carried on the bus/queue to durable consumers is richer — it additionally carries the asset snapshot (`name`, `type`), the task `title`, the History `activityEntryType` conclusion, and, for `MaintenanceTaskCreated`, `MaintenanceTaskUpdated`, and `MaintenanceTaskAdvanced`, the resulting **`nextDue`** as a producer-owned conclusion. `nextDue` is required so the [notifications](./notifications.md) durable scheduler can schedule/reschedule a reminder **without reading maintenance-task storage back** (ADR-0010); `MaintenanceTaskDeleted` needs no `nextDue` (its consumer cancels). These payload fields are **not** added to the telemetry blobs, which stay PII-free. The full payload contract lives in [data-model.md](../../reference/data-model.md) (domain-events table). Implementation must populate `nextDue` where these events are constructed in the application layer, using the task's `nextDue` after creation, update, or advancement.
 
 ### `MaintenanceTaskCreated` — on successful task creation
 
@@ -152,6 +206,26 @@ All three route patterns must be added to the operation name mapping in `technic
 | `doubles[0]` | `count`                | Always `1`                                                                                    |
 | `doubles[1]` | `event_time_ms`        | Event timestamp (ms since epoch)                                                              |
 | `doubles[2]` | `interval_days_approx` | Interval normalized to approximate days for analytics (days×1, weeks×7, months×30, years×365) |
+
+### `MaintenanceTaskUpdated` — on an edit that changes `title`, `intervalValue`, or `intervalUnit`
+
+Published only when the edit's resulting values differ from the task's current stored values (mirrors `MaintenanceTaskAdvanced`'s guard). Not published for a no-op edit.
+
+| Field        | Name                   | Value                                                                                                   |
+| ------------ | ---------------------- | ------------------------------------------------------------------------------------------------------- |
+| `indexes[0]` | —                      | `owner_id` (partition key for per-owner queries)                                                        |
+| `blobs[0]`   | `event_type`           | `"MaintenanceTaskUpdated"`                                                                              |
+| `blobs[1]`   | `aggregate_type`       | `"MaintenanceTask"`                                                                                     |
+| `blobs[2]`   | `maintenance_task_id`  | Task UUID                                                                                               |
+| `blobs[3]`   | `asset_id`             | Asset UUID                                                                                              |
+| `blobs[4]`   | `owner_id`             | Owner UUID                                                                                              |
+| `blobs[5]`   | `actor_id`             | UUID of the authenticated user                                                                          |
+| `blobs[6]`   | `source_use_case`      | `"UpdateMaintenanceTask"`                                                                               |
+| `blobs[7]`   | `schema_version`       | `"v1"`                                                                                                  |
+| `blobs[8]`   | `result`               | `"success"`                                                                                             |
+| `doubles[0]` | `count`                | Always `1`                                                                                              |
+| `doubles[1]` | `event_time_ms`        | Event timestamp (ms since epoch)                                                                        |
+| `doubles[2]` | `interval_days_approx` | Resulting interval (post-edit) normalized to approximate days, same formula as `MaintenanceTaskCreated` |
 
 ### `MaintenanceTaskDeleted` — on successful task deletion
 
@@ -198,10 +272,7 @@ Published only when `record.performedAt > task.lastCompletedDate` (i.e. when `ne
   interval enum. Future distance/hour tasks need an explicit discriminator such as
   `type: "time" | "distance"` and separate fields like `lastCompletedOdometer` /
   `nextDueMileage`.
-- Editing a task's title or interval after creation
-- UI entry points and post-creation navigation. This spec covers the API contract; asset detail
-  placement, task list presentation, the "Log maintenance" shortcut, and inline/modal/drawer/route
-  choices belong to a UI design pass.
+- Directly setting `lastCompletedDate` or `nextDue` via the edit endpoint — moving the schedule without evidence of completed work is "reschedule," a distinct concern tracked in #178 (snooze + reschedule); the boundary is deliberate so the two features don't collide
 - Dashboard-only detail fields such as estimated duration, location/where, assignee/vendor, and
   task notes. They are not part of the current maintenance-task contract and must be specified
   before the dashboard can render them from live API data.


### PR DESCRIPTION
## Summary

- Specify issue #180's task-edit behavior before implementation.
- Split delivery into backend (`S2`) and UI (`S3`) acceptance criteria, keeping all new criteria unchecked until their tested implementation lands.

## Related

Refs #180

## Risk

**Level:** L

**Why:** Feature-spec prose only; no executable contract or runtime behavior changes.

**Human validation budget:**

L — Glance evidence. Do not read the diff.

## Evidence

- The spec's S2/S3 split matches the planned backend-then-frontend delivery order.

## Test plan

- [x] Confirm all new criteria remain unchecked until tested code is on `main`.
- [x] Run `git diff --check`.

## Spec / AC

[`maintenance-task.md`](docs/specs/features/maintenance-task.md) — establishes unchecked S2 and S3 criteria for #180.
