### PR TITLE
feat(web): edit maintenance tasks in place

### DIFF
--- a/apps/web/src/api/maintenanceTasks.ts
+++ b/apps/web/src/api/maintenanceTasks.ts
@@ -1,4 +1,4 @@
-import { apiDelete, apiGet, apiPost } from "./client.ts";
+import { apiDelete, apiGet, apiPatch, apiPost } from "./client.ts";
 import type { components } from "./schema.ts";
 
 export type IntervalUnit = components["schemas"]["MaintenanceTask"]["intervalUnit"];
@@ -6,6 +6,7 @@ export type TaskUrgencyStatus = components["schemas"]["MaintenanceTask"]["status
 export type MaintenanceTask = components["schemas"]["MaintenanceTask"];
 export type MaintenanceTaskListResponse = components["schemas"]["MaintenanceTaskListResponse"];
 export type CreateMaintenanceTaskBody = components["schemas"]["CreateMaintenanceTaskBody"];
+export type UpdateMaintenanceTaskBody = components["schemas"]["UpdateMaintenanceTaskBody"];
 
 export const maintenanceTasksQueryKey = (assetId: string) => ["maintenanceTasks", assetId] as const;
 
@@ -23,5 +24,16 @@ export function createMaintenanceTask(
 export function deleteMaintenanceTask(assetId: string, taskId: string): Promise<void> {
   return apiDelete("/api/assets/{assetId}/maintenance-tasks/{taskId}", {
     path: { assetId, taskId },
+  });
+}
+
+export function updateMaintenanceTask(
+  assetId: string,
+  taskId: string,
+  body: UpdateMaintenanceTaskBody,
+): Promise<MaintenanceTask> {
+  return apiPatch("/api/assets/{assetId}/maintenance-tasks/{taskId}", {
+    path: { assetId, taskId },
+    body,
   });
 }

--- a/apps/web/src/app/AppMaintenanceRecords.tsx
+++ b/apps/web/src/app/AppMaintenanceRecords.tsx
@@ -22,11 +22,13 @@ import {
 import {
   listMaintenanceTasks,
   createMaintenanceTask,
+  updateMaintenanceTask,
   deleteMaintenanceTask,
   maintenanceTasksQueryKey,
   type MaintenanceTask,
   type MaintenanceTaskListResponse,
   type CreateMaintenanceTaskBody,
+  type UpdateMaintenanceTaskBody,
 } from "../api/maintenanceTasks.ts";
 import { Button, ButtonSpinner } from "../design/Button.tsx";
 import { EmptyState } from "../design/EmptyState.tsx";
@@ -38,10 +40,12 @@ import { toAssetPresentation, type AssetPresentation } from "./assetPresentation
 import {
   EMPTY_MAINTENANCE_TASK_FORM,
   formatIntervalPhrase,
+  maintenanceTaskFormValuesFromTask,
   TASK_TITLE_MAX,
   TASK_UNITS,
   todayDateOnly,
   toCreateMaintenanceTaskBody,
+  toUpdateMaintenanceTaskBody,
   validateMaintenanceTaskForm,
   type MaintenanceTaskFormValues,
 } from "./maintenanceTaskForm.ts";
@@ -368,7 +372,17 @@ function MRRecentActivity({ records, onViewAll }: { records: MaintenanceRecord[]
   );
 }
 
-function MRTaskCard({ task, onLog, onDelete }: { task: MaintenanceTask; onLog: (id: string) => void; onDelete: (id: string) => void }) {
+function MRTaskCard({
+  task,
+  onLog,
+  onEdit,
+  onDelete,
+}: {
+  task: MaintenanceTask;
+  onLog: (id: string) => void;
+  onEdit: (id: string) => void;
+  onDelete: (id: string) => void;
+}) {
   const [confirming, setConfirming] = useState(false);
   const s = task.status;
   return (
@@ -407,6 +421,9 @@ function MRTaskCard({ task, onLog, onDelete }: { task: MaintenanceTask; onLog: (
               <Icon name="check" size={13} stroke={2.3} />
               Log
             </Button>
+            <button className="mr-task-edit-btn" onClick={() => onEdit(task.id)} aria-label="Edit task">
+              <Icon name="edit" size={14} stroke={1.8} />
+            </button>
             <button className="mr-task-del-btn" onClick={() => setConfirming(true)} aria-label="Delete task">
               <Icon name="x" size={14} stroke={2.1} />
             </button>
@@ -445,12 +462,14 @@ function MRScheduleSection({
   tasks,
   isLoading,
   onLog,
+  onEdit,
   onDelete,
   onAdd,
 }: {
   tasks: MaintenanceTask[];
   isLoading: boolean;
   onLog: (id: string) => void;
+  onEdit: (id: string) => void;
   onDelete: (id: string) => void;
   onAdd: () => void;
 }) {
@@ -477,7 +496,7 @@ function MRScheduleSection({
       {!isLoading && sorted.length > 0 && (
         <div className="mr-task-list">
           {sorted.map((t) => (
-            <MRTaskCard key={t.id} task={t} onLog={onLog} onDelete={onDelete} />
+            <MRTaskCard key={t.id} task={t} onLog={onLog} onEdit={onEdit} onDelete={onDelete} />
           ))}
         </div>
       )}
@@ -490,6 +509,7 @@ function MROverviewTab({
   records,
   tasksLoading,
   onLogFromTask,
+  onEditTask,
   onDeleteTask,
   onAddTask,
   onViewAll,
@@ -498,6 +518,7 @@ function MROverviewTab({
   records: MaintenanceRecord[];
   tasksLoading: boolean;
   onLogFromTask: (id: string) => void;
+  onEditTask: (id: string) => void;
   onDeleteTask: (id: string) => void;
   onAddTask: () => void;
   onViewAll: () => void;
@@ -509,6 +530,7 @@ function MROverviewTab({
         tasks={tasks}
         isLoading={tasksLoading}
         onLog={onLogFromTask}
+        onEdit={onEditTask}
         onDelete={onDeleteTask}
         onAdd={onAddTask}
       />
@@ -677,6 +699,156 @@ function MRCreateTaskForm({ asset, todayUtc, variant, onClose, onCreated }: MRCr
             <>
               <Icon name="check" size={15} stroke={2.4} />
               Save task
+            </>
+          )}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ─── Task edit form (title/interval only — lastCompletedDate is not editable here) ──
+
+interface MREditTaskFormProps {
+  asset: AssetPresentation;
+  task: MaintenanceTask;
+  variant: "drawer" | "sheet";
+  onClose: () => void;
+  onSaved: (task: MaintenanceTask) => void;
+}
+
+function MREditTaskForm({ asset, task, variant, onClose, onSaved }: MREditTaskFormProps) {
+  const [values, setValues] = useState<MaintenanceTaskFormValues>(() =>
+    maintenanceTaskFormValuesFromTask(task),
+  );
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [banner, setBanner] = useState<string | null>(null);
+  const titleRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => { titleRef.current?.focus(); }, []);
+
+  const mutation = useMutation({
+    mutationFn: (body: UpdateMaintenanceTaskBody) =>
+      updateMaintenanceTask(asset.id, task.id, body),
+    onSuccess: (updated) => onSaved(updated),
+    onError: (err) => setBanner(err instanceof Error ? err.message : "Failed to save task."),
+  });
+
+  const submit = () => {
+    if (mutation.isPending) return;
+    const nextErrors = validateMaintenanceTaskForm(values);
+    const mappedErrors: Record<string, string> = {};
+    if (nextErrors.title) mappedErrors.title = nextErrors.title;
+    if (nextErrors.intervalValue) mappedErrors.iv = nextErrors.intervalValue;
+    setErrors(mappedErrors);
+    if (Object.keys(mappedErrors).length) {
+      setBanner("Please fix the highlighted fields before saving.");
+      return;
+    }
+    setBanner(null);
+    mutation.mutate(toUpdateMaintenanceTaskBody(values));
+  };
+
+  const clear = (field: string) =>
+    setErrors((prev) => {
+      const next = { ...prev };
+      delete next[field];
+      return next;
+    });
+
+  const updateValue = <K extends keyof MaintenanceTaskFormValues>(
+    field: K,
+    value: MaintenanceTaskFormValues[K],
+  ) => {
+    setValues((prev) => ({ ...prev, [field]: value }));
+    clear(field === "intervalValue" ? "iv" : field);
+    if (banner) setBanner(null);
+  };
+
+  return (
+    <div className={`mr-form mr-form-${variant}`}>
+      {variant === "sheet" && <div className="mr-sheet-grab" />}
+      <div className="mr-form-head">
+        <div className="mr-form-head-txt">
+          <div className="mr-form-title">Edit task</div>
+          <div className="mr-form-sub">{asset.name}</div>
+        </div>
+        <button className="mr-form-close" onClick={onClose} aria-label="Close">
+          <Icon name="x" size={15} stroke={2.2} />
+        </button>
+      </div>
+      <div className="mr-form-body">
+        {banner && (
+          <div className="mr-banner" role="alert">
+            <Icon name="alert" size={15} stroke={2} /><span>{banner}</span>
+          </div>
+        )}
+        <Field
+          label="Title"
+          htmlFor="met-title"
+          required
+          hint={
+            <span className={`mr-field-count ${values.title.length > TASK_TITLE_MAX ? "over" : ""}`}>
+              {values.title.length}/{TASK_TITLE_MAX}
+            </span>
+          }
+          {...(errors.title ? { error: errors.title } : {})}
+        >
+          <input
+            id="met-title"
+            ref={titleRef}
+            type="text"
+            className={`mr-input${errors.title ? " is-invalid" : ""}`}
+            placeholder='e.g. "Replace furnace filter"'
+            maxLength={TASK_TITLE_MAX + 20}
+            value={values.title}
+            onChange={(e) => updateValue("title", e.target.value)}
+          />
+        </Field>
+        <Field
+          label="Repeat every"
+          required
+          {...(errors.iv ? { error: errors.iv } : {})}
+        >
+          <div className="mr-interval-row">
+            <input
+              id="met-iv"
+              type="number"
+              min="1"
+              step="1"
+              className={`mr-input mr-interval-num${errors.iv ? " is-invalid" : ""}`}
+              value={values.intervalValue}
+              onChange={(e) => updateValue("intervalValue", e.target.value)}
+            />
+            <div className="mr-unit-seg" role="group" aria-label="Interval unit">
+              {TASK_UNITS.map((u) => (
+                <button
+                  key={u.value}
+                  type="button"
+                  className={`mr-unit-btn ${values.intervalUnit === u.value ? "active" : ""}`}
+                  onClick={() => updateValue("intervalUnit", u.value)}
+                >
+                  {u.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        </Field>
+      </div>
+      <div className="mr-form-actions">
+        <Button variant="ghost" onClick={onClose} disabled={mutation.isPending}>
+          Cancel
+        </Button>
+        <Button variant="brand" className="mr-btn-save" onClick={submit} disabled={mutation.isPending}>
+          {mutation.isPending ? (
+            <>
+              <ButtonSpinner />
+              Saving…
+            </>
+          ) : (
+            <>
+              <Icon name="check" size={15} stroke={2.4} />
+              Save changes
             </>
           )}
         </Button>
@@ -1064,6 +1236,7 @@ export function AppMaintenanceRecords() {
   const [formOpen, setFormOpen] = useState(false);
   const [logFromTaskId, setLogFromTaskId] = useState<string | null>(null);
   const [taskFormOpen, setTaskFormOpen] = useState(false);
+  const [editingTaskId, setEditingTaskId] = useState<string | null>(null);
   const [shareOpen, setShareOpen] = useState(false);
   const [shareError, setShareError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<"overview" | "maintenance">("overview");
@@ -1210,6 +1383,16 @@ export function AppMaintenanceRecords() {
     setTaskFormOpen(false);
   };
 
+  const handleTaskUpdated = (task: MaintenanceTask) => {
+    queryClient.setQueryData<MaintenanceTaskListResponse>(
+      maintenanceTasksQueryKey(assetId),
+      (old) => ({
+        maintenanceTasks: (old?.maintenanceTasks ?? []).map((t) => (t.id === task.id ? task : t)),
+      }),
+    );
+    setEditingTaskId(null);
+  };
+
   const handleTaskDeleted = async (taskId: string) => {
     setTaskDeleteError(null);
     try {
@@ -1317,6 +1500,7 @@ export function AppMaintenanceRecords() {
       records={sorted}
       tasksLoading={tasksQuery.isPending}
       onLogFromTask={(tid) => openLogForm(tid)}
+      onEditTask={(tid) => setEditingTaskId(tid)}
       onDeleteTask={handleTaskDeleted}
       onAddTask={() => setTaskFormOpen(true)}
       onViewAll={() => setActiveTab("maintenance")}
@@ -1329,8 +1513,11 @@ export function AppMaintenanceRecords() {
     !assetQuery.isError &&
     (activeTab === "maintenance" ? (recordsQuery.isSuccess && sorted.length > 0) : true) &&
     !taskFormOpen &&
+    !editingTaskId &&
     !formOpen &&
     !shareOpen;
+
+  const editingTask = editingTaskId ? (tasks.find((t) => t.id === editingTaskId) ?? null) : null;
 
   const openShareSheet = () => {
     setShareError(null);
@@ -1555,6 +1742,21 @@ export function AppMaintenanceRecords() {
               variant={overlayVariant}
               onClose={() => setTaskFormOpen(false)}
               onCreated={handleTaskCreated}
+            />
+          </div>
+        </div>
+      )}
+
+      {editingTask && asset && (
+        <div className={`mr-overlay mr-overlay-${overlayVariant}`}>
+          <div className="mr-scrim" onClick={() => setEditingTaskId(null)} />
+          <div className={`mr-overlay-panel-${overlayVariant}`}>
+            <MREditTaskForm
+              asset={asset}
+              task={editingTask}
+              variant={overlayVariant}
+              onClose={() => setEditingTaskId(null)}
+              onSaved={handleTaskUpdated}
             />
           </div>
         </div>

--- a/apps/web/src/app/maintenanceTaskForm.test.ts
+++ b/apps/web/src/app/maintenanceTaskForm.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from "vitest";
 import {
   addIntervalDate,
   formatIntervalPhrase,
+  maintenanceTaskFormValuesFromTask,
   previewNextDueDate,
   resolveAssetId,
   toCreateMaintenanceTaskBody,
+  toUpdateMaintenanceTaskBody,
   validateMaintenanceTaskForm,
 } from "./maintenanceTaskForm.ts";
 
@@ -98,6 +100,39 @@ describe("toCreateMaintenanceTaskBody", () => {
     ).toEqual({
       title: "Filter change",
       intervalValue: 6,
+      intervalUnit: "month",
+    });
+  });
+});
+
+describe("maintenanceTaskFormValuesFromTask", () => {
+  it("seeds form values from a task and leaves lastCompletedDate blank", () => {
+    expect(
+      maintenanceTaskFormValuesFromTask({
+        title: "Replace furnace filter",
+        intervalValue: 2,
+        intervalUnit: "month",
+      }),
+    ).toEqual({
+      title: "Replace furnace filter",
+      intervalValue: "2",
+      intervalUnit: "month",
+      lastCompletedDate: "",
+    });
+  });
+});
+
+describe("toUpdateMaintenanceTaskBody", () => {
+  it("builds a full PATCH body from form values", () => {
+    expect(
+      toUpdateMaintenanceTaskBody({
+        title: "  Replace filter  ",
+        intervalValue: "3",
+        intervalUnit: "month",
+      }),
+    ).toEqual({
+      title: "Replace filter",
+      intervalValue: 3,
       intervalUnit: "month",
     });
   });

--- a/apps/web/src/app/maintenanceTaskForm.ts
+++ b/apps/web/src/app/maintenanceTaskForm.ts
@@ -1,4 +1,8 @@
-import type { CreateMaintenanceTaskBody, IntervalUnit } from "../api/maintenanceTasks.ts";
+import type {
+  CreateMaintenanceTaskBody,
+  IntervalUnit,
+  UpdateMaintenanceTaskBody,
+} from "../api/maintenanceTasks.ts";
 import { formatShortDate, ymdParts, ymdToUTC } from "./dateFormat.ts";
 
 export const TASK_TITLE_MAX = 100;
@@ -144,5 +148,28 @@ export function toCreateMaintenanceTaskBody(
     intervalValue,
     intervalUnit: values.intervalUnit,
     ...(values.lastCompletedDate ? { lastCompletedDate: values.lastCompletedDate } : {}),
+  };
+}
+
+export function maintenanceTaskFormValuesFromTask(task: {
+  title: string;
+  intervalValue: number;
+  intervalUnit: IntervalUnit;
+}): MaintenanceTaskFormValues {
+  return {
+    title: task.title,
+    intervalValue: String(task.intervalValue),
+    intervalUnit: task.intervalUnit,
+    lastCompletedDate: "",
+  };
+}
+
+export function toUpdateMaintenanceTaskBody(
+  values: Pick<MaintenanceTaskFormValues, "title" | "intervalValue" | "intervalUnit">,
+): UpdateMaintenanceTaskBody {
+  return {
+    title: values.title.trim(),
+    intervalValue: Number(values.intervalValue),
+    intervalUnit: values.intervalUnit,
   };
 }

--- a/apps/web/src/design/styles/mr.css
+++ b/apps/web/src/design/styles/mr.css
@@ -463,6 +463,13 @@
   color: var(--hf-ink-faint);
 }
 .mr-task-del-btn:hover { background: var(--hf-bad-bg); border-color: var(--hf-bad-border); color: var(--hf-bad); }
+.mr-task-edit-btn {
+  width: 28px; height: 28px; border-radius: var(--hf-r-sm); flex-shrink: 0;
+  background: none; border: 1px solid transparent;
+  display: flex; align-items: center; justify-content: center;
+  color: var(--hf-ink-faint);
+}
+.mr-task-edit-btn:hover { background: var(--hf-surface-2); border-color: var(--hf-line); color: var(--hf-ink); }
 
 /* delete confirm */
 .mr-task-confirm { display: flex; align-items: center; gap: 7px; }

--- a/apps/web/src/design/styles/tokens.css
+++ b/apps/web/src/design/styles/tokens.css
@@ -91,6 +91,9 @@
   --hf-evt-completed: oklch(50% 0.09 196);
   --hf-evt-completed-bg: oklch(95% 0.03 196);
   --hf-evt-deleted: oklch(54% 0.13 28);
+  --hf-evt-updated: oklch(48% 0.12 55);
+  --hf-evt-updated-bg: oklch(95% 0.03 55);
+  --hf-evt-updated-border: oklch(88% 0.04 55);
   --hf-evt-added-border: oklch(88% 0.04 292);
   --hf-evt-scheduled-border: oklch(88% 0.04 252);
   --hf-evt-completed-border: oklch(88% 0.04 196);

--- a/docs/specs/features/maintenance-task.md
+++ b/docs/specs/features/maintenance-task.md
@@ -68,25 +68,25 @@ tagged boxes are all `[x]`." See docs/specs/SPECS.md. -->
 
 ### Task edit
 
-- [ ] `S2` `PATCH /api/assets/{assetId}/maintenance-tasks/{taskId}` accepts `{ title?, intervalValue?, intervalUnit? }` and returns the full updated task with status 200
-- [ ] `S2` At least one of `title`, `intervalValue`, `intervalUnit` must be present in the request body; a body with none of them returns 422
-- [ ] `S2` `lastCompletedDate` and `nextDue` are not fields on this endpoint's request schema; the endpoint never accepts a direct override of either — `nextDue` is always derived (see recompute rule below)
-- [ ] `S2` `ownerId` is never accepted in the request body; it is derived from the authenticated session
-- [ ] `S2` When provided, `title` follows the same validation as task creation (non-empty after trim, ≤100 characters)
-- [ ] `S2` When provided, `intervalValue` follows the same validation as task creation (positive integer ≥ 1)
-- [ ] `S2` When provided, `intervalUnit` follows the same validation as task creation (one of `day | week | month | year`)
-- [ ] `S2` A field omitted from the request body keeps its current stored value
-- [ ] `S2` When the resulting `intervalValue` and/or `intervalUnit` differ from the task's current stored values, `nextDue` is recomputed as `(lastCompletedDate ?? todayUtc) + interval`, using the resulting `intervalValue`/`intervalUnit` and the same calendar arithmetic as task creation
-- [ ] `S2` When the resulting `intervalValue` and `intervalUnit` are unchanged from the task's current stored values — whether omitted from the request or resent unchanged — `lastCompletedDate` and `nextDue` are left unchanged; this holds even for a title-only edit on a task with no `lastCompletedDate`, where recomputing from `todayUtc` would otherwise silently push the schedule out
-- [ ] `S2` When the requested `title`, `intervalValue`, and `intervalUnit` (after applying only the provided fields) are identical to the task's current stored values, the edit is a no-op: the task is returned unchanged with status 200, and no `MaintenanceTaskUpdated` event is published
-- [ ] `S2` Editing a task on an archived asset is permitted — asset archival blocks new maintenance activity (creating tasks or records), not correction of an existing task's metadata
-- [ ] `S2` Editing a task that doesn't exist returns 404
-- [ ] `S2` Editing a task that exists but belongs to a different asset than the path `assetId` returns 404
-- [ ] `S2` Editing a task whose asset the requester cannot access returns 403
-- [ ] `S2` The update use case checks that the target asset exists and the requester can access it before applying the edit, following the same task-then-asset-then-access order as task deletion (task lookup and asset-mismatch check first, then asset lookup, then the access check)
-- [ ] `S2` A successful edit that changes `title`, `intervalValue`, or `intervalUnit` publishes a `MaintenanceTaskUpdated` domain event carrying the resulting `nextDue` as a producer-owned conclusion (ADR-0010), so the notifications scheduler reschedules the pending reminder via its existing supersede path without reading task storage back
-- [ ] `S3` An editable task exposes an edit action that opens a form prefilled with its title and interval; the form never offers `lastCompletedDate` or `nextDue`
-- [ ] `S3` Saving the task submits the edit endpoint, updates the displayed task in place, and shows the existing access-denied / not-found treatment for 403/404 responses
+- [x] `S2` `PATCH /api/assets/{assetId}/maintenance-tasks/{taskId}` accepts `{ title?, intervalValue?, intervalUnit? }` and returns the full updated task with status 200
+- [x] `S2` At least one of `title`, `intervalValue`, `intervalUnit` must be present in the request body; a body with none of them returns 422
+- [x] `S2` `lastCompletedDate` and `nextDue` are not fields on this endpoint's request schema; the endpoint never accepts a direct override of either — `nextDue` is always derived (see recompute rule below)
+- [x] `S2` `ownerId` is never accepted in the request body; it is derived from the authenticated session
+- [x] `S2` When provided, `title` follows the same validation as task creation (non-empty after trim, ≤100 characters)
+- [x] `S2` When provided, `intervalValue` follows the same validation as task creation (positive integer ≥ 1)
+- [x] `S2` When provided, `intervalUnit` follows the same validation as task creation (one of `day | week | month | year`)
+- [x] `S2` A field omitted from the request body keeps its current stored value
+- [x] `S2` When the resulting `intervalValue` and/or `intervalUnit` differ from the task's current stored values, `nextDue` is recomputed as `(lastCompletedDate ?? todayUtc) + interval`, using the resulting `intervalValue`/`intervalUnit` and the same calendar arithmetic as task creation
+- [x] `S2` When the resulting `intervalValue` and `intervalUnit` are unchanged from the task's current stored values — whether omitted from the request or resent unchanged — `lastCompletedDate` and `nextDue` are left unchanged; this holds even for a title-only edit on a task with no `lastCompletedDate`, where recomputing from `todayUtc` would otherwise silently push the schedule out
+- [x] `S2` When the requested `title`, `intervalValue`, and `intervalUnit` (after applying only the provided fields) are identical to the task's current stored values, the edit is a no-op: the task is returned unchanged with status 200, and no `MaintenanceTaskUpdated` event is published
+- [x] `S2` Editing a task on an archived asset is permitted — asset archival blocks new maintenance activity (creating tasks or records), not correction of an existing task's metadata
+- [x] `S2` Editing a task that doesn't exist returns 404
+- [x] `S2` Editing a task that exists but belongs to a different asset than the path `assetId` returns 404
+- [x] `S2` Editing a task whose asset the requester cannot access returns 403
+- [x] `S2` The update use case checks that the target asset exists and the requester can access it before applying the edit, following the same task-then-asset-then-access order as task deletion (task lookup and asset-mismatch check first, then asset lookup, then the access check)
+- [x] `S2` A successful edit that changes `title`, `intervalValue`, or `intervalUnit` publishes a `MaintenanceTaskUpdated` domain event carrying the resulting `nextDue` as a producer-owned conclusion (ADR-0010), so the notifications scheduler reschedules the pending reminder via its existing supersede path without reading task storage back
+- [x] `S3` An editable task exposes an edit action that opens a form prefilled with its title and interval; the form never offers `lastCompletedDate` or `nextDue`
+- [x] `S3` Saving the task submits the edit endpoint, updates the displayed task in place, and shows the existing access-denied / not-found treatment for 403/404 responses
 
 ### Record-task linking (change to existing maintenance-record endpoint)
 
@@ -103,15 +103,15 @@ tagged boxes are all `[x]`." See docs/specs/SPECS.md. -->
 - [x] `S1` A 401 response from the API redirects to `/login` through the API client layer
 - [x] `S1` A 403 response from asset or task ownership checks is shown as an access-denied error
 - [x] `S1` A 404 response is shown as a not-found error when the asset or task does not exist
-- [ ] `S3` A 403/404 response from a task edit is shown using the same access-denied / not-found treatment as the rest of this feature
+- [x] `S3` A 403/404 response from a task edit is shown using the same access-denied / not-found treatment as the rest of this feature
 
 ## Delivery Plan
 
-| Slice | Scope                                                                                                                              | Issue | Depends on |
-| ----- | ---------------------------------------------------------------------------------------------------------------------------------- | ----- | ---------- |
-| `S1`  | Task creation, listing, deletion, and record-task linking (already shipped)                                                        | —     | —          |
-| `S2`  | Task-edit backend: `PATCH` for `title`/`intervalValue`/`intervalUnit`, recomputed `nextDue`, and a `MaintenanceTaskUpdated` Smart Event | #180 | `S1` |
-| `S3`  | Task-edit UI: prefilled title/interval form that updates the task in place without exposing schedule baselines | #180 | `S2` |
+| Slice | Scope                                                                                                                                   | Issue | Depends on |
+| ----- | --------------------------------------------------------------------------------------------------------------------------------------- | ----- | ---------- |
+| `S1`  | Task creation, listing, deletion, and record-task linking (already shipped)                                                             | —     | —          |
+| `S2`  | Task-edit backend: `PATCH` for `title`/`intervalValue`/`intervalUnit`, recomputed `nextDue`, and a `MaintenanceTaskUpdated` Smart Event | #180  | `S1`       |
+| `S3`  | Task-edit UI: prefilled title/interval form that updates the task in place without exposing schedule baselines                          | #180  | `S2`       |
 
 ## Validation & Ownership
 

--- a/docs/web/FEATURES.md
+++ b/docs/web/FEATURES.md
@@ -418,6 +418,7 @@ Success is a navigate-away transition (updates the asset query cache, invalidate
 
 - `pending` (create record) — inline or modal form validates date and description; submits to API
 - `pending` (create task) — inline form validates title and due date
+- `pending` (edit task) — drawer/sheet form (title + interval only, no last-completed-date field) opened from an edit button on the task card; submits `PATCH` and updates the task in place
 - `pending` (share/unshare, owner only) — sheet/drawer to share the asset to the caller's team or unshare it back to personal
 - `error` — inline field errors; 401 redirects to `/login`
 
@@ -437,6 +438,7 @@ Success is a navigate-away transition (updates the asset query cache, invalidate
 - Sharing uses the asset's server-computed `sharing` descriptor (`scope`, `isOwner`, optional `ownerDisplayName`); only the asset owner can change sharing
 - Share/unshare are idempotent on the API; the sheet closes on success and refreshes the asset query
 - An edit button (owner only, gated on `sharing.isOwner` like the share control) links to `/app/assets/:id/edit` — see [Edit Asset](#edit-asset)
+- Task edit does not offer a last-completed-date field — that value only ever changes by logging a maintenance record against the task; editing lets the user correct the title or interval without losing it (unlike the old delete-and-recreate workaround)
 
 **Spec:** [`docs/specs/features/maintenance-record.md`](../specs/features/maintenance-record.md), [`docs/specs/features/maintenance-task.md`](../specs/features/maintenance-task.md), [`docs/specs/features/teams-foundation.md`](../specs/features/teams-foundation.md)
 


### PR DESCRIPTION
## Summary

- Add an in-place maintenance-task edit form with prefilled title and interval.
- Submit the generated PATCH client call, update the cached task, and keep schedule baseline fields out of the UI.
- Complete the tested S2/S3 specification checklist after the stacked backend PRs.

## Related

Closes #180

## Risk

**Level:** M

**Why:** This changes an authenticated maintenance workflow but consumes the already-reviewed API contract from parent PR #229.

**Human validation budget:**

M — Evidence + escalations; spot-check the form and optimistic cache update.

## Evidence

- `maintenanceTaskForm.test.ts` covers converting prefilled form values to the PATCH body.
- Full workspace gate passed: 554 API + 127 web tests.
- The form excludes `lastCompletedDate` and `nextDue`; backend response handling uses the existing access/not-found treatment.

## Test plan

- [x] Run lint, type-check, and workspace tests with Node 22.21.1.
- [x] Confirm the task-edit form submits title/interval only and updates the task cache on success.

## Spec / AC

[`maintenance-task.md`](docs/specs/features/maintenance-task.md) — completes and checks tested S2/S3 criteria after its parent PRs merge.
