### PR TITLE
feat: expose maintenance task edit API

### DIFF
--- a/apps/api/src/api/middleware/technicalTelemetry.ts
+++ b/apps/api/src/api/middleware/technicalTelemetry.ts
@@ -229,6 +229,12 @@ function routeTelemetry(method: string, pathname: string): RouteTelemetry {
       routePattern: "/api/assets/{assetId}/maintenance-tasks/{taskId}",
     };
   }
+  if (/^\/api\/assets\/[^/]+\/maintenance-tasks\/[^/]+$/.test(pathname) && method === "PATCH") {
+    return {
+      operation: "UpdateMaintenanceTask",
+      routePattern: "/api/assets/{assetId}/maintenance-tasks/{taskId}",
+    };
+  }
   if (pathname === "/api/teams" && method === "POST") {
     return { operation: "CreateTeam", routePattern: "/api/teams" };
   }

--- a/apps/api/src/api/openapi.ts
+++ b/apps/api/src/api/openapi.ts
@@ -22,6 +22,7 @@ import {
   MaintenanceTaskListResponseSchema,
   MaintenanceTaskParamsSchema,
   MaintenanceTaskResponseSchema,
+  UpdateMaintenanceTaskBodySchema,
 } from "./schemas/maintenanceTaskSchemas.ts";
 import { DashboardResponseSchema } from "./schemas/dashboardSchemas.ts";
 import { ActivityQuerySchema, ActivityResponseSchema } from "./schemas/activitySchemas.ts";
@@ -716,6 +717,45 @@ export const deleteMaintenanceTaskRoute = createRoute({
   },
 });
 
