### PR TITLE
fix(web): render OAuth loading spinner as circle

### DIFF
--- a/apps/web/src/auth/authStyles.test.ts
+++ b/apps/web/src/auth/authStyles.test.ts
@@ -1,0 +1,10 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const authCss = readFileSync(new URL("./styles/auth.css", import.meta.url), "utf8");
+
+describe("auth loading styles", () => {
+  it("keeps the OAuth redirect spinner circular", () => {
+    expect(authCss).toMatch(/\.au-spinner\s*\{[^}]*border-radius:\s*var\(--hf-r-full\);/s);
+  });
+});

--- a/apps/web/src/auth/styles/auth.css
+++ b/apps/web/src/auth/styles/auth.css
@@ -328,7 +328,7 @@
 .au-spinner {
   position: absolute;
   inset: -9px;
-  border-radius: var(--hf-r-xl);
+  border-radius: var(--hf-r-full);
   border: 2.5px solid var(--hf-brand-bg);
   border-top-color: var(--hf-brand);
   animation: au-spin 0.8s linear infinite;

--- a/pitfalls.md
+++ b/pitfalls.md
@@ -2,6 +2,28 @@
 
 This file is a running log of small-but-annoying issues we've hit, plus the fix that worked.
 
+## 2026-08-21 — Vitest `?raw` CSS imports are empty
+
+### Symptom
+
+A web stylesheet regression test imported `auth.css?raw`, but Vitest supplied an
+empty string, so the assertion failed without reading the stylesheet.
+
+### Cause
+
+The current Vitest/Vite test configuration does not transform CSS `?raw` imports
+into their source text.
+
+### Fix
+
+Read the stylesheet with `readFileSync(new URL("./styles/auth.css", import.meta.url), "utf8")`
+from the test instead.
+
+### How to avoid next time
+
+Use a module URL and `node:fs` for source-level CSS assertions unless the test
+configuration explicitly enables raw CSS handling.
+
 ## 2026-08-21 — lint-staged cannot stash through a symlinked `.claude`
 
 ### Symptom


### PR DESCRIPTION
## Summary

- Change the login OAuth redirect spinner from a rounded-square ring to a circular ring using the shared full-radius token.
- Add a CSS regression test and audit the other spinner implementations; they already use circular geometry.

## Risk

**Level:** L

**Why:** This is a one-property visual-only change in the login loading state with no auth logic, API, or data-model changes.

**Human validation budget:** L — Glance evidence. Do not read the diff.

## Evidence

- [x] `apps/web/src/auth/authStyles.test.ts` — `keeps the OAuth redirect spinner circular`
- [x] Manual local repro: held the OAuth request on `/login`, confirmed `.au-spinner` computes to `border-radius: 999px` and keeps `animationName: au-spin`; the badge remains on its original `20px` radius.
- [x] Fresh adversarial diff review — no findings.
- [x] `pnpm lint`
- [x] `pnpm type-check`
- [x] `pnpm -r test` — 682 tests passed
- [x] `pnpm --filter @snaveevans/pineapple-web build`

## Test plan

- [x] Run the focused regression test against the old rule and confirm red, then rerun after the fix and confirm green.
- [x] Run the full workspace lint, type-check, test, and web build commands.
- [x] Verify the login redirect state manually in a browser with the OAuth request held open.

## Spec / AC

Not applicable: visual bug fix only; no product behavior or API contract changed.

## Validation gate

- [x] Rebased on latest `main`
- [x] Lint / type-check / tests green locally
- [x] Adversarial review run (fresh code-review pass; no findings)
- [x] Safe findings self-fixed; product escalations listed below
- [x] Docs / spec AC / `FEATURES.md` update not required for this visual-only fix
- [x] OpenAPI + web `api:types` regeneration not applicable; no contract changed

**Escalations (need human decision):**

None.