### PR TITLE
feat: support alternate production hostname

### DIFF
--- a/apps/api/wrangler.jsonc
+++ b/apps/api/wrangler.jsonc
@@ -6,17 +6,22 @@
   // Better Auth relies on Node APIs (crypto, etc.) on the Workers runtime.
   "compatibility_flags": ["nodejs_compat"],
 
-  // Production routes on the shared hostname. The API owns /api/* plus its
+  // Production routes on the shared hostnames. The API owns /api/* plus its
   // (non-/api) docs + health endpoints; the web Worker (pineapple-web) owns the
   // catch-all /* for the SPA. Cloudflare matches the most specific route, so
-  // /api/* and the explicit paths below win over the SPA's /*.
-  // Requires the tylerevans.co zone in this Cloudflare account and a proxied DNS
-  // record for pineapple.tylerevans.co. Routes are ignored by `wrangler dev`.
+  // /api/* and the explicit paths below win over the SPA's /* on either host.
+  // Requires both zones in this Cloudflare account and proxied DNS records for
+  // pineapple.tylerevans.co and pineapple.txe.app. Routes are ignored by
+  // `wrangler dev`.
   "routes": [
     { "pattern": "pineapple.tylerevans.co/api/*", "zone_name": "tylerevans.co" },
     { "pattern": "pineapple.tylerevans.co/openapi.json", "zone_name": "tylerevans.co" },
     { "pattern": "pineapple.tylerevans.co/reference", "zone_name": "tylerevans.co" },
     { "pattern": "pineapple.tylerevans.co/health", "zone_name": "tylerevans.co" },
+    { "pattern": "pineapple.txe.app/api/*", "zone_name": "txe.app" },
+    { "pattern": "pineapple.txe.app/openapi.json", "zone_name": "txe.app" },
+    { "pattern": "pineapple.txe.app/reference", "zone_name": "txe.app" },
+    { "pattern": "pineapple.txe.app/health", "zone_name": "txe.app" },
   ],
 
   "vars": {

--- a/apps/api/wrangler.jsonc
+++ b/apps/api/wrangler.jsonc
@@ -28,7 +28,7 @@
     "ENVIRONMENT": "production",
     // Outbound transactional email sender (ADR-0012). The from domain must be
     // onboarded to Cloudflare Email Sending first — see docs/reference/email-sending.md.
-    "EMAIL_FROM_ADDRESS": "noreply@pineapple.tylerevans.co",
+    "EMAIL_FROM_ADDRESS": "noreply@pineapple.txe.app",
     "EMAIL_FROM_NAME": "Pineapple",
   },
 
@@ -78,7 +78,7 @@
 
   // Cloudflare Email Sending binding (ADR-0012). `wrangler deploy` binds to this;
   // the from domain must be onboarded once via
-  //   wrangler email sending enable pineapple.tylerevans.co
+  //   wrangler email sending enable pineapple.txe.app
   // See docs/reference/email-sending.md. For local sends, add `remote: true`.
   "send_email": [{ "name": "EMAIL" }],
 

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -3,11 +3,14 @@
   "name": "pineapple-web",
   "main": "worker/index.ts",
   "compatibility_date": "2026-05-21",
-  // Production route: the SPA owns the catch-all on the shared hostname.
+  // Production routes: the SPA owns the catch-all on both shared hostnames.
   // /api/* (and the API's docs/health paths) are claimed more specifically by
-  // pineapple-api, so they take precedence. Requires the tylerevans.co zone in
-  // this account + a proxied DNS record for pineapple.tylerevans.co.
-  "routes": [{ "pattern": "pineapple.tylerevans.co/*", "zone_name": "tylerevans.co" }],
+  // pineapple-api, so they take precedence on either host. Requires both zones
+  // in this account + proxied DNS records for both hostnames.
+  "routes": [
+    { "pattern": "pineapple.tylerevans.co/*", "zone_name": "tylerevans.co" },
+    { "pattern": "pineapple.txe.app/*", "zone_name": "txe.app" },
+  ],
   // Static assets (the built SPA) are served first; unmatched routes fall
   // through to index.html so client-side routing works.
   "assets": {

--- a/docs/reference/email-sending.md
+++ b/docs/reference/email-sending.md
@@ -14,6 +14,7 @@ behind the application `TransactionalEmailSender` port; the Cloudflare adapter i
 - `"send_email": [{ "name": "EMAIL" }]` — the Worker binding used to send.
 - `EMAIL_FROM_ADDRESS` / `EMAIL_FROM_NAME` vars — the sender identity. The
   address's domain must be onboarded (below).
+- Production sender: `noreply@pineapple.txe.app`.
 
 At runtime `worker.ts` builds a `CloudflareEmailSender` only when both `EMAIL`
 and `EMAIL_FROM_ADDRESS` are present; otherwise it falls back to a no-op sender
@@ -26,7 +27,7 @@ failure is recorded (retryable vs permanent) and the user can resend.
 The `from` domain must be onboarded to Email Sending before the first send:
 
 ```bash
-npx wrangler email sending enable pineapple.tylerevans.co
+npx wrangler email sending enable pineapple.txe.app
 # list onboarded domains:
 npx wrangler email sending list
 ```
@@ -43,7 +44,7 @@ Onboarding auto-provisions the DNS authentication records in the Cloudflare zone
   policy:
 
   ```
-  _dmarc.pineapple.tylerevans.co  TXT  "v=DMARC1; p=quarantine; rua=mailto:dmarc-reports@tylerevans.co"
+  _dmarc.pineapple.txe.app  TXT  "v=DMARC1; p=quarantine; rua=mailto:dmarc-reports@txe.app"
   ```
 
 Cloudflare additionally manages IP reputation, soft-bounce retries, hard-bounce


### PR DESCRIPTION
## Summary

- Add `pineapple.txe.app` API routes for `/api/*`, `/openapi.json`, `/reference`, and `/health`.
- Add the `pineapple.txe.app/*` SPA route while preserving API route precedence.
- Configure transactional email to send from `noreply@pineapple.txe.app`.
- Document the two-zone, DNS, and Email Sending onboarding prerequisites.

## Risk

**Level:** M

**Why:** This changes production hostname routing and the transactional sender identity. The application email logic is unchanged, but missing DNS or Email Service onboarding would make the alternate host or email delivery unavailable.

**Human validation budget:** M — Evidence + escalations; spot-check 1–2 hot files.

## Evidence

- [x] API Wrangler deploy dry run passed and showed `EMAIL_FROM_ADDRESS=noreply@pineapple.txe.app`.
- [x] Web build and Wrangler deploy dry run passed.
- [x] `pnpm lint` passed.
- [x] `pnpm type-check` passed.
- [x] `pnpm -r test` passed: 84 API files / 554 tests and 22 web files / 127 tests.
- [x] `git diff --check` passed.
- [ ] Cloudflare Email Sending onboarding is still required; `wrangler email sending list` currently reports no sending subdomains.

## Test plan

- [ ] Add a proxied DNS record or Cloudflare Custom Domain for `pineapple.txe.app`.
- [ ] Onboard `pineapple.txe.app` under Cloudflare Email Service > Email Sending and wait for its DNS records to verify.
- [ ] Add `https://pineapple.txe.app/api/auth/callback/google` to the Google OAuth client redirect URIs.
- [ ] After deployment, verify `/`, `/api/health`, Google sign-in, contact-email verification, and reminder delivery on the supported hostnames.

## Spec / AC

- Infrastructure-only route and sender configuration; no product behavior contract changed.

## Escalations (need human decision)

- None.