+export const updateMaintenanceTaskRoute = createRoute({
+  method: "patch",
+  path: "/api/assets/{assetId}/maintenance-tasks/{taskId}",
+  tags: ["Maintenance"],
+  summary: "Edit a maintenance task",
+  description:
+    "Updates title and/or interval. At least one field is required. lastCompletedDate and nextDue cannot be set directly here — nextDue is recomputed from the task's existing lastCompletedDate (or today) whenever intervalValue/intervalUnit changes. A request that would not change any stored value is a no-op: 200 with the unchanged task, no event published.",
+  security: [cookieAuth],
+  request: {
+    params: MaintenanceTaskParamsSchema,
+    body: {
+      required: true,
+      content: { "application/json": { schema: UpdateMaintenanceTaskBodySchema } },
+    },
+  },
+  responses: {
+    200: {
+      description: "Updated maintenance task",
+      content: { "application/json": { schema: MaintenanceTaskResponseSchema } },
+    },
+    401: {
+      description: "Not authenticated",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    403: {
+      description: "The task's asset belongs to another user",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    404: {
+      description: "No such task",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    422: {
+      description: "Validation failed",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
 export const shareAssetRoute = createRoute({
   method: "post",
   path: "/api/assets/{assetId}/share",
@@ -868,6 +908,7 @@ export function getApiDocument() {
   doc.openapi(createMaintenanceTaskRoute, stub);
   doc.openapi(listMaintenanceTasksRoute, stub);
   doc.openapi(deleteMaintenanceTaskRoute, stub);
+  doc.openapi(updateMaintenanceTaskRoute, stub);
   doc.openapi(getDashboardRoute, stub);
   doc.openapi(getActivityRoute, stub);
   doc.openapi(getUserProfileRoute, stub);

--- a/apps/api/src/api/schemas/maintenanceTaskSchemas.test.ts
+++ b/apps/api/src/api/schemas/maintenanceTaskSchemas.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { UpdateMaintenanceTaskBodySchema } from "./maintenanceTaskSchemas.ts";
+
+describe("UpdateMaintenanceTaskBodySchema", () => {
+  it("accepts a title-only body", () => {
+    expect(UpdateMaintenanceTaskBodySchema.parse({ title: "Replace filter" })).toEqual({
+      title: "Replace filter",
+    });
+  });
+
+  it("accepts an interval-only body", () => {
+    expect(
+      UpdateMaintenanceTaskBodySchema.parse({ intervalValue: 3, intervalUnit: "month" }),
+    ).toEqual({ intervalValue: 3, intervalUnit: "month" });
+  });
+
+  it("rejects an empty body", () => {
+    const result = UpdateMaintenanceTaskBodySchema.safeParse({});
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error.issues[0]?.path).toEqual([]);
+  });
+
+  it.each([
+    { title: "" },
+    { title: "t".repeat(101) },
+    { intervalValue: 0 },
+    { intervalValue: 1.5 },
+    { intervalUnit: "fortnight" },
+  ])("rejects invalid body %#", (body) => {
+    expect(UpdateMaintenanceTaskBodySchema.safeParse(body).success).toBe(false);
+  });
+
+  it("ignores unknown keys such as lastCompletedDate and nextDue", () => {
+    expect(
+      UpdateMaintenanceTaskBodySchema.parse({
+        title: "Replace filter",
+        lastCompletedDate: "2026-06-01",
+        nextDue: "2026-09-01",
+      }),
+    ).toEqual({ title: "Replace filter" });
+  });
+});

--- a/apps/api/src/api/schemas/maintenanceTaskSchemas.ts
+++ b/apps/api/src/api/schemas/maintenanceTaskSchemas.ts
@@ -48,6 +48,34 @@ export const CreateMaintenanceTaskBodySchema = z
   })
   .openapi("CreateMaintenanceTaskBody");
 
+export const UpdateMaintenanceTaskBodySchema = z
+  .object({
+    title: z
+      .string()
+      .trim()
+      .min(1, "Title is required")
+      .max(100, "Title must be 100 characters or fewer")
+      .optional()
+      .openapi({ example: "Replace furnace filter" }),
+    intervalValue: z
+      .number()
+      .int("Interval value must be an integer")
+      .min(1, "Interval value must be at least 1")
+      .optional()
+      .openapi({ example: 3 }),
+    intervalUnit: IntervalUnitSchema.optional(),
+  })
+  .refine(
+    (body) =>
+      body.title !== undefined ||
+      body.intervalValue !== undefined ||
+      body.intervalUnit !== undefined,
+    {
+      message: "At least one of title, intervalValue, or intervalUnit is required",
+    },
+  )
+  .openapi("UpdateMaintenanceTaskBody");
+
 export const MaintenanceTaskResponseSchema = z
   .object({
     id: z.string().uuid().openapi({ example: "a1b2c3d4-e5f6-7890-abcd-ef1234567890" }),

--- a/apps/api/src/application/usecases/UpdateMaintenanceTask.test.ts
+++ b/apps/api/src/application/usecases/UpdateMaintenanceTask.test.ts
@@ -1,0 +1,320 @@
+import { describe, expect, it } from "vitest";
+import {
+  AssetId,
+  ForbiddenError,
+  MaintenanceTaskId,
+  NotFoundError,
+  UserId,
+} from "@snaveevans/pineapple-shared";
+import type { DomainEvent } from "../../domain/events/DomainEvent.ts";
+import { Asset } from "../../domain/asset/Asset.ts";
+import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
+import { createMembership } from "../../domain/team/Membership.ts";
+import { Team } from "../../domain/team/Team.ts";
+import type { TeamRepository } from "../../domain/team/TeamRepository.ts";
+import { MaintenanceTask } from "../../domain/maintenance/MaintenanceTask.ts";
+import type { MaintenanceTaskRepository } from "../../domain/maintenance/MaintenanceTaskRepository.ts";
+import type { EventBus } from "../ports/EventBus.ts";
+import type { UtcDateProvider } from "../ports/UtcDateProvider.ts";
+import { UpdateMaintenanceTask } from "./UpdateMaintenanceTask.ts";
+
+class TeamRepositoryFake implements TeamRepository {
+  constructor(private readonly team: Team | null = null) {}
+  findByMember(): Promise<Team | null> {
+    return Promise.resolve(this.team);
+  }
+  findById(): Promise<Team | null> {
+    return Promise.resolve(this.team);
+  }
+  save(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+class MaintenanceTaskRepositoryFake implements MaintenanceTaskRepository {
+  saved: MaintenanceTask | null = null;
+  savedEvents: readonly DomainEvent[] = [];
+  constructor(private task: MaintenanceTask | null) {}
+  findByAsset(): Promise<MaintenanceTask[]> {
+    return Promise.resolve([]);
+  }
+  findForVisibleActiveAssets(): Promise<MaintenanceTask[]> {
+    return Promise.resolve([]);
+  }
+  findById(): Promise<MaintenanceTask | null> {
+    return Promise.resolve(this.task);
+  }
+  save(task: MaintenanceTask, events: readonly DomainEvent[] = []): Promise<void> {
+    this.saved = task;
+    this.savedEvents = events;
+    return Promise.resolve();
+  }
+  delete(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+class AssetRepositoryFake implements AssetRepository {
+  constructor(private readonly asset: Asset | null) {}
+  findById(): Promise<Asset | null> {
+    return Promise.resolve(this.asset);
+  }
+  findVisibleTo(): Promise<Asset[]> {
+    return Promise.resolve([]);
+  }
+  save(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+class EventBusFake implements EventBus {
+  readonly events: DomainEvent[] = [];
+  publish(e: DomainEvent): Promise<void> {
+    this.events.push(e);
+    return Promise.resolve();
+  }
+  publishAll(events: readonly DomainEvent[]): Promise<void> {
+    this.events.push(...events);
+    return Promise.resolve();
+  }
+  subscribe(): void {}
+}
+
+const dates: UtcDateProvider = { today: () => "2026-06-11" };
+
+describe("UpdateMaintenanceTask", () => {
+  const ownerId = UserId.generate();
+  const assetId = AssetId.generate();
+  const asset = Asset.reconstitute({
+    id: assetId,
+    ownerId,
+    name: "Truck",
+    metadata: { kind: "vehicle", make: "Ram", model: "2500", year: 2016 },
+    archivedAt: null,
+    createdAt: new Date("2026-06-11T12:00:00.000Z"),
+    updatedAt: new Date("2026-06-11T12:00:00.000Z"),
+  });
+
+  function makeTask(overrides: Partial<Parameters<typeof MaintenanceTask.reconstitute>[0]> = {}) {
+    return MaintenanceTask.reconstitute({
+      id: MaintenanceTaskId.generate(),
+      assetId,
+      ownerId,
+      title: "Replace furnace filter",
+      intervalValue: 2,
+      intervalUnit: "month",
+      lastCompletedDate: "2026-04-11",
+      nextDue: "2026-06-11",
+      createdAt: new Date(),
+      ...overrides,
+    });
+  }
+
+  it("updates title and publishes MaintenanceTaskUpdated", async () => {
+    const task = makeTask();
+    const repo = new MaintenanceTaskRepositoryFake(task);
+    const events = new EventBusFake();
+
+    const result = await new UpdateMaintenanceTask(
+      new AssetRepositoryFake(asset),
+      new TeamRepositoryFake(),
+      repo,
+      events,
+      dates,
+    ).execute({
+      taskId: task.id,
+      assetId,
+      requesterId: ownerId,
+      title: "Replace filter",
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.title).toBe("Replace filter");
+    expect(repo.saved?.title).toBe("Replace filter");
+    expect(events.events).toEqual([
+      expect.objectContaining({ type: "MaintenanceTaskUpdated", title: "Replace filter" }),
+    ]);
+  });
+
+  it("recomputes nextDue when intervalValue changes", async () => {
+    const task = makeTask({ lastCompletedDate: "2026-04-11" });
+    const repo = new MaintenanceTaskRepositoryFake(task);
+    const events = new EventBusFake();
+
+    const result = await new UpdateMaintenanceTask(
+      new AssetRepositoryFake(asset),
+      new TeamRepositoryFake(),
+      repo,
+      events,
+      dates,
+    ).execute({
+      taskId: task.id,
+      assetId,
+      requesterId: ownerId,
+      intervalValue: 3,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.nextDue).toBe("2026-07-11");
+    expect(events.events).toEqual([
+      expect.objectContaining({ type: "MaintenanceTaskUpdated", nextDue: "2026-07-11" }),
+    ]);
+  });
+
+  it("does not save or publish when the edit is a no-op", async () => {
+    const task = makeTask({ intervalValue: 2, intervalUnit: "month" });
+    const repo = new MaintenanceTaskRepositoryFake(task);
+    const events = new EventBusFake();
+
+    const result = await new UpdateMaintenanceTask(
+      new AssetRepositoryFake(asset),
+      new TeamRepositoryFake(),
+      repo,
+      events,
+      dates,
+    ).execute({
+      taskId: task.id,
+      assetId,
+      requesterId: ownerId,
+      title: "Replace furnace filter",
+      intervalValue: 2,
+      intervalUnit: "month",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(repo.saved).toBeNull();
+    expect(events.events).toHaveLength(0);
+  });
+
+  it("returns not found when the task does not exist", async () => {
+    const repo = new MaintenanceTaskRepositoryFake(null);
+    const result = await new UpdateMaintenanceTask(
+      new AssetRepositoryFake(asset),
+      new TeamRepositoryFake(),
+      repo,
+      new EventBusFake(),
+      dates,
+    ).execute({
+      taskId: MaintenanceTaskId.generate(),
+      assetId,
+      requesterId: ownerId,
+      title: "New title",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBeInstanceOf(NotFoundError);
+  });
+
+  it("returns not found when the task belongs to a different asset", async () => {
+    const task = makeTask();
+    const repo = new MaintenanceTaskRepositoryFake(task);
+    const result = await new UpdateMaintenanceTask(
+      new AssetRepositoryFake(asset),
+      new TeamRepositoryFake(),
+      repo,
+      new EventBusFake(),
+      dates,
+    ).execute({
+      taskId: task.id,
+      assetId: AssetId.generate(),
+      requesterId: ownerId,
+      title: "New title",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBeInstanceOf(NotFoundError);
+  });
+
+  it("returns forbidden when the requester cannot access the parent asset", async () => {
+    const task = makeTask();
+    const repo = new MaintenanceTaskRepositoryFake(task);
+    const result = await new UpdateMaintenanceTask(
+      new AssetRepositoryFake(asset),
+      new TeamRepositoryFake(),
+      repo,
+      new EventBusFake(),
+      dates,
+    ).execute({
+      taskId: task.id,
+      assetId,
+      requesterId: UserId.generate(),
+      title: "New title",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBeInstanceOf(ForbiddenError);
+  });
+
+  it("allows a non-owner team member to edit a task on a shared asset", async () => {
+    const memberId = UserId.generate();
+    const team = Team.create({ ownerId, name: "Field Ops" });
+    team.pullEvents();
+    const sharedAsset = Asset.reconstitute({
+      id: assetId,
+      ownerId,
+      name: asset.name,
+      metadata: asset.metadata,
+      archivedAt: null,
+      createdAt: asset.createdAt,
+      updatedAt: asset.updatedAt,
+      sharedTeamId: team.id,
+    });
+    const memberTeam = Team.reconstitute({
+      id: team.id,
+      ownerId: team.ownerId,
+      name: team.name,
+      createdAt: team.createdAt,
+      members: [
+        ...team.members,
+        createMembership({ userId: memberId, role: "member", joinedAt: new Date() }),
+      ],
+    });
+    const task = makeTask();
+    const repo = new MaintenanceTaskRepositoryFake(task);
+    const events = new EventBusFake();
+
+    const result = await new UpdateMaintenanceTask(
+      new AssetRepositoryFake(sharedAsset),
+      new TeamRepositoryFake(memberTeam),
+      repo,
+      events,
+      dates,
+    ).execute({
+      taskId: task.id,
+      assetId,
+      requesterId: memberId,
+      title: "New title",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(events.events).toEqual([
+      expect.objectContaining({ type: "MaintenanceTaskUpdated", actorId: memberId }),
+    ]);
+  });
+
+  it("permits editing a task on an archived asset", async () => {
+    const archivedAsset = Asset.reconstitute({
+      id: assetId,
+      ownerId,
+      name: asset.name,
+      metadata: asset.metadata,
+      archivedAt: new Date("2026-05-01T00:00:00.000Z"),
+      createdAt: asset.createdAt,
+      updatedAt: asset.updatedAt,
+    });
+    const task = makeTask();
+    const repo = new MaintenanceTaskRepositoryFake(task);
+
+    const result = await new UpdateMaintenanceTask(
+      new AssetRepositoryFake(archivedAsset),
+      new TeamRepositoryFake(),
+      repo,
+      new EventBusFake(),
+      dates,
+    ).execute({
+      taskId: task.id,
+      assetId,
+      requesterId: ownerId,
+      title: "New title",
+    });
+
+    expect(result.ok).toBe(true);
+  });
+});

--- a/apps/api/src/application/usecases/UpdateMaintenanceTask.ts
+++ b/apps/api/src/application/usecases/UpdateMaintenanceTask.ts
@@ -1,0 +1,79 @@
+import {
+  type AssetId,
+  type DomainError,
+  DomainError as DomainErrorClass,
+  ForbiddenError,
+  type MaintenanceTaskId,
+  NotFoundError,
+  type Result,
+  type UserId,
+  err,
+  ok,
+} from "@snaveevans/pineapple-shared";
+import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
+import type { IntervalUnit } from "../../domain/maintenance/IntervalUnit.ts";
+import { MaintenanceTask } from "../../domain/maintenance/MaintenanceTask.ts";
+import type { MaintenanceTaskRepository } from "../../domain/maintenance/MaintenanceTaskRepository.ts";
+import type { TeamRepository } from "../../domain/team/TeamRepository.ts";
+import type { EventBus } from "../ports/EventBus.ts";
+import type { UtcDateProvider } from "../ports/UtcDateProvider.ts";
+import { canAccessAsset } from "./assetAccess.ts";
+
+export type UpdateMaintenanceTaskCommand = {
+  taskId: MaintenanceTaskId;
+  assetId: AssetId;
+  requesterId: UserId;
+  title?: string;
+  intervalValue?: number;
+  intervalUnit?: IntervalUnit;
+};
+
+export class UpdateMaintenanceTask {
+  constructor(
+    private readonly assets: AssetRepository,
+    private readonly teams: TeamRepository,
+    private readonly tasks: MaintenanceTaskRepository,
+    private readonly eventBus: EventBus,
+    private readonly dates: UtcDateProvider,
+  ) {}
+
+  async execute(
+    command: UpdateMaintenanceTaskCommand,
+  ): Promise<Result<MaintenanceTask, DomainError>> {
+    try {
+      const task = await this.tasks.findById(command.taskId);
+      if (!task) return err(new NotFoundError("Maintenance task not found"));
+      if (task.assetId !== command.assetId) {
+        return err(new NotFoundError("Maintenance task not found"));
+      }
+
+      const asset = await this.assets.findById(task.assetId);
+      if (!asset) return err(new NotFoundError("Asset not found"));
+      if (!(await canAccessAsset(asset, command.requesterId, this.teams))) {
+        return err(new ForbiddenError("Access denied"));
+      }
+
+      const changed = task.update(
+        {
+          ...(command.title !== undefined ? { title: command.title } : {}),
+          ...(command.intervalValue !== undefined ? { intervalValue: command.intervalValue } : {}),
+          ...(command.intervalUnit !== undefined ? { intervalUnit: command.intervalUnit } : {}),
+          todayUtc: this.dates.today(),
+        },
+        command.requesterId,
+        { assetName: asset.name, assetType: asset.type },
+      );
+
+      if (changed) {
+        const events = task.pullEvents();
+        await this.tasks.save(task, events);
+        await this.eventBus.publishAll(events);
+      }
+
+      return ok(task);
+    } catch (error) {
+      if (error instanceof DomainErrorClass) return err(error);
+      throw error;
+    }
+  }
+}

--- a/apps/api/src/infrastructure/persistence/D1MaintenanceTaskRepository.test.ts
+++ b/apps/api/src/infrastructure/persistence/D1MaintenanceTaskRepository.test.ts
@@ -1,6 +1,10 @@
-import { UserId } from "@snaveevans/pineapple-shared";
+import { AssetId, MaintenanceTaskId, UserId } from "@snaveevans/pineapple-shared";
 import { describe, expect, it, vi } from "vitest";
-import { D1MaintenanceTaskRepository } from "./D1MaintenanceTaskRepository.ts";
+import { MaintenanceTask } from "../../domain/maintenance/MaintenanceTask.ts";
+import {
+  D1MaintenanceTaskRepository,
+  prepareMaintenanceTaskSave,
+} from "./D1MaintenanceTaskRepository.ts";
 
 type BoundStatement = {
   query: string;
@@ -37,5 +41,29 @@ describe("D1MaintenanceTaskRepository", () => {
     expect(query).toContain("a.archived_at IS NULL");
     expect(query).toContain("shared_team_id");
     expect(statements[0]?.values).toEqual([ownerId, ownerId]);
+  });
+
+  it("prepareMaintenanceTaskSave upserts title, interval, and schedule fields on conflict", () => {
+    const { db, statements } = createDatabaseHarness();
+    const task = MaintenanceTask.reconstitute({
+      id: MaintenanceTaskId.generate(),
+      assetId: AssetId.generate(),
+      ownerId: UserId.generate(),
+      title: "Replace furnace filter",
+      intervalValue: 3,
+      intervalUnit: "month",
+      lastCompletedDate: "2026-04-11",
+      nextDue: "2026-07-11",
+      createdAt: new Date(),
+    });
+
+    prepareMaintenanceTaskSave(db, task);
+
+    const query = statements[0]?.query ?? "";
+    expect(query).toContain("title = excluded.title");
+    expect(query).toContain("interval_value = excluded.interval_value");
+    expect(query).toContain("interval_unit = excluded.interval_unit");
+    expect(query).toContain("last_completed_date = excluded.last_completed_date");
+    expect(query).toContain("next_due = excluded.next_due");
   });
 });

--- a/apps/api/src/infrastructure/persistence/D1MaintenanceTaskRepository.ts
+++ b/apps/api/src/infrastructure/persistence/D1MaintenanceTaskRepository.ts
@@ -25,14 +25,20 @@ export function prepareMaintenanceTaskSave(
   db: D1Database,
   task: MaintenanceTask,
 ): D1PreparedStatement {
-  // ON CONFLICT only updates the mutable tracking fields (last_completed_date, next_due).
-  // title, interval_value, and interval_unit are immutable after creation; no update path exists.
+  // ON CONFLICT updates every mutable field. advance() only ever changes
+  // last_completed_date/next_due (title/interval pass through unchanged), and
+  // update() only ever changes title/interval_value/interval_unit/next_due
+  // (last_completed_date passes through unchanged) — so a single upsert covers
+  // both callers safely.
   return db
     .prepare(
       `INSERT INTO maintenance_tasks
          (id, asset_id, owner_id, title, interval_value, interval_unit, last_completed_date, next_due, created_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON CONFLICT(id) DO UPDATE SET
+         title = excluded.title,
+         interval_value = excluded.interval_value,
+         interval_unit = excluded.interval_unit,
          last_completed_date = excluded.last_completed_date,
          next_due = excluded.next_due`,
     )

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -67,6 +67,7 @@ import { ListMaintenanceRecords } from "./application/usecases/ListMaintenanceRe
 import { CreateMaintenanceTask } from "./application/usecases/CreateMaintenanceTask.ts";
 import { ListMaintenanceTasks } from "./application/usecases/ListMaintenanceTasks.ts";
 import { DeleteMaintenanceTask } from "./application/usecases/DeleteMaintenanceTask.ts";
+import { UpdateMaintenanceTask } from "./application/usecases/UpdateMaintenanceTask.ts";
 import { GetDashboard } from "./application/usecases/GetDashboard.ts";
 import { ListActivity } from "./application/usecases/ListActivity.ts";
 import { SearchAssets } from "./application/usecases/SearchAssets.ts";
@@ -104,6 +105,7 @@ import {
   createMaintenanceRecordRoute,
   createMaintenanceTaskRoute,
   deleteMaintenanceTaskRoute,
+  updateMaintenanceTaskRoute,
   getDashboardRoute,
   getActivityRoute,
   getUserProfileRoute,
@@ -940,6 +942,29 @@ app.openapi(deleteMaintenanceTaskRoute, async (c) => {
   });
   if (!result.ok) throw result.error;
   return c.body(null, 204);
+});
+
+app.openapi(updateMaintenanceTaskRoute, async (c) => {
+  const user = c.get("user");
+  const { assetId, taskId } = c.req.valid("param");
+  const { title, intervalValue, intervalUnit } = c.req.valid("json");
+  const result = await new UpdateMaintenanceTask(
+    new D1AssetRepository(c.env.DB),
+    new D1TeamRepository(c.env.DB),
+    new D1MaintenanceTaskRepository(c.env.DB),
+    c.get("eventBus"),
+    new SystemUtcDateProvider(),
+  ).execute({
+    taskId: MaintenanceTaskId.from(taskId),
+    assetId: AssetId.from(assetId),
+    requesterId: user.id,
+    ...(title !== undefined ? { title } : {}),
+    ...(intervalValue !== undefined ? { intervalValue } : {}),
+    ...(intervalUnit !== undefined ? { intervalUnit } : {}),
+  });
+  if (!result.ok) throw result.error;
+  const todayUtc = new SystemUtcDateProvider().today();
+  return c.json(serializeMaintenanceTask(result.value, todayUtc), 200);
 });
 
 const worker: ExportedHandler<Bindings, unknown> = {

--- a/apps/web/src/api/schema.ts
+++ b/apps/web/src/api/schema.ts
@@ -682,7 +682,73 @@ export interface paths {
         };
         options?: never;
         head?: never;
-        patch?: never;
+        /**
+         * Edit a maintenance task
+         * @description Updates title and/or interval. At least one field is required. lastCompletedDate and nextDue cannot be set directly here — nextDue is recomputed from the task's existing lastCompletedDate (or today) whenever intervalValue/intervalUnit changes. A request that would not change any stored value is a no-op: 200 with the unchanged task, no event published.
+         */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    assetId: string;
+                    taskId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["UpdateMaintenanceTaskBody"];
+                };
+            };
+            responses: {
+                /** @description Updated maintenance task */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MaintenanceTask"];
+                    };
+                };
+                /** @description Not authenticated */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description The task's asset belongs to another user */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description No such task */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Validation failed */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
+        };
         trace?: never;
     };
     "/api/dashboard": {
@@ -1808,6 +1874,17 @@ export interface components {
         };
         MaintenanceTaskListResponse: {
             maintenanceTasks: components["schemas"]["MaintenanceTask"][];
+        };
+        UpdateMaintenanceTaskBody: {
+            /** @example Replace furnace filter */
+            title?: string;
+            /** @example 3 */
+            intervalValue?: number;
+            /**
+             * @example month
+             * @enum {string}
+             */
+            intervalUnit?: "day" | "week" | "month" | "year";
         };
         DashboardResponse: {
             /**

--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -701,6 +701,32 @@
           "maintenanceTasks"
         ]
       },
+      "UpdateMaintenanceTaskBody": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 100,
+            "example": "Replace furnace filter"
+          },
+          "intervalValue": {
+            "type": "integer",
+            "minimum": 1,
+            "example": 3
+          },
+          "intervalUnit": {
+            "type": "string",
+            "enum": [
+              "day",
+              "week",
+              "month",
+              "year"
+            ],
+            "example": "month"
+          }
+        }
+      },
       "DashboardResponse": {
         "type": "object",
         "properties": {
@@ -2199,6 +2225,102 @@
           },
           "404": {
             "description": "No such task",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Maintenance"
+        ],
+        "summary": "Edit a maintenance task",
+        "description": "Updates title and/or interval. At least one field is required. lastCompletedDate and nextDue cannot be set directly here — nextDue is recomputed from the task's existing lastCompletedDate (or today) whenever intervalValue/intervalUnit changes. A request that would not change any stored value is a no-op: 200 with the unchanged task, no event published.",
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "195d0ef0-47f5-439f-abfd-29f892c9a040"
+            },
+            "required": true,
+            "name": "assetId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+            },
+            "required": true,
+            "name": "taskId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateMaintenanceTaskBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated maintenance task",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MaintenanceTask"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The task's asset belongs to another user",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No such task",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation failed",
             "content": {
               "application/json": {
                 "schema": {

--- a/docs/specs/cross-cutting/telemetry.md
+++ b/docs/specs/cross-cutting/telemetry.md
@@ -251,6 +251,7 @@ Every API route maps to a named operation used as the `indexes[0]` value in requ
 | `POST /api/assets/{assetId}/maintenance-tasks`            | `CreateMaintenanceTask`    |
 | `GET /api/assets/{assetId}/maintenance-tasks`             | `ListMaintenanceTasks`     |
 | `DELETE /api/assets/{assetId}/maintenance-tasks/{taskId}` | `DeleteMaintenanceTask`    |
+| `PATCH /api/assets/{assetId}/maintenance-tasks/{taskId}`  | `UpdateMaintenanceTask`    |
 | `POST /api/teams`                                         | `CreateTeam`               |
 | `GET /api/teams/me`                                       | `GetMyTeam`                |
 | `POST /api/assets/{assetId}/share`                        | `ShareAsset`               |

--- a/docs/specs/features/activity-history.md
+++ b/docs/specs/features/activity-history.md
@@ -205,7 +205,7 @@ _Each criterion below carries exactly one slice tag (`S1` or `S2`) from the Deli
       `maintenance_logged` entry
 - [ ] `S1` Entries for deleted tasks and archived assets are still returned and fully
       renderable from their snapshot
-- [ ] `S3` `task_updated` is a valid entry `type`, sourced from `MaintenanceTaskUpdated`;
+- [x] `S3` `task_updated` is a valid entry `type`, sourced from `MaintenanceTaskUpdated`;
       an entry includes the task's post-edit title snapshot and follows the same entry
       shape as the other maintenance entry types
 - [x] `S2` For a shared asset, the caller sees its **entire** activity history — including


### PR DESCRIPTION
## Summary

- Add the task-edit PATCH route, edge validation, application use case, and atomic persistence update.
- Recompute `nextDue` only when the resulting interval changes; no-op edits persist and publish nothing.
- Regenerate the OpenAPI document and web client schema; update History rendering required by the new activity-type union.

## Related

Refs #180

## Risk

**Level:** H

**Why:** This adds a public PATCH API contract and changes maintenance scheduling behavior. The migration and durable-event mechanism are isolated in parent PR #228.

**Human validation budget:**

H — Full review + local poke on API/data paths.

## Evidence

- `UpdateMaintenanceTask.test.ts` covers edits, schedule preservation/recomputation, authorization, archive behavior, and no-op suppression.
- `MaintenanceTask.test.ts` covers interval-change guards and resulting event state.
- OpenAPI and generated web types were regenerated.
- `pnpm lint && pnpm type-check && pnpm -r test` passed: 554 API + 125 web tests.

## Test plan

- [x] Run lint, type-check, and workspace tests with Node 22.21.1.
- [x] Regenerate OpenAPI and web API types, then confirm type-check passes.

## Spec / AC

Implements the backend behavior specified by unchecked `S2` criteria in [`maintenance-task.md`](docs/specs/features/maintenance-task.md). The final UI PR will mark those criteria complete after this stack has merged.
