### PR TITLE
fix: provision alternate hostname DNS

### DIFF
--- a/apps/api/wrangler.jsonc
+++ b/apps/api/wrangler.jsonc
@@ -10,9 +10,9 @@
   // (non-/api) docs + health endpoints; the web Worker (pineapple-web) owns the
   // catch-all /* for the SPA. Cloudflare matches the most specific route, so
   // /api/* and the explicit paths below win over the SPA's /* on either host.
-  // Requires both zones in this Cloudflare account and proxied DNS records for
-  // pineapple.tylerevans.co and pineapple.txe.app. Routes are ignored by
-  // `wrangler dev`.
+  // Requires both zones in this Cloudflare account. The primary hostname needs
+  // a proxied DNS record; the alternate hostname's record is provisioned by the
+  // web Worker's Custom Domain. Routes are ignored by `wrangler dev`.
   "routes": [
     { "pattern": "pineapple.tylerevans.co/api/*", "zone_name": "tylerevans.co" },
     { "pattern": "pineapple.tylerevans.co/openapi.json", "zone_name": "tylerevans.co" },

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -3,13 +3,14 @@
   "name": "pineapple-web",
   "main": "worker/index.ts",
   "compatibility_date": "2026-05-21",
-  // Production routes: the SPA owns the catch-all on both shared hostnames.
+  // Production routing: the SPA owns the catch-all on both shared hostnames.
   // /api/* (and the API's docs/health paths) are claimed more specifically by
-  // pineapple-api, so they take precedence on either host. Requires both zones
-  // in this account + proxied DNS records for both hostnames.
+  // pineapple-api, so they take precedence on either host. The primary hostname
+  // uses a route; the alternate hostname uses a Custom Domain so Cloudflare
+  // provisions its DNS record and certificate automatically.
   "routes": [
     { "pattern": "pineapple.tylerevans.co/*", "zone_name": "tylerevans.co" },
-    { "pattern": "pineapple.txe.app/*", "zone_name": "txe.app" },
+    { "pattern": "pineapple.txe.app", "custom_domain": true },
   ],
   // Static assets (the built SPA) are served first; unmatched routes fall
   // through to index.html so client-side routing works.


### PR DESCRIPTION
## Summary

- Replace the `pineapple.txe.app/*` route with a Cloudflare Custom Domain on `pineapple-web`.
- Keep the API Worker’s more-specific `pineapple.txe.app` routes for `/api/*`, `/health`, and documentation paths.
- Document that the Custom Domain provisions the alternate hostname DNS record and certificate.

## Risk

**Level:** M

**Why:** This changes production hostname routing and Cloudflare DNS provisioning. The application code is unchanged, but an invalid Worker/domain association could make the alternate hostname unavailable.

**Human validation budget:** M — Evidence + escalations; spot-check 1–2 hot files.

## Evidence

- [x] API Wrangler deploy dry run passed.
- [x] Web build and Wrangler deploy dry run passed with `custom_domain: true`.
- [x] `pnpm lint` passed.
- [x] `pnpm type-check` passed.
- [x] `pnpm -r test` passed: 84 API files / 554 tests and 22 web files / 127 tests.
- [x] `git diff --check` passed.

## Test plan

- [ ] After deployment, confirm Cloudflare creates the `pineapple.txe.app` DNS record and certificate.
- [ ] Confirm `https://pineapple.txe.app/` serves the SPA.
- [ ] Confirm `https://pineapple.txe.app/api/health` is handled by `pineapple-api`.
- [ ] Confirm Google OAuth and email verification work on the alternate hostname.

## Spec / AC

- Infrastructure-only routing configuration; no product behavior contract changed.

## Escalations (need human decision)

- None.