### PR TITLE
feat(maintenance): edit and delete maintenance records with schedule reconciliation (#181)

### DIFF
--- a/.agents/skills/test-author/SKILL.md
+++ b/.agents/skills/test-author/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: test-author
+description: Author an implementation-blind test plan for an Open Brain issue or spec slice — hunt spec gaps, record caller-visible corner cases in the feature spec, and post the prioritized plan as a GitHub issue comment. Use whenever the user asks for a test plan, testing criteria, coverage gaps, what to test, or to test-author an issue, including before spec-implement and after a spec lands. Do not use to write tests or production code (spec-implement), to judge whether existing tests pin the plan (test-review), or to open a PR (validation-gate).
+---
+
+Work conversationally. Confirm the target issue and any unresolved product
+calls before writing. Do not invent product policy, and do not generate the
+spec delta or issue comment until the gaps that need a human ruling are
+either answered or parked as Open Questions.
+
+This skill sits **between** `spec-author` and `spec-implement`. Specs own
+behavior. The GitHub issue owns the test plan. ADRs own hard-to-reverse
+choices. There is no `docs/testing/` home — ADR-0002 forbids a third typed
+doc.
+
+## Hard rules
+
+1. **Do not read implementation.** Stay out of `packages/**`, test files,
+   and handler source. Existing tests and code bias the plan toward what
+   already happens. The spec and the issue are the inputs. If you already
+   saw code earlier in the conversation, do not go back for more, and do
+   not tailor the plan to it.
+2. **Do not write production code or test files.** `spec-implement` does
+   that from the spec plus this plan.
+3. **Do not invent product policy.** Unspecified behavior is a question, an
+   Open Question on the spec, or an escalation — not a quiet default.
+4. **Do not create a test-plan doc in the repo.** No `docs/testing/`, no
+   plan pasted into `AGENTS.md`. Behavior goes in the spec; the plan goes
+   on the issue.
+5. **Do not reuse an error string for a different case.** A metadata
+   message must not describe a non-object body. Propose a new string in the
+   house style and confirm it.
+
+## Find the target
+
+Do not expect an argument. Resolve the issue from, in order:
+
+1. An explicit number or URL in the user request
+2. Leading digits in the branch name (`feat/5-…` → `#5`)
+3. The issue linked from the spec's Delivery Plan for the slice in play
+4. Ask if still ambiguous
+
+Then **run this** and work from the output — do not guess the spec inventory:
+
+```bash
+gh issue view <N> --json title,body,labels,comments
+find docs/specs/features docs/specs/cross-cutting -name "*.md" | sort
+```
+
+Identify the feature spec the issue names (or the Delivery Plan row that
+points at this issue). Read **that spec**, every **Related Spec** it lists,
+and any ADR it cites. Read `docs/specs/SPECS.md` only if you need the
+status / checkbox rules.
+
+State in one line: issue, spec path, and whether this is a first plan or a
+revision of an existing `<!-- openbrain-test-author -->` comment.
+
+## 1. Restate the contract
+
+In your own words, one sentence: what the slice does, and what must never
+happen. Pull “must never happen” from the spec’s acceptance criteria, edge
+table, and Out of Scope — not from how you imagine the code works.
+
+## 2. Hunt gaps
+
+Work through [gap-checklist.md](gap-checklist.md). Catalogue every place the
+spec is silent, contradictory, or weaker than the failure it would allow (for
+example “500; no successful create” that still permits a leftover row).
+
+Group the catalogue:
+
+- **Already specified** — plan a test; do not rewrite the spec
+- **Needs a product call** — ask. Do not proceed to write until each is
+  answered or parked
+- **Test strategy only** — how to fake a port, what to spy. Issue comment
+  only; not spec material
+- **Architectural** — hard to reverse, real alternatives. Offer
+  `adr-author`; do not smuggle the choice into an edge-table row
+
+Ask the product questions in a tight list. Prefer one round of answers over
+guessing “the usual REST thing.”
+
+If the conversation already answered the calls (this session or a prior
+comment), restate those answers in one block and proceed. Do not re-ask.
+
+## 3. Split the artifact
+
+Every fact has one home:
+
+| Fact                                                                                   | Home                                                                                                        |
+| -------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| Caller-visible behavior, validation strings, status codes, defaults, failure leftovers | Feature spec (edge table, Observable Contract, new AC boxes only when the behavior must be gated on `main`) |
+| Why a hard-to-reverse option won                                                       | ADR via `adr-author`, only when the user wants that lock                                                    |
+| Prioritized tests, spies, fakes, minimum confidence set                                | GitHub issue comment (and later the implementing PR’s Test plan, which links here)                          |
+
+Hand back to `spec-author` instead of editing when the spec is missing,
+still `draft`/`wip`, or needs new personas / a rewritten contract — not just
+sharper edges.
+
+## 4. Update the spec
+
+Read `docs/specs/templates/feature-spec.template.md` only if you need the
+section map. Then edit the **existing** feature spec:
+
+- Add or tighten **Edge Cases & Error States** rows. A row that only says
+  “500” for a dual-write failure is incomplete — say what is left behind.
+- Add exact **validation messages** to the Observable Contract. House style
+  is a backticked field in a sentence, or a short period-terminated
+  sentence (`Unauthorized.`, `Request body must be valid JSON.`).
+- Add **acceptance criteria** only for newly decided behavior that must not
+  merge without a test. Leave them unchecked (`- [ ]`). Tag them with the
+  slice that owns the work (usually the issue’s existing `Sn`). Do not
+  uncheck boxes you did not add.
+- If you add unchecked boxes to a spec marked `active`, flip **Status** to
+  `in-progress` and update the matching row in `docs/specs/SPECS.md`.
+  Checked-on-a-branch is not “on `main`”; new gaps mean the slice is not
+  done.
+- Put unresolved calls in **Open Questions**, each a concrete either/or.
+- Move future work (telemetry, repair queue) to **Out of Scope**, not fake
+  ACs.
+- Do **not** put test names, fake types, file paths, or constant identifiers
+  (`ERROR_*`) in the spec. Those are mechanism.
+
+If a new error string will apply to every JSON POST, add one edge-table row
+on [rest-api](../../../docs/specs/features/rest-api.md) and keep the exact
+wording on the operation spec that first needs it. Sibling routes reuse that
+wording later; they do not invent a parallel sentence.
+
+## 5. Post the plan on the issue
+
+Look for an existing comment that contains `<!-- openbrain-test-author -->`.
+
+- **None** → `gh issue comment <N> --body-file …`
+- **Found** → patch that comment (`gh api repos/{owner}/{repo}/issues/comments/{id} -X PATCH`) so the issue has one live plan
+
+Use this shape. Keep it short enough to execute; link the spec for wording
+rather than pasting the whole contract.
+
+```markdown
+<!-- openbrain-test-author -->
+
+## Test plan — <issue title>
+
+Blind to implementation. Source: <spec path> (plus related specs / ADRs named there).
+
+### Must never happen
+
+- …
+
+### Product calls recorded this round
+
+- …
+
+### P0 — ship blockers
+
+One test (or a tight pair) per row. Highest bug-per-effort first.
+
+1. …
+2. …
+
+### P1 — silent corruption / contract
+
+- …
+
+### P2 — only if cheap
+
+- …
+
+### Minimum confidence set
+
+The smallest list that would still catch the expensive failure. Usually ≤ 8.
+
+### Out of scope for this issue
+
+- …
+
+### Suggested test split
+
+Filenames / fakes for `spec-implement`. Not spec material.
+```
+
+Write tests as **observable assertions** (status, body string, store count,
+embedder input, leftover row/vector). Do not prescribe implementation.
+
+## 6. Report back
+
+In-session, give the user:
+
+- Spec path and a bullet list of what changed (new rows, new strings, new
+  ACs, status flip)
+- Link to the issue comment
+- Any Open Questions still parked
+- Whether an ADR was offered or skipped, and why
+
+Do not implement the handler, the error constant, or the tests unless the
+user explicitly switches you to `spec-implement`.

--- a/.agents/skills/test-author/gap-checklist.md
+++ b/.agents/skills/test-author/gap-checklist.md
@@ -1,0 +1,98 @@
+# Gap checklist
+
+Work through each concern against the **spec and issue**, not the code.
+A gap is either a product call (ask), a spec edit (behavior), or a test idea
+(issue comment). Do not invent the missing policy.
+
+---
+
+## Auth and trust
+
+See `docs/specs/cross-cutting/authentication.md` when the feature is
+authenticated.
+
+- Does auth run before body parse and domain work? A 401 on invalid JSON or
+  empty content is the test that proves it.
+- Missing vs wrong vs empty vs whitespace `x-api-key` — same 401 body?
+- Missing server `API_KEY` — 500 fail-closed, not a public route?
+- Key accepted anywhere it must not be (query, JSON body, `Authorization`)?
+- Is the key treated as a subject, owner, or stored field?
+- Does any error body echo the presented or configured key?
+
+## Validation
+
+- Required vs optional vs omitted vs empty vs whitespace-only — each field,
+  separately.
+- Wrong JSON types (`null`, number, bool, array, object) for every accepted
+  field.
+- Valid JSON that is not the documented shape (top-level `[]`, `"x"`,
+  `42`). This is **not** the same case as a bad field.
+- Invalid JSON (`{`, empty body, form-encoded) vs valid-but-wrong.
+- Extra / attacker-supplied server-owned fields (`id`, timestamps,
+  `embedding_model`, `similarity`). Ignore or reject — pick one and pin that
+  none of the attacker values stick.
+- Unicode, interior whitespace, null bytes, oversize. Silent truncate is a
+  corruption bug if two sides of a write can disagree.
+
+Do not reuse an error string for a different case. Propose a new one.
+
+## State and leftovers
+
+The expensive bugs are partial success.
+
+- What is written on the happy path (row, vector, both)? In what observable
+  order?
+- For **each** dependency failure (embed, document store, index, clock): HTTP
+  status, body, **and** leftover state on every store.
+- If the handler compensates (delete the row, delete the vector), what happens
+  when compensation itself fails? Usually still `500`, no 201, leftovers
+  possible — say that; do not pretend an in-request delete is a transaction.
+- Validation / 401 / missing-config must write nothing and should not call the
+  embedder.
+- Retry after `500` is a **new** create unless the spec says otherwise (no
+  silent upsert).
+- Two identical successes are two records unless upsert is in scope.
+
+## Time, identity, concurrency
+
+- Who assigns `id`? UUID version/format if the spec cares.
+- `created_at` / `updated_at` / `embedded_at` on first write — equal? Clock-skew
+  if they come from different places?
+- Parallel requests must not share an id or clobber each other.
+- Idempotency keys? If unspecified, assume none.
+
+## Cross-feature coupling
+
+- A write here becomes a fetch / search / delete later. Does create promise an
+  embedding that search will rely on?
+- Does a failure mode produce a row that later specs treat as legal (fetchable,
+  un-embedded) even though _this_ feature promised embed?
+- Eventual consistency the caller can observe (201 then search miss) belongs in
+  the spec as a warning, not only in an ADR.
+
+## Observability and secrets
+
+- Spec says do not log content, metadata, keys, embeddings. If the plan needs a
+  logger assertion, put it on the issue, not in the spec.
+- Future telemetry / queue / repair is Out of Scope until a spec exists. Do not
+  add ACs for it.
+
+## HTTP / surface
+
+See `docs/specs/features/rest-api.md` for the shared envelope.
+
+- Wrong method → `405`. Unknown path → `404`. Trailing slash.
+- `Cache-Control: no-store` on authenticated responses and `/health`.
+- Content-Type missing or wrong — pin `400` vs `415`.
+- Envelope is `{ error: string }` or the success shape. No extra top-level keys
+  unless specified.
+
+## What to put where
+
+After the pass, every item is one of:
+
+1. **Spec row / message / AC** — caller can observe it
+2. **Issue-comment test** — how we will prove (1)
+3. **Question** — still unspecified; ask or park
+4. **ADR candidate** — hard to reverse; offer `adr-author`
+5. **Out of scope** — name it so it cannot sneak into this slice

--- a/.agents/skills/test-review/SKILL.md
+++ b/.agents/skills/test-review/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: test-review
+description: Adversarial review of tests against the feature spec and the GitHub issue test plan. Checks leftover spies, exact error strings, auth-before-parse, and boxes checked too early. Use after spec-implement, before validation-gate, or whenever the user asks whether the tests actually pin the spec, to review coverage, or to test-review an issue or branch. Do not use to write a blind plan (test-author), implement the slice (spec-implement), or review production code for bugs (pr-review).
+---
+
+# Test review
+
+Finds holes in the **tests**, not in the handler. `test-author` was blind on
+purpose. This skill is the one allowed to read `packages/**` test files and
+say whether they pin the contract.
+
+This skill sits **between** `spec-implement` and `validation-gate`. Specs own
+behavior. The issue comment owns the plan. Tests must prove both.
+
+## Identify, don't fix
+
+This skill finds problems. It does not solve them. Do not edit test files,
+production code, or the spec. Do not suggest patches or "extract a helper."
+State what is missing or lying, and the consequence (a leftover row would
+still go green; a box is checked without a spy).
+
+A finding is complete when a reader knows the gap and what it would let ship.
+
+## Find the target
+
+Do not expect an argument. Resolve issue and spec from, in order:
+
+1. Explicit issue / spec / PR in the user request
+2. Delivery Plan `Issue` cell on the spec this branch touches
+3. Leading digits in the branch name (`feat/5-…` → `#5`)
+4. Ask if still ambiguous
+
+Then **run this**:
+
+```bash
+gh issue view <N> --comments
+find docs/specs/features docs/specs/cross-cutting -name "*.md" | sort
+git diff --name-only main...HEAD -- '*test*' '*spec*'
+```
+
+Load:
+
+- The feature spec and every Related Spec it lists
+- The **latest** issue comment containing `<!-- openbrain-test-author -->`
+- Test files in the branch diff (and existing tests for the same feature on
+  this branch — not production handlers unless a test is unreadable without
+  the assertion target)
+
+If there is **no plan comment**, stop and hand back to `test-author`.
+Reviewing tests against vibes is how we re-derive the plan.
+
+State in one line: issue, spec path, plan comment URL, and which test files
+you will read.
+
+## 1. Build the expected set
+
+From the spec, list every acceptance criterion tagged for this slice and every
+Edge Cases / Observable Contract row that is caller-visible.
+
+From the issue plan, list every **Minimum confidence set** item and every
+**P0** row. Treat those as required. P1 is a finding only when the user asked
+for a full pass, or when skipping it would let a P0 failure hide (wrong error
+string reused, leftover unspied).
+
+Do not add new product policy. If the spec and the plan disagree, that is
+itself a finding — hand back to `test-author`, do not pick a winner.
+
+## 2. Read the tests
+
+Read the test files. You may skim fakes/helpers they import. Stay out of
+handler source unless you cannot tell what an assertion is pointing at.
+
+For each required item, record one of:
+
+| Verdict              | Meaning                                                                                                       |
+| -------------------- | ------------------------------------------------------------------------------------------------------------- |
+| **Pinned**           | A test would fail if the behavior regressed the way the plan fears                                            |
+| **Status-only**      | A status/body check exists, but the expensive part (leftover row, embedder input, key-on-row) is not asserted |
+| **Wrong string**     | Test expects a message that belongs to a different case                                                       |
+| **Missing**          | No test                                                                                                       |
+| **Contradicts spec** | Test encodes a different contract than the spec / plan                                                        |
+| **Box lie**          | Spec box is `[x]` and the matching test is missing, status-only, or contradicts                               |
+
+Work through [pin-checklist.md](pin-checklist.md). That list is the difference
+between "we have a 500 test" and "a leftover row would fail CI."
+
+## 3. Score findings
+
+Keep a finding when it is **real and would let a ship-blocker through**. Drop
+nits (test names, extra P2 coverage, style).
+
+Typical keepers:
+
+- Minimum-confidence or P0 item is Missing or Status-only
+- Dual-write `500` test does not assert leftover state on **every** store
+- Auth test does not prove **before parse** (401 on invalid JSON / empty
+  content)
+- Error string reused for a different case
+- Attacker-supplied server fields not shown to bounce
+- Oversize path allows stored text ≠ embedded text
+- Spec box `[x]` without a pinning test
+- New observable behavior in tests that the spec never recorded
+
+## 4. Report in-session
+
+Verdict:
+
+- **Changes requested** — any keeper. The slice is not done.
+- **Approved** — every minimum-confidence item and every new AC is Pinned; no
+  box lies.
+
+```markdown
+## Test review: changes requested | approved
+
+Issue #<N> · <spec path>
+Plan: <comment URL>
+
+### Unpinned (required)
+
+- **<plan/spec item>** — Missing | Status-only | Wrong string | …
+  What the current test actually asserts, and the bug that would stay green.
+
+### Box lies
+
+- `docs/specs/…` — `[x]` without a pinning test / …
+
+### Plan vs spec disagreements
+
+- …
+
+### Pinned (for the record)
+
+- Short checklist of required items that are actually pinned.
+
+### Not scored
+
+P1/P2 you looked at and left alone, or parked product calls.
+```
+
+On approval, keep Unpinned / Box lies empty and say in one line what the tests
+would catch.
+
+Do **not** post this on the PR. `pr-review` owns PR comments. Fold survivors
+into the `validation-gate` evidence / escalations when that skill runs.
+
+## What this skill is not
+
+- Not `test-author` — do not invent a new plan or edit the spec
+- Not `pr-review` — do not review handler bugs or architecture
+- Not `spec-implement` — do not write the missing tests
+- Not a coverage-percentage check. One leftover-state spy beats twenty
+  duplicate `201` tests

--- a/.agents/skills/test-review/pin-checklist.md
+++ b/.agents/skills/test-review/pin-checklist.md
@@ -1,0 +1,72 @@
+# Pin checklist
+
+A behavior is **pinned** only when a test would fail the way the plan fears,
+not merely when a status code is asserted. Work through each row against the
+tests you read.
+
+---
+
+## Leftovers and side effects
+
+- Embed / store / index (or any other port the spec names) can fail
+  independently. Each injection has its own test.
+- Every `500` dual-write test asserts **count / presence on every store**, not
+  only HTTP. "500 and we didn't look at D1" is Status-only.
+- Compensation paths: store-fail-after-index asserts the vector is gone;
+  index-fail-after-store asserts the row is gone.
+- `400` / `401` / missing-config `500` assert **zero writes and embedder not
+  called**.
+- Retry-after-500 is a new create if the spec says so (two POSTs, two ids) —
+  only if the plan required it.
+
+## Auth before work
+
+- Missing, wrong, empty, and whitespace `x-api-key` share one `401` body.
+- At least one test sends **invalid JSON or empty content without a key** and
+  still expects `401`, not `400`. That is the before-parse pin.
+- Missing server `API_KEY` is `500` with the configured-key message, and writes
+  nothing.
+- Key is not accepted from query, JSON body, or `Authorization`.
+- Persist spy: the stored document has no key-shaped field.
+- Error bodies never echo the presented or configured key.
+
+## Strings and cases
+
+- Each documented validation message is asserted **exactly**, on the case it
+  belongs to.
+- A metadata message is not used for a non-object body (or any other different
+  case).
+- Invalid JSON and valid-but-not-an-object are different tests.
+
+## Defaults, trim, coupling
+
+- Omitted / empty / whitespace-only fields match the spec (including `source`
+  → `"manual"` when specified).
+- Trimmed `content` is what the **store and the embedder** both saw. A
+  response-only trim check is Status-only.
+- Stored text equals embedded text on success. Oversize is a reject, not a
+  truncate, when the spec says so.
+- Create-style embed uses the **document** task if the plan requires that spy.
+  A 201 with no task assertion will not catch a silent prefix bug.
+
+## Server-owned fields
+
+- Caller-supplied `id`, timestamps, `embedding_model`, `similarity` do not
+  stick (rejected or ignored — whatever the spec/plan said).
+- `similarity` is absent on create responses if the spec says so.
+- Two sequential creates get two ids.
+
+## Boxes and honesty
+
+- A spec `[x]` has a pinning test on this branch (or already on `main` if this
+  slice did not touch that box).
+- New ACs added by `test-author` are not checked off with a status-only test.
+- Tests do not encode behavior the spec never recorded. If they do, that is a
+  plan-vs-spec disagreement, not a free pass.
+
+## Do not require
+
+- P2 items (header case, logger greps, timing-safe microbenchmarks)
+- Search / fetch / CLI coverage on a create issue
+- Line coverage percentages
+- Production-handler walkthroughs

--- a/apps/api/src/api/errors.ts
+++ b/apps/api/src/api/errors.ts
@@ -7,6 +7,7 @@ import {
   ConflictError,
   TooManyRequestsError,
   UnauthorizedError,
+  ServiceUnavailableError,
 } from "@snaveevans/pineapple-shared";
 
 /**
@@ -27,11 +28,16 @@ export function toHttpError(c: Context, error: DomainError): Response {
               ? 409
               : error instanceof TooManyRequestsError
                 ? 429
-                : 500;
+                : error instanceof ServiceUnavailableError
+                  ? 503
+                  : 500;
 
   const body: Record<string, unknown> = { error: error.message };
   if (error instanceof ValidationError && error.field) {
     body["field"] = error.field;
+  }
+  if (error instanceof ServiceUnavailableError && error.code) {
+    body["code"] = error.code;
   }
   return c.json(body, status);
 }

--- a/apps/api/src/api/middleware/technicalTelemetry.ts
+++ b/apps/api/src/api/middleware/technicalTelemetry.ts
@@ -3,6 +3,7 @@ import {
   ConflictError,
   ForbiddenError,
   NotFoundError,
+  ServiceUnavailableError,
   TooManyRequestsError,
   UnauthorizedError,
   ValidationError,
@@ -211,6 +212,18 @@ function routeTelemetry(method: string, pathname: string): RouteTelemetry {
       routePattern: "/api/assets/{assetId}/maintenance-records",
     };
   }
+  if (/^\/api\/assets\/[^/]+\/maintenance-records\/[^/]+$/.test(pathname) && method === "PATCH") {
+    return {
+      operation: "UpdateMaintenanceRecord",
+      routePattern: "/api/assets/{assetId}/maintenance-records/{recordId}",
+    };
+  }
+  if (/^\/api\/assets\/[^/]+\/maintenance-records\/[^/]+$/.test(pathname) && method === "DELETE") {
+    return {
+      operation: "DeleteMaintenanceRecord",
+      routePattern: "/api/assets/{assetId}/maintenance-records/{recordId}",
+    };
+  }
   if (/^\/api\/assets\/[^/]+\/maintenance-tasks$/.test(pathname) && method === "POST") {
     return {
       operation: "CreateMaintenanceTask",
@@ -260,6 +273,7 @@ export function statusFromError(error: unknown): number {
   if (error instanceof ValidationError) return 422;
   if (error instanceof ConflictError) return 409;
   if (error instanceof TooManyRequestsError) return 429;
+  if (error instanceof ServiceUnavailableError) return 503;
   return 500;
 }
 

--- a/apps/api/src/api/openapi.ts
+++ b/apps/api/src/api/openapi.ts
@@ -13,8 +13,10 @@ import {
 import {
   CreateMaintenanceRecordBodySchema,
   MaintenanceAssetIdParamSchema,
+  MaintenanceRecordIdParamSchema,
   MaintenanceRecordListResponseSchema,
   MaintenanceRecordResponseSchema,
+  UpdateMaintenanceRecordBodySchema,
 } from "./schemas/maintenanceRecordSchemas.ts";
 import {
   CreateMaintenanceTaskBodySchema,
@@ -341,6 +343,87 @@ export const listMaintenanceRecordsRoute = createRoute({
     },
     404: {
       description: "No such asset",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
+export const updateMaintenanceRecordRoute = createRoute({
+  method: "patch",
+  path: "/api/assets/{assetId}/maintenance-records/{recordId}",
+  tags: ["Maintenance"],
+  summary: "Edit a maintenance record",
+  description:
+    "Updates title, performedAt, and/or notes. Empty string notes clears the notes. If the record is linked to a task, the task schedule is reconciled. CAS concurrency check retries on conflict. A no-op edit returns 200 with the unchanged record.",
+  security: [cookieAuth],
+  request: {
+    params: MaintenanceRecordIdParamSchema,
+    body: {
+      required: true,
+      content: { "application/json": { schema: UpdateMaintenanceRecordBodySchema } },
+    },
+  },
+  responses: {
+    200: {
+      description: "Updated maintenance record",
+      content: { "application/json": { schema: MaintenanceRecordResponseSchema } },
+    },
+    401: {
+      description: "Not authenticated",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    403: {
+      description: "The asset belongs to another user",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    404: {
+      description: "No such record or asset",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    409: {
+      description: "The asset is archived or concurrent conflict exceeded retries",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    422: {
+      description: "Validation failed",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    503: {
+      description: "Maintenance writes are temporarily frozen",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
+export const deleteMaintenanceRecordRoute = createRoute({
+  method: "delete",
+  path: "/api/assets/{assetId}/maintenance-records/{recordId}",
+  tags: ["Maintenance"],
+  summary: "Delete a maintenance record",
+  description:
+    "Permanently deletes the maintenance record. If linked to a task, the task schedule is reconciled to the surviving records or initial baseline.",
+  security: [cookieAuth],
+  request: { params: MaintenanceRecordIdParamSchema },
+  responses: {
+    204: { description: "Maintenance record deleted" },
+    401: {
+      description: "Not authenticated",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    403: {
+      description: "The asset belongs to another user",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    404: {
+      description: "No such record or asset",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    409: {
+      description: "The asset is archived or concurrent conflict exceeded retries",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    503: {
+      description: "Maintenance writes are temporarily frozen",
       content: { "application/json": { schema: ErrorResponseSchema } },
     },
   },
@@ -905,6 +988,8 @@ export function getApiDocument() {
   doc.openapi(searchAssetsRoute, stub);
   doc.openapi(createMaintenanceRecordRoute, stub);
   doc.openapi(listMaintenanceRecordsRoute, stub);
+  doc.openapi(updateMaintenanceRecordRoute, stub);
+  doc.openapi(deleteMaintenanceRecordRoute, stub);
   doc.openapi(createMaintenanceTaskRoute, stub);
   doc.openapi(listMaintenanceTasksRoute, stub);
   doc.openapi(deleteMaintenanceTaskRoute, stub);

--- a/apps/api/src/api/schemas/maintenanceRecordSchemas.test.ts
+++ b/apps/api/src/api/schemas/maintenanceRecordSchemas.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import {
   CreateMaintenanceRecordBodySchema,
   MaintenanceAssetIdParamSchema,

--- a/apps/api/src/api/schemas/maintenanceRecordSchemas.test.ts
+++ b/apps/api/src/api/schemas/maintenanceRecordSchemas.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it } from "vitest";
 import {
   CreateMaintenanceRecordBodySchema,
   MaintenanceAssetIdParamSchema,
+  MaintenanceRecordIdParamSchema,
   MaintenanceRecordResponseSchema,
+  UpdateMaintenanceRecordBodySchema,
 } from "./maintenanceRecordSchemas.ts";
 
 describe("maintenance record schemas", () => {
@@ -37,6 +38,35 @@ describe("maintenance record schemas", () => {
 
   it("rejects malformed asset ids", () => {
     expect(MaintenanceAssetIdParamSchema.safeParse({ assetId: "not-a-uuid" }).success).toBe(false);
+    expect(
+      MaintenanceRecordIdParamSchema.safeParse({
+        assetId: "not-a-uuid",
+        recordId: "e914b960-772f-46a7-b6fb-f333dcfc7fc9",
+      }).success,
+    ).toBe(false);
+  });
+
+  it("accepts valid partial updates in UpdateMaintenanceRecordBodySchema", () => {
+    expect(
+      UpdateMaintenanceRecordBodySchema.parse({
+        title: "Updated Oil",
+        notes: null,
+      }),
+    ).toEqual({ title: "Updated Oil", notes: null });
+  });
+
+  it("rejects unknown/forbidden keys in UpdateMaintenanceRecordBodySchema with strict mode", () => {
+    expect(
+      UpdateMaintenanceRecordBodySchema.safeParse({
+        title: "Oil Change",
+        taskId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      }).success,
+    ).toBe(false);
+    expect(
+      UpdateMaintenanceRecordBodySchema.safeParse({
+        id: "e914b960-772f-46a7-b6fb-f333dcfc7fc9",
+      }).success,
+    ).toBe(false);
   });
 
   it("accepts the documented response shape with nullable notes", () => {

--- a/apps/api/src/api/schemas/maintenanceRecordSchemas.ts
+++ b/apps/api/src/api/schemas/maintenanceRecordSchemas.ts
@@ -11,6 +11,23 @@ export const MaintenanceAssetIdParamSchema = z.object({
     }),
 });
 
+export const MaintenanceRecordIdParamSchema = z.object({
+  assetId: z
+    .string()
+    .uuid("Asset id must be a UUID")
+    .openapi({
+      param: { name: "assetId", in: "path" },
+      example: "195d0ef0-47f5-439f-abfd-29f892c9a040",
+    }),
+  recordId: z
+    .string()
+    .uuid("Record id must be a UUID")
+    .openapi({
+      param: { name: "recordId", in: "path" },
+      example: "e914b960-772f-46a7-b6fb-f333dcfc7fc9",
+    }),
+});
+
 export const CreateMaintenanceRecordBodySchema = z
   .object({
     title: z
@@ -33,6 +50,27 @@ export const CreateMaintenanceRecordBodySchema = z
       .openapi({ example: "a1b2c3d4-e5f6-7890-abcd-ef1234567890" }),
   })
   .openapi("CreateMaintenanceRecordBody");
+
+export const UpdateMaintenanceRecordBodySchema = z
+  .object({
+    title: z
+      .string()
+      .trim()
+      .min(1, "Title is required")
+      .max(100, "Title must be 100 characters or fewer")
+      .optional()
+      .openapi({ example: "Changed synthetic oil" }),
+    performedAt: DateOnlySchema.optional(),
+    notes: z
+      .string()
+      .trim()
+      .max(1000, "Notes must be 1000 characters or fewer")
+      .nullable()
+      .optional()
+      .openapi({ example: "Used 7 quarts of 5W-20 synthetic oil." }),
+  })
+  .strict()
+  .openapi("UpdateMaintenanceRecordBody");
 
 export const MaintenanceRecordResponseSchema = z
   .object({

--- a/apps/api/src/application/ports/MaintenanceRecordWriter.ts
+++ b/apps/api/src/application/ports/MaintenanceRecordWriter.ts
@@ -9,4 +9,22 @@ export interface MaintenanceRecordWriter {
     advancedTask: MaintenanceTask | null,
     events?: readonly DomainEvent[],
   ): Promise<void>;
+
+  /** Updates the record and optional reconciled task atomically with CAS on revisions. Returns false on conflict. */
+  update(
+    record: MaintenanceRecord,
+    expectedRecordRevision: number,
+    reconciledTask: MaintenanceTask | null,
+    expectedTaskRevision?: number,
+    events?: readonly DomainEvent[],
+  ): Promise<boolean>;
+
+  /** Deletes the record and updates optional reconciled task atomically with CAS on revisions. Returns false on conflict. */
+  delete(
+    record: MaintenanceRecord,
+    expectedRecordRevision: number,
+    reconciledTask: MaintenanceTask | null,
+    expectedTaskRevision?: number,
+    events?: readonly DomainEvent[],
+  ): Promise<boolean>;
 }

--- a/apps/api/src/application/ports/MaintenanceWriteGate.ts
+++ b/apps/api/src/application/ports/MaintenanceWriteGate.ts
@@ -1,0 +1,3 @@
+export interface MaintenanceWriteGate {
+  isWritable(): Promise<boolean>;
+}

--- a/apps/api/src/application/usecases/CreateMaintenanceRecord.test.ts
+++ b/apps/api/src/application/usecases/CreateMaintenanceRecord.test.ts
@@ -66,6 +66,14 @@ class MaintenanceRecordWriterFake implements MaintenanceRecordWriter {
     this.savedEvents = events;
     return Promise.resolve();
   }
+
+  update(): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+
+  delete(): Promise<boolean> {
+    return Promise.resolve(true);
+  }
 }
 
 class MaintenanceTaskRepositoryFake implements MaintenanceTaskRepository {

--- a/apps/api/src/application/usecases/CreateMaintenanceRecord.ts
+++ b/apps/api/src/application/usecases/CreateMaintenanceRecord.ts
@@ -8,6 +8,7 @@ import {
   type MaintenanceTaskId,
   NotFoundError,
   type Result,
+  ServiceUnavailableError,
   type UserId,
   ValidationError,
   err,
@@ -19,6 +20,7 @@ import type { MaintenanceTaskRepository } from "../../domain/maintenance/Mainten
 import type { TeamRepository } from "../../domain/team/TeamRepository.ts";
 import type { EventBus } from "../ports/EventBus.ts";
 import type { MaintenanceRecordWriter } from "../ports/MaintenanceRecordWriter.ts";
+import type { MaintenanceWriteGate } from "../ports/MaintenanceWriteGate.ts";
 import type { UtcDateProvider } from "../ports/UtcDateProvider.ts";
 import { canAccessAsset } from "./assetAccess.ts";
 
@@ -39,12 +41,19 @@ export class CreateMaintenanceRecord {
     private readonly tasks: MaintenanceTaskRepository,
     private readonly eventBus: EventBus,
     private readonly dates: UtcDateProvider,
+    private readonly writeGate?: MaintenanceWriteGate,
   ) {}
 
   async execute(
     command: CreateMaintenanceRecordCommand,
   ): Promise<Result<MaintenanceRecord, DomainError>> {
     try {
+      if (this.writeGate && !(await this.writeGate.isWritable())) {
+        return err(
+          new ServiceUnavailableError("Changes are temporarily paused", "maintenance_write_frozen"),
+        );
+      }
+
       const asset = await this.assets.findById(command.assetId);
       if (!asset) return err(new NotFoundError("Asset not found"));
       if (!(await canAccessAsset(asset, command.requesterId, this.teams))) {

--- a/apps/api/src/application/usecases/CreateMaintenanceTask.ts
+++ b/apps/api/src/application/usecases/CreateMaintenanceTask.ts
@@ -6,6 +6,7 @@ import {
   ForbiddenError,
   NotFoundError,
   type Result,
+  ServiceUnavailableError,
   type UserId,
   err,
   ok,
@@ -16,6 +17,7 @@ import type { MaintenanceTaskRepository } from "../../domain/maintenance/Mainten
 import type { IntervalUnit } from "../../domain/maintenance/IntervalUnit.ts";
 import type { TeamRepository } from "../../domain/team/TeamRepository.ts";
 import type { EventBus } from "../ports/EventBus.ts";
+import type { MaintenanceWriteGate } from "../ports/MaintenanceWriteGate.ts";
 import type { UtcDateProvider } from "../ports/UtcDateProvider.ts";
 import { canAccessAsset } from "./assetAccess.ts";
 
@@ -35,12 +37,19 @@ export class CreateMaintenanceTask {
     private readonly tasks: MaintenanceTaskRepository,
     private readonly eventBus: EventBus,
     private readonly dates: UtcDateProvider,
+    private readonly writeGate?: MaintenanceWriteGate,
   ) {}
 
   async execute(
     command: CreateMaintenanceTaskCommand,
   ): Promise<Result<MaintenanceTask, DomainError>> {
     try {
+      if (this.writeGate && !(await this.writeGate.isWritable())) {
+        return err(
+          new ServiceUnavailableError("Changes are temporarily paused", "maintenance_write_frozen"),
+        );
+      }
+
       const asset = await this.assets.findById(command.assetId);
       if (!asset) return err(new NotFoundError("Asset not found"));
       if (!(await canAccessAsset(asset, command.requesterId, this.teams))) {

--- a/apps/api/src/application/usecases/DeleteMaintenanceRecord.test.ts
+++ b/apps/api/src/application/usecases/DeleteMaintenanceRecord.test.ts
@@ -1,0 +1,526 @@
+import { describe, expect, it } from "vitest";
+import {
+  AssetId,
+  ConflictError,
+  ForbiddenError,
+  MaintenanceRecordId,
+  MaintenanceTaskId,
+  NotFoundError,
+  ServiceUnavailableError,
+  UserId,
+} from "@snaveevans/pineapple-shared";
+import { Asset } from "../../domain/asset/Asset.ts";
+import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
+import { Team } from "../../domain/team/Team.ts";
+import type { TeamRepository } from "../../domain/team/TeamRepository.ts";
+import type { DomainEvent } from "../../domain/events/DomainEvent.ts";
+import { MaintenanceRecord } from "../../domain/maintenance/MaintenanceRecord.ts";
+import type { MaintenanceRecordRepository } from "../../domain/maintenance/MaintenanceRecordRepository.ts";
+import { MaintenanceTask } from "../../domain/maintenance/MaintenanceTask.ts";
+import type { MaintenanceTaskRepository } from "../../domain/maintenance/MaintenanceTaskRepository.ts";
+import type { EventBus } from "../ports/EventBus.ts";
+import type { MaintenanceRecordWriter } from "../ports/MaintenanceRecordWriter.ts";
+import type { MaintenanceWriteGate } from "../ports/MaintenanceWriteGate.ts";
+import { DeleteMaintenanceRecord } from "./DeleteMaintenanceRecord.ts";
+
+class AssetRepositoryFake implements AssetRepository {
+  constructor(private readonly asset: Asset | null) {}
+  findById(): Promise<Asset | null> {
+    return Promise.resolve(this.asset);
+  }
+  findVisibleTo(): Promise<Asset[]> {
+    return Promise.resolve([]);
+  }
+  save(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+class TeamRepositoryFake implements TeamRepository {
+  constructor(private readonly team: Team | null = null) {}
+  findByMember(): Promise<Team | null> {
+    return Promise.resolve(this.team);
+  }
+  findById(): Promise<Team | null> {
+    return Promise.resolve(this.team);
+  }
+  save(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+class MaintenanceRecordRepositoryFake implements MaintenanceRecordRepository {
+  constructor(private readonly records: MaintenanceRecord[]) {}
+  findByAsset(): Promise<MaintenanceRecord[]> {
+    return Promise.resolve(this.records.map((r) => this.cloneRecord(r)));
+  }
+  findById(id: string): Promise<MaintenanceRecord | null> {
+    const found = this.records.find((r) => r.id === id);
+    return Promise.resolve(found ? this.cloneRecord(found) : null);
+  }
+  findByTask(taskId: string): Promise<MaintenanceRecord[]> {
+    return Promise.resolve(
+      this.records.filter((r) => r.taskId === taskId).map((r) => this.cloneRecord(r)),
+    );
+  }
+  save(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  private cloneRecord(r: MaintenanceRecord): MaintenanceRecord {
+    return MaintenanceRecord.reconstitute({
+      id: r.id,
+      assetId: r.assetId,
+      ownerId: r.ownerId,
+      title: r.title,
+      performedAt: r.performedAt,
+      notes: r.notes,
+      taskId: r.taskId,
+      createdAt: r.createdAt,
+      revision: r.revision,
+    });
+  }
+}
+
+class MaintenanceTaskRepositoryFake implements MaintenanceTaskRepository {
+  constructor(private readonly tasks: MaintenanceTask[] = []) {}
+  findByAsset(): Promise<MaintenanceTask[]> {
+    return Promise.resolve(this.tasks.map((t) => this.cloneTask(t)));
+  }
+  findForVisibleActiveAssets(): Promise<MaintenanceTask[]> {
+    return Promise.resolve(this.tasks.map((t) => this.cloneTask(t)));
+  }
+  findById(id: string): Promise<MaintenanceTask | null> {
+    const found = this.tasks.find((t) => t.id === id);
+    return Promise.resolve(found ? this.cloneTask(found) : null);
+  }
+  save(): Promise<void> {
+    return Promise.resolve();
+  }
+  delete(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  private cloneTask(t: MaintenanceTask): MaintenanceTask {
+    return MaintenanceTask.reconstitute({
+      id: t.id,
+      assetId: t.assetId,
+      ownerId: t.ownerId,
+      title: t.title,
+      intervalValue: t.intervalValue,
+      intervalUnit: t.intervalUnit,
+      scheduleSeedDate: t.scheduleSeedDate,
+      initialLastCompletedDate: t.initialLastCompletedDate,
+      lastCompletedDate: t.lastCompletedDate,
+      nextDue: t.nextDue,
+      createdAt: t.createdAt,
+      revision: t.revision,
+    });
+  }
+}
+
+class MaintenanceRecordWriterFake implements MaintenanceRecordWriter {
+  deletedRecord: MaintenanceRecord | null = null;
+  reconciledTask: MaintenanceTask | null = null;
+  events: readonly DomainEvent[] = [];
+  failDeleteWithCas = false;
+
+  save(): Promise<void> {
+    return Promise.resolve();
+  }
+  update(): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+  delete(
+    record: MaintenanceRecord,
+    _expectedRecordRevision: number,
+    reconciledTask: MaintenanceTask | null,
+    _expectedTaskRevision?: number,
+    events: readonly DomainEvent[] = [],
+  ): Promise<boolean> {
+    if (this.failDeleteWithCas) {
+      return Promise.resolve(false);
+    }
+    this.deletedRecord = record;
+    this.reconciledTask = reconciledTask;
+    this.events = events;
+    return Promise.resolve(true);
+  }
+}
+
+class EventBusFake implements EventBus {
+  readonly events: DomainEvent[] = [];
+  publish(event: DomainEvent): Promise<void> {
+    this.events.push(event);
+    return Promise.resolve();
+  }
+  publishAll(events: readonly DomainEvent[]): Promise<void> {
+    this.events.push(...events);
+    return Promise.resolve();
+  }
+  subscribe(): void {}
+}
+
+class MaintenanceWriteGateFake implements MaintenanceWriteGate {
+  constructor(private readonly mode: "open" | "frozen" = "open") {}
+  isWritable(): Promise<boolean> {
+    return Promise.resolve(this.mode === "open");
+  }
+}
+
+describe("DeleteMaintenanceRecord", () => {
+  const ownerId = UserId.generate();
+
+  function assetFor(owner = ownerId): Asset {
+    return Asset.create({
+      ownerId: owner,
+      name: "Truck",
+      metadata: { kind: "vehicle", make: "Ram", model: "2500", year: 2016 },
+    });
+  }
+
+  function makeRecord(
+    asset: Asset,
+    overrides: {
+      id?: MaintenanceRecordId;
+      title?: string;
+      performedAt?: string;
+      notes?: string | null;
+      taskId?: MaintenanceTaskId | null;
+      revision?: number;
+    } = {},
+  ): MaintenanceRecord {
+    return MaintenanceRecord.reconstitute({
+      id: overrides.id ?? MaintenanceRecordId.generate(),
+      assetId: asset.id,
+      ownerId: asset.ownerId,
+      title: overrides.title ?? "Oil Change",
+      performedAt: overrides.performedAt ?? "2026-05-01",
+      notes: overrides.notes !== undefined ? overrides.notes : "Standard filter",
+      taskId: overrides.taskId !== undefined ? overrides.taskId : null,
+      createdAt: new Date("2026-05-01T12:00:00.000Z"),
+      revision: overrides.revision ?? 1,
+    });
+  }
+
+  function makeTask(
+    asset: Asset,
+    overrides: {
+      id?: MaintenanceTaskId;
+      title?: string;
+      intervalValue?: number;
+      intervalUnit?: "day" | "week" | "month" | "year";
+      scheduleSeedDate?: string;
+      initialLastCompletedDate?: string | null;
+      lastCompletedDate?: string | null;
+      nextDue?: string;
+      revision?: number;
+    } = {},
+  ): MaintenanceTask {
+    return MaintenanceTask.reconstitute({
+      id: overrides.id ?? MaintenanceTaskId.generate(),
+      assetId: asset.id,
+      ownerId: asset.ownerId,
+      title: overrides.title ?? "Routine Service",
+      intervalValue: overrides.intervalValue ?? 3,
+      intervalUnit: overrides.intervalUnit ?? "month",
+      scheduleSeedDate: overrides.scheduleSeedDate ?? "2026-01-01",
+      initialLastCompletedDate: overrides.initialLastCompletedDate ?? null,
+      lastCompletedDate:
+        overrides.lastCompletedDate !== undefined ? overrides.lastCompletedDate : "2026-05-01",
+      nextDue: overrides.nextDue ?? "2026-08-01",
+      createdAt: new Date("2026-01-01T10:00:00.000Z"),
+      revision: overrides.revision ?? 1,
+    });
+  }
+
+  it("deletes an unlinked record and publishes MaintenanceRecordDeleted", async () => {
+    const asset = assetFor();
+    const record = makeRecord(asset);
+    const writer = new MaintenanceRecordWriterFake();
+    const events = new EventBusFake();
+
+    const result = await new DeleteMaintenanceRecord(
+      new AssetRepositoryFake(asset),
+      new TeamRepositoryFake(),
+      new MaintenanceRecordRepositoryFake([record]),
+      writer,
+      new MaintenanceTaskRepositoryFake([]),
+      events,
+      new MaintenanceWriteGateFake("open"),
+    ).execute({
+      assetId: asset.id,
+      recordId: record.id,
+      requesterId: ownerId,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(writer.deletedRecord?.id).toBe(record.id);
+    expect(writer.deletedRecord?.revision).toBe(2);
+    expect(writer.reconciledTask).toBeNull();
+    expect(events.events).toHaveLength(1);
+    expect(events.events[0]).toMatchObject({
+      type: "MaintenanceRecordDeleted",
+      assetId: asset.id,
+      ownerId,
+      actorId: ownerId,
+      maintenanceRecordId: record.id,
+      deleted: {
+        title: record.title,
+        performedAt: record.performedAt,
+        notes: record.notes,
+      },
+    });
+  });
+
+  it("deletes the latest linked record and rewinds the task to the surviving previous record", async () => {
+    const asset = assetFor();
+    const task = makeTask(asset, {
+      scheduleSeedDate: "2026-01-01",
+      lastCompletedDate: "2026-05-01",
+      nextDue: "2026-08-01",
+      intervalValue: 3,
+      intervalUnit: "month",
+    });
+    const olderRecord = makeRecord(asset, { taskId: task.id, performedAt: "2026-02-01" });
+    const latestRecord = makeRecord(asset, { taskId: task.id, performedAt: "2026-05-01" });
+    const writer = new MaintenanceRecordWriterFake();
+    const events = new EventBusFake();
+
+    const result = await new DeleteMaintenanceRecord(
+      new AssetRepositoryFake(asset),
+      new TeamRepositoryFake(),
+      new MaintenanceRecordRepositoryFake([olderRecord, latestRecord]),
+      writer,
+      new MaintenanceTaskRepositoryFake([task]),
+      events,
+      new MaintenanceWriteGateFake("open"),
+    ).execute({
+      assetId: asset.id,
+      recordId: latestRecord.id,
+      requesterId: ownerId,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(writer.reconciledTask).not.toBeNull();
+    expect(writer.reconciledTask?.lastCompletedDate).toBe("2026-02-01");
+    expect(writer.reconciledTask?.nextDue).toBe("2026-05-01");
+    expect(writer.reconciledTask?.revision).toBe(2);
+
+    expect(events.events).toHaveLength(2);
+    expect(events.events[0]).toMatchObject({
+      type: "MaintenanceRecordDeleted",
+      maintenanceRecordId: latestRecord.id,
+    });
+    expect(events.events[1]).toMatchObject({
+      type: "MaintenanceTaskReconciled",
+      maintenanceTaskId: task.id,
+      lastCompletedDate: "2026-02-01",
+      nextDue: "2026-05-01",
+    });
+  });
+
+  it("deletes the only linked record on a task without initial completion and resets to seed date schedule", async () => {
+    const asset = assetFor();
+    const task = makeTask(asset, {
+      scheduleSeedDate: "2026-01-01",
+      initialLastCompletedDate: null,
+      lastCompletedDate: "2026-03-01",
+      nextDue: "2026-06-01",
+      intervalValue: 3,
+      intervalUnit: "month",
+    });
+    const onlyRecord = makeRecord(asset, { taskId: task.id, performedAt: "2026-03-01" });
+    const writer = new MaintenanceRecordWriterFake();
+    const events = new EventBusFake();
+
+    const result = await new DeleteMaintenanceRecord(
+      new AssetRepositoryFake(asset),
+      new TeamRepositoryFake(),
+      new MaintenanceRecordRepositoryFake([onlyRecord]),
+      writer,
+      new MaintenanceTaskRepositoryFake([task]),
+      events,
+      new MaintenanceWriteGateFake("open"),
+    ).execute({
+      assetId: asset.id,
+      recordId: onlyRecord.id,
+      requesterId: ownerId,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(writer.reconciledTask).not.toBeNull();
+    expect(writer.reconciledTask?.lastCompletedDate).toBeNull();
+    expect(writer.reconciledTask?.nextDue).toBe("2026-04-01"); // 2026-01-01 + 3 months
+
+    expect(events.events).toHaveLength(2);
+    expect(events.events[1]).toMatchObject({
+      type: "MaintenanceTaskReconciled",
+      maintenanceTaskId: task.id,
+      lastCompletedDate: null,
+      nextDue: "2026-04-01",
+    });
+  });
+
+  it("deletes a non-latest linked record without changing task schedule", async () => {
+    const asset = assetFor();
+    const task = makeTask(asset, {
+      scheduleSeedDate: "2026-01-01",
+      lastCompletedDate: "2026-05-01",
+      nextDue: "2026-08-01",
+      intervalValue: 3,
+      intervalUnit: "month",
+    });
+    const olderRecord = makeRecord(asset, { taskId: task.id, performedAt: "2026-02-01" });
+    const latestRecord = makeRecord(asset, { taskId: task.id, performedAt: "2026-05-01" });
+    const writer = new MaintenanceRecordWriterFake();
+    const events = new EventBusFake();
+
+    // Deleting the older record
+    const result = await new DeleteMaintenanceRecord(
+      new AssetRepositoryFake(asset),
+      new TeamRepositoryFake(),
+      new MaintenanceRecordRepositoryFake([olderRecord, latestRecord]),
+      writer,
+      new MaintenanceTaskRepositoryFake([task]),
+      events,
+      new MaintenanceWriteGateFake("open"),
+    ).execute({
+      assetId: asset.id,
+      recordId: olderRecord.id,
+      requesterId: ownerId,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(writer.reconciledTask).toBeNull();
+    expect(events.events).toHaveLength(1);
+    expect(events.events[0]).toMatchObject({
+      type: "MaintenanceRecordDeleted",
+      maintenanceRecordId: olderRecord.id,
+    });
+  });
+
+  it("returns 503 when write gate is frozen", async () => {
+    const asset = assetFor();
+    const record = makeRecord(asset);
+    const result = await new DeleteMaintenanceRecord(
+      new AssetRepositoryFake(asset),
+      new TeamRepositoryFake(),
+      new MaintenanceRecordRepositoryFake([record]),
+      new MaintenanceRecordWriterFake(),
+      new MaintenanceTaskRepositoryFake([]),
+      new EventBusFake(),
+      new MaintenanceWriteGateFake("frozen"),
+    ).execute({
+      assetId: asset.id,
+      recordId: record.id,
+      requesterId: ownerId,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(ServiceUnavailableError);
+      expect((result.error as ServiceUnavailableError).code).toBe("maintenance_write_frozen");
+    }
+  });
+
+  it("returns 409 Conflict when asset is archived", async () => {
+    const asset = assetFor();
+    asset.archivedAt = new Date("2026-06-01T00:00:00.000Z");
+    const record = makeRecord(asset);
+
+    const result = await new DeleteMaintenanceRecord(
+      new AssetRepositoryFake(asset),
+      new TeamRepositoryFake(),
+      new MaintenanceRecordRepositoryFake([record]),
+      new MaintenanceRecordWriterFake(),
+      new MaintenanceTaskRepositoryFake([]),
+      new EventBusFake(),
+      new MaintenanceWriteGateFake("open"),
+    ).execute({
+      assetId: asset.id,
+      recordId: record.id,
+      requesterId: ownerId,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(ConflictError);
+    }
+  });
+
+  it("returns 404 when record does not belong to asset in route", async () => {
+    const asset = assetFor();
+    const record = makeRecord(asset);
+    const otherAssetId = AssetId.generate();
+
+    const result = await new DeleteMaintenanceRecord(
+      new AssetRepositoryFake(asset),
+      new TeamRepositoryFake(),
+      new MaintenanceRecordRepositoryFake([record]),
+      new MaintenanceRecordWriterFake(),
+      new MaintenanceTaskRepositoryFake([]),
+      new EventBusFake(),
+      new MaintenanceWriteGateFake("open"),
+    ).execute({
+      assetId: otherAssetId,
+      recordId: record.id,
+      requesterId: ownerId,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(NotFoundError);
+    }
+  });
+
+  it("returns 403 when requester does not have access to asset", async () => {
+    const asset = assetFor();
+    const record = makeRecord(asset);
+
+    const result = await new DeleteMaintenanceRecord(
+      new AssetRepositoryFake(asset),
+      new TeamRepositoryFake(),
+      new MaintenanceRecordRepositoryFake([record]),
+      new MaintenanceRecordWriterFake(),
+      new MaintenanceTaskRepositoryFake([]),
+      new EventBusFake(),
+      new MaintenanceWriteGateFake("open"),
+    ).execute({
+      assetId: asset.id,
+      recordId: record.id,
+      requesterId: UserId.generate(),
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(ForbiddenError);
+    }
+  });
+
+  it("returns 409 Conflict when CAS retries are exhausted", async () => {
+    const asset = assetFor();
+    const record = makeRecord(asset);
+    const writer = new MaintenanceRecordWriterFake();
+    writer.failDeleteWithCas = true;
+
+    const result = await new DeleteMaintenanceRecord(
+      new AssetRepositoryFake(asset),
+      new TeamRepositoryFake(),
+      new MaintenanceRecordRepositoryFake([record]),
+      writer,
+      new MaintenanceTaskRepositoryFake([]),
+      new EventBusFake(),
+      new MaintenanceWriteGateFake("open"),
+    ).execute({
+      assetId: asset.id,
+      recordId: record.id,
+      requesterId: ownerId,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(ConflictError);
+    }
+  });
+});

--- a/apps/api/src/application/usecases/DeleteMaintenanceRecord.ts
+++ b/apps/api/src/application/usecases/DeleteMaintenanceRecord.ts
@@ -1,0 +1,120 @@
+import {
+  type AssetId,
+  ConflictError,
+  type DomainError,
+  DomainError as DomainErrorClass,
+  ForbiddenError,
+  type MaintenanceRecordId,
+  NotFoundError,
+  type Result,
+  ServiceUnavailableError,
+  type UserId,
+  err,
+  ok,
+} from "@snaveevans/pineapple-shared";
+import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
+import type { MaintenanceRecordRepository } from "../../domain/maintenance/MaintenanceRecordRepository.ts";
+import type { MaintenanceTaskRepository } from "../../domain/maintenance/MaintenanceTaskRepository.ts";
+import type { TeamRepository } from "../../domain/team/TeamRepository.ts";
+import type { EventBus } from "../ports/EventBus.ts";
+import type { MaintenanceRecordWriter } from "../ports/MaintenanceRecordWriter.ts";
+import type { MaintenanceWriteGate } from "../ports/MaintenanceWriteGate.ts";
+import { canAccessAsset } from "./assetAccess.ts";
+
+const MAX_CAS_ATTEMPTS = 4;
+
+export type DeleteMaintenanceRecordCommand = {
+  assetId: AssetId;
+  recordId: MaintenanceRecordId;
+  requesterId: UserId;
+};
+
+export class DeleteMaintenanceRecord {
+  constructor(
+    private readonly assets: AssetRepository,
+    private readonly teams: TeamRepository,
+    private readonly records: MaintenanceRecordRepository,
+    private readonly recordWriter: MaintenanceRecordWriter,
+    private readonly tasks: MaintenanceTaskRepository,
+    private readonly eventBus: EventBus,
+    private readonly writeGate?: MaintenanceWriteGate,
+  ) {}
+
+  async execute(command: DeleteMaintenanceRecordCommand): Promise<Result<void, DomainError>> {
+    try {
+      if (this.writeGate && !(await this.writeGate.isWritable())) {
+        return err(
+          new ServiceUnavailableError("Changes are temporarily paused", "maintenance_write_frozen"),
+        );
+      }
+
+      for (let attempt = 0; attempt < MAX_CAS_ATTEMPTS; attempt++) {
+        const asset = await this.assets.findById(command.assetId);
+        if (!asset) return err(new NotFoundError("Asset not found"));
+
+        const record = await this.records.findById(command.recordId);
+        if (!record || record.assetId !== command.assetId) {
+          return err(new NotFoundError("Maintenance record not found"));
+        }
+
+        if (!(await canAccessAsset(asset, command.requesterId, this.teams))) {
+          return err(new ForbiddenError("Access denied"));
+        }
+
+        if (asset.archivedAt !== null) {
+          return err(new ConflictError("Cannot delete maintenance on an archived asset"));
+        }
+
+        const expectedRecordRevision = record.revision;
+        const assetSnapshot = { assetName: asset.name, assetType: asset.type };
+
+        record.delete(command.requesterId, assetSnapshot);
+
+        let task = null;
+        let expectedTaskRevision: number | undefined = undefined;
+        let taskReconciled = false;
+
+        if (record.taskId !== null) {
+          task = await this.tasks.findById(record.taskId);
+          if (task) {
+            expectedTaskRevision = task.revision;
+            const taskRecords = await this.records.findByTask(task.id);
+            const survivingRecords = taskRecords
+              .filter((r) => r.id !== record.id)
+              .map((r) => ({ performedAt: r.performedAt }));
+            taskReconciled = task.reconcile(
+              survivingRecords,
+              record.id,
+              command.requesterId,
+              assetSnapshot,
+            );
+          }
+        }
+
+        const recordEvents = record.pullEvents();
+        const taskEvents = task && taskReconciled ? task.pullEvents() : [];
+
+        const success = await this.recordWriter.delete(
+          record,
+          expectedRecordRevision,
+          taskReconciled ? task : null,
+          expectedTaskRevision,
+          [...recordEvents, ...taskEvents],
+        );
+
+        if (success) {
+          await this.eventBus.publishAll(recordEvents);
+          if (task && taskReconciled) {
+            await this.eventBus.publishAll(taskEvents);
+          }
+          return ok(undefined);
+        }
+      }
+
+      return err(new ConflictError("Concurrent modification conflict"));
+    } catch (error) {
+      if (error instanceof DomainErrorClass) return err(error);
+      throw error;
+    }
+  }
+}

--- a/apps/api/src/application/usecases/DeleteMaintenanceTask.ts
+++ b/apps/api/src/application/usecases/DeleteMaintenanceTask.ts
@@ -6,6 +6,7 @@ import {
   type MaintenanceTaskId,
   NotFoundError,
   type Result,
+  ServiceUnavailableError,
   type UserId,
   err,
   ok,
@@ -14,6 +15,7 @@ import type { MaintenanceTaskRepository } from "../../domain/maintenance/Mainten
 import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
 import type { TeamRepository } from "../../domain/team/TeamRepository.ts";
 import type { EventBus } from "../ports/EventBus.ts";
+import type { MaintenanceWriteGate } from "../ports/MaintenanceWriteGate.ts";
 import { canAccessAsset } from "./assetAccess.ts";
 
 export type DeleteMaintenanceTaskCommand = {
@@ -28,10 +30,17 @@ export class DeleteMaintenanceTask {
     private readonly teams: TeamRepository,
     private readonly tasks: MaintenanceTaskRepository,
     private readonly eventBus: EventBus,
+    private readonly writeGate?: MaintenanceWriteGate,
   ) {}
 
   async execute(command: DeleteMaintenanceTaskCommand): Promise<Result<void, DomainError>> {
     try {
+      if (this.writeGate && !(await this.writeGate.isWritable())) {
+        return err(
+          new ServiceUnavailableError("Changes are temporarily paused", "maintenance_write_frozen"),
+        );
+      }
+
       const task = await this.tasks.findById(command.taskId);
       if (!task) return err(new NotFoundError("Maintenance task not found"));
       if (task.assetId !== command.assetId) {

--- a/apps/api/src/application/usecases/ListMaintenanceRecords.test.ts
+++ b/apps/api/src/application/usecases/ListMaintenanceRecords.test.ts
@@ -48,6 +48,14 @@ class MaintenanceRecordRepositoryFake implements MaintenanceRecordRepository {
     return Promise.resolve(this.records);
   }
 
+  findById(id: string): Promise<MaintenanceRecord | null> {
+    return Promise.resolve(this.records.find((r) => r.id === id) ?? null);
+  }
+
+  findByTask(taskId: string): Promise<MaintenanceRecord[]> {
+    return Promise.resolve(this.records.filter((r) => r.taskId === taskId));
+  }
+
   save(): Promise<void> {
     return Promise.resolve();
   }

--- a/apps/api/src/application/usecases/UpdateMaintenanceRecord.test.ts
+++ b/apps/api/src/application/usecases/UpdateMaintenanceRecord.test.ts
@@ -1,0 +1,591 @@
+import { describe, expect, it } from "vitest";
+import {
+  AssetId,
+  ConflictError,
+  ForbiddenError,
+  MaintenanceRecordId,
+  MaintenanceTaskId,
+  NotFoundError,
+  ServiceUnavailableError,
+  UserId,
+  ValidationError,
+} from "@snaveevans/pineapple-shared";
+import { Asset } from "../../domain/asset/Asset.ts";
+import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
+import { Team } from "../../domain/team/Team.ts";
+import type { TeamRepository } from "../../domain/team/TeamRepository.ts";
+import type { DomainEvent } from "../../domain/events/DomainEvent.ts";
+import { MaintenanceRecord } from "../../domain/maintenance/MaintenanceRecord.ts";
+import type { MaintenanceRecordRepository } from "../../domain/maintenance/MaintenanceRecordRepository.ts";
+import { MaintenanceTask } from "../../domain/maintenance/MaintenanceTask.ts";
+import type { MaintenanceTaskRepository } from "../../domain/maintenance/MaintenanceTaskRepository.ts";
+import type { EventBus } from "../ports/EventBus.ts";
+import type { MaintenanceRecordWriter } from "../ports/MaintenanceRecordWriter.ts";
+import type { MaintenanceWriteGate } from "../ports/MaintenanceWriteGate.ts";
+import type { UtcDateProvider } from "../ports/UtcDateProvider.ts";
+import { UpdateMaintenanceRecord } from "./UpdateMaintenanceRecord.ts";
+
+class AssetRepositoryFake implements AssetRepository {
+  constructor(private readonly asset: Asset | null) {}
+  findById(): Promise<Asset | null> {
+    return Promise.resolve(this.asset);
+  }
+  findVisibleTo(): Promise<Asset[]> {
+    return Promise.resolve([]);
+  }
+  save(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+class TeamRepositoryFake implements TeamRepository {
+  constructor(private readonly team: Team | null = null) {}
+  findByMember(): Promise<Team | null> {
+    return Promise.resolve(this.team);
+  }
+  findById(): Promise<Team | null> {
+    return Promise.resolve(this.team);
+  }
+  save(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+class MaintenanceRecordRepositoryFake implements MaintenanceRecordRepository {
+  constructor(private readonly records: MaintenanceRecord[]) {}
+  findByAsset(): Promise<MaintenanceRecord[]> {
+    return Promise.resolve(this.records.map((r) => this.cloneRecord(r)));
+  }
+  findById(id: string): Promise<MaintenanceRecord | null> {
+    const found = this.records.find((r) => r.id === id);
+    return Promise.resolve(found ? this.cloneRecord(found) : null);
+  }
+  findByTask(taskId: string): Promise<MaintenanceRecord[]> {
+    return Promise.resolve(
+      this.records.filter((r) => r.taskId === taskId).map((r) => this.cloneRecord(r)),
+    );
+  }
+  save(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  private cloneRecord(r: MaintenanceRecord): MaintenanceRecord {
+    return MaintenanceRecord.reconstitute({
+      id: r.id,
+      assetId: r.assetId,
+      ownerId: r.ownerId,
+      title: r.title,
+      performedAt: r.performedAt,
+      notes: r.notes,
+      taskId: r.taskId,
+      createdAt: r.createdAt,
+      revision: r.revision,
+    });
+  }
+}
+
+class MaintenanceTaskRepositoryFake implements MaintenanceTaskRepository {
+  constructor(private readonly tasks: MaintenanceTask[] = []) {}
+  findByAsset(): Promise<MaintenanceTask[]> {
+    return Promise.resolve(this.tasks.map((t) => this.cloneTask(t)));
+  }
+  findForVisibleActiveAssets(): Promise<MaintenanceTask[]> {
+    return Promise.resolve(this.tasks.map((t) => this.cloneTask(t)));
+  }
+  findById(id: string): Promise<MaintenanceTask | null> {
+    const found = this.tasks.find((t) => t.id === id);
+    return Promise.resolve(found ? this.cloneTask(found) : null);
+  }
+  save(): Promise<void> {
+    return Promise.resolve();
+  }
+  delete(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  private cloneTask(t: MaintenanceTask): MaintenanceTask {
+    return MaintenanceTask.reconstitute({
+      id: t.id,
+      assetId: t.assetId,
+      ownerId: t.ownerId,
+      title: t.title,
+      intervalValue: t.intervalValue,
+      intervalUnit: t.intervalUnit,
+      scheduleSeedDate: t.scheduleSeedDate,
+      initialLastCompletedDate: t.initialLastCompletedDate,
+      lastCompletedDate: t.lastCompletedDate,
+      nextDue: t.nextDue,
+      createdAt: t.createdAt,
+      revision: t.revision,
+    });
+  }
+}
+
+class MaintenanceRecordWriterFake implements MaintenanceRecordWriter {
+  updatedRecord: MaintenanceRecord | null = null;
+  reconciledTask: MaintenanceTask | null = null;
+  events: readonly DomainEvent[] = [];
+  failUpdateWithCas = false;
+
+  save(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  update(
+    record: MaintenanceRecord,
+    _expectedRecordRevision: number,
+    reconciledTask: MaintenanceTask | null,
+    _expectedTaskRevision?: number,
+    events: readonly DomainEvent[] = [],
+  ): Promise<boolean> {
+    if (this.failUpdateWithCas) {
+      return Promise.resolve(false);
+    }
+    this.updatedRecord = record;
+    this.reconciledTask = reconciledTask;
+    this.events = events;
+    return Promise.resolve(true);
+  }
+
+  delete(): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+}
+
+class EventBusFake implements EventBus {
+  readonly events: DomainEvent[] = [];
+  publish(event: DomainEvent): Promise<void> {
+    this.events.push(event);
+    return Promise.resolve();
+  }
+  publishAll(events: readonly DomainEvent[]): Promise<void> {
+    this.events.push(...events);
+    return Promise.resolve();
+  }
+  subscribe(): void {}
+}
+
+class MaintenanceWriteGateFake implements MaintenanceWriteGate {
+  constructor(private readonly mode: "open" | "frozen" = "open") {}
+  isWritable(): Promise<boolean> {
+    return Promise.resolve(this.mode === "open");
+  }
+}
+
+const dates: UtcDateProvider = { today: () => "2026-06-09" };
+
+describe("UpdateMaintenanceRecord", () => {
+  const ownerId = UserId.generate();
+
+  function assetFor(owner = ownerId): Asset {
+    return Asset.create({
+      ownerId: owner,
+      name: "Truck",
+      metadata: { kind: "vehicle", make: "Ram", model: "2500", year: 2016 },
+    });
+  }
+
+  function makeRecord(
+    asset: Asset,
+    overrides: {
+      id?: MaintenanceRecordId;
+      title?: string;
+      performedAt?: string;
+      notes?: string | null;
+      taskId?: MaintenanceTaskId | null;
+      revision?: number;
+    } = {},
+  ): MaintenanceRecord {
+    return MaintenanceRecord.reconstitute({
+      id: overrides.id ?? MaintenanceRecordId.generate(),
+      assetId: asset.id,
+      ownerId: asset.ownerId,
+      title: overrides.title ?? "Oil Change",
+      performedAt: overrides.performedAt ?? "2026-05-01",
+      notes: overrides.notes !== undefined ? overrides.notes : "Standard filter",
+      taskId: overrides.taskId !== undefined ? overrides.taskId : null,
+      createdAt: new Date("2026-05-01T12:00:00.000Z"),
+      revision: overrides.revision ?? 1,
+    });
+  }
+
+  function makeTask(
+    asset: Asset,
+    overrides: {
+      id?: MaintenanceTaskId;
+      title?: string;
+      intervalValue?: number;
+      intervalUnit?: "day" | "week" | "month" | "year";
+      scheduleSeedDate?: string;
+      initialLastCompletedDate?: string | null;
+      lastCompletedDate?: string | null;
+      nextDue?: string;
+      revision?: number;
+    } = {},
+  ): MaintenanceTask {
+    return MaintenanceTask.reconstitute({
+      id: overrides.id ?? MaintenanceTaskId.generate(),
+      assetId: asset.id,
+      ownerId: asset.ownerId,
+      title: overrides.title ?? "Routine Service",
+      intervalValue: overrides.intervalValue ?? 3,
+      intervalUnit: overrides.intervalUnit ?? "month",
+      scheduleSeedDate: overrides.scheduleSeedDate ?? "2026-01-01",
+      initialLastCompletedDate: overrides.initialLastCompletedDate ?? null,
+      lastCompletedDate:
+        overrides.lastCompletedDate !== undefined ? overrides.lastCompletedDate : "2026-05-01",
+      nextDue: overrides.nextDue ?? "2026-08-01",
+      createdAt: new Date("2026-01-01T10:00:00.000Z"),
+      revision: overrides.revision ?? 1,
+    });
+  }
+
+  it("updates an unlinked record title and notes with revision + 1 and emits MaintenanceRecordUpdated", async () => {
+    const asset = assetFor();
+    const record = makeRecord(asset, { title: "Old Title", notes: "Old Notes" });
+    const writer = new MaintenanceRecordWriterFake();
+    const events = new EventBusFake();
+
+    const result = await new UpdateMaintenanceRecord(
+      new AssetRepositoryFake(asset),
+      new TeamRepositoryFake(),
+      new MaintenanceRecordRepositoryFake([record]),
+      writer,
+      new MaintenanceTaskRepositoryFake([]),
+      events,
+      dates,
+      new MaintenanceWriteGateFake("open"),
+    ).execute({
+      assetId: asset.id,
+      recordId: record.id,
+      requesterId: ownerId,
+      title: "New Title",
+      notes: "New Notes",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.title).toBe("New Title");
+    expect(result.value.notes).toBe("New Notes");
+    expect(result.value.revision).toBe(2);
+    expect(writer.updatedRecord).toBe(result.value);
+    expect(writer.reconciledTask).toBeNull();
+    expect(events.events).toHaveLength(1);
+    expect(events.events[0]).toMatchObject({
+      type: "MaintenanceRecordUpdated",
+      assetId: asset.id,
+      ownerId,
+      actorId: ownerId,
+      maintenanceRecordId: record.id,
+      before: {
+        title: "Old Title",
+        performedAt: "2026-05-01",
+        notes: "Old Notes",
+      },
+      after: {
+        title: "New Title",
+        performedAt: "2026-05-01",
+        notes: "New Notes",
+      },
+    });
+  });
+
+  it("advances linked task schedule when performedAt is updated to a later date", async () => {
+    const asset = assetFor();
+    const task = makeTask(asset, {
+      scheduleSeedDate: "2026-01-01",
+      lastCompletedDate: "2026-05-01",
+      nextDue: "2026-08-01",
+      intervalValue: 3,
+      intervalUnit: "month",
+    });
+    const record = makeRecord(asset, {
+      taskId: task.id,
+      performedAt: "2026-05-01",
+    });
+    const writer = new MaintenanceRecordWriterFake();
+    const events = new EventBusFake();
+
+    const result = await new UpdateMaintenanceRecord(
+      new AssetRepositoryFake(asset),
+      new TeamRepositoryFake(),
+      new MaintenanceRecordRepositoryFake([record]),
+      writer,
+      new MaintenanceTaskRepositoryFake([task]),
+      events,
+      dates,
+      new MaintenanceWriteGateFake("open"),
+    ).execute({
+      assetId: asset.id,
+      recordId: record.id,
+      requesterId: ownerId,
+      performedAt: "2026-06-01",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.performedAt).toBe("2026-06-01");
+    expect(result.value.revision).toBe(2);
+    expect(writer.reconciledTask).not.toBeNull();
+    expect(writer.reconciledTask?.lastCompletedDate).toBe("2026-06-01");
+    expect(writer.reconciledTask?.nextDue).toBe("2026-09-01");
+    expect(writer.reconciledTask?.revision).toBe(2);
+
+    expect(events.events).toHaveLength(2);
+    expect(events.events[0]).toMatchObject({
+      type: "MaintenanceRecordUpdated",
+      maintenanceRecordId: record.id,
+    });
+    expect(events.events[1]).toMatchObject({
+      type: "MaintenanceTaskReconciled",
+      maintenanceTaskId: task.id,
+      lastCompletedDate: "2026-06-01",
+      nextDue: "2026-09-01",
+      sourceRecordId: record.id,
+    });
+  });
+
+  it("rewinds linked task schedule when performedAt is updated to an earlier date and surviving record exists", async () => {
+    const asset = assetFor();
+    const task = makeTask(asset, {
+      scheduleSeedDate: "2026-01-01",
+      lastCompletedDate: "2026-05-01",
+      nextDue: "2026-08-01",
+      intervalValue: 3,
+      intervalUnit: "month",
+    });
+    const earlierRecord = makeRecord(asset, {
+      taskId: task.id,
+      performedAt: "2026-04-01",
+    });
+    const latestRecord = makeRecord(asset, {
+      taskId: task.id,
+      performedAt: "2026-05-01",
+    });
+    const writer = new MaintenanceRecordWriterFake();
+    const events = new EventBusFake();
+
+    // Editing latest record from May 1 to March 1 -> latest surviving is now April 1
+    const result = await new UpdateMaintenanceRecord(
+      new AssetRepositoryFake(asset),
+      new TeamRepositoryFake(),
+      new MaintenanceRecordRepositoryFake([earlierRecord, latestRecord]),
+      writer,
+      new MaintenanceTaskRepositoryFake([task]),
+      events,
+      dates,
+      new MaintenanceWriteGateFake("open"),
+    ).execute({
+      assetId: asset.id,
+      recordId: latestRecord.id,
+      requesterId: ownerId,
+      performedAt: "2026-03-01",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.performedAt).toBe("2026-03-01");
+    expect(writer.reconciledTask?.lastCompletedDate).toBe("2026-04-01");
+    expect(writer.reconciledTask?.nextDue).toBe("2026-07-01");
+    expect(events.events).toContainEqual(
+      expect.objectContaining({
+        type: "MaintenanceTaskReconciled",
+        maintenanceTaskId: task.id,
+        lastCompletedDate: "2026-04-01",
+        nextDue: "2026-07-01",
+      }),
+    );
+  });
+
+  it("no-ops without events or writes when patch values match existing values", async () => {
+    const asset = assetFor();
+    const record = makeRecord(asset, { title: "Title", performedAt: "2026-05-01", notes: "Notes" });
+    const writer = new MaintenanceRecordWriterFake();
+    const events = new EventBusFake();
+
+    const result = await new UpdateMaintenanceRecord(
+      new AssetRepositoryFake(asset),
+      new TeamRepositoryFake(),
+      new MaintenanceRecordRepositoryFake([record]),
+      writer,
+      new MaintenanceTaskRepositoryFake([]),
+      events,
+      dates,
+      new MaintenanceWriteGateFake("open"),
+    ).execute({
+      assetId: asset.id,
+      recordId: record.id,
+      requesterId: ownerId,
+      title: "Title",
+      performedAt: "2026-05-01",
+      notes: "Notes",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.revision).toBe(1);
+    expect(writer.updatedRecord).toBeNull();
+    expect(events.events).toHaveLength(0);
+  });
+
+  it("returns 503 when write gate is frozen", async () => {
+    const asset = assetFor();
+    const record = makeRecord(asset);
+    const result = await new UpdateMaintenanceRecord(
+      new AssetRepositoryFake(asset),
+      new TeamRepositoryFake(),
+      new MaintenanceRecordRepositoryFake([record]),
+      new MaintenanceRecordWriterFake(),
+      new MaintenanceTaskRepositoryFake([]),
+      new EventBusFake(),
+      dates,
+      new MaintenanceWriteGateFake("frozen"),
+    ).execute({
+      assetId: asset.id,
+      recordId: record.id,
+      requesterId: ownerId,
+      title: "New Title",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(ServiceUnavailableError);
+      expect((result.error as ServiceUnavailableError).code).toBe("maintenance_write_frozen");
+    }
+  });
+
+  it("returns 409 Conflict when asset is archived", async () => {
+    const asset = assetFor();
+    asset.archivedAt = new Date("2026-06-01T00:00:00.000Z");
+    const record = makeRecord(asset);
+
+    const result = await new UpdateMaintenanceRecord(
+      new AssetRepositoryFake(asset),
+      new TeamRepositoryFake(),
+      new MaintenanceRecordRepositoryFake([record]),
+      new MaintenanceRecordWriterFake(),
+      new MaintenanceTaskRepositoryFake([]),
+      new EventBusFake(),
+      dates,
+      new MaintenanceWriteGateFake("open"),
+    ).execute({
+      assetId: asset.id,
+      recordId: record.id,
+      requesterId: ownerId,
+      title: "New Title",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(ConflictError);
+    }
+  });
+
+  it("returns 404 when record does not belong to the asset in the route", async () => {
+    const asset = assetFor();
+    const otherAssetId = AssetId.generate();
+    const record = makeRecord(asset); // record has asset.id, but route is otherAssetId
+
+    const result = await new UpdateMaintenanceRecord(
+      new AssetRepositoryFake(asset),
+      new TeamRepositoryFake(),
+      new MaintenanceRecordRepositoryFake([record]),
+      new MaintenanceRecordWriterFake(),
+      new MaintenanceTaskRepositoryFake([]),
+      new EventBusFake(),
+      dates,
+      new MaintenanceWriteGateFake("open"),
+    ).execute({
+      assetId: otherAssetId,
+      recordId: record.id,
+      requesterId: ownerId,
+      title: "New Title",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(NotFoundError);
+    }
+  });
+
+  it("returns 403 when requester does not have access to asset", async () => {
+    const asset = assetFor();
+    const record = makeRecord(asset);
+
+    const result = await new UpdateMaintenanceRecord(
+      new AssetRepositoryFake(asset),
+      new TeamRepositoryFake(),
+      new MaintenanceRecordRepositoryFake([record]),
+      new MaintenanceRecordWriterFake(),
+      new MaintenanceTaskRepositoryFake([]),
+      new EventBusFake(),
+      dates,
+      new MaintenanceWriteGateFake("open"),
+    ).execute({
+      assetId: asset.id,
+      recordId: record.id,
+      requesterId: UserId.generate(),
+      title: "New Title",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(ForbiddenError);
+    }
+  });
+
+  it("returns 422 when performedAt is in the future", async () => {
+    const asset = assetFor();
+    const record = makeRecord(asset);
+
+    const result = await new UpdateMaintenanceRecord(
+      new AssetRepositoryFake(asset),
+      new TeamRepositoryFake(),
+      new MaintenanceRecordRepositoryFake([record]),
+      new MaintenanceRecordWriterFake(),
+      new MaintenanceTaskRepositoryFake([]),
+      new EventBusFake(),
+      dates,
+      new MaintenanceWriteGateFake("open"),
+    ).execute({
+      assetId: asset.id,
+      recordId: record.id,
+      requesterId: ownerId,
+      performedAt: "2026-06-10",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(ValidationError);
+      expect((result.error as ValidationError).field).toBe("performedAt");
+    }
+  });
+
+  it("returns 409 Conflict when CAS retries are exhausted", async () => {
+    const asset = assetFor();
+    const record = makeRecord(asset);
+    const writer = new MaintenanceRecordWriterFake();
+    writer.failUpdateWithCas = true;
+
+    const result = await new UpdateMaintenanceRecord(
+      new AssetRepositoryFake(asset),
+      new TeamRepositoryFake(),
+      new MaintenanceRecordRepositoryFake([record]),
+      writer,
+      new MaintenanceTaskRepositoryFake([]),
+      new EventBusFake(),
+      dates,
+      new MaintenanceWriteGateFake("open"),
+    ).execute({
+      assetId: asset.id,
+      recordId: record.id,
+      requesterId: ownerId,
+      title: "New Title",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(ConflictError);
+    }
+  });
+});

--- a/apps/api/src/application/usecases/UpdateMaintenanceRecord.ts
+++ b/apps/api/src/application/usecases/UpdateMaintenanceRecord.ts
@@ -1,0 +1,152 @@
+import {
+  type AssetId,
+  ConflictError,
+  type DomainError,
+  DomainError as DomainErrorClass,
+  ForbiddenError,
+  type MaintenanceRecordId,
+  NotFoundError,
+  type Result,
+  ServiceUnavailableError,
+  type UserId,
+  ValidationError,
+  err,
+  ok,
+} from "@snaveevans/pineapple-shared";
+import type { AssetRepository } from "../../domain/asset/AssetRepository.ts";
+import type { MaintenanceRecord } from "../../domain/maintenance/MaintenanceRecord.ts";
+import type { MaintenanceRecordRepository } from "../../domain/maintenance/MaintenanceRecordRepository.ts";
+import type { MaintenanceTaskRepository } from "../../domain/maintenance/MaintenanceTaskRepository.ts";
+import type { TeamRepository } from "../../domain/team/TeamRepository.ts";
+import type { EventBus } from "../ports/EventBus.ts";
+import type { MaintenanceRecordWriter } from "../ports/MaintenanceRecordWriter.ts";
+import type { MaintenanceWriteGate } from "../ports/MaintenanceWriteGate.ts";
+import type { UtcDateProvider } from "../ports/UtcDateProvider.ts";
+import { canAccessAsset } from "./assetAccess.ts";
+
+const MAX_CAS_ATTEMPTS = 4;
+
+export type UpdateMaintenanceRecordCommand = {
+  assetId: AssetId;
+  recordId: MaintenanceRecordId;
+  requesterId: UserId;
+  title?: string;
+  performedAt?: string;
+  notes?: string | null;
+};
+
+export class UpdateMaintenanceRecord {
+  constructor(
+    private readonly assets: AssetRepository,
+    private readonly teams: TeamRepository,
+    private readonly records: MaintenanceRecordRepository,
+    private readonly recordWriter: MaintenanceRecordWriter,
+    private readonly tasks: MaintenanceTaskRepository,
+    private readonly eventBus: EventBus,
+    private readonly dates: UtcDateProvider,
+    private readonly writeGate?: MaintenanceWriteGate,
+  ) {}
+
+  async execute(
+    command: UpdateMaintenanceRecordCommand,
+  ): Promise<Result<MaintenanceRecord, DomainError>> {
+    try {
+      if (this.writeGate && !(await this.writeGate.isWritable())) {
+        return err(
+          new ServiceUnavailableError("Changes are temporarily paused", "maintenance_write_frozen"),
+        );
+      }
+
+      if (
+        command.title === undefined &&
+        command.performedAt === undefined &&
+        command.notes === undefined
+      ) {
+        return err(new ValidationError("At least one field must be provided"));
+      }
+
+      for (let attempt = 0; attempt < MAX_CAS_ATTEMPTS; attempt++) {
+        const asset = await this.assets.findById(command.assetId);
+        if (!asset) return err(new NotFoundError("Asset not found"));
+
+        const record = await this.records.findById(command.recordId);
+        if (!record || record.assetId !== command.assetId) {
+          return err(new NotFoundError("Maintenance record not found"));
+        }
+
+        if (!(await canAccessAsset(asset, command.requesterId, this.teams))) {
+          return err(new ForbiddenError("Access denied"));
+        }
+
+        if (asset.archivedAt !== null) {
+          return err(new ConflictError("Cannot edit maintenance on an archived asset"));
+        }
+
+        const expectedRecordRevision = record.revision;
+        const assetSnapshot = { assetName: asset.name, assetType: asset.type };
+
+        const changed = record.update(
+          {
+            ...(command.title !== undefined ? { title: command.title } : {}),
+            ...(command.performedAt !== undefined ? { performedAt: command.performedAt } : {}),
+            ...(command.notes !== undefined ? { notes: command.notes } : {}),
+            todayUtc: this.dates.today(),
+          },
+          command.requesterId,
+          assetSnapshot,
+        );
+
+        if (!changed) {
+          return ok(record);
+        }
+
+        let task = null;
+        let expectedTaskRevision: number | undefined = undefined;
+        let taskReconciled = false;
+
+        if (record.taskId !== null) {
+          task = await this.tasks.findById(record.taskId);
+          if (task) {
+            expectedTaskRevision = task.revision;
+            const taskRecords = await this.records.findByTask(task.id);
+            const survivingRecords = taskRecords.map((r) =>
+              r.id === record.id
+                ? { performedAt: record.performedAt }
+                : { performedAt: r.performedAt },
+            );
+            taskReconciled = task.reconcile(
+              survivingRecords,
+              record.id,
+              command.requesterId,
+              assetSnapshot,
+            );
+          }
+        }
+
+        const recordEvents = record.pullEvents();
+        const taskEvents = task && taskReconciled ? task.pullEvents() : [];
+
+        const success = await this.recordWriter.update(
+          record,
+          expectedRecordRevision,
+          taskReconciled ? task : null,
+          expectedTaskRevision,
+          [...recordEvents, ...taskEvents],
+        );
+
+        if (success) {
+          await this.eventBus.publishAll(recordEvents);
+          if (task && taskReconciled) {
+            await this.eventBus.publishAll(taskEvents);
+          }
+          return ok(record);
+        }
+      }
+
+      return err(new ConflictError("Concurrent modification conflict"));
+    } catch (error) {
+      if (error instanceof DomainErrorClass) return err(error);
+      throw error;
+    }
+  }
+}

--- a/apps/api/src/application/usecases/UpdateMaintenanceTask.ts
+++ b/apps/api/src/application/usecases/UpdateMaintenanceTask.ts
@@ -6,6 +6,7 @@ import {
   type MaintenanceTaskId,
   NotFoundError,
   type Result,
+  ServiceUnavailableError,
   type UserId,
   err,
   ok,
@@ -16,6 +17,7 @@ import { MaintenanceTask } from "../../domain/maintenance/MaintenanceTask.ts";
 import type { MaintenanceTaskRepository } from "../../domain/maintenance/MaintenanceTaskRepository.ts";
 import type { TeamRepository } from "../../domain/team/TeamRepository.ts";
 import type { EventBus } from "../ports/EventBus.ts";
+import type { MaintenanceWriteGate } from "../ports/MaintenanceWriteGate.ts";
 import type { UtcDateProvider } from "../ports/UtcDateProvider.ts";
 import { canAccessAsset } from "./assetAccess.ts";
 
@@ -35,12 +37,19 @@ export class UpdateMaintenanceTask {
     private readonly tasks: MaintenanceTaskRepository,
     private readonly eventBus: EventBus,
     private readonly dates: UtcDateProvider,
+    private readonly writeGate?: MaintenanceWriteGate,
   ) {}
 
   async execute(
     command: UpdateMaintenanceTaskCommand,
   ): Promise<Result<MaintenanceTask, DomainError>> {
     try {
+      if (this.writeGate && !(await this.writeGate.isWritable())) {
+        return err(
+          new ServiceUnavailableError("Changes are temporarily paused", "maintenance_write_frozen"),
+        );
+      }
+
       const task = await this.tasks.findById(command.taskId);
       if (!task) return err(new NotFoundError("Maintenance task not found"));
       if (task.assetId !== command.assetId) {

--- a/apps/api/src/domain/activity/ActivityEntry.ts
+++ b/apps/api/src/domain/activity/ActivityEntry.ts
@@ -4,6 +4,8 @@ import type { AssetType } from "../asset/AssetType.ts";
 export const ACTIVITY_ENTRY_TYPES = [
   "asset_added",
   "maintenance_logged",
+  "maintenance_record_updated",
+  "maintenance_record_deleted",
   "task_completed",
   "task_scheduled",
   "task_updated",

--- a/apps/api/src/domain/maintenance/MaintenanceRecord.test.ts
+++ b/apps/api/src/domain/maintenance/MaintenanceRecord.test.ts
@@ -92,8 +92,119 @@ describe("MaintenanceRecord", () => {
       notes: original.notes,
       taskId: null,
       createdAt: original.createdAt,
+      revision: 2,
     });
 
     expect(record.pullEvents()).toEqual([]);
+    expect(record.revision).toBe(2);
+  });
+
+  describe("update", () => {
+    it("updates title, performedAt, notes, increments revision, and emits MaintenanceRecordUpdated", () => {
+      const record = create({ title: "Old Title", performedAt: "2026-06-01", notes: "Old notes" });
+      record.pullEvents();
+
+      const actorId = UserId.generate();
+      const updated = record.update(
+        {
+          title: "  New Title  ",
+          performedAt: "2026-06-05",
+          notes: "  New notes  ",
+          todayUtc: "2026-06-09",
+        },
+        actorId,
+        { assetName: "Truck", assetType: "vehicle" },
+      );
+
+      expect(updated).toBe(true);
+      expect(record.title).toBe("New Title");
+      expect(record.performedAt).toBe("2026-06-05");
+      expect(record.notes).toBe("New notes");
+      expect(record.revision).toBe(1);
+
+      const events = record.pullEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        type: "MaintenanceRecordUpdated",
+        maintenanceRecordId: record.id,
+        assetId,
+        ownerId,
+        actorId,
+        assetName,
+        assetType,
+        recordRevision: 1,
+        before: { title: "Old Title", performedAt: "2026-06-01", notes: "Old notes" },
+        after: { title: "New Title", performedAt: "2026-06-05", notes: "New notes" },
+        activityEntryType: "maintenance_record_updated",
+      });
+    });
+
+    it("clears notes when given explicit null or whitespace", () => {
+      const record = create({ notes: "Some notes" });
+      record.pullEvents();
+
+      record.update({ notes: "   ", todayUtc: "2026-06-09" }, ownerId, { assetName, assetType });
+      expect(record.notes).toBeNull();
+    });
+
+    it("returns false and emits no event when values are unchanged (no-op)", () => {
+      const record = create({ title: "Same", performedAt: "2026-06-01", notes: "Same" });
+      record.pullEvents();
+
+      const updated = record.update(
+        { title: "Same", performedAt: "2026-06-01", notes: "Same", todayUtc: "2026-06-09" },
+        ownerId,
+        { assetName, assetType },
+      );
+
+      expect(updated).toBe(false);
+      expect(record.revision).toBe(0);
+      expect(record.pullEvents()).toHaveLength(0);
+    });
+
+    it.each([
+      [{ title: "   " }, "title"],
+      [{ title: "t".repeat(101) }, "title"],
+      [{ notes: "n".repeat(1001) }, "notes"],
+      [{ performedAt: "2026-6-09" }, "performedAt"],
+      [{ performedAt: "2026-06-10" }, "performedAt"],
+    ])("rejects invalid update input %o", (overrides, field) => {
+      const record = create();
+      record.pullEvents();
+
+      try {
+        record.update({ todayUtc: "2026-06-09", ...overrides }, ownerId, { assetName, assetType });
+        expect.fail("Expected validation to fail");
+      } catch (error) {
+        expect(error).toBeInstanceOf(ValidationError);
+        expect((error as ValidationError).field).toBe(field);
+      }
+    });
+  });
+
+  describe("delete", () => {
+    it("increments revision and emits MaintenanceRecordDeleted with snapshot", () => {
+      const record = create({ title: "To Delete", performedAt: "2026-06-01", notes: "Note" });
+      record.pullEvents();
+
+      const actorId = UserId.generate();
+      record.delete(actorId, { assetName, assetType });
+
+      expect(record.revision).toBe(1);
+      const events = record.pullEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        type: "MaintenanceRecordDeleted",
+        maintenanceRecordId: record.id,
+        assetId,
+        ownerId,
+        actorId,
+        assetName,
+        assetType,
+        recordRevision: 1,
+        deleted: { title: "To Delete", performedAt: "2026-06-01", notes: "Note" },
+        activityEntryType: "maintenance_record_deleted",
+      });
+    });
   });
 });

--- a/apps/api/src/domain/maintenance/MaintenanceRecord.ts
+++ b/apps/api/src/domain/maintenance/MaintenanceRecord.ts
@@ -13,20 +13,48 @@ import {
   MaintenanceRecordCreated,
   type MaintenanceRecordActivityEntryType,
 } from "./events/MaintenanceRecordCreated.ts";
+import { MaintenanceRecordDeleted } from "./events/MaintenanceRecordDeleted.ts";
+import { MaintenanceRecordUpdated } from "./events/MaintenanceRecordUpdated.ts";
 
 export class MaintenanceRecord {
   private _domainEvents: DomainEvent[] = [];
+  private _title: string;
+  private _performedAt: string;
+  private _notes: string | null;
+  private _revision: number;
 
   private constructor(
     readonly id: MaintenanceRecordId,
     readonly assetId: AssetId,
     readonly ownerId: UserId,
-    readonly title: string,
-    readonly performedAt: string,
-    readonly notes: string | null,
+    title: string,
+    performedAt: string,
+    notes: string | null,
     readonly taskId: MaintenanceTaskId | null,
     readonly createdAt: Date,
-  ) {}
+    revision: number = 0,
+  ) {
+    this._title = title;
+    this._performedAt = performedAt;
+    this._notes = notes;
+    this._revision = revision;
+  }
+
+  get title(): string {
+    return this._title;
+  }
+
+  get performedAt(): string {
+    return this._performedAt;
+  }
+
+  get notes(): string | null {
+    return this._notes;
+  }
+
+  get revision(): number {
+    return this._revision;
+  }
 
   static create(props: {
     assetId: AssetId;
@@ -71,6 +99,7 @@ export class MaintenanceRecord {
       notes,
       props.taskId ?? null,
       new Date(),
+      0,
     );
     record._domainEvents.push(
       MaintenanceRecordCreated({
@@ -90,6 +119,117 @@ export class MaintenanceRecord {
     return record;
   }
 
+  update(
+    props: {
+      title?: string;
+      performedAt?: string;
+      notes?: string | null;
+      todayUtc: string;
+    },
+    actorId: UserId,
+    assetSnapshot: { assetName: string; assetType: AssetType },
+  ): boolean {
+    let nextTitle = this._title;
+    if (props.title !== undefined) {
+      const trimmed = props.title.trim();
+      if (!trimmed) throw new ValidationError("Title is required", "title");
+      if (trimmed.length > 100) {
+        throw new ValidationError("Title must be 100 characters or fewer", "title");
+      }
+      nextTitle = trimmed;
+    }
+
+    let nextPerformedAt = this._performedAt;
+    if (props.performedAt !== undefined) {
+      validateDateOnly(props.performedAt, "performedAt");
+      try {
+        validateDateOnly(props.todayUtc);
+      } catch {
+        throw new InvariantError("UTC date provider returned an invalid date");
+      }
+      if (props.performedAt > props.todayUtc) {
+        throw new ValidationError("Performed date must be today or earlier", "performedAt");
+      }
+      nextPerformedAt = props.performedAt;
+    }
+
+    let nextNotes = this._notes;
+    if (props.notes !== undefined) {
+      if (props.notes === null) {
+        nextNotes = null;
+      } else {
+        const trimmedNotes = props.notes.trim();
+        if (trimmedNotes.length > 1000) {
+          throw new ValidationError("Notes must be 1000 characters or fewer", "notes");
+        }
+        nextNotes = trimmedNotes || null;
+      }
+    }
+
+    const changed =
+      nextTitle !== this._title ||
+      nextPerformedAt !== this._performedAt ||
+      nextNotes !== this._notes;
+
+    if (!changed) return false;
+
+    const before = {
+      title: this._title,
+      performedAt: this._performedAt,
+      notes: this._notes,
+    };
+
+    this._title = nextTitle;
+    this._performedAt = nextPerformedAt;
+    this._notes = nextNotes;
+    this._revision += 1;
+
+    const after = {
+      title: this._title,
+      performedAt: this._performedAt,
+      notes: this._notes,
+    };
+
+    this._domainEvents.push(
+      MaintenanceRecordUpdated({
+        maintenanceRecordId: this.id,
+        assetId: this.assetId,
+        ownerId: this.ownerId,
+        actorId,
+        assetName: assetSnapshot.assetName,
+        assetType: assetSnapshot.assetType,
+        createdAt: this.createdAt,
+        recordRevision: this._revision,
+        taskId: this.taskId,
+        before,
+        after,
+      }),
+    );
+    return true;
+  }
+
+  delete(actorId: UserId, assetSnapshot: { assetName: string; assetType: AssetType }): void {
+    this._revision += 1;
+    this._domainEvents.push(
+      MaintenanceRecordDeleted({
+        maintenanceRecordId: this.id,
+        assetId: this.assetId,
+        ownerId: this.ownerId,
+        actorId,
+        assetName: assetSnapshot.assetName,
+        assetType: assetSnapshot.assetType,
+        createdAt: this.createdAt,
+        recordRevision: this._revision,
+        taskId: this.taskId,
+        deleted: {
+          title: this._title,
+          performedAt: this._performedAt,
+          notes: this._notes,
+        },
+      }),
+    );
+  }
+
   static reconstitute(props: {
     id: MaintenanceRecordId;
     assetId: AssetId;
@@ -99,6 +239,7 @@ export class MaintenanceRecord {
     notes: string | null;
     taskId: MaintenanceTaskId | null;
     createdAt: Date;
+    revision?: number;
   }): MaintenanceRecord {
     return new MaintenanceRecord(
       props.id,
@@ -109,6 +250,7 @@ export class MaintenanceRecord {
       props.notes,
       props.taskId,
       props.createdAt,
+      props.revision ?? 0,
     );
   }
 

--- a/apps/api/src/domain/maintenance/MaintenanceRecordRepository.ts
+++ b/apps/api/src/domain/maintenance/MaintenanceRecordRepository.ts
@@ -1,8 +1,15 @@
-import type { AssetId, UserId } from "@snaveevans/pineapple-shared";
+import type {
+  AssetId,
+  MaintenanceRecordId,
+  MaintenanceTaskId,
+  UserId,
+} from "@snaveevans/pineapple-shared";
 import type { MaintenanceRecord } from "./MaintenanceRecord.ts";
 
 export interface MaintenanceRecordRepository {
+  findById(id: MaintenanceRecordId): Promise<MaintenanceRecord | null>;
   /** Returns records ordered by performedAt DESC, then createdAt DESC. */
   findByAsset(assetId: AssetId, ownerId: UserId): Promise<MaintenanceRecord[]>;
+  findByTask(taskId: MaintenanceTaskId): Promise<MaintenanceRecord[]>;
   save(record: MaintenanceRecord): Promise<void>;
 }

--- a/apps/api/src/domain/maintenance/MaintenanceTask.test.ts
+++ b/apps/api/src/domain/maintenance/MaintenanceTask.test.ts
@@ -291,7 +291,7 @@ describe("MaintenanceTask.update", () => {
     expect(task.nextDue).toBe("2026-07-11");
   });
 
-  it("recomputes nextDue from todayUtc when there is no lastCompletedDate", () => {
+  it("recomputes nextDue from scheduleSeedDate when there is no lastCompletedDate", () => {
     const task = makeTask({ intervalValue: 2, intervalUnit: "month" });
     task.pullEvents();
 
@@ -301,7 +301,7 @@ describe("MaintenanceTask.update", () => {
     });
 
     expect(result).toBe(true);
-    expect(task.nextDue).toBe("2026-08-01");
+    expect(task.nextDue).toBe("2026-07-11");
   });
 
   it("emits MaintenanceTaskUpdated when a value actually changes", () => {
@@ -441,5 +441,113 @@ describe("addInterval calendar arithmetic", () => {
       todayUtc: "2024-02-29",
     });
     expect(task.nextDue).toBe("2025-02-28");
+  });
+});
+
+describe("MaintenanceTask.reconcile", () => {
+  it("rewinds to previous latest record when latest record is removed", () => {
+    const task = makeTask({
+      lastCompletedDate: "2026-01-01",
+      intervalValue: 1,
+      intervalUnit: "month",
+    });
+    task.pullEvents();
+
+    const recordId = MaintenanceRecordId.generate();
+    // Simulate advance from a 2026-03-01 record
+    task.advance("2026-03-01", recordId, actorId, { assetName, assetType });
+    expect(task.lastCompletedDate).toBe("2026-03-01");
+    expect(task.nextDue).toBe("2026-04-01");
+    task.pullEvents();
+
+    // Reconcile with only an intermediate record at 2026-02-01 surviving
+    const sourceRecordId = MaintenanceRecordId.generate();
+    const changed = task.reconcile([{ performedAt: "2026-02-01" }], sourceRecordId, actorId, {
+      assetName,
+      assetType,
+    });
+
+    expect(changed).toBe(true);
+    expect(task.lastCompletedDate).toBe("2026-02-01");
+    expect(task.nextDue).toBe("2026-03-01");
+
+    const events = task.pullEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: "MaintenanceTaskReconciled",
+      maintenanceTaskId: task.id,
+      lastCompletedDate: "2026-02-01",
+      nextDue: "2026-03-01",
+      sourceRecordId,
+      activityEntryType: null,
+    });
+  });
+
+  it("rewinds to initial seed when all surviving records are deleted on seeded task", () => {
+    const task = makeTask({
+      lastCompletedDate: "2026-01-01",
+      intervalValue: 1,
+      intervalUnit: "month",
+    });
+    task.pullEvents();
+
+    task.advance("2026-03-01", MaintenanceRecordId.generate(), actorId, { assetName, assetType });
+    task.pullEvents();
+
+    const changed = task.reconcile([], MaintenanceRecordId.generate(), actorId, {
+      assetName,
+      assetType,
+    });
+    expect(changed).toBe(true);
+    expect(task.lastCompletedDate).toBe("2026-01-01");
+    expect(task.nextDue).toBe("2026-02-01");
+  });
+
+  it("becomes null and uses scheduleSeedDate when all records deleted on unseeded task", () => {
+    const task = makeTask({
+      intervalValue: 1,
+      intervalUnit: "month",
+      todayUtc: "2026-06-01",
+    });
+    task.pullEvents();
+
+    expect(task.scheduleSeedDate).toBe("2026-06-01");
+    expect(task.initialLastCompletedDate).toBeNull();
+
+    task.advance("2026-06-15", MaintenanceRecordId.generate(), actorId, { assetName, assetType });
+    expect(task.lastCompletedDate).toBe("2026-06-15");
+    expect(task.nextDue).toBe("2026-07-15");
+    task.pullEvents();
+
+    const changed = task.reconcile([], MaintenanceRecordId.generate(), actorId, {
+      assetName,
+      assetType,
+    });
+    expect(changed).toBe(true);
+    expect(task.lastCompletedDate).toBeNull();
+    expect(task.nextDue).toBe("2026-07-01"); // 2026-06-01 + 1 month
+  });
+
+  it("returns false and emits no event when surviving records produce same lastCompletedDate and nextDue", () => {
+    const task = makeTask({
+      lastCompletedDate: "2026-01-01",
+      intervalValue: 1,
+      intervalUnit: "month",
+    });
+    task.pullEvents();
+
+    task.advance("2026-03-01", MaintenanceRecordId.generate(), actorId, { assetName, assetType });
+    task.pullEvents();
+
+    // Reconcile where latest surviving is still 2026-03-01
+    const changed = task.reconcile(
+      [{ performedAt: "2026-02-01" }, { performedAt: "2026-03-01" }],
+      MaintenanceRecordId.generate(),
+      actorId,
+      { assetName, assetType },
+    );
+
+    expect(changed).toBe(false);
+    expect(task.pullEvents()).toHaveLength(0);
   });
 });

--- a/apps/api/src/domain/maintenance/MaintenanceTask.ts
+++ b/apps/api/src/domain/maintenance/MaintenanceTask.ts
@@ -13,6 +13,7 @@ import { type IntervalUnit, INTERVAL_UNITS, addInterval } from "./IntervalUnit.t
 import { MaintenanceTaskAdvanced } from "./events/MaintenanceTaskAdvanced.ts";
 import { MaintenanceTaskCreated } from "./events/MaintenanceTaskCreated.ts";
 import { MaintenanceTaskDeleted } from "./events/MaintenanceTaskDeleted.ts";
+import { MaintenanceTaskReconciled } from "./events/MaintenanceTaskReconciled.ts";
 import { MaintenanceTaskUpdated } from "./events/MaintenanceTaskUpdated.ts";
 
 export class MaintenanceTask {
@@ -22,6 +23,9 @@ export class MaintenanceTask {
   private _intervalUnit: IntervalUnit;
   private _lastCompletedDate: string | null;
   private _nextDue: string;
+  private _scheduleSeedDate: string;
+  private _initialLastCompletedDate: string | null;
+  private _revision: number;
 
   private constructor(
     readonly id: MaintenanceTaskId,
@@ -33,12 +37,18 @@ export class MaintenanceTask {
     lastCompletedDate: string | null,
     nextDue: string,
     readonly createdAt: Date,
+    scheduleSeedDate: string,
+    initialLastCompletedDate: string | null,
+    revision: number = 0,
   ) {
     this._title = title;
     this._intervalValue = intervalValue;
     this._intervalUnit = intervalUnit;
     this._lastCompletedDate = lastCompletedDate;
     this._nextDue = nextDue;
+    this._scheduleSeedDate = scheduleSeedDate;
+    this._initialLastCompletedDate = initialLastCompletedDate;
+    this._revision = revision;
   }
 
   get title(): string {
@@ -59,6 +69,18 @@ export class MaintenanceTask {
 
   get nextDue(): string {
     return this._nextDue;
+  }
+
+  get scheduleSeedDate(): string {
+    return this._scheduleSeedDate;
+  }
+
+  get initialLastCompletedDate(): string | null {
+    return this._initialLastCompletedDate;
+  }
+
+  get revision(): number {
+    return this._revision;
   }
 
   willAdvance(performedAt: string): boolean {
@@ -109,6 +131,8 @@ export class MaintenanceTask {
       lastCompletedDate = props.lastCompletedDate;
     }
 
+    const scheduleSeedDate = lastCompletedDate ?? props.todayUtc;
+    const initialLastCompletedDate = lastCompletedDate;
     const baseline = lastCompletedDate ?? props.todayUtc;
     const nextDue = addInterval(baseline, props.intervalValue, props.intervalUnit);
 
@@ -122,6 +146,9 @@ export class MaintenanceTask {
       lastCompletedDate,
       nextDue,
       new Date(),
+      scheduleSeedDate,
+      initialLastCompletedDate,
+      0,
     );
     task._domainEvents.push(
       MaintenanceTaskCreated({
@@ -152,6 +179,7 @@ export class MaintenanceTask {
     }
     this._lastCompletedDate = performedAt;
     this._nextDue = addInterval(performedAt, this.intervalValue, this.intervalUnit);
+    this._revision += 1;
     this._domainEvents.push(
       MaintenanceTaskAdvanced({
         maintenanceTaskId: this.id,
@@ -171,7 +199,7 @@ export class MaintenanceTask {
 
   /**
    * Applies a partial edit of title/interval. Recomputes nextDue from
-   * lastCompletedDate (or todayUtc when absent) only when the resulting
+   * lastCompletedDate (or scheduleSeedDate when absent) only when the resulting
    * intervalValue/intervalUnit actually differ from what's stored — resending
    * the current interval alongside a title change never touches lastCompletedDate
    * or nextDue. Publishes no event and returns false when the resulting values
@@ -211,12 +239,7 @@ export class MaintenanceTask {
       nextIntervalValue !== this._intervalValue || nextIntervalUnit !== this._intervalUnit;
     let nextDue = this._nextDue;
     if (intervalChanged) {
-      try {
-        validateDateOnly(props.todayUtc);
-      } catch {
-        throw new InvariantError("UTC date provider returned an invalid date");
-      }
-      const baseline = this._lastCompletedDate ?? props.todayUtc;
+      const baseline = this._lastCompletedDate ?? this._scheduleSeedDate;
       nextDue = addInterval(baseline, nextIntervalValue, nextIntervalUnit);
     }
 
@@ -230,6 +253,7 @@ export class MaintenanceTask {
     this._intervalValue = nextIntervalValue;
     this._intervalUnit = nextIntervalUnit;
     this._nextDue = nextDue;
+    this._revision += 1;
 
     this._domainEvents.push(
       MaintenanceTaskUpdated({
@@ -248,7 +272,61 @@ export class MaintenanceTask {
     return true;
   }
 
+  /**
+   * Reconciles task lastCompletedDate and nextDue against remaining linked records and initial seed.
+   * Returns true and emits MaintenanceTaskReconciled if and only if lastCompletedDate or nextDue changed.
+   */
+  reconcile(
+    survivingRecords: { performedAt: string }[],
+    sourceRecordId: MaintenanceRecordId,
+    actorId: UserId,
+    assetSnapshot: { assetName: string; assetType: AssetType },
+  ): boolean {
+    const candidateDates: string[] = [];
+    if (this._initialLastCompletedDate !== null) {
+      candidateDates.push(this._initialLastCompletedDate);
+    }
+    for (const r of survivingRecords) {
+      candidateDates.push(r.performedAt);
+    }
+
+    let newLastCompletedDate: string | null = null;
+    if (candidateDates.length > 0) {
+      candidateDates.sort();
+      newLastCompletedDate = candidateDates[candidateDates.length - 1] ?? null;
+    }
+
+    const baseline = newLastCompletedDate ?? this._scheduleSeedDate;
+    const newNextDue = addInterval(baseline, this._intervalValue, this._intervalUnit);
+
+    const changed =
+      newLastCompletedDate !== this._lastCompletedDate || newNextDue !== this._nextDue;
+    if (!changed) return false;
+
+    this._lastCompletedDate = newLastCompletedDate;
+    this._nextDue = newNextDue;
+    this._revision += 1;
+
+    this._domainEvents.push(
+      MaintenanceTaskReconciled({
+        maintenanceTaskId: this.id,
+        assetId: this.assetId,
+        ownerId: this.ownerId,
+        actorId,
+        assetName: assetSnapshot.assetName,
+        assetType: assetSnapshot.assetType,
+        title: this._title,
+        lastCompletedDate: this._lastCompletedDate,
+        nextDue: this._nextDue,
+        sourceRecordId,
+        taskRevision: this._revision,
+      }),
+    );
+    return true;
+  }
+
   remove(actorId: UserId, assetSnapshot: { assetName: string; assetType: AssetType }): void {
+    this._revision += 1;
     this._domainEvents.push(
       MaintenanceTaskDeleted({
         maintenanceTaskId: this.id,
@@ -272,7 +350,18 @@ export class MaintenanceTask {
     lastCompletedDate: string | null;
     nextDue: string;
     createdAt: Date;
+    scheduleSeedDate?: string;
+    initialLastCompletedDate?: string | null;
+    revision?: number;
   }): MaintenanceTask {
+    const scheduleSeedDate =
+      props.scheduleSeedDate ??
+      props.lastCompletedDate ??
+      props.createdAt.toISOString().slice(0, 10);
+    const initialLastCompletedDate =
+      props.initialLastCompletedDate !== undefined
+        ? props.initialLastCompletedDate
+        : props.lastCompletedDate;
     return new MaintenanceTask(
       props.id,
       props.assetId,
@@ -283,6 +372,9 @@ export class MaintenanceTask {
       props.lastCompletedDate,
       props.nextDue,
       props.createdAt,
+      scheduleSeedDate,
+      initialLastCompletedDate,
+      props.revision ?? 0,
     );
   }
 

--- a/apps/api/src/domain/maintenance/events/MaintenanceRecordDeleted.ts
+++ b/apps/api/src/domain/maintenance/events/MaintenanceRecordDeleted.ts
@@ -1,0 +1,51 @@
+import type {
+  AssetId,
+  MaintenanceRecordId,
+  MaintenanceTaskId,
+  UserId,
+} from "@snaveevans/pineapple-shared";
+import type { AssetType } from "../../asset/AssetType.ts";
+import { createDomainEventMetadata, type DomainEvent } from "../../events/DomainEvent.ts";
+import type { MaintenanceRecordSnapshot } from "./MaintenanceRecordUpdated.ts";
+
+export type MaintenanceRecordDeleted = DomainEvent & {
+  type: "MaintenanceRecordDeleted";
+  maintenanceRecordId: MaintenanceRecordId;
+  assetId: AssetId;
+  ownerId: UserId;
+  actorId: UserId;
+  assetName: string;
+  assetType: AssetType;
+  createdAt: Date;
+  recordRevision: number;
+  taskId: MaintenanceTaskId | null;
+  deleted: MaintenanceRecordSnapshot;
+  activityEntryType: "maintenance_record_deleted";
+};
+
+export const MaintenanceRecordDeleted = (props: {
+  maintenanceRecordId: MaintenanceRecordId;
+  assetId: AssetId;
+  ownerId: UserId;
+  actorId: UserId;
+  assetName: string;
+  assetType: AssetType;
+  createdAt: Date;
+  recordRevision: number;
+  taskId: MaintenanceTaskId | null;
+  deleted: MaintenanceRecordSnapshot;
+}): MaintenanceRecordDeleted => ({
+  ...createDomainEventMetadata(),
+  type: "MaintenanceRecordDeleted",
+  maintenanceRecordId: props.maintenanceRecordId,
+  assetId: props.assetId,
+  ownerId: props.ownerId,
+  actorId: props.actorId,
+  assetName: props.assetName,
+  assetType: props.assetType,
+  createdAt: props.createdAt,
+  recordRevision: props.recordRevision,
+  taskId: props.taskId,
+  deleted: props.deleted,
+  activityEntryType: "maintenance_record_deleted",
+});

--- a/apps/api/src/domain/maintenance/events/MaintenanceRecordUpdated.ts
+++ b/apps/api/src/domain/maintenance/events/MaintenanceRecordUpdated.ts
@@ -1,0 +1,59 @@
+import type {
+  AssetId,
+  MaintenanceRecordId,
+  MaintenanceTaskId,
+  UserId,
+} from "@snaveevans/pineapple-shared";
+import type { AssetType } from "../../asset/AssetType.ts";
+import { createDomainEventMetadata, type DomainEvent } from "../../events/DomainEvent.ts";
+
+export type MaintenanceRecordSnapshot = {
+  title: string;
+  performedAt: string;
+  notes: string | null;
+};
+
+export type MaintenanceRecordUpdated = DomainEvent & {
+  type: "MaintenanceRecordUpdated";
+  maintenanceRecordId: MaintenanceRecordId;
+  assetId: AssetId;
+  ownerId: UserId;
+  actorId: UserId;
+  assetName: string;
+  assetType: AssetType;
+  createdAt: Date;
+  recordRevision: number;
+  taskId: MaintenanceTaskId | null;
+  before: MaintenanceRecordSnapshot;
+  after: MaintenanceRecordSnapshot;
+  activityEntryType: "maintenance_record_updated";
+};
+
+export const MaintenanceRecordUpdated = (props: {
+  maintenanceRecordId: MaintenanceRecordId;
+  assetId: AssetId;
+  ownerId: UserId;
+  actorId: UserId;
+  assetName: string;
+  assetType: AssetType;
+  createdAt: Date;
+  recordRevision: number;
+  taskId: MaintenanceTaskId | null;
+  before: MaintenanceRecordSnapshot;
+  after: MaintenanceRecordSnapshot;
+}): MaintenanceRecordUpdated => ({
+  ...createDomainEventMetadata(),
+  type: "MaintenanceRecordUpdated",
+  maintenanceRecordId: props.maintenanceRecordId,
+  assetId: props.assetId,
+  ownerId: props.ownerId,
+  actorId: props.actorId,
+  assetName: props.assetName,
+  assetType: props.assetType,
+  createdAt: props.createdAt,
+  recordRevision: props.recordRevision,
+  taskId: props.taskId,
+  before: props.before,
+  after: props.after,
+  activityEntryType: "maintenance_record_updated",
+});

--- a/apps/api/src/domain/maintenance/events/MaintenanceTaskReconciled.ts
+++ b/apps/api/src/domain/maintenance/events/MaintenanceTaskReconciled.ts
@@ -1,0 +1,53 @@
+import type {
+  AssetId,
+  MaintenanceRecordId,
+  MaintenanceTaskId,
+  UserId,
+} from "@snaveevans/pineapple-shared";
+import type { AssetType } from "../../asset/AssetType.ts";
+import { createDomainEventMetadata, type DomainEvent } from "../../events/DomainEvent.ts";
+
+export type MaintenanceTaskReconciled = DomainEvent & {
+  type: "MaintenanceTaskReconciled";
+  maintenanceTaskId: MaintenanceTaskId;
+  assetId: AssetId;
+  ownerId: UserId;
+  actorId: UserId;
+  assetName: string;
+  assetType: AssetType;
+  title: string;
+  lastCompletedDate: string | null;
+  nextDue: string;
+  sourceRecordId: MaintenanceRecordId;
+  taskRevision: number;
+  activityEntryType: null;
+};
+
+export const MaintenanceTaskReconciled = (props: {
+  maintenanceTaskId: MaintenanceTaskId;
+  assetId: AssetId;
+  ownerId: UserId;
+  actorId: UserId;
+  assetName: string;
+  assetType: AssetType;
+  title: string;
+  lastCompletedDate: string | null;
+  nextDue: string;
+  sourceRecordId: MaintenanceRecordId;
+  taskRevision: number;
+}): MaintenanceTaskReconciled => ({
+  ...createDomainEventMetadata(),
+  type: "MaintenanceTaskReconciled",
+  maintenanceTaskId: props.maintenanceTaskId,
+  assetId: props.assetId,
+  ownerId: props.ownerId,
+  actorId: props.actorId,
+  assetName: props.assetName,
+  assetType: props.assetType,
+  title: props.title,
+  lastCompletedDate: props.lastCompletedDate,
+  nextDue: props.nextDue,
+  sourceRecordId: props.sourceRecordId,
+  taskRevision: props.taskRevision,
+  activityEntryType: null,
+});

--- a/apps/api/src/infrastructure/activity/ActivityEventMessage.ts
+++ b/apps/api/src/infrastructure/activity/ActivityEventMessage.ts
@@ -7,6 +7,8 @@ import type { AssetType } from "../../domain/asset/AssetType.ts";
 import type { AssetCreated } from "../../domain/asset/events/AssetCreated.ts";
 import type { DomainEvent } from "../../domain/events/DomainEvent.ts";
 import type { MaintenanceRecordCreated } from "../../domain/maintenance/events/MaintenanceRecordCreated.ts";
+import type { MaintenanceRecordDeleted } from "../../domain/maintenance/events/MaintenanceRecordDeleted.ts";
+import type { MaintenanceRecordUpdated } from "../../domain/maintenance/events/MaintenanceRecordUpdated.ts";
 import type { MaintenanceTaskAdvanced } from "../../domain/maintenance/events/MaintenanceTaskAdvanced.ts";
 import type { MaintenanceTaskCreated } from "../../domain/maintenance/events/MaintenanceTaskCreated.ts";
 import type { MaintenanceTaskDeleted } from "../../domain/maintenance/events/MaintenanceTaskDeleted.ts";
@@ -19,6 +21,8 @@ export const ACTIVITY_HISTORY_DLQ_NAME = "pineapple-activity-history-dlq";
 type ActivityDomainEvent =
   | AssetCreated
   | MaintenanceRecordCreated
+  | MaintenanceRecordUpdated
+  | MaintenanceRecordDeleted
   | MaintenanceTaskCreated
   | MaintenanceTaskUpdated
   | MaintenanceTaskAdvanced
@@ -60,6 +64,33 @@ export type MaintenanceRecordCreatedActivityEventMessage = ActivityEventCommon<
   taskId: MaintenanceTaskId | null;
 };
 
+export type MaintenanceRecordUpdatedActivityEventMessage = ActivityEventCommon<
+  "MaintenanceRecordUpdated",
+  "maintenance_record_updated"
+> & {
+  maintenanceRecordId: MaintenanceRecordId;
+  title: string;
+  performedAt: string;
+  createdAt: string;
+  recordRevision: number;
+  taskId: MaintenanceTaskId | null;
+  before: { title: string; performedAt: string; notes: string | null };
+  after: { title: string; performedAt: string; notes: string | null };
+};
+
+export type MaintenanceRecordDeletedActivityEventMessage = ActivityEventCommon<
+  "MaintenanceRecordDeleted",
+  "maintenance_record_deleted"
+> & {
+  maintenanceRecordId: MaintenanceRecordId;
+  title: string;
+  performedAt: string;
+  createdAt: string;
+  recordRevision: number;
+  taskId: MaintenanceTaskId | null;
+  deleted: { title: string; performedAt: string; notes: string | null };
+};
+
 export type MaintenanceTaskCreatedActivityEventMessage = ActivityEventCommon<
   "MaintenanceTaskCreated",
   "task_scheduled"
@@ -97,6 +128,8 @@ export type MaintenanceTaskDeletedActivityEventMessage = ActivityEventCommon<
 export type ActivityEventMessage =
   | AssetCreatedActivityEventMessage
   | MaintenanceRecordCreatedActivityEventMessage
+  | MaintenanceRecordUpdatedActivityEventMessage
+  | MaintenanceRecordDeletedActivityEventMessage
   | MaintenanceTaskCreatedActivityEventMessage
   | MaintenanceTaskUpdatedActivityEventMessage
   | MaintenanceTaskAdvancedActivityEventMessage
@@ -115,6 +148,8 @@ type ActivityMessageValidatorMap = {
 const ACTIVITY_EVENT_MESSAGE_FACTORIES = {
   AssetCreated: fromAssetCreated,
   MaintenanceRecordCreated: fromMaintenanceRecordCreated,
+  MaintenanceRecordUpdated: fromMaintenanceRecordUpdated,
+  MaintenanceRecordDeleted: fromMaintenanceRecordDeleted,
   MaintenanceTaskCreated: fromMaintenanceTaskCreated,
   MaintenanceTaskUpdated: fromMaintenanceTaskUpdated,
   MaintenanceTaskAdvanced: fromMaintenanceTaskAdvanced,
@@ -129,6 +164,21 @@ const ACTIVITY_EVENT_MESSAGE_VALIDATORS = {
     isString(value.performedAt) &&
     (value.taskId === null || isString(value.taskId)) &&
     (value.activityEntryType === "maintenance_logged" || value.activityEntryType === null),
+  MaintenanceRecordUpdated: (value) =>
+    isString(value.maintenanceRecordId) &&
+    isString(value.title) &&
+    isString(value.performedAt) &&
+    (value.taskId === null || isString(value.taskId)) &&
+    value.activityEntryType === "maintenance_record_updated" &&
+    isRecord(value.before) &&
+    isRecord(value.after),
+  MaintenanceRecordDeleted: (value) =>
+    isString(value.maintenanceRecordId) &&
+    isString(value.title) &&
+    isString(value.performedAt) &&
+    (value.taskId === null || isString(value.taskId)) &&
+    value.activityEntryType === "maintenance_record_deleted" &&
+    isRecord(value.deleted),
   MaintenanceTaskCreated: (value) =>
     isString(value.maintenanceTaskId) &&
     isString(value.title) &&
@@ -198,6 +248,37 @@ function fromMaintenanceRecordCreated(
     title: event.title,
     performedAt: event.performedAt,
     taskId: event.taskId,
+  };
+}
+
+function fromMaintenanceRecordUpdated(
+  event: MaintenanceRecordUpdated,
+): MaintenanceRecordUpdatedActivityEventMessage {
+  return {
+    ...common(event, event.activityEntryType),
+    maintenanceRecordId: event.maintenanceRecordId,
+    title: event.after.title,
+    performedAt: event.after.performedAt,
+    createdAt: event.createdAt.toISOString(),
+    recordRevision: event.recordRevision,
+    taskId: event.taskId,
+    before: event.before,
+    after: event.after,
+  };
+}
+
+function fromMaintenanceRecordDeleted(
+  event: MaintenanceRecordDeleted,
+): MaintenanceRecordDeletedActivityEventMessage {
+  return {
+    ...common(event, event.activityEntryType),
+    maintenanceRecordId: event.maintenanceRecordId,
+    title: event.deleted.title,
+    performedAt: event.deleted.performedAt,
+    createdAt: event.createdAt.toISOString(),
+    recordRevision: event.recordRevision,
+    taskId: event.taskId,
+    deleted: event.deleted,
   };
 }
 

--- a/apps/api/src/infrastructure/activity/D1ActivityLogRepository.test.ts
+++ b/apps/api/src/infrastructure/activity/D1ActivityLogRepository.test.ts
@@ -76,6 +76,7 @@ describe("D1ActivityLogRepository", () => {
       event.title,
       event.performedAt,
       expect.any(String),
+      null,
     ]);
   });
 
@@ -134,6 +135,7 @@ describe("D1ActivityLogRepository", () => {
       "Backdated oil change",
       "2026-05-09",
       expect.any(String),
+      null,
     ]);
   });
 
@@ -162,6 +164,105 @@ describe("D1ActivityLogRepository", () => {
       "Replace furnace filter",
       null,
       expect.any(String),
+      null,
+    ]);
+  });
+
+  it("projects a record edit as a maintenance_record_updated activity entry with audit snapshot", async () => {
+    const { db, statements } = createDatabaseHarness();
+    const event: ActivityEventMessage = {
+      id: "e2d3cf94-3779-43ea-b595-dac35dcba45a",
+      type: "MaintenanceRecordUpdated",
+      activityEntryType: "maintenance_record_updated",
+      occurredAt: "2026-06-09T18:25:24.887Z",
+      assetId: AssetId.from("195d0ef0-47f5-439f-abfd-29f892c9a040"),
+      ownerId: UserId.from("7d914909-c903-41a4-a13a-82cbd0f61851"),
+      actorId: UserId.from("71afbc20-f2e0-4fc8-a989-278437cf792c"),
+      actorDisplayName: "Pat Rivera",
+      assetName: "Truck",
+      assetType: "vehicle",
+      maintenanceRecordId: MaintenanceRecordId.from("e914b960-772f-46a7-b6fb-f333dcfc7fc9"),
+      title: "New Title",
+      performedAt: "2026-05-02",
+      createdAt: "2026-05-01T12:00:00.000Z",
+      recordRevision: 2,
+      taskId: null,
+      before: { title: "Old Title", performedAt: "2026-05-01", notes: "Old Notes" },
+      after: { title: "New Title", performedAt: "2026-05-02", notes: "New Notes" },
+    };
+
+    await new D1ActivityLogRepository(db).recordEvent(event);
+
+    expect(statements).toHaveLength(1);
+    expect(statements[0]?.values).toEqual([
+      event.id,
+      event.id,
+      event.ownerId,
+      event.actorId,
+      "Pat Rivera",
+      "maintenance_record_updated",
+      event.occurredAt,
+      event.assetId,
+      event.assetName,
+      event.assetType,
+      "New Title",
+      "2026-05-02",
+      expect.any(String),
+      JSON.stringify({
+        recordId: "e914b960-772f-46a7-b6fb-f333dcfc7fc9",
+        taskId: null,
+        createdAt: "2026-05-01T12:00:00.000Z",
+        before: { title: "Old Title", performedAt: "2026-05-01", notes: "Old Notes" },
+        after: { title: "New Title", performedAt: "2026-05-02", notes: "New Notes" },
+      }),
+    ]);
+  });
+
+  it("projects a record deletion as a maintenance_record_deleted activity entry with audit snapshot", async () => {
+    const { db, statements } = createDatabaseHarness();
+    const event: ActivityEventMessage = {
+      id: "e2d3cf94-3779-43ea-b595-dac35dcba45a",
+      type: "MaintenanceRecordDeleted",
+      activityEntryType: "maintenance_record_deleted",
+      occurredAt: "2026-06-09T18:25:24.887Z",
+      assetId: AssetId.from("195d0ef0-47f5-439f-abfd-29f892c9a040"),
+      ownerId: UserId.from("7d914909-c903-41a4-a13a-82cbd0f61851"),
+      actorId: UserId.from("71afbc20-f2e0-4fc8-a989-278437cf792c"),
+      actorDisplayName: "Pat Rivera",
+      assetName: "Truck",
+      assetType: "vehicle",
+      maintenanceRecordId: MaintenanceRecordId.from("e914b960-772f-46a7-b6fb-f333dcfc7fc9"),
+      title: "Deleted Record",
+      performedAt: "2026-05-01",
+      createdAt: "2026-05-01T12:00:00.000Z",
+      recordRevision: 1,
+      taskId: null,
+      deleted: { title: "Deleted Record", performedAt: "2026-05-01", notes: null },
+    };
+
+    await new D1ActivityLogRepository(db).recordEvent(event);
+
+    expect(statements).toHaveLength(1);
+    expect(statements[0]?.values).toEqual([
+      event.id,
+      event.id,
+      event.ownerId,
+      event.actorId,
+      "Pat Rivera",
+      "maintenance_record_deleted",
+      event.occurredAt,
+      event.assetId,
+      event.assetName,
+      event.assetType,
+      "Deleted Record",
+      "2026-05-01",
+      expect.any(String),
+      JSON.stringify({
+        recordId: "e914b960-772f-46a7-b6fb-f333dcfc7fc9",
+        taskId: null,
+        createdAt: "2026-05-01T12:00:00.000Z",
+        deleted: { title: "Deleted Record", performedAt: "2026-05-01", notes: null },
+      }),
     ]);
   });
 

--- a/apps/api/src/infrastructure/activity/D1ActivityLogRepository.ts
+++ b/apps/api/src/infrastructure/activity/D1ActivityLogRepository.ts
@@ -110,8 +110,8 @@ export class D1ActivityLogRepository implements ActivityLogRepository {
       .prepare(
         `INSERT INTO activity_entries
            (id, source_event_id, owner_id, actor_id, actor_display_name, type, occurred_at,
-            asset_id, asset_name, asset_type, title, performed_at, created_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            asset_id, asset_name, asset_type, title, performed_at, created_at, audit_snapshot_json)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
          ON CONFLICT(source_event_id) DO NOTHING`,
       )
       .bind(
@@ -128,6 +128,7 @@ export class D1ActivityLogRepository implements ActivityLogRepository {
         entry.title,
         entry.performedAt,
         new Date().toISOString(),
+        entry.auditSnapshotJson,
       );
   }
 
@@ -232,6 +233,7 @@ function entryFromEvent(event: ActivityEventMessage): {
   assetType: AssetType;
   title: string | null;
   performedAt: string | null;
+  auditSnapshotJson: string | null;
 } | null {
   if (event.activityEntryType === null) return null;
 
@@ -245,13 +247,47 @@ function entryFromEvent(event: ActivityEventMessage): {
 
   switch (event.type) {
     case "AssetCreated":
-      return { ...base, type: event.activityEntryType, title: null, performedAt: null };
+      return {
+        ...base,
+        type: event.activityEntryType,
+        title: null,
+        performedAt: null,
+        auditSnapshotJson: null,
+      };
     case "MaintenanceRecordCreated":
       return {
         ...base,
         type: event.activityEntryType,
         title: event.title,
         performedAt: event.performedAt,
+        auditSnapshotJson: null,
+      };
+    case "MaintenanceRecordUpdated":
+      return {
+        ...base,
+        type: event.activityEntryType,
+        title: event.title,
+        performedAt: event.performedAt,
+        auditSnapshotJson: JSON.stringify({
+          recordId: event.maintenanceRecordId,
+          taskId: event.taskId,
+          createdAt: event.createdAt,
+          before: event.before,
+          after: event.after,
+        }),
+      };
+    case "MaintenanceRecordDeleted":
+      return {
+        ...base,
+        type: event.activityEntryType,
+        title: event.title,
+        performedAt: event.performedAt,
+        auditSnapshotJson: JSON.stringify({
+          recordId: event.maintenanceRecordId,
+          taskId: event.taskId,
+          createdAt: event.createdAt,
+          deleted: event.deleted,
+        }),
       };
     case "MaintenanceTaskAdvanced":
       return {
@@ -259,13 +295,32 @@ function entryFromEvent(event: ActivityEventMessage): {
         type: event.activityEntryType,
         title: event.title,
         performedAt: event.performedAt,
+        auditSnapshotJson: null,
       };
     case "MaintenanceTaskCreated":
-      return { ...base, type: event.activityEntryType, title: event.title, performedAt: null };
+      return {
+        ...base,
+        type: event.activityEntryType,
+        title: event.title,
+        performedAt: null,
+        auditSnapshotJson: null,
+      };
     case "MaintenanceTaskUpdated":
-      return { ...base, type: event.activityEntryType, title: event.title, performedAt: null };
+      return {
+        ...base,
+        type: event.activityEntryType,
+        title: event.title,
+        performedAt: null,
+        auditSnapshotJson: null,
+      };
     case "MaintenanceTaskDeleted":
-      return { ...base, type: event.activityEntryType, title: event.title, performedAt: null };
+      return {
+        ...base,
+        type: event.activityEntryType,
+        title: event.title,
+        performedAt: null,
+        auditSnapshotJson: null,
+      };
   }
 }
 

--- a/apps/api/src/infrastructure/notifications/NotificationEventMessage.ts
+++ b/apps/api/src/infrastructure/notifications/NotificationEventMessage.ts
@@ -3,6 +3,7 @@ import type { DomainEvent } from "../../domain/events/DomainEvent.ts";
 import type { MaintenanceTaskAdvanced } from "../../domain/maintenance/events/MaintenanceTaskAdvanced.ts";
 import type { MaintenanceTaskCreated } from "../../domain/maintenance/events/MaintenanceTaskCreated.ts";
 import type { MaintenanceTaskDeleted } from "../../domain/maintenance/events/MaintenanceTaskDeleted.ts";
+import type { MaintenanceTaskReconciled } from "../../domain/maintenance/events/MaintenanceTaskReconciled.ts";
 import type { MaintenanceTaskUpdated } from "../../domain/maintenance/events/MaintenanceTaskUpdated.ts";
 
 export const NOTIFICATION_EVENTS_CONSUMER = "notification_events";
@@ -13,6 +14,7 @@ type NotificationDomainEvent =
   | MaintenanceTaskCreated
   | MaintenanceTaskUpdated
   | MaintenanceTaskAdvanced
+  | MaintenanceTaskReconciled
   | MaintenanceTaskDeleted;
 
 type NotificationDomainEventType = NotificationDomainEvent["type"];
@@ -47,6 +49,13 @@ export type MaintenanceTaskAdvancedNotificationMessage =
     performedAt: string;
   };
 
+export type MaintenanceTaskReconciledNotificationMessage =
+  NotificationEventCommon<"MaintenanceTaskReconciled"> & {
+    nextDue: string;
+    lastCompletedDate: string | null;
+    sourceRecordId: string;
+  };
+
 export type MaintenanceTaskDeletedNotificationMessage =
   NotificationEventCommon<"MaintenanceTaskDeleted">;
 
@@ -54,6 +63,7 @@ export type NotificationEventMessage =
   | MaintenanceTaskCreatedNotificationMessage
   | MaintenanceTaskUpdatedNotificationMessage
   | MaintenanceTaskAdvancedNotificationMessage
+  | MaintenanceTaskReconciledNotificationMessage
   | MaintenanceTaskDeletedNotificationMessage;
 
 type FactoryMap = {
@@ -70,6 +80,7 @@ const FACTORIES = {
   MaintenanceTaskCreated: fromCreated,
   MaintenanceTaskUpdated: fromUpdated,
   MaintenanceTaskAdvanced: fromAdvanced,
+  MaintenanceTaskReconciled: fromReconciled,
   MaintenanceTaskDeleted: fromDeleted,
 } satisfies FactoryMap;
 
@@ -78,6 +89,7 @@ const VALIDATORS = {
   MaintenanceTaskUpdated: (value) => isString(value.nextDue),
   MaintenanceTaskAdvanced: (value) =>
     isString(value.nextDue) && isString(value.maintenanceRecordId) && isString(value.performedAt),
+  MaintenanceTaskReconciled: (value) => isString(value.nextDue) && isString(value.sourceRecordId),
   MaintenanceTaskDeleted: () => true,
 } satisfies ValidatorMap;
 
@@ -129,6 +141,17 @@ function fromAdvanced(event: MaintenanceTaskAdvanced): MaintenanceTaskAdvancedNo
     nextDue: event.nextDue,
     maintenanceRecordId: event.maintenanceRecordId,
     performedAt: event.performedAt,
+  };
+}
+
+function fromReconciled(
+  event: MaintenanceTaskReconciled,
+): MaintenanceTaskReconciledNotificationMessage {
+  return {
+    ...common(event),
+    nextDue: event.nextDue,
+    lastCompletedDate: event.lastCompletedDate,
+    sourceRecordId: event.sourceRecordId,
   };
 }
 

--- a/apps/api/src/infrastructure/persistence/D1MaintenanceRecordRepository.test.ts
+++ b/apps/api/src/infrastructure/persistence/D1MaintenanceRecordRepository.test.ts
@@ -89,4 +89,42 @@ describe("D1MaintenanceRecordRepository", () => {
     expect(statements).toHaveLength(1);
     expect(statements[0]?.run).toHaveBeenCalledOnce();
   });
+
+  it("prepends mutation_guards CAS check in update batch and returns true on success", async () => {
+    const { db, batch, statements } = createDatabaseHarness();
+    batch.mockResolvedValue([
+      { meta: { changes: 1 } }, // mutation_guards
+      { meta: { changes: 1 } }, // maintenance_records
+      { meta: { changes: 1 } }, // maintenance_tasks
+    ]);
+    const { record, task } = createEntities();
+
+    const result = await new D1MaintenanceRecordRepository(db).update(record, 1, task, 2);
+
+    expect(result).toBe(true);
+    expect(statements).toHaveLength(3);
+    expect(statements[0]?.query).toContain("INSERT INTO mutation_guards");
+    expect(statements[1]?.query).toContain("UPDATE maintenance_records");
+    expect(statements[2]?.query).toContain("UPDATE maintenance_tasks");
+  });
+
+  it("returns false on update when batch throws a CHECK constraint failure", async () => {
+    const { db, batch } = createDatabaseHarness();
+    batch.mockRejectedValue(new Error("D1_ERROR: CHECK constraint failed: assertion = 1"));
+    const { record, task } = createEntities();
+
+    const result = await new D1MaintenanceRecordRepository(db).update(record, 1, task, 2);
+
+    expect(result).toBe(false);
+  });
+
+  it("returns false on delete when batch throws a CHECK constraint failure", async () => {
+    const { db, batch } = createDatabaseHarness();
+    batch.mockRejectedValue(new Error("D1_ERROR: CHECK constraint failed: assertion = 1"));
+    const { record } = createEntities();
+
+    const result = await new D1MaintenanceRecordRepository(db).delete(record, 1);
+
+    expect(result).toBe(false);
+  });
 });

--- a/apps/api/src/infrastructure/persistence/D1MaintenanceRecordRepository.ts
+++ b/apps/api/src/infrastructure/persistence/D1MaintenanceRecordRepository.ts
@@ -22,14 +22,24 @@ type MaintenanceRecordRow = {
   notes: string | null;
   task_id: string | null;
   created_at: string;
+  revision: number;
 };
 
-const SELECT_COLUMNS = "id, asset_id, owner_id, title, performed_at, notes, task_id, created_at";
+const SELECT_COLUMNS =
+  "id, asset_id, owner_id, title, performed_at, notes, task_id, created_at, revision";
 
 export class D1MaintenanceRecordRepository
   implements MaintenanceRecordRepository, MaintenanceRecordWriter
 {
   constructor(private readonly db: D1Database) {}
+
+  async findById(id: MaintenanceRecordId): Promise<MaintenanceRecord | null> {
+    const row = await this.db
+      .prepare(`SELECT ${SELECT_COLUMNS} FROM maintenance_records WHERE id = ?`)
+      .bind(id)
+      .first<MaintenanceRecordRow>();
+    return row ? this.#rowToRecord(row) : null;
+  }
 
   async findByAsset(assetId: AssetId, ownerId: UserId): Promise<MaintenanceRecord[]> {
     const result = await this.db
@@ -44,6 +54,19 @@ export class D1MaintenanceRecordRepository
     return result.results.map((row) => this.#rowToRecord(row));
   }
 
+  async findByTask(taskId: MaintenanceTaskId): Promise<MaintenanceRecord[]> {
+    const result = await this.db
+      .prepare(
+        `SELECT ${SELECT_COLUMNS}
+         FROM maintenance_records
+         WHERE task_id = ?
+         ORDER BY performed_at DESC, created_at DESC`,
+      )
+      .bind(taskId)
+      .all<MaintenanceRecordRow>();
+    return result.results.map((row) => this.#rowToRecord(row));
+  }
+
   async save(
     record: MaintenanceRecord,
     advancedTask: MaintenanceTask | null = null,
@@ -52,8 +75,8 @@ export class D1MaintenanceRecordRepository
     const recordStatement = this.db
       .prepare(
         `INSERT INTO maintenance_records
-           (id, asset_id, owner_id, title, performed_at, notes, task_id, created_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+           (id, asset_id, owner_id, title, performed_at, notes, task_id, created_at, revision)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       )
       .bind(
         record.id,
@@ -64,6 +87,7 @@ export class D1MaintenanceRecordRepository
         record.notes,
         record.taskId,
         record.createdAt.toISOString(),
+        record.revision,
       );
 
     if (advancedTask === null && events.length === 0) {
@@ -83,7 +107,203 @@ export class D1MaintenanceRecordRepository
     await this.db.batch([...statements, ...outboxStatements]);
   }
 
+  async update(
+    record: MaintenanceRecord,
+    expectedRecordRevision: number,
+    reconciledTask: MaintenanceTask | null = null,
+    expectedTaskRevision?: number,
+    events: readonly DomainEvent[] = [],
+  ): Promise<boolean> {
+    const guardStatement = this.db
+      .prepare(
+        `INSERT INTO mutation_guards (name, assertion)
+         VALUES (
+           'cas_guard',
+           (
+             SELECT CASE
+               WHEN (SELECT revision FROM maintenance_records WHERE id = ?) = ?
+                AND (? IS NULL OR (SELECT revision FROM maintenance_tasks WHERE id = ?) = ?)
+               THEN 1
+               ELSE 0
+             END
+           )
+         )
+         ON CONFLICT(name) DO UPDATE SET assertion = excluded.assertion`,
+      )
+      .bind(
+        record.id,
+        expectedRecordRevision,
+        reconciledTask ? reconciledTask.id : null,
+        reconciledTask ? reconciledTask.id : null,
+        expectedTaskRevision !== undefined ? expectedTaskRevision : null,
+      );
+
+    const recordStatement = this.db
+      .prepare(
+        `UPDATE maintenance_records
+         SET title = ?, performed_at = ?, notes = ?, revision = ?
+         WHERE id = ? AND revision = ?`,
+      )
+      .bind(
+        record.title,
+        record.performedAt,
+        record.notes,
+        record.revision,
+        record.id,
+        expectedRecordRevision,
+      );
+
+    const statements: D1PreparedStatement[] = [guardStatement, recordStatement];
+
+    if (reconciledTask !== null && expectedTaskRevision !== undefined) {
+      const taskStatement = this.db
+        .prepare(
+          `UPDATE maintenance_tasks
+           SET last_completed_date = ?, next_due = ?, revision = ?
+           WHERE id = ? AND revision = ?`,
+        )
+        .bind(
+          reconciledTask.lastCompletedDate,
+          reconciledTask.nextDue,
+          reconciledTask.revision,
+          reconciledTask.id,
+          expectedTaskRevision,
+        );
+      statements.push(taskStatement);
+    }
+
+    const outboxStatements = events
+      .flatMap((event) => [
+        prepareActivityOutboxInsert(this.db, event),
+        prepareNotificationOutboxInsert(this.db, event),
+      ])
+      .filter((statement): statement is D1PreparedStatement => statement !== null);
+
+    try {
+      const results = await this.db.batch([...statements, ...outboxStatements]);
+      const recordResult = results[1];
+      if (!recordResult || recordResult.meta.changes !== 1) {
+        return false;
+      }
+
+      if (reconciledTask !== null) {
+        const taskResult = results[2];
+        if (!taskResult || taskResult.meta.changes !== 1) {
+          return false;
+        }
+      }
+
+      return true;
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        (error.message.includes("CHECK constraint failed") ||
+          error.message.includes("assertion = 1") ||
+          error.message.includes("D1_ERROR"))
+      ) {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  async delete(
+    record: MaintenanceRecord,
+    expectedRecordRevision: number,
+    reconciledTask: MaintenanceTask | null = null,
+    expectedTaskRevision?: number,
+    events: readonly DomainEvent[] = [],
+  ): Promise<boolean> {
+    const guardStatement = this.db
+      .prepare(
+        `INSERT INTO mutation_guards (name, assertion)
+         VALUES (
+           'cas_guard',
+           (
+             SELECT CASE
+               WHEN (SELECT revision FROM maintenance_records WHERE id = ?) = ?
+                AND (? IS NULL OR (SELECT revision FROM maintenance_tasks WHERE id = ?) = ?)
+               THEN 1
+               ELSE 0
+             END
+           )
+         )
+         ON CONFLICT(name) DO UPDATE SET assertion = excluded.assertion`,
+      )
+      .bind(
+        record.id,
+        expectedRecordRevision,
+        reconciledTask ? reconciledTask.id : null,
+        reconciledTask ? reconciledTask.id : null,
+        expectedTaskRevision !== undefined ? expectedTaskRevision : null,
+      );
+
+    const recordStatement = this.db
+      .prepare(
+        `DELETE FROM maintenance_records
+         WHERE id = ? AND revision = ?`,
+      )
+      .bind(record.id, expectedRecordRevision);
+
+    const statements: D1PreparedStatement[] = [guardStatement, recordStatement];
+
+    if (reconciledTask !== null && expectedTaskRevision !== undefined) {
+      const taskStatement = this.db
+        .prepare(
+          `UPDATE maintenance_tasks
+           SET last_completed_date = ?, next_due = ?, revision = ?
+           WHERE id = ? AND revision = ?`,
+        )
+        .bind(
+          reconciledTask.lastCompletedDate,
+          reconciledTask.nextDue,
+          reconciledTask.revision,
+          reconciledTask.id,
+          expectedTaskRevision,
+        );
+      statements.push(taskStatement);
+    }
+
+    const outboxStatements = events
+      .flatMap((event) => [
+        prepareActivityOutboxInsert(this.db, event),
+        prepareNotificationOutboxInsert(this.db, event),
+      ])
+      .filter((statement): statement is D1PreparedStatement => statement !== null);
+
+    try {
+      const results = await this.db.batch([...statements, ...outboxStatements]);
+      const recordResult = results[1];
+      if (!recordResult || recordResult.meta.changes !== 1) {
+        return false;
+      }
+
+      if (reconciledTask !== null) {
+        const taskResult = results[2];
+        if (!taskResult || taskResult.meta.changes !== 1) {
+          return false;
+        }
+      }
+
+      return true;
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        (error.message.includes("CHECK constraint failed") ||
+          error.message.includes("assertion = 1") ||
+          error.message.includes("D1_ERROR"))
+      ) {
+        return false;
+      }
+      throw error;
+    }
+  }
+
   #rowToRecord(row: MaintenanceRecordRow): MaintenanceRecord {
+    if (row.revision === null || row.revision === undefined) {
+      throw new Error(`Invariant violation: record ${row.id} has null revision after rollout`);
+    }
+
     return MaintenanceRecord.reconstitute({
       id: MaintenanceRecordId.from(row.id),
       assetId: AssetId.from(row.asset_id),
@@ -93,6 +313,7 @@ export class D1MaintenanceRecordRepository
       notes: row.notes,
       taskId: row.task_id ? MaintenanceTaskId.from(row.task_id) : null,
       createdAt: new Date(row.created_at),
+      revision: row.revision,
     });
   }
 }

--- a/apps/api/src/infrastructure/persistence/D1MaintenanceTaskRepository.ts
+++ b/apps/api/src/infrastructure/persistence/D1MaintenanceTaskRepository.ts
@@ -16,31 +16,32 @@ type MaintenanceTaskRow = {
   last_completed_date: string | null;
   next_due: string;
   created_at: string;
+  schedule_seed_date?: string | null;
+  initial_last_completed_date?: string | null;
+  revision?: number | null;
 };
 
 const SELECT_COLUMNS =
-  "id, asset_id, owner_id, title, interval_value, interval_unit, last_completed_date, next_due, created_at";
+  "id, asset_id, owner_id, title, interval_value, interval_unit, last_completed_date, next_due, created_at, schedule_seed_date, initial_last_completed_date, revision";
 
 export function prepareMaintenanceTaskSave(
   db: D1Database,
   task: MaintenanceTask,
 ): D1PreparedStatement {
-  // ON CONFLICT updates every mutable field. advance() only ever changes
-  // last_completed_date/next_due (title/interval pass through unchanged), and
-  // update() only ever changes title/interval_value/interval_unit/next_due
-  // (last_completed_date passes through unchanged) — so a single upsert covers
-  // both callers safely.
   return db
     .prepare(
       `INSERT INTO maintenance_tasks
-         (id, asset_id, owner_id, title, interval_value, interval_unit, last_completed_date, next_due, created_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+         (id, asset_id, owner_id, title, interval_value, interval_unit, last_completed_date, next_due, created_at, schedule_seed_date, initial_last_completed_date, revision)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON CONFLICT(id) DO UPDATE SET
          title = excluded.title,
          interval_value = excluded.interval_value,
          interval_unit = excluded.interval_unit,
          last_completed_date = excluded.last_completed_date,
-         next_due = excluded.next_due`,
+         next_due = excluded.next_due,
+         schedule_seed_date = excluded.schedule_seed_date,
+         initial_last_completed_date = excluded.initial_last_completed_date,
+         revision = excluded.revision`,
     )
     .bind(
       task.id,
@@ -52,6 +53,9 @@ export function prepareMaintenanceTaskSave(
       task.lastCompletedDate,
       task.nextDue,
       task.createdAt.toISOString(),
+      task.scheduleSeedDate,
+      task.initialLastCompletedDate,
+      task.revision,
     );
 }
 
@@ -75,7 +79,8 @@ export class D1MaintenanceTaskRepository implements MaintenanceTaskRepository {
     const result = await this.db
       .prepare(
         `SELECT t.id, t.asset_id, t.owner_id, t.title, t.interval_value, t.interval_unit,
-                t.last_completed_date, t.next_due, t.created_at
+                t.last_completed_date, t.next_due, t.created_at, t.schedule_seed_date,
+                t.initial_last_completed_date, t.revision
          FROM maintenance_tasks t
          INNER JOIN assets a ON a.id = t.asset_id
          WHERE a.archived_at IS NULL
@@ -113,18 +118,31 @@ export class D1MaintenanceTaskRepository implements MaintenanceTaskRepository {
   }
 
   async delete(taskId: MaintenanceTaskId, events: readonly DomainEvent[] = []): Promise<void> {
+    const unlinkStatement = this.db
+      .prepare(
+        "UPDATE maintenance_records SET task_id = NULL, revision = revision + 1 WHERE task_id = ?",
+      )
+      .bind(taskId);
+
+    const deleteStatement = this.db
+      .prepare("DELETE FROM maintenance_tasks WHERE id = ?")
+      .bind(taskId);
+
     const outboxStatements = prepareOutboxInserts(this.db, events);
 
-    await this.db.batch([
-      this.db
-        .prepare("UPDATE maintenance_records SET task_id = NULL WHERE task_id = ?")
-        .bind(taskId),
-      this.db.prepare("DELETE FROM maintenance_tasks WHERE id = ?").bind(taskId),
-      ...outboxStatements,
-    ]);
+    await this.db.batch([unlinkStatement, deleteStatement, ...outboxStatements]);
   }
 
   #rowToTask(row: MaintenanceTaskRow): MaintenanceTask {
+    if (row.schedule_seed_date === null || row.schedule_seed_date === undefined) {
+      throw new Error(
+        `Invariant violation: task ${row.id} has null schedule_seed_date after rollout`,
+      );
+    }
+    if (row.revision === null || row.revision === undefined) {
+      throw new Error(`Invariant violation: task ${row.id} has null revision after rollout`);
+    }
+
     return MaintenanceTask.reconstitute({
       id: MaintenanceTaskId.from(row.id),
       assetId: AssetId.from(row.asset_id),
@@ -135,6 +153,9 @@ export class D1MaintenanceTaskRepository implements MaintenanceTaskRepository {
       lastCompletedDate: row.last_completed_date,
       nextDue: row.next_due,
       createdAt: new Date(row.created_at),
+      scheduleSeedDate: row.schedule_seed_date,
+      initialLastCompletedDate: row.initial_last_completed_date ?? null,
+      revision: row.revision,
     });
   }
 }

--- a/apps/api/src/infrastructure/persistence/D1MaintenanceWriteGate.ts
+++ b/apps/api/src/infrastructure/persistence/D1MaintenanceWriteGate.ts
@@ -1,0 +1,19 @@
+import type { MaintenanceWriteGate } from "../../application/ports/MaintenanceWriteGate.ts";
+
+export class D1MaintenanceWriteGate implements MaintenanceWriteGate {
+  constructor(private readonly db: D1Database) {}
+
+  async isWritable(): Promise<boolean> {
+    try {
+      const row = await this.db
+        .prepare("SELECT mode FROM maintenance_write_gate WHERE id = 1")
+        .first<{ mode: string }>();
+      return row?.mode === "open";
+    } catch (error) {
+      // Fail closed when write gate cannot be checked (e.g. table unmigrated or DB outage),
+      // but log the error so database issues are immediately observable in server logs.
+      console.error("Failed to query maintenance_write_gate; failing closed as frozen:", error);
+      return false;
+    }
+  }
+}

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -9,6 +9,7 @@ import {
   DomainError,
   Email,
   MAINTENANCE_DUE_SOON_LEAD_DAYS,
+  MaintenanceRecordId,
   MaintenanceTaskId,
   NotificationId,
 } from "@snaveevans/pineapple-shared";
@@ -64,10 +65,13 @@ import { GetAsset } from "./application/usecases/GetAsset.ts";
 import { ListAssets } from "./application/usecases/ListAssets.ts";
 import { CreateMaintenanceRecord } from "./application/usecases/CreateMaintenanceRecord.ts";
 import { ListMaintenanceRecords } from "./application/usecases/ListMaintenanceRecords.ts";
+import { UpdateMaintenanceRecord } from "./application/usecases/UpdateMaintenanceRecord.ts";
+import { DeleteMaintenanceRecord } from "./application/usecases/DeleteMaintenanceRecord.ts";
 import { CreateMaintenanceTask } from "./application/usecases/CreateMaintenanceTask.ts";
 import { ListMaintenanceTasks } from "./application/usecases/ListMaintenanceTasks.ts";
 import { DeleteMaintenanceTask } from "./application/usecases/DeleteMaintenanceTask.ts";
 import { UpdateMaintenanceTask } from "./application/usecases/UpdateMaintenanceTask.ts";
+import { D1MaintenanceWriteGate } from "./infrastructure/persistence/D1MaintenanceWriteGate.ts";
 import { GetDashboard } from "./application/usecases/GetDashboard.ts";
 import { ListActivity } from "./application/usecases/ListActivity.ts";
 import { SearchAssets } from "./application/usecases/SearchAssets.ts";
@@ -103,6 +107,8 @@ import { createMutatingRequestOutboxRelayMiddleware } from "./api/middleware/mut
 import {
   createAssetRoute,
   createMaintenanceRecordRoute,
+  updateMaintenanceRecordRoute,
+  deleteMaintenanceRecordRoute,
   createMaintenanceTaskRoute,
   deleteMaintenanceTaskRoute,
   updateMaintenanceTaskRoute,
@@ -856,6 +862,7 @@ app.openapi(createMaintenanceRecordRoute, async (c) => {
     new D1MaintenanceTaskRepository(c.env.DB),
     c.get("eventBus"),
     new SystemUtcDateProvider(),
+    new D1MaintenanceWriteGate(c.env.DB),
   ).execute({
     assetId: AssetId.from(assetId),
     requesterId: user.id,
@@ -866,6 +873,51 @@ app.openapi(createMaintenanceRecordRoute, async (c) => {
   });
   if (!result.ok) throw result.error;
   return c.json(serializeMaintenanceRecord(result.value), 201);
+});
+
+app.openapi(updateMaintenanceRecordRoute, async (c) => {
+  const user = c.get("user");
+  const { assetId, recordId } = c.req.valid("param");
+  const { title, performedAt, notes } = c.req.valid("json");
+  const result = await new UpdateMaintenanceRecord(
+    new D1AssetRepository(c.env.DB),
+    new D1TeamRepository(c.env.DB),
+    new D1MaintenanceRecordRepository(c.env.DB),
+    new D1MaintenanceRecordRepository(c.env.DB),
+    new D1MaintenanceTaskRepository(c.env.DB),
+    c.get("eventBus"),
+    new SystemUtcDateProvider(),
+    new D1MaintenanceWriteGate(c.env.DB),
+  ).execute({
+    assetId: AssetId.from(assetId),
+    recordId: MaintenanceRecordId.from(recordId),
+    requesterId: user.id,
+    ...(title !== undefined ? { title } : {}),
+    ...(performedAt !== undefined ? { performedAt } : {}),
+    ...(notes !== undefined ? { notes } : {}),
+  });
+  if (!result.ok) throw result.error;
+  return c.json(serializeMaintenanceRecord(result.value), 200);
+});
+
+app.openapi(deleteMaintenanceRecordRoute, async (c) => {
+  const user = c.get("user");
+  const { assetId, recordId } = c.req.valid("param");
+  const result = await new DeleteMaintenanceRecord(
+    new D1AssetRepository(c.env.DB),
+    new D1TeamRepository(c.env.DB),
+    new D1MaintenanceRecordRepository(c.env.DB),
+    new D1MaintenanceRecordRepository(c.env.DB),
+    new D1MaintenanceTaskRepository(c.env.DB),
+    c.get("eventBus"),
+    new D1MaintenanceWriteGate(c.env.DB),
+  ).execute({
+    assetId: AssetId.from(assetId),
+    recordId: MaintenanceRecordId.from(recordId),
+    requesterId: user.id,
+  });
+  if (!result.ok) throw result.error;
+  return c.body(null, 204);
 });
 
 app.openapi(listMaintenanceRecordsRoute, async (c) => {
@@ -895,6 +947,7 @@ app.openapi(createMaintenanceTaskRoute, async (c) => {
     new D1MaintenanceTaskRepository(c.env.DB),
     c.get("eventBus"),
     new SystemUtcDateProvider(),
+    new D1MaintenanceWriteGate(c.env.DB),
   ).execute({
     assetId: AssetId.from(assetId),
     requesterId: user.id,
@@ -935,6 +988,7 @@ app.openapi(deleteMaintenanceTaskRoute, async (c) => {
     new D1TeamRepository(c.env.DB),
     new D1MaintenanceTaskRepository(c.env.DB),
     c.get("eventBus"),
+    new D1MaintenanceWriteGate(c.env.DB),
   ).execute({
     taskId: MaintenanceTaskId.from(taskId),
     assetId: AssetId.from(assetId),
@@ -954,6 +1008,7 @@ app.openapi(updateMaintenanceTaskRoute, async (c) => {
     new D1MaintenanceTaskRepository(c.env.DB),
     c.get("eventBus"),
     new SystemUtcDateProvider(),
+    new D1MaintenanceWriteGate(c.env.DB),
   ).execute({
     taskId: MaintenanceTaskId.from(taskId),
     assetId: AssetId.from(assetId),

--- a/apps/web/src/api/maintenanceRecords.ts
+++ b/apps/web/src/api/maintenanceRecords.ts
@@ -1,9 +1,10 @@
-import { apiGet, apiPost } from "./client.ts";
+import { apiDelete, apiGet, apiPatch, apiPost } from "./client.ts";
 import type { components } from "./schema.ts";
 
 export type MaintenanceRecord = components["schemas"]["MaintenanceRecord"];
 export type MaintenanceRecordListResponse = components["schemas"]["MaintenanceRecordListResponse"];
 export type CreateMaintenanceRecordBody = components["schemas"]["CreateMaintenanceRecordBody"];
+export type UpdateMaintenanceRecordBody = components["schemas"]["UpdateMaintenanceRecordBody"];
 
 export const maintenanceRecordsQueryKey = (assetId: string) =>
   ["maintenanceRecords", assetId] as const;
@@ -17,4 +18,21 @@ export function createMaintenanceRecord(
   body: CreateMaintenanceRecordBody,
 ): Promise<MaintenanceRecord> {
   return apiPost("/api/assets/{assetId}/maintenance-records", { path: { assetId }, body });
+}
+
+export function updateMaintenanceRecord(
+  assetId: string,
+  recordId: string,
+  body: UpdateMaintenanceRecordBody,
+): Promise<MaintenanceRecord> {
+  return apiPatch("/api/assets/{assetId}/maintenance-records/{recordId}", {
+    path: { assetId, recordId },
+    body,
+  });
+}
+
+export function deleteMaintenanceRecord(assetId: string, recordId: string): Promise<void> {
+  return apiDelete("/api/assets/{assetId}/maintenance-records/{recordId}", {
+    path: { assetId, recordId },
+  });
 }

--- a/apps/web/src/api/schema.ts
+++ b/apps/web/src/api/schema.ts
@@ -479,6 +479,175 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/assets/{assetId}/maintenance-records/{recordId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Delete a maintenance record
+         * @description Permanently deletes the maintenance record. If linked to a task, the task schedule is reconciled to the surviving records or initial baseline.
+         */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    assetId: string;
+                    recordId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Maintenance record deleted */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Not authenticated */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description The asset belongs to another user */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description No such record or asset */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description The asset is archived or concurrent conflict exceeded retries */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Maintenance writes are temporarily frozen */
+                503: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        /**
+         * Edit a maintenance record
+         * @description Updates title, performedAt, and/or notes. Empty string notes clears the notes. If the record is linked to a task, the task schedule is reconciled. CAS concurrency check retries on conflict. A no-op edit returns 200 with the unchanged record.
+         */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    assetId: string;
+                    recordId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["UpdateMaintenanceRecordBody"];
+                };
+            };
+            responses: {
+                /** @description Updated maintenance record */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MaintenanceRecord"];
+                    };
+                };
+                /** @description Not authenticated */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description The asset belongs to another user */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description No such record or asset */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description The asset is archived or concurrent conflict exceeded retries */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Validation failed */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Maintenance writes are temporarily frozen */
+                503: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
+        };
+        trace?: never;
+    };
     "/api/assets/{assetId}/maintenance-tasks": {
         parameters: {
             query?: never;
@@ -813,7 +982,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    type?: "asset_added" | "maintenance_logged" | "task_completed" | "task_scheduled" | "task_updated" | "task_deleted";
+                    type?: "asset_added" | "maintenance_logged" | "maintenance_record_updated" | "maintenance_record_deleted" | "task_completed" | "task_scheduled" | "task_updated" | "task_deleted";
                     assetId?: string;
                     cursor?: string;
                     limit?: number;
@@ -1809,6 +1978,17 @@ export interface components {
         MaintenanceRecordListResponse: {
             maintenanceRecords: components["schemas"]["MaintenanceRecord"][];
         };
+        UpdateMaintenanceRecordBody: {
+            /** @example Changed synthetic oil */
+            title?: string;
+            /**
+             * Format: date
+             * @example 2026-06-09
+             */
+            performedAt?: string;
+            /** @example Used 7 quarts of 5W-20 synthetic oil. */
+            notes?: string | null;
+        };
         MaintenanceTask: {
             /**
              * Format: uuid
@@ -2010,7 +2190,7 @@ export interface components {
              * @example maintenance_logged
              * @enum {string}
              */
-            type: "asset_added" | "maintenance_logged" | "task_completed" | "task_scheduled" | "task_updated" | "task_deleted";
+            type: "asset_added" | "maintenance_logged" | "maintenance_record_updated" | "maintenance_record_deleted" | "task_completed" | "task_scheduled" | "task_updated" | "task_deleted";
             /**
              * Format: date-time
              * @example 2026-06-09T18:25:24.887Z
@@ -2062,7 +2242,7 @@ export interface components {
              * @example maintenance_logged
              * @enum {string}
              */
-            type: "asset_added" | "maintenance_logged" | "task_completed" | "task_scheduled" | "task_updated" | "task_deleted";
+            type: "asset_added" | "maintenance_logged" | "maintenance_record_updated" | "maintenance_record_deleted" | "task_completed" | "task_scheduled" | "task_updated" | "task_deleted";
             /** @example 4 */
             count: number;
         };

--- a/apps/web/src/app/AppActivityHistory.tsx
+++ b/apps/web/src/app/AppActivityHistory.tsx
@@ -60,6 +60,18 @@ const TYPE_CONFIG: Record<ActivityEntryType, ActivityTypeConfig> = {
     label: "Maintenance logged",
     color: "var(--hh-maint)",
   },
+  maintenance_record_updated: {
+    icon: "edit",
+    verb: "Edited maintenance",
+    label: "Maintenance edited",
+    color: "var(--hh-updated)",
+  },
+  maintenance_record_deleted: {
+    icon: "x",
+    verb: "Removed maintenance",
+    label: "Maintenance removed",
+    color: "var(--hh-deleted)",
+  },
   task_completed: {
     icon: "check",
     verb: "Completed task",
@@ -104,6 +116,8 @@ function emptyTypeCounts(): TypeCounts {
   return {
     asset_added: 0,
     maintenance_logged: 0,
+    maintenance_record_updated: 0,
+    maintenance_record_deleted: 0,
     task_completed: 0,
     task_scheduled: 0,
     task_updated: 0,
@@ -495,12 +509,7 @@ function ActivityTimeline({
             </span>
           </div>
           {group.entries.map((entry) => (
-            <ActivityEventCard
-              key={entry.id}
-              entry={entry}
-              now={now}
-              viewerUserId={viewerUserId}
-            />
+            <ActivityEventCard key={entry.id} entry={entry} now={now} viewerUserId={viewerUserId} />
           ))}
         </section>
       ))}

--- a/apps/web/src/app/AppMaintenanceRecords.test.tsx
+++ b/apps/web/src/app/AppMaintenanceRecords.test.tsx
@@ -1,0 +1,305 @@
+// @vitest-environment happy-dom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiError } from "../api/client.ts";
+import { getAsset, type AssetResponse } from "../api/assets.ts";
+import {
+  listMaintenanceRecords,
+  updateMaintenanceRecord,
+  deleteMaintenanceRecord,
+  type MaintenanceRecord,
+} from "../api/maintenanceRecords.ts";
+import { listMaintenanceTasks } from "../api/maintenanceTasks.ts";
+import { AppMaintenanceRecords } from "./AppMaintenanceRecords.tsx";
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean | undefined;
+}
+
+const navigate = vi.fn();
+
+vi.mock("react-router", () => ({
+  Link: ({ children, to, ...props }: { children: React.ReactNode; to: string }) => (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  ),
+  useNavigate: () => navigate,
+  useParams: () => ({ assetId: "asset-1" }),
+}));
+
+vi.mock("./AppChrome", () => ({
+  HFTopBar: () => <header />,
+  HFBottomNav: () => <nav />,
+}));
+
+vi.mock("../api/assets.ts", () => ({
+  getAsset: vi.fn(),
+  shareAsset: vi.fn(),
+  unshareAsset: vi.fn(),
+  assetQueryKey: (id: string) => ["asset", id],
+  assetsQueryKey: ["assets"],
+}));
+
+vi.mock("../api/maintenanceRecords.ts", () => ({
+  listMaintenanceRecords: vi.fn(),
+  createMaintenanceRecord: vi.fn(),
+  updateMaintenanceRecord: vi.fn(),
+  deleteMaintenanceRecord: vi.fn(),
+  maintenanceRecordsQueryKey: (id: string) => ["maintenanceRecords", id],
+}));
+
+vi.mock("../api/maintenanceTasks.ts", () => ({
+  listMaintenanceTasks: vi.fn(),
+  createMaintenanceTask: vi.fn(),
+  updateMaintenanceTask: vi.fn(),
+  deleteMaintenanceTask: vi.fn(),
+  maintenanceTasksQueryKey: (id: string) => ["maintenanceTasks", id],
+}));
+
+vi.mock("../api/dashboard.ts", () => ({
+  getDashboard: vi.fn().mockResolvedValue({ todayUtc: "2026-06-09" }),
+  dashboardQueryKey: ["dashboard"],
+}));
+
+vi.mock("../api/teams.ts", () => ({
+  getMyTeam: vi.fn().mockResolvedValue({ team: null }),
+  teamQueryKey: ["myTeam"],
+}));
+
+const getAssetMock = vi.mocked(getAsset);
+const listMaintenanceRecordsMock = vi.mocked(listMaintenanceRecords);
+const updateMaintenanceRecordMock = vi.mocked(updateMaintenanceRecord);
+const deleteMaintenanceRecordMock = vi.mocked(deleteMaintenanceRecord);
+const listMaintenanceTasksMock = vi.mocked(listMaintenanceTasks);
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+let queryClient: QueryClient | null = null;
+
+function mockAsset(overrides: Partial<AssetResponse> = {}): AssetResponse {
+  return {
+    id: "asset-1",
+    name: "Truck",
+    type: "vehicle",
+    metadata: { kind: "vehicle", make: "Ram", model: "2500", year: 2016 },
+    archivedAt: null,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    sharing: { scope: "personal", isOwner: true },
+    ...overrides,
+  };
+}
+
+function mockRecord(overrides: Partial<MaintenanceRecord> = {}): MaintenanceRecord {
+  return {
+    id: "rec-1",
+    assetId: "asset-1",
+    title: "Oil change",
+    performedAt: "2026-05-01",
+    notes: "5W-30 synthetic",
+    taskId: null,
+    createdAt: "2026-05-01T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+  queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  getAssetMock.mockResolvedValue(mockAsset());
+  listMaintenanceRecordsMock.mockResolvedValue({
+    maintenanceRecords: [mockRecord()],
+  });
+  listMaintenanceTasksMock.mockResolvedValue({
+    maintenanceTasks: [],
+  });
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root?.unmount();
+  });
+  container?.remove();
+  root = null;
+  container = null;
+  queryClient?.clear();
+  queryClient = null;
+  globalThis.IS_REACT_ACT_ENVIRONMENT = false;
+  vi.clearAllMocks();
+});
+
+async function waitFor(assertion: () => boolean) {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    if (assertion()) return;
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  }
+  if (!assertion()) throw new Error("Timed out waiting for expected UI");
+}
+
+async function renderApp() {
+  if (queryClient === null) throw new Error("Query client was not initialized");
+  const client = queryClient;
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+
+  await act(async () => {
+    root?.render(
+      <QueryClientProvider client={client}>
+        <AppMaintenanceRecords />
+      </QueryClientProvider>,
+    );
+  });
+}
+
+function setInputValue(input: HTMLInputElement, value: string) {
+  const valueSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+  if (valueSetter === undefined) throw new Error("Input does not have a value setter");
+  valueSetter.call(input, value);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+  input.dispatchEvent(new Event("change", { bubbles: true }));
+}
+
+describe("AppMaintenanceRecords edit and delete", () => {
+  it("renders maintenance record action buttons on active assets", async () => {
+    await renderApp();
+    await waitFor(() => Boolean(container?.querySelector(".mr-tab")));
+
+    // Switch to Maintenance tab
+    const tabs = container?.querySelectorAll<HTMLButtonElement>(".mr-tab");
+    const maintTab = Array.from(tabs ?? []).find((t) => t.textContent?.includes("Maintenance"));
+    await act(async () => {
+      maintTab?.click();
+    });
+
+    await waitFor(() => Boolean(container?.querySelector(".mr-record-actions")));
+    expect(container?.querySelector(".mr-record-edit-btn")).not.toBeNull();
+    expect(container?.querySelector(".mr-record-del-btn")).not.toBeNull();
+  });
+
+  it("hides maintenance record action buttons on archived assets", async () => {
+    getAssetMock.mockResolvedValue(mockAsset({ archivedAt: "2026-06-01T00:00:00.000Z" }));
+    await renderApp();
+    await waitFor(() => Boolean(container?.querySelector(".mr-tab")));
+
+    // Switch to Maintenance tab
+    const tabs = container?.querySelectorAll<HTMLButtonElement>(".mr-tab");
+    const maintTab = Array.from(tabs ?? []).find((t) => t.textContent?.includes("Maintenance"));
+    await act(async () => {
+      maintTab?.click();
+    });
+
+    await waitFor(() => Boolean(container?.querySelector(".mr-tl-title")));
+    expect(container?.querySelector(".mr-record-actions")).toBeNull();
+    expect(container?.querySelector(".mr-hero-add")).toBeNull();
+  });
+
+  it("opens edit form, pre-fills record values, and updates record successfully", async () => {
+    updateMaintenanceRecordMock.mockResolvedValue(mockRecord({ title: "Updated Oil Change" }));
+
+    await renderApp();
+    await waitFor(() => Boolean(container?.querySelector(".mr-tab")));
+
+    const tabs = container?.querySelectorAll<HTMLButtonElement>(".mr-tab");
+    const maintTab = Array.from(tabs ?? []).find((t) => t.textContent?.includes("Maintenance"));
+    await act(async () => {
+      maintTab?.click();
+    });
+
+    await waitFor(() => Boolean(container?.querySelector(".mr-record-edit-btn")));
+    const editBtn = container?.querySelector<HTMLButtonElement>(".mr-record-edit-btn");
+    await act(async () => {
+      editBtn?.click();
+    });
+
+    await waitFor(() => Boolean(container?.querySelector("#mre-title")));
+    const titleInput = container?.querySelector<HTMLInputElement>("#mre-title");
+    expect(titleInput?.value).toBe("Oil change");
+
+    await act(async () => {
+      if (titleInput) {
+        setInputValue(titleInput, "Updated Oil Change");
+      }
+    });
+
+    const submitBtn = container?.querySelector<HTMLButtonElement>('button[type="submit"]');
+    await act(async () => {
+      submitBtn?.click();
+    });
+
+    expect(updateMaintenanceRecordMock).toHaveBeenCalledWith("asset-1", "rec-1", {
+      title: "Updated Oil Change",
+      performedAt: "2026-05-01",
+      notes: "5W-30 synthetic",
+    });
+  });
+
+  it("opens delete confirmation modal and deletes record", async () => {
+    deleteMaintenanceRecordMock.mockResolvedValue();
+
+    await renderApp();
+    await waitFor(() => Boolean(container?.querySelector(".mr-tab")));
+
+    const tabs = container?.querySelectorAll<HTMLButtonElement>(".mr-tab");
+    const maintTab = Array.from(tabs ?? []).find((t) => t.textContent?.includes("Maintenance"));
+    await act(async () => {
+      maintTab?.click();
+    });
+
+    await waitFor(() => Boolean(container?.querySelector(".mr-record-del-btn")));
+    const delBtn = container?.querySelector<HTMLButtonElement>(".mr-record-del-btn");
+    await act(async () => {
+      delBtn?.click();
+    });
+
+    await waitFor(() => Boolean(container?.querySelector(".mr-confirm-dialog")));
+    expect(container?.querySelector(".mr-confirm-dialog-title")?.textContent).toContain(
+      "Delete maintenance record?",
+    );
+
+    const confirmDeleteBtn = container?.querySelector<HTMLButtonElement>(".mr-task-confirm-yes");
+    await act(async () => {
+      confirmDeleteBtn?.click();
+    });
+
+    expect(deleteMaintenanceRecordMock).toHaveBeenCalledWith("asset-1", "rec-1");
+  });
+
+  it("handles 503 frozen write error when updating", async () => {
+    updateMaintenanceRecordMock.mockRejectedValue(new ApiError(503, { error: "Changes paused" }));
+
+    await renderApp();
+    await waitFor(() => Boolean(container?.querySelector(".mr-tab")));
+
+    const tabs = container?.querySelectorAll<HTMLButtonElement>(".mr-tab");
+    const maintTab = Array.from(tabs ?? []).find((t) => t.textContent?.includes("Maintenance"));
+    await act(async () => {
+      maintTab?.click();
+    });
+
+    await waitFor(() => Boolean(container?.querySelector(".mr-record-edit-btn")));
+    const editBtn = container?.querySelector<HTMLButtonElement>(".mr-record-edit-btn");
+    await act(async () => {
+      editBtn?.click();
+    });
+
+    await waitFor(() => Boolean(container?.querySelector("#mre-title")));
+    const submitBtn = container?.querySelector<HTMLButtonElement>('button[type="submit"]');
+    await act(async () => {
+      submitBtn?.click();
+    });
+
+    await waitFor(() => Boolean(container?.querySelector(".mr-banner")));
+    expect(container?.querySelector(".mr-banner")?.textContent).toContain(
+      "Maintenance changes are temporarily paused",
+    );
+  });
+});

--- a/apps/web/src/app/AppMaintenanceRecords.tsx
+++ b/apps/web/src/app/AppMaintenanceRecords.tsx
@@ -15,9 +15,12 @@ import { getMyTeam, teamQueryKey } from "../api/teams.ts";
 import {
   listMaintenanceRecords,
   createMaintenanceRecord,
+  updateMaintenanceRecord,
+  deleteMaintenanceRecord,
   maintenanceRecordsQueryKey,
   type MaintenanceRecord,
   type MaintenanceRecordListResponse,
+  type UpdateMaintenanceRecordBody,
 } from "../api/maintenanceRecords.ts";
 import {
   listMaintenanceTasks,
@@ -113,8 +116,7 @@ function groupByYear(sorted: MaintenanceRecord[]): YearGroup[] {
     }
     const prev = sorted[i - 1];
     const next = sorted[i + 1];
-    const sameDay =
-      (prev?.performedAt === r.performedAt) || (next?.performedAt === r.performedAt);
+    const sameDay = prev?.performedAt === r.performedAt || next?.performedAt === r.performedAt;
     cur.items.push({ ...r, sameDay });
   });
   return groups;
@@ -122,7 +124,17 @@ function groupByYear(sorted: MaintenanceRecord[]): YearGroup[] {
 
 // ─── sub-components ──────────────────────────────────────────────────────────
 
-function MRTimeline({ groups }: { groups: YearGroup[] }) {
+function MRTimeline({
+  groups,
+  canMutate,
+  onEditRecord,
+  onDeleteRecord,
+}: {
+  groups: YearGroup[];
+  canMutate: boolean;
+  onEditRecord: (record: MaintenanceRecord) => void;
+  onDeleteRecord: (record: MaintenanceRecord) => void;
+}) {
   return (
     <div className="mr-tl">
       {groups.map((g) => (
@@ -147,9 +159,35 @@ function MRTimeline({ groups }: { groups: YearGroup[] }) {
                   <span className="mr-tl-ago-inline">· {relAgo(r.performedAt)}</span>
                   {r.sameDay && <span className="mr-tl-sameday">same day</span>}
                 </div>
-                <div className="mr-tl-title">
-                  {r.title}
-                  {r.sameDay && <span className="mr-tl-sameday mr-tl-sameday-wide">same day</span>}
+                <div className="mr-tl-head-row">
+                  <div className="mr-tl-title">
+                    {r.title}
+                    {r.sameDay && (
+                      <span className="mr-tl-sameday mr-tl-sameday-wide">same day</span>
+                    )}
+                  </div>
+                  {canMutate && (
+                    <div className="mr-record-actions">
+                      <button
+                        type="button"
+                        className="mr-record-edit-btn"
+                        onClick={() => onEditRecord(r)}
+                        title="Edit record"
+                        aria-label="Edit record"
+                      >
+                        <Icon name="edit" size={13} stroke={1.8} />
+                      </button>
+                      <button
+                        type="button"
+                        className="mr-record-del-btn"
+                        onClick={() => onDeleteRecord(r)}
+                        title="Delete record"
+                        aria-label="Delete record"
+                      >
+                        <Icon name="x" size={13} stroke={2.1} />
+                      </button>
+                    </div>
+                  )}
                 </div>
                 {r.notes && <p className="mr-tl-notes">{r.notes}</p>}
               </div>
@@ -161,18 +199,38 @@ function MRTimeline({ groups }: { groups: YearGroup[] }) {
   );
 }
 
-function MRTable({ groups }: { groups: YearGroup[] }) {
+function MRTable({
+  groups,
+  canMutate,
+  onEditRecord,
+  onDeleteRecord,
+}: {
+  groups: YearGroup[];
+  canMutate: boolean;
+  onEditRecord: (record: MaintenanceRecord) => void;
+  onDeleteRecord: (record: MaintenanceRecord) => void;
+}) {
   return (
     <div className="mr-table" role="table">
       <div className="mr-thead" role="row">
-        <span className="mr-th mr-th-date" role="columnheader">Performed</span>
-        <span className="mr-th mr-th-work" role="columnheader">Work performed</span>
-        <span className="mr-th mr-th-notes" role="columnheader">Notes</span>
-        <span className="mr-th mr-th-logged" role="columnheader">Logged</span>
+        <span className="mr-th mr-th-date" role="columnheader">
+          Performed
+        </span>
+        <span className="mr-th mr-th-work" role="columnheader">
+          Work performed
+        </span>
+        <span className="mr-th mr-th-notes" role="columnheader">
+          Notes
+        </span>
+        <span className="mr-th mr-th-logged" role="columnheader">
+          Logged
+        </span>
       </div>
       {groups.map((g) => (
         <div className="mr-tbody" key={g.year} role="rowgroup">
-          <div className="mr-trow-year" role="row"><span>{g.year}</span></div>
+          <div className="mr-trow-year" role="row">
+            <span>{g.year}</span>
+          </div>
           {g.items.map((r) => (
             <div className="mr-trow" role="row" key={r.id}>
               <span className="mr-td mr-td-date" role="cell">
@@ -188,6 +246,28 @@ function MRTable({ groups }: { groups: YearGroup[] }) {
               </span>
               <span className="mr-td mr-td-logged" role="cell">
                 {relAgo(r.createdAt.slice(0, 10))}
+                {canMutate && (
+                  <div className="mr-record-actions" style={{ marginTop: 4 }}>
+                    <button
+                      type="button"
+                      className="mr-record-edit-btn"
+                      onClick={() => onEditRecord(r)}
+                      title="Edit record"
+                      aria-label="Edit record"
+                    >
+                      <Icon name="edit" size={13} stroke={1.8} />
+                    </button>
+                    <button
+                      type="button"
+                      className="mr-record-del-btn"
+                      onClick={() => onDeleteRecord(r)}
+                      title="Delete record"
+                      aria-label="Delete record"
+                    >
+                      <Icon name="x" size={13} stroke={2.1} />
+                    </button>
+                  </div>
+                )}
               </span>
             </div>
           ))}
@@ -305,7 +385,9 @@ function MRHealthSummary({ tasks }: { tasks: MaintenanceTask[] }) {
         <div className="mr-health-chip mr-health-chip-overdue">
           <span className="mr-health-chip-dot" />
           <span className="mr-health-chip-val">{overdue}</span>
-          <span className="mr-health-chip-lbl">{overdue === 1 ? "task overdue" : "tasks overdue"}</span>
+          <span className="mr-health-chip-lbl">
+            {overdue === 1 ? "task overdue" : "tasks overdue"}
+          </span>
         </div>
       )}
       {soon > 0 && (
@@ -326,7 +408,13 @@ function MRHealthSummary({ tasks }: { tasks: MaintenanceTask[] }) {
   );
 }
 
-function MRRecentActivity({ records, onViewAll }: { records: MaintenanceRecord[]; onViewAll: () => void }) {
+function MRRecentActivity({
+  records,
+  onViewAll,
+}: {
+  records: MaintenanceRecord[];
+  onViewAll: () => void;
+}) {
   const recent = [...records].slice(0, 3);
   return (
     <div className="mr-recent">
@@ -354,7 +442,8 @@ function MRRecentActivity({ records, onViewAll }: { records: MaintenanceRecord[]
                   <span className="mr-recent-title">{r.title}</span>
                   {r.taskId && (
                     <span className="mr-tl-task-badge">
-                      <Icon name="calendar" size={11} stroke={2} />Scheduled
+                      <Icon name="calendar" size={11} stroke={2} />
+                      Scheduled
                     </span>
                   )}
                 </div>
@@ -391,12 +480,18 @@ function MRTaskCard({
         <span className="mr-task-dot" data-status={s} />
         <div className="mr-task-info">
           <div className="mr-task-title">{task.title}</div>
-          <div className="mr-task-interval">{formatIntervalPhrase(task.intervalValue, task.intervalUnit)}</div>
+          <div className="mr-task-interval">
+            {formatIntervalPhrase(task.intervalValue, task.intervalUnit)}
+          </div>
         </div>
       </div>
       <div className="mr-task-card-right">
         <span className={`mr-due-badge mr-due-badge-${s}`}>
-          <Icon name={s === "overdue" ? "alert" : s === "soon" ? "clock-sm" : "check"} size={11} stroke={2} />
+          <Icon
+            name={s === "overdue" ? "alert" : s === "soon" ? "clock-sm" : "check"}
+            size={11}
+            stroke={2}
+          />
           {nextDueLabel(task.daysDue, task.nextDue)}
         </span>
         {confirming ? (
@@ -411,7 +506,11 @@ function MRTaskCard({
             >
               Delete
             </Button>
-            <Button variant="ghost" className="mr-task-confirm-no" onClick={() => setConfirming(false)}>
+            <Button
+              variant="ghost"
+              className="mr-task-confirm-no"
+              onClick={() => setConfirming(false)}
+            >
               Cancel
             </Button>
           </div>
@@ -421,10 +520,18 @@ function MRTaskCard({
               <Icon name="check" size={13} stroke={2.3} />
               Log
             </Button>
-            <button className="mr-task-edit-btn" onClick={() => onEdit(task.id)} aria-label="Edit task">
+            <button
+              className="mr-task-edit-btn"
+              onClick={() => onEdit(task.id)}
+              aria-label="Edit task"
+            >
               <Icon name="edit" size={14} stroke={1.8} />
             </button>
-            <button className="mr-task-del-btn" onClick={() => setConfirming(true)} aria-label="Delete task">
+            <button
+              className="mr-task-del-btn"
+              onClick={() => setConfirming(true)}
+              aria-label="Delete task"
+            >
               <Icon name="x" size={14} stroke={2.1} />
             </button>
           </div>
@@ -438,7 +545,13 @@ function MRTaskEmpty({ onAdd }: { onAdd: () => void }) {
   return (
     <div className="mr-task-empty">
       <Icon name="calendar" size={18} color="var(--hf-ink-faint)" stroke={1.6} />
-      <span>No scheduled tasks — <button className="mr-task-empty-link" onClick={onAdd}>add one</button> to track recurring work.</span>
+      <span>
+        No scheduled tasks —{" "}
+        <button className="mr-task-empty-link" onClick={onAdd}>
+          add one
+        </button>{" "}
+        to track recurring work.
+      </span>
     </div>
   );
 }
@@ -483,7 +596,9 @@ function MRScheduleSection({
           {overdueCount > 0 ? (
             <span className="mr-due-badge mr-due-badge-overdue">{overdueCount} overdue</span>
           ) : (
-            <span className="mr-hist-meta">{tasks.length} {tasks.length === 1 ? "task" : "tasks"}</span>
+            <span className="mr-hist-meta">
+              {tasks.length} {tasks.length === 1 ? "task" : "tasks"}
+            </span>
           )}
         </div>
         <Button variant="secondary" className="mr-schedule-add-btn" onClick={onAdd}>
@@ -555,7 +670,9 @@ function MRCreateTaskForm({ asset, todayUtc, variant, onClose, onCreated }: MRCr
   const [banner, setBanner] = useState<string | null>(null);
   const titleRef = useRef<HTMLInputElement>(null);
 
-  useEffect(() => { titleRef.current?.focus(); }, []);
+  useEffect(() => {
+    titleRef.current?.focus();
+  }, []);
 
   const mutation = useMutation({
     mutationFn: (body: CreateMaintenanceTaskBody) => createMaintenanceTask(asset.id, body),
@@ -612,7 +729,8 @@ function MRCreateTaskForm({ asset, todayUtc, variant, onClose, onCreated }: MRCr
       <div className="mr-form-body">
         {banner && (
           <div className="mr-banner" role="alert">
-            <Icon name="alert" size={15} stroke={2} /><span>{banner}</span>
+            <Icon name="alert" size={15} stroke={2} />
+            <span>{banner}</span>
           </div>
         )}
         <Field
@@ -620,7 +738,9 @@ function MRCreateTaskForm({ asset, todayUtc, variant, onClose, onCreated }: MRCr
           htmlFor="mt-title"
           required
           hint={
-            <span className={`mr-field-count ${values.title.length > TASK_TITLE_MAX ? "over" : ""}`}>
+            <span
+              className={`mr-field-count ${values.title.length > TASK_TITLE_MAX ? "over" : ""}`}
+            >
               {values.title.length}/{TASK_TITLE_MAX}
             </span>
           }
@@ -637,11 +757,7 @@ function MRCreateTaskForm({ asset, todayUtc, variant, onClose, onCreated }: MRCr
             onChange={(e) => updateValue("title", e.target.value)}
           />
         </Field>
-        <Field
-          label="Repeat every"
-          required
-          {...(errors.iv ? { error: errors.iv } : {})}
-        >
+        <Field label="Repeat every" required {...(errors.iv ? { error: errors.iv } : {})}>
           <div className="mr-interval-row">
             <input
               id="mt-iv"
@@ -689,7 +805,12 @@ function MRCreateTaskForm({ asset, todayUtc, variant, onClose, onCreated }: MRCr
         <Button variant="ghost" onClick={onClose} disabled={mutation.isPending}>
           Cancel
         </Button>
-        <Button variant="brand" className="mr-btn-save" onClick={submit} disabled={mutation.isPending}>
+        <Button
+          variant="brand"
+          className="mr-btn-save"
+          onClick={submit}
+          disabled={mutation.isPending}
+        >
           {mutation.isPending ? (
             <>
               <ButtonSpinner />
@@ -725,11 +846,12 @@ function MREditTaskForm({ asset, task, variant, onClose, onSaved }: MREditTaskFo
   const [banner, setBanner] = useState<string | null>(null);
   const titleRef = useRef<HTMLInputElement>(null);
 
-  useEffect(() => { titleRef.current?.focus(); }, []);
+  useEffect(() => {
+    titleRef.current?.focus();
+  }, []);
 
   const mutation = useMutation({
-    mutationFn: (body: UpdateMaintenanceTaskBody) =>
-      updateMaintenanceTask(asset.id, task.id, body),
+    mutationFn: (body: UpdateMaintenanceTaskBody) => updateMaintenanceTask(asset.id, task.id, body),
     onSuccess: (updated) => onSaved(updated),
     onError: (err) => setBanner(err instanceof Error ? err.message : "Failed to save task."),
   });
@@ -780,7 +902,8 @@ function MREditTaskForm({ asset, task, variant, onClose, onSaved }: MREditTaskFo
       <div className="mr-form-body">
         {banner && (
           <div className="mr-banner" role="alert">
-            <Icon name="alert" size={15} stroke={2} /><span>{banner}</span>
+            <Icon name="alert" size={15} stroke={2} />
+            <span>{banner}</span>
           </div>
         )}
         <Field
@@ -788,7 +911,9 @@ function MREditTaskForm({ asset, task, variant, onClose, onSaved }: MREditTaskFo
           htmlFor="met-title"
           required
           hint={
-            <span className={`mr-field-count ${values.title.length > TASK_TITLE_MAX ? "over" : ""}`}>
+            <span
+              className={`mr-field-count ${values.title.length > TASK_TITLE_MAX ? "over" : ""}`}
+            >
               {values.title.length}/{TASK_TITLE_MAX}
             </span>
           }
@@ -805,11 +930,7 @@ function MREditTaskForm({ asset, task, variant, onClose, onSaved }: MREditTaskFo
             onChange={(e) => updateValue("title", e.target.value)}
           />
         </Field>
-        <Field
-          label="Repeat every"
-          required
-          {...(errors.iv ? { error: errors.iv } : {})}
-        >
+        <Field label="Repeat every" required {...(errors.iv ? { error: errors.iv } : {})}>
           <div className="mr-interval-row">
             <input
               id="met-iv"
@@ -839,7 +960,12 @@ function MREditTaskForm({ asset, task, variant, onClose, onSaved }: MREditTaskFo
         <Button variant="ghost" onClick={onClose} disabled={mutation.isPending}>
           Cancel
         </Button>
-        <Button variant="brand" className="mr-btn-save" onClick={submit} disabled={mutation.isPending}>
+        <Button
+          variant="brand"
+          className="mr-btn-save"
+          onClick={submit}
+          disabled={mutation.isPending}
+        >
           {mutation.isPending ? (
             <>
               <ButtonSpinner />
@@ -862,11 +988,7 @@ function MREditTaskForm({ asset, task, variant, onClose, onSaved }: MREditTaskFo
 const TITLE_MAX = 100;
 const NOTES_MAX = 1000;
 
-function validateForm(
-  title: string,
-  performedAt: string,
-  notes: string,
-): Record<string, string> {
+function validateForm(title: string, performedAt: string, notes: string): Record<string, string> {
   const errors: Record<string, string> = {};
   const t = title.trim();
   if (!t) errors.title = "Title is required.";
@@ -888,7 +1010,15 @@ interface MRFormProps {
   preselectedTaskId?: string | null;
 }
 
-function MRForm({ asset, assetId, variant, onClose, onSaved, tasks = [], preselectedTaskId = null }: MRFormProps) {
+function MRForm({
+  asset,
+  assetId,
+  variant,
+  onClose,
+  onSaved,
+  tasks = [],
+  preselectedTaskId = null,
+}: MRFormProps) {
   const [title, setTitle] = useState("");
   const [performedAt, setPerformedAt] = useState(todayDateOnly());
   const [notes, setNotes] = useState("");
@@ -950,7 +1080,12 @@ function MRForm({ asset, assetId, variant, onClose, onSaved, tasks = [], presele
         </button>
       </div>
 
-      <form onSubmit={(e) => { e.preventDefault(); handleSubmit(); }}>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          handleSubmit();
+        }}
+      >
         <div className="mr-form-body">
           {banner && (
             <div className="mr-banner" role="alert">
@@ -1067,7 +1202,12 @@ function MRForm({ asset, assetId, variant, onClose, onSaved, tasks = [], presele
           <Button type="button" variant="ghost" onClick={onClose} disabled={mutation.isPending}>
             Cancel
           </Button>
-          <Button type="submit" variant="brand" className="mr-btn-save" disabled={mutation.isPending}>
+          <Button
+            type="submit"
+            variant="brand"
+            className="mr-btn-save"
+            disabled={mutation.isPending}
+          >
             {mutation.isPending ? (
               <>
                 <ButtonSpinner />
@@ -1082,6 +1222,273 @@ function MRForm({ asset, assetId, variant, onClose, onSaved, tasks = [], presele
           </Button>
         </div>
       </form>
+    </div>
+  );
+}
+
+// ─── edit record form ────────────────────────────────────────────────────────
+
+interface MREditRecordFormProps {
+  asset: AssetPresentation;
+  record: MaintenanceRecord;
+  todayUtc: string;
+  variant: "drawer" | "sheet";
+  onClose: () => void;
+  onSaved: (record: MaintenanceRecord) => void;
+}
+
+function MREditRecordForm({
+  asset,
+  record,
+  todayUtc,
+  variant,
+  onClose,
+  onSaved,
+}: MREditRecordFormProps) {
+  const [title, setTitle] = useState(record.title);
+  const [performedAt, setPerformedAt] = useState(record.performedAt);
+  const [notes, setNotes] = useState(record.notes ?? "");
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  const [banner, setBanner] = useState<string | null>(null);
+  const titleRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    titleRef.current?.focus();
+  }, []);
+
+  const mutation = useMutation({
+    mutationFn: (body: UpdateMaintenanceRecordBody) =>
+      updateMaintenanceRecord(asset.id, record.id, body),
+    onSuccess: (updated) => onSaved(updated),
+    onError: (err) => {
+      if (err instanceof ApiError && err.status === 503) {
+        setBanner("Maintenance changes are temporarily paused. Please try again in a moment.");
+        return;
+      }
+      if (err instanceof ApiError && err.status === 409) {
+        setBanner(
+          err.message || "Cannot edit maintenance on an archived asset or concurrent modification.",
+        );
+        return;
+      }
+      setBanner(err instanceof Error ? err.message : "Failed to save. Please try again.");
+    },
+  });
+
+  const clearErr = (field: string) =>
+    setFieldErrors((prev) => {
+      if (!prev[field]) return prev;
+      const next = { ...prev };
+      delete next[field];
+      return next;
+    });
+
+  const handleSubmit = () => {
+    if (mutation.isPending) return;
+    const errs = validateForm(title, performedAt, notes);
+    setFieldErrors(errs);
+    if (Object.keys(errs).length) {
+      setBanner("Please fix the highlighted fields before saving.");
+      return;
+    }
+    setBanner(null);
+    mutation.mutate({
+      title: title.trim(),
+      performedAt,
+      notes: notes.trim() ? notes.trim() : null,
+    });
+  };
+
+  return (
+    <div className={`mr-form mr-form-${variant}`}>
+      {variant === "sheet" && <div className="mr-sheet-grab" />}
+      <div className="mr-form-head">
+        <div className="mr-form-head-txt">
+          <div className="mr-form-title">Edit maintenance record</div>
+          <div className="mr-form-sub">{asset.name}</div>
+        </div>
+        <button className="mr-form-close" onClick={onClose} aria-label="Close">
+          <Icon name="x" size={15} stroke={2.2} />
+        </button>
+      </div>
+
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          handleSubmit();
+        }}
+      >
+        <div className="mr-form-body">
+          {banner && (
+            <div className="mr-banner" role="alert">
+              <Icon name="alert" size={15} stroke={2} />
+              <span>{banner}</span>
+            </div>
+          )}
+
+          <Field
+            label="Title"
+            htmlFor="mre-title"
+            required
+            hint={
+              <span className={`mr-field-count ${title.length > TITLE_MAX ? "over" : ""}`}>
+                {title.length}/{TITLE_MAX}
+              </span>
+            }
+            {...(fieldErrors.title ? { error: fieldErrors.title } : {})}
+          >
+            <input
+              id="mre-title"
+              ref={titleRef}
+              type="text"
+              className={`mr-input${fieldErrors.title ? " is-invalid" : ""}`}
+              placeholder='What did you do? e.g. "Oil change"'
+              maxLength={TITLE_MAX + 20}
+              value={title}
+              onChange={(e) => {
+                setTitle(e.target.value);
+                clearErr("title");
+                if (banner) setBanner(null);
+              }}
+            />
+          </Field>
+
+          <Field
+            label="Performed date"
+            htmlFor="mre-date"
+            required
+            {...(fieldErrors.performedAt
+              ? { error: fieldErrors.performedAt }
+              : { sub: "When the work was done. Today or earlier." })}
+          >
+            <input
+              id="mre-date"
+              type="date"
+              className={`mr-input mr-input-date${fieldErrors.performedAt ? " is-invalid" : ""}`}
+              max={todayUtc}
+              value={performedAt}
+              onChange={(e) => {
+                setPerformedAt(e.target.value);
+                clearErr("performedAt");
+                if (banner) setBanner(null);
+              }}
+            />
+          </Field>
+
+          <Field
+            label="Notes"
+            htmlFor="mre-notes"
+            hint={
+              <span className={`mr-field-count ${notes.length > NOTES_MAX ? "over" : ""}`}>
+                {notes.length}/{NOTES_MAX}
+              </span>
+            }
+            {...(fieldErrors.notes
+              ? { error: fieldErrors.notes }
+              : {
+                  sub: "Free-form details. Clear field to remove notes.",
+                })}
+          >
+            <textarea
+              id="mre-notes"
+              className={`mr-input mr-textarea${fieldErrors.notes ? " is-invalid" : ""}`}
+              placeholder="Optional — location, condition, cost, vendor, quantity…"
+              value={notes}
+              onChange={(e) => {
+                setNotes(e.target.value);
+                clearErr("notes");
+                if (banner) setBanner(null);
+              }}
+            />
+          </Field>
+        </div>
+
+        <div className="mr-form-actions">
+          <Button type="button" variant="ghost" onClick={onClose} disabled={mutation.isPending}>
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            variant="brand"
+            className="mr-btn-save"
+            disabled={mutation.isPending}
+          >
+            {mutation.isPending ? (
+              <>
+                <ButtonSpinner />
+                Saving…
+              </>
+            ) : (
+              <>
+                <Icon name="check" size={15} stroke={2.4} />
+                Save changes
+              </>
+            )}
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+// ─── delete record dialog ───────────────────────────────────────────────────
+
+interface MRDeleteRecordDialogProps {
+  assetId: string;
+  record: MaintenanceRecord;
+  onClose: () => void;
+  onDeleted: (recordId: string) => void;
+}
+
+function MRDeleteRecordDialog({ assetId, record, onClose, onDeleted }: MRDeleteRecordDialogProps) {
+  const [error, setError] = useState<string | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: () => deleteMaintenanceRecord(assetId, record.id),
+    onSuccess: () => onDeleted(record.id),
+    onError: (err) => {
+      if (err instanceof ApiError && err.status === 503) {
+        setError("Maintenance changes are temporarily paused. Please try again in a moment.");
+        return;
+      }
+      if (err instanceof ApiError && err.status === 409) {
+        setError(err.message || "Cannot delete maintenance on an archived asset.");
+        return;
+      }
+      setError(err instanceof Error ? err.message : "Failed to delete record.");
+    },
+  });
+
+  return (
+    <div className="mr-confirm-dialog" role="dialog" aria-labelledby="del-rec-title">
+      <div className="mr-confirm-dialog-title" id="del-rec-title">
+        Delete maintenance record?
+      </div>
+      <div className="mr-confirm-dialog-desc">
+        Are you sure you want to delete <strong>{record.title}</strong> performed on{" "}
+        {fmtDate(record.performedAt)}?
+        {record.taskId &&
+          " If this record advanced a scheduled task, the task schedule will be recalculated."}
+      </div>
+      {error && (
+        <div className="mr-banner" role="alert">
+          <Icon name="alert" size={15} stroke={2} />
+          <span>{error}</span>
+        </div>
+      )}
+      <div className="mr-confirm-dialog-actions">
+        <Button variant="ghost" onClick={onClose} disabled={mutation.isPending}>
+          Cancel
+        </Button>
+        <Button
+          variant="brand"
+          className="mr-task-confirm-yes"
+          onClick={() => mutation.mutate()}
+          disabled={mutation.isPending}
+        >
+          {mutation.isPending ? "Deleting…" : "Delete record"}
+        </Button>
+      </div>
     </div>
   );
 }
@@ -1167,7 +1574,12 @@ function MRShareSheet({
             </div>
             {isShared && (
               <div className="mr-shr-owner-note">
-                <Icon name="info" size={14} color="var(--hf-ink-faint)" style={{ flexShrink: 0, marginTop: 1 }} />
+                <Icon
+                  name="info"
+                  size={14}
+                  color="var(--hf-ink-faint)"
+                  style={{ flexShrink: 0, marginTop: 1 }}
+                />
                 Unsharing removes access immediately for every team member.
               </div>
             )}
@@ -1237,6 +1649,8 @@ export function AppMaintenanceRecords() {
   const [logFromTaskId, setLogFromTaskId] = useState<string | null>(null);
   const [taskFormOpen, setTaskFormOpen] = useState(false);
   const [editingTaskId, setEditingTaskId] = useState<string | null>(null);
+  const [editingRecord, setEditingRecord] = useState<MaintenanceRecord | null>(null);
+  const [deletingRecord, setDeletingRecord] = useState<MaintenanceRecord | null>(null);
   const [shareOpen, setShareOpen] = useState(false);
   const [shareError, setShareError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<"overview" | "maintenance">("overview");
@@ -1248,8 +1662,10 @@ export function AppMaintenanceRecords() {
     queryFn: () => getAsset(assetId),
     enabled: !!assetId,
     retry: (count, err) =>
-      !(err instanceof ApiError && (err.status === 401 || err.status === 403 || err.status === 404)) &&
-      count < 2,
+      !(
+        err instanceof ApiError &&
+        (err.status === 401 || err.status === 403 || err.status === 404)
+      ) && count < 2,
   });
 
   const recordsQuery = useQuery({
@@ -1257,7 +1673,10 @@ export function AppMaintenanceRecords() {
     queryFn: () => listMaintenanceRecords(assetId),
     enabled: !!assetId && assetQuery.isSuccess,
     retry: (count, err) =>
-      !(err instanceof ApiError && (err.status === 401 || err.status === 403 || err.status === 404)) && count < 2,
+      !(
+        err instanceof ApiError &&
+        (err.status === 401 || err.status === 403 || err.status === 404)
+      ) && count < 2,
   });
 
   const tasksQuery = useQuery({
@@ -1271,7 +1690,7 @@ export function AppMaintenanceRecords() {
   const dashboardTodayQuery = useQuery({
     queryKey: dashboardQueryKey,
     queryFn: getDashboard,
-    enabled: taskFormOpen,
+    enabled: taskFormOpen || !!editingRecord,
     staleTime: 60_000,
     select: (data) => data.todayUtc,
   });
@@ -1334,6 +1753,8 @@ export function AppMaintenanceRecords() {
 
   const asset = assetQuery.data ? toAssetPresentation(assetQuery.data) : null;
   const sharing = assetQuery.data?.sharing ?? null;
+  const isArchived = Boolean(assetQuery.data?.archivedAt);
+  const canMutate = !isArchived;
 
   const sorted = useMemo(
     () => sortRecords(recordsQuery.data?.maintenanceRecords ?? []),
@@ -1341,10 +1762,7 @@ export function AppMaintenanceRecords() {
   );
   const groups = useMemo(() => groupByYear(sorted), [sorted]);
 
-  const tasks = useMemo(
-    () => (tasksQuery.data?.maintenanceTasks ?? []),
-    [tasksQuery.data],
-  );
+  const tasks = useMemo(() => tasksQuery.data?.maintenanceTasks ?? [], [tasksQuery.data]);
 
   const effectiveDensity = isMobile ? "timeline" : density;
 
@@ -1365,7 +1783,32 @@ export function AppMaintenanceRecords() {
     if (!logFromTaskId) setActiveTab("maintenance");
   };
 
+  const handleRecordUpdated = (updated: MaintenanceRecord) => {
+    queryClient.setQueryData(
+      maintenanceRecordsQueryKey(assetId),
+      (old: MaintenanceRecordListResponse | undefined): MaintenanceRecordListResponse => ({
+        maintenanceRecords: (old?.maintenanceRecords ?? []).map((r) =>
+          r.id === updated.id ? updated : r,
+        ),
+      }),
+    );
+    void queryClient.invalidateQueries({ queryKey: maintenanceTasksQueryKey(assetId) });
+    setEditingRecord(null);
+  };
+
+  const handleRecordDeleted = (deletedId: string) => {
+    queryClient.setQueryData(
+      maintenanceRecordsQueryKey(assetId),
+      (old: MaintenanceRecordListResponse | undefined): MaintenanceRecordListResponse => ({
+        maintenanceRecords: (old?.maintenanceRecords ?? []).filter((r) => r.id !== deletedId),
+      }),
+    );
+    void queryClient.invalidateQueries({ queryKey: maintenanceTasksQueryKey(assetId) });
+    setDeletingRecord(null);
+  };
+
   const openLogForm = (fromTaskId: string | null = null) => {
+    if (!canMutate) return;
     setLogFromTaskId(fromTaskId);
     setFormOpen(true);
   };
@@ -1399,7 +1842,9 @@ export function AppMaintenanceRecords() {
       await deleteMaintenanceTask(assetId, taskId);
       queryClient.setQueryData<MaintenanceTaskListResponse>(
         maintenanceTasksQueryKey(assetId),
-        (old) => ({ maintenanceTasks: (old?.maintenanceTasks ?? []).filter((t) => t.id !== taskId) }),
+        (old) => ({
+          maintenanceTasks: (old?.maintenanceTasks ?? []).filter((t) => t.id !== taskId),
+        }),
       );
     } catch (e) {
       const msg = e instanceof Error ? e.message : "Failed to delete task. Please try again.";
@@ -1411,7 +1856,9 @@ export function AppMaintenanceRecords() {
   // ── derive page title
   useEffect(() => {
     document.title = asset ? `${asset.name} — Maintenance · FieldOps` : "Maintenance · FieldOps";
-    return () => { document.title = "FieldOps"; };
+    return () => {
+      document.title = "FieldOps";
+    };
   }, [asset]);
 
   // ── error kinds
@@ -1448,17 +1895,24 @@ export function AppMaintenanceRecords() {
   const renderHistory = () => {
     if (recordsQuery.isPending) return <MRLoading density={effectiveDensity} />;
     if (recordsQuery.isError)
-      return (
-        <MRErrorState
-          kind="error"
-          onRetry={() => void recordsQuery.refetch()}
-        />
-      );
+      return <MRErrorState kind="error" onRetry={() => void recordsQuery.refetch()} />;
     if (sorted.length === 0)
       return <MREmpty assetName={asset?.name ?? "this asset"} onAdd={() => openLogForm()} />;
-    return effectiveDensity === "table"
-      ? <MRTable groups={groups} />
-      : <MRTimeline groups={groups} />;
+    return effectiveDensity === "table" ? (
+      <MRTable
+        groups={groups}
+        canMutate={canMutate}
+        onEditRecord={(r) => setEditingRecord(r)}
+        onDeleteRecord={(r) => setDeletingRecord(r)}
+      />
+    ) : (
+      <MRTimeline
+        groups={groups}
+        canMutate={canMutate}
+        onEditRecord={(r) => setEditingRecord(r)}
+        onDeleteRecord={(r) => setDeletingRecord(r)}
+      />
+    );
   };
 
   const histBlock = (
@@ -1477,13 +1931,15 @@ export function AppMaintenanceRecords() {
                 className={density === "timeline" ? "active" : ""}
                 onClick={() => setDensity("timeline")}
               >
-                <Icon name="menu" size={14} stroke={2} />Timeline
+                <Icon name="menu" size={14} stroke={2} />
+                Timeline
               </button>
               <button
                 className={density === "table" ? "active" : ""}
                 onClick={() => setDensity("table")}
               >
-                <Icon name="grid" size={13} stroke={2} />Table
+                <Icon name="grid" size={13} stroke={2} />
+                Table
               </button>
             </div>
           )}
@@ -1511,7 +1967,7 @@ export function AppMaintenanceRecords() {
   const showMobileAddBar =
     isMobile &&
     !assetQuery.isError &&
-    (activeTab === "maintenance" ? (recordsQuery.isSuccess && sorted.length > 0) : true) &&
+    (activeTab === "maintenance" ? recordsQuery.isSuccess && sorted.length > 0 : true) &&
     !taskFormOpen &&
     !editingTaskId &&
     !formOpen &&
@@ -1537,7 +1993,9 @@ export function AppMaintenanceRecords() {
         <div className="mr-focus-wrap">
           {/* breadcrumb */}
           <div className="mr-crumb">
-            <Link to={paths.assets} className="mr-crumb-link">Assets</Link>
+            <Link to={paths.assets} className="mr-crumb-link">
+              Assets
+            </Link>
             <Icon name="chevron-right" size={14} color="var(--hf-ink-faint)" />
             <span className="mr-crumb-cur">{asset?.name ?? "…"}</span>
           </div>
@@ -1553,8 +2011,9 @@ export function AppMaintenanceRecords() {
                   <span className="mr-dot" />
                   <span>{asset.summary}</span>
                 </div>
-                {sharing && sharing.scope === "team" && (
-                  sharing.isOwner ? (
+                {sharing &&
+                  sharing.scope === "team" &&
+                  (sharing.isOwner ? (
                     <button
                       type="button"
                       className="mr-share-badge is-owner"
@@ -1572,8 +2031,7 @@ export function AppMaintenanceRecords() {
                       <Icon name="users" size={11} stroke={2.2} />
                       <span>Shared by {sharing.ownerDisplayName ?? "a teammate"}</span>
                     </span>
-                  )
-                )}
+                  ))}
               </div>
               <div className="mr-hero-actions">
                 {sharing?.isOwner && (
@@ -1597,7 +2055,7 @@ export function AppMaintenanceRecords() {
                     <Icon name="users" size={16} stroke={1.8} />
                   </button>
                 )}
-                {!recordsQuery.isPending && (
+                {!recordsQuery.isPending && canMutate && (
                   <Button variant="brand" className="mr-hero-add" onClick={() => openLogForm()}>
                     <Icon name="plus" size={16} stroke={2.2} />
                     Log maintenance
@@ -1608,7 +2066,10 @@ export function AppMaintenanceRecords() {
           ) : assetQuery.isPending ? (
             <div className="mr-hero">
               <div className="mr-skel" style={{ width: 56, height: 56, borderRadius: 14 }} />
-              <div className="mr-hero-id" style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+              <div
+                className="mr-hero-id"
+                style={{ display: "flex", flexDirection: "column", gap: 8 }}
+              >
                 <span className="mr-skel mr-skel-w80" style={{ height: 28, borderRadius: 8 }} />
                 <span className="mr-skel mr-skel-w50" />
               </div>
@@ -1652,18 +2113,13 @@ export function AppMaintenanceRecords() {
               onClick={() => setActiveTab("maintenance")}
             >
               Maintenance{" "}
-              <span className="mr-tab-count">
-                {recordsQuery.isSuccess ? sorted.length : "—"}
-              </span>
+              <span className="mr-tab-count">{recordsQuery.isSuccess ? sorted.length : "—"}</span>
             </button>
           </div>
 
           {/* content or full-page error */}
           {assetQuery.isError ? (
-            <MRErrorState
-              kind="error"
-              onRetry={() => void assetQuery.refetch()}
-            />
+            <MRErrorState kind="error" onRetry={() => void assetQuery.refetch()} />
           ) : activeTab === "overview" ? (
             <>
               {sharing && !sharing.isOwner && sharing.scope === "team" && (
@@ -1704,7 +2160,7 @@ export function AppMaintenanceRecords() {
         </div>
       </main>
 
-      {showMobileAddBar && (
+      {showMobileAddBar && canMutate && (
         <div className="mr-addbar">
           <Button variant="brand" className="mr-addbar-btn" onClick={() => openLogForm()}>
             <Icon name="plus" size={17} stroke={2.2} />
@@ -1717,16 +2173,55 @@ export function AppMaintenanceRecords() {
 
       {formOpen && asset && (
         <div className={`mr-overlay mr-overlay-${overlayVariant}`}>
-          <div className="mr-scrim" onClick={() => { setFormOpen(false); setLogFromTaskId(null); }} />
+          <div
+            className="mr-scrim"
+            onClick={() => {
+              setFormOpen(false);
+              setLogFromTaskId(null);
+            }}
+          />
           <div className={`mr-overlay-panel-${overlayVariant}`}>
             <MRForm
               asset={asset}
               assetId={assetId}
               variant={overlayVariant}
-              onClose={() => { setFormOpen(false); setLogFromTaskId(null); }}
+              onClose={() => {
+                setFormOpen(false);
+                setLogFromTaskId(null);
+              }}
               onSaved={handleSaved}
               tasks={tasks}
               preselectedTaskId={logFromTaskId}
+            />
+          </div>
+        </div>
+      )}
+
+      {editingRecord && asset && (
+        <div className={`mr-overlay mr-overlay-${overlayVariant}`}>
+          <div className="mr-scrim" onClick={() => setEditingRecord(null)} />
+          <div className={`mr-overlay-panel-${overlayVariant}`}>
+            <MREditRecordForm
+              asset={asset}
+              record={editingRecord}
+              todayUtc={taskFormTodayUtc}
+              variant={overlayVariant}
+              onClose={() => setEditingRecord(null)}
+              onSaved={handleRecordUpdated}
+            />
+          </div>
+        </div>
+      )}
+
+      {deletingRecord && asset && (
+        <div className="mr-overlay mr-overlay-modal">
+          <div className="mr-scrim" onClick={() => setDeletingRecord(null)} />
+          <div className="mr-overlay-panel-modal">
+            <MRDeleteRecordDialog
+              assetId={assetId}
+              record={deletingRecord}
+              onClose={() => setDeletingRecord(null)}
+              onDeleted={handleRecordDeleted}
             />
           </div>
         </div>

--- a/apps/web/src/design/styles/mr.css
+++ b/apps/web/src/design/styles/mr.css
@@ -3,261 +3,967 @@
    Breakpoints use the same container contract: @container hfapp.
    Phones <=600 · tablet 601–1000 · desktop >1000. */
 
-.mr-root { position: relative; }
-.mr-scroll { overflow-y: auto; overflow-x: hidden; }
-.mr-scroll::-webkit-scrollbar { width: 10px; }
-.mr-scroll::-webkit-scrollbar-thumb { background: var(--hf-line); border-radius: var(--hf-r-sm); border: 3px solid transparent; background-clip: content-box; }
+.mr-root {
+  position: relative;
+}
+.mr-scroll {
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+.mr-scroll::-webkit-scrollbar {
+  width: 10px;
+}
+.mr-scroll::-webkit-scrollbar-thumb {
+  background: var(--hf-line);
+  border-radius: var(--hf-r-sm);
+  border: 3px solid transparent;
+  background-clip: content-box;
+}
 
 /* Buttons → design/Button + primitives.css (.hf-btn*). Brand CTAs use variant="brand". */
 
 /* ============ layout scaffolds ============ */
-.mr-main { flex: 1; min-height: 0; }
-.mr-body { flex: 1; min-height: 0; display: flex; }
+.mr-main {
+  flex: 1;
+  min-height: 0;
+}
+.mr-body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+}
 
 /* FOCUS — centered column */
-.mr-focus-wrap { max-width: 920px; margin: 0 auto; padding: 28px 32px 64px; display: flex; flex-direction: column; gap: 20px; }
+.mr-focus-wrap {
+  max-width: 920px;
+  margin: 0 auto;
+  padding: 28px 32px 64px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
 
 /* RAIL — master/detail */
 .mr-rail {
-  width: 320px; flex-shrink: 0; border-right: 1px solid var(--hf-line);
-  background: var(--hf-surface); display: flex; flex-direction: column; min-height: 0;
+  width: 320px;
+  flex-shrink: 0;
+  border-right: 1px solid var(--hf-line);
+  background: var(--hf-surface);
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
 }
 .mr-rail-head {
-  display: flex; align-items: center; justify-content: space-between;
-  padding: 16px 18px 10px; font-size: 13px; font-weight: 700; color: var(--hf-ink);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 18px 10px;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--hf-ink);
   letter-spacing: -0.01em;
 }
-.mr-rail-count { color: var(--hf-ink-faint); font-size: 11.5px; }
-.mr-rail-list { flex: 1; min-height: 0; overflow-y: auto; padding: 0 10px 14px; display: flex; flex-direction: column; gap: 2px; }
-.mr-rail-row {
-  display: flex; align-items: center; gap: 11px; width: 100%; text-align: left;
-  padding: 9px 10px; border-radius: var(--hf-r); border: 1px solid transparent; background: none;
+.mr-rail-count {
+  color: var(--hf-ink-faint);
+  font-size: 11.5px;
 }
-.mr-rail-row:hover { background: var(--hf-surface-2); }
-.mr-rail-row.active { background: var(--hf-brand-bg); }
-.mr-rail-row.active .mr-rail-row-name { color: var(--hf-brand-2); }
-.mr-rail-row-txt { min-width: 0; flex: 1; }
-.mr-rail-row-name { font-size: 13.5px; font-weight: 600; color: var(--hf-ink); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; letter-spacing: -0.01em; }
-.mr-rail-row-sub { font-size: 11.5px; color: var(--hf-ink-soft); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; margin-top: 1px; }
-.mr-detail { flex: 1; min-width: 0; }
-.mr-detail-inner { max-width: 860px; padding: 26px 32px 64px; display: flex; flex-direction: column; gap: 20px; }
+.mr-rail-list {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 0 10px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.mr-rail-row {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  width: 100%;
+  text-align: left;
+  padding: 9px 10px;
+  border-radius: var(--hf-r);
+  border: 1px solid transparent;
+  background: none;
+}
+.mr-rail-row:hover {
+  background: var(--hf-surface-2);
+}
+.mr-rail-row.active {
+  background: var(--hf-brand-bg);
+}
+.mr-rail-row.active .mr-rail-row-name {
+  color: var(--hf-brand-2);
+}
+.mr-rail-row-txt {
+  min-width: 0;
+  flex: 1;
+}
+.mr-rail-row-name {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--hf-ink);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  letter-spacing: -0.01em;
+}
+.mr-rail-row-sub {
+  font-size: 11.5px;
+  color: var(--hf-ink-soft);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-top: 1px;
+}
+.mr-detail {
+  flex: 1;
+  min-width: 0;
+}
+.mr-detail-inner {
+  max-width: 860px;
+  padding: 26px 32px 64px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
 
 /* TWO-PANE — workspace */
-.mr-main[data-layout="twopane"] { display: flex; flex-direction: column; }
-.mr-hero-band {
-  padding: 22px 36px 20px; border-bottom: 1px solid var(--hf-line);
-  background: var(--hf-surface); display: flex; flex-direction: column; gap: 14px; flex-shrink: 0;
+.mr-main[data-layout="twopane"] {
+  display: flex;
+  flex-direction: column;
 }
-.mr-twopane-grid { flex: 1; min-height: 0; display: grid; grid-template-columns: minmax(0,1fr) 360px; }
-.mr-twopane-main { min-width: 0; padding: 22px 32px 56px; overflow-y: auto; display: flex; flex-direction: column; gap: 18px; }
+.mr-hero-band {
+  padding: 22px 36px 20px;
+  border-bottom: 1px solid var(--hf-line);
+  background: var(--hf-surface);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  flex-shrink: 0;
+}
+.mr-twopane-grid {
+  flex: 1;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 360px;
+}
+.mr-twopane-main {
+  min-width: 0;
+  padding: 22px 32px 56px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
 .mr-twopane-side {
-  border-left: 1px solid var(--hf-line); background: var(--hf-surface);
-  padding: 22px 22px 40px; overflow-y: auto; display: flex; flex-direction: column; gap: 18px;
+  border-left: 1px solid var(--hf-line);
+  background: var(--hf-surface);
+  padding: 22px 22px 40px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
 }
 
 /* ============ breadcrumb ============ */
-.mr-crumb { display: flex; align-items: center; gap: 7px; font-size: 12.5px; }
-.mr-crumb-link { background: none; border: none; padding: 0; color: var(--hf-brand); font-weight: 600; font-size: 12.5px; }
-.mr-crumb-link:hover { text-decoration: underline; }
-.mr-crumb-cur { color: var(--hf-ink-soft); font-weight: 500; }
+.mr-crumb {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 12.5px;
+}
+.mr-crumb-link {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--hf-brand);
+  font-weight: 600;
+  font-size: 12.5px;
+}
+.mr-crumb-link:hover {
+  text-decoration: underline;
+}
+.mr-crumb-cur {
+  color: var(--hf-ink-soft);
+  font-weight: 500;
+}
 
 /* ============ hero ============ */
-.mr-hero { display: flex; align-items: center; gap: 16px; }
-.mr-hero-id { min-width: 0; flex: 1; }
-.mr-hero-name { margin: 0; font-size: 26px; font-weight: 700; letter-spacing: -0.025em; color: var(--hf-ink); line-height: 1.1; }
-.mr-hero-meta { margin-top: 5px; display: flex; align-items: center; gap: 9px; flex-wrap: wrap; font-size: 13px; color: var(--hf-ink-soft); }
-.mr-hero-meta .hf-mono { font-family: var(--hf-mono); font-size: 12px; color: var(--hf-ink); }
-.mr-dot { width: 3px; height: 3px; border-radius: 50%; background: var(--hf-ink-faint); }
-.mr-hero-add { align-self: flex-start; flex-shrink: 0; }
+.mr-hero {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+.mr-hero-id {
+  min-width: 0;
+  flex: 1;
+}
+.mr-hero-name {
+  margin: 0;
+  font-size: 26px;
+  font-weight: 700;
+  letter-spacing: -0.025em;
+  color: var(--hf-ink);
+  line-height: 1.1;
+}
+.mr-hero-meta {
+  margin-top: 5px;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  flex-wrap: wrap;
+  font-size: 13px;
+  color: var(--hf-ink-soft);
+}
+.mr-hero-meta .hf-mono {
+  font-family: var(--hf-mono);
+  font-size: 12px;
+  color: var(--hf-ink);
+}
+.mr-dot {
+  width: 3px;
+  height: 3px;
+  border-radius: 50%;
+  background: var(--hf-ink-faint);
+}
+.mr-hero-add {
+  align-self: flex-start;
+  flex-shrink: 0;
+}
 .mr-hero-actions {
-  display: flex; align-items: flex-start; gap: 8px; flex-shrink: 0; align-self: flex-start;
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  flex-shrink: 0;
+  align-self: flex-start;
 }
 
 /* ============ sharing (hero badge + action + sheet) ============ */
 .mr-share-badge {
-  margin-top: 8px; display: inline-flex; align-items: center; gap: 5px;
-  padding: 3px 9px 3px 7px; border-radius: var(--hf-r-full); border: 1px solid transparent;
-  font-size: 11px; font-weight: 600; letter-spacing: -0.005em;
-  max-width: 100%; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
-  font-family: var(--hf-sans); background: none;
+  margin-top: 8px;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 9px 3px 7px;
+  border-radius: var(--hf-r-full);
+  border: 1px solid transparent;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+  max-width: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-family: var(--hf-sans);
+  background: none;
 }
-.mr-share-badge span { overflow: hidden; text-overflow: ellipsis; }
+.mr-share-badge span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 .mr-share-badge.is-owner {
-  background: var(--hf-brand-bg); color: var(--hf-brand-2);
+  background: var(--hf-brand-bg);
+  color: var(--hf-brand-2);
   border-color: var(--hf-ok-border);
   cursor: pointer;
 }
 .mr-share-badge.is-member {
-  background: var(--hf-surface-2); color: var(--hf-ink-soft); border-color: var(--hf-line);
+  background: var(--hf-surface-2);
+  color: var(--hf-ink-soft);
+  border-color: var(--hf-line);
 }
 .mr-share-btn {
-  flex-shrink: 0; width: 38px; height: 38px; border-radius: var(--hf-r);
-  border: 1px solid var(--hf-line); background: var(--hf-surface);
-  color: var(--hf-ink-soft); display: flex; align-items: center; justify-content: center;
+  flex-shrink: 0;
+  width: 38px;
+  height: 38px;
+  border-radius: var(--hf-r);
+  border: 1px solid var(--hf-line);
+  background: var(--hf-surface);
+  color: var(--hf-ink-soft);
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
-.mr-share-btn:hover { color: var(--hf-ink); border-color: var(--hf-ink-faint); }
+.mr-share-btn:hover {
+  color: var(--hf-ink);
+  border-color: var(--hf-ink-faint);
+}
 .mr-share-btn.is-active {
-  background: var(--hf-brand-bg); border-color: var(--hf-ok-border); color: var(--hf-brand-2);
+  background: var(--hf-brand-bg);
+  border-color: var(--hf-ok-border);
+  color: var(--hf-brand-2);
 }
-.mr-share-btn:disabled { opacity: 0.55; cursor: not-allowed; }
+.mr-share-btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
 
 .mr-shr-strip {
-  display: flex; align-items: flex-start; gap: 9px;
-  margin-bottom: 14px; padding: 10px 12px;
-  background: var(--hf-surface-2); border: 1px solid var(--hf-line);
+  display: flex;
+  align-items: flex-start;
+  gap: 9px;
+  margin-bottom: 14px;
+  padding: 10px 12px;
+  background: var(--hf-surface-2);
+  border: 1px solid var(--hf-line);
   border-radius: var(--hf-r-sm, 10px);
-  font-size: 12px; color: var(--hf-ink-soft); line-height: 1.5;
+  font-size: 12px;
+  color: var(--hf-ink-soft);
+  line-height: 1.5;
 }
 
 .mr-shr-tile {
-  width: 52px; height: 52px; border-radius: var(--hf-r-lg);
-  background: var(--hf-brand-bg); color: var(--hf-brand-2);
-  display: flex; align-items: center; justify-content: center;
+  width: 52px;
+  height: 52px;
+  border-radius: var(--hf-r-lg);
+  background: var(--hf-brand-bg);
+  color: var(--hf-brand-2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
   margin: 2px auto 0;
 }
 .mr-shr-sub {
-  font-size: 13px; color: var(--hf-ink-soft); text-align: center; line-height: 1.5; padding: 0 6px;
+  font-size: 13px;
+  color: var(--hf-ink-soft);
+  text-align: center;
+  line-height: 1.5;
+  padding: 0 6px;
 }
 .mr-shr-team-row {
-  display: flex; align-items: center; gap: 11px;
-  padding: 12px 13px; border: 1px solid var(--hf-line); border-radius: var(--hf-r, 12px);
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  padding: 12px 13px;
+  border: 1px solid var(--hf-line);
+  border-radius: var(--hf-r, 12px);
   background: var(--hf-surface-2);
 }
 .mr-shr-team-mark {
-  width: 36px; height: 36px; border-radius: var(--hf-r);
-  background: var(--hf-surface); border: 1px solid var(--hf-line); color: var(--hf-brand-2);
-  display: flex; align-items: center; justify-content: center; flex-shrink: 0;
+  width: 36px;
+  height: 36px;
+  border-radius: var(--hf-r);
+  background: var(--hf-surface);
+  border: 1px solid var(--hf-line);
+  color: var(--hf-brand-2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
 }
-.mr-shr-team-name { font-size: 13.5px; font-weight: 600; color: var(--hf-ink); }
-.mr-shr-team-sub { font-size: 11.5px; color: var(--hf-ink-faint); margin-top: 1px; }
+.mr-shr-team-name {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--hf-ink);
+}
+.mr-shr-team-sub {
+  font-size: 11.5px;
+  color: var(--hf-ink-faint);
+  margin-top: 1px;
+}
 .mr-shr-owner-note {
-  display: flex; gap: 8px; padding: 10px 12px;
-  background: var(--hf-surface-2); border-radius: var(--hf-r-sm, 10px);
-  font-size: 12px; color: var(--hf-ink-soft); line-height: 1.5;
+  display: flex;
+  gap: 8px;
+  padding: 10px 12px;
+  background: var(--hf-surface-2);
+  border-radius: var(--hf-r-sm, 10px);
+  font-size: 12px;
+  color: var(--hf-ink-soft);
+  line-height: 1.5;
 }
 .mr-shr-unshare-btn {
-  width: 100%; padding: 13px; border-radius: var(--hf-r);
-  background: var(--hf-surface); border: 1.5px solid var(--hf-bad); color: var(--hf-bad);
-  font-size: 14.5px; font-weight: 600;
+  width: 100%;
+  padding: 13px;
+  border-radius: var(--hf-r);
+  background: var(--hf-surface);
+  border: 1.5px solid var(--hf-bad);
+  color: var(--hf-bad);
+  font-size: 14.5px;
+  font-weight: 600;
 }
-.mr-shr-unshare-btn:hover { background: color-mix(in oklch, var(--hf-bad) 8%, var(--hf-surface)); }
-.mr-shr-unshare-btn:disabled { opacity: 0.55; cursor: not-allowed; }
+.mr-shr-unshare-btn:hover {
+  background: color-mix(in oklch, var(--hf-bad) 8%, var(--hf-surface));
+}
+.mr-shr-unshare-btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
 .mr-shr-body {
-  display: flex; flex-direction: column; gap: 14px; padding: 8px 4px 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 8px 4px 4px;
 }
-.mr-shr-head-title { font-size: 17px; font-weight: 700; color: var(--hf-ink); letter-spacing: -0.02em; }
-.mr-shr-head-sub { font-size: 12.5px; color: var(--hf-ink-soft); margin-top: 2px; }
+.mr-shr-head-title {
+  font-size: 17px;
+  font-weight: 700;
+  color: var(--hf-ink);
+  letter-spacing: -0.02em;
+}
+.mr-shr-head-sub {
+  font-size: 12.5px;
+  color: var(--hf-ink-soft);
+  margin-top: 2px;
+}
 .mr-shr-error {
-  font-size: 12.5px; color: var(--hf-bad); line-height: 1.4; text-align: center;
+  font-size: 12.5px;
+  color: var(--hf-bad);
+  line-height: 1.4;
+  text-align: center;
 }
-.mr-shr-error a { color: var(--hf-bad); font-weight: 600; text-decoration: underline; }
+.mr-shr-error a {
+  color: var(--hf-bad);
+  font-weight: 600;
+  text-decoration: underline;
+}
 
 /* ============ tabs ============ */
-.mr-tabs { display: flex; gap: 4px; border-bottom: 1px solid var(--hf-line); margin-top: 2px; }
-.mr-tab {
-  position: relative; padding: 9px 4px 12px; margin-right: 18px; background: none; border: none;
-  font-size: 14px; font-weight: 500; color: var(--hf-ink-soft);
-  display: inline-flex; align-items: center; gap: 7px;
+.mr-tabs {
+  display: flex;
+  gap: 4px;
+  border-bottom: 1px solid var(--hf-line);
+  margin-top: 2px;
 }
-.mr-tab:hover { color: var(--hf-ink); }
-.mr-tab.active { color: var(--hf-ink); font-weight: 600; }
-.mr-tab.active::after { content: ""; position: absolute; left: 0; right: 0; bottom: -1px; height: 2px; background: var(--hf-brand); border-radius: var(--hf-r-full); }
-.mr-tab-count { font-family: var(--hf-mono); font-size: 11px; color: var(--hf-ink-faint); background: var(--hf-surface-2); border: 1px solid var(--hf-line); padding: 1px 6px; border-radius: var(--hf-r-full); }
-.mr-tab.active .mr-tab-count { color: var(--hf-brand-2); }
+.mr-tab {
+  position: relative;
+  padding: 9px 4px 12px;
+  margin-right: 18px;
+  background: none;
+  border: none;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--hf-ink-soft);
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+.mr-tab:hover {
+  color: var(--hf-ink);
+}
+.mr-tab.active {
+  color: var(--hf-ink);
+  font-weight: 600;
+}
+.mr-tab.active::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -1px;
+  height: 2px;
+  background: var(--hf-brand);
+  border-radius: var(--hf-r-full);
+}
+.mr-tab-count {
+  font-family: var(--hf-mono);
+  font-size: 11px;
+  color: var(--hf-ink-faint);
+  background: var(--hf-surface-2);
+  border: 1px solid var(--hf-line);
+  padding: 1px 6px;
+  border-radius: var(--hf-r-full);
+}
+.mr-tab.active .mr-tab-count {
+  color: var(--hf-brand-2);
+}
 
 /* ============ history head ============ */
-.mr-hist-wrap { display: flex; flex-direction: column; gap: 16px; }
-.mr-hist-head { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; }
-.mr-hist-head-txt { display: flex; align-items: baseline; gap: 10px; }
-.mr-hist-title { font-size: 14px; font-weight: 700; color: var(--hf-ink); letter-spacing: -0.01em; }
-.mr-hist-meta { font-family: var(--hf-mono); font-size: 11.5px; color: var(--hf-ink-faint); }
-.mr-density { display: flex; gap: 2px; background: var(--hf-surface-2); border: 1px solid var(--hf-line); border-radius: var(--hf-r); padding: 3px; }
-.mr-density button {
-  display: inline-flex; align-items: center; gap: 6px; padding: 5px 11px; border-radius: var(--hf-r-sm);
-  border: none; background: none; font-size: 12.5px; font-weight: 500; color: var(--hf-ink-soft);
+.mr-hist-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
 }
-.mr-density button.active { background: var(--hf-surface); color: var(--hf-ink); font-weight: 600; box-shadow: var(--hf-shadow-1); }
+.mr-hist-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+.mr-hist-head-txt {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+}
+.mr-hist-title {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--hf-ink);
+  letter-spacing: -0.01em;
+}
+.mr-hist-meta {
+  font-family: var(--hf-mono);
+  font-size: 11.5px;
+  color: var(--hf-ink-faint);
+}
+.mr-density {
+  display: flex;
+  gap: 2px;
+  background: var(--hf-surface-2);
+  border: 1px solid var(--hf-line);
+  border-radius: var(--hf-r);
+  padding: 3px;
+}
+.mr-density button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 11px;
+  border-radius: var(--hf-r-sm);
+  border: none;
+  background: none;
+  font-size: 12.5px;
+  font-weight: 500;
+  color: var(--hf-ink-soft);
+}
+.mr-density button.active {
+  background: var(--hf-surface);
+  color: var(--hf-ink);
+  font-weight: 600;
+  box-shadow: var(--hf-shadow-1);
+}
 
 /* ============ TIMELINE ============ */
-.mr-tl { display: flex; flex-direction: column; }
-.mr-tl-year { display: flex; align-items: center; gap: 12px; margin: 4px 0 14px; }
-.mr-tl-group:first-child .mr-tl-year { margin-top: 0; }
-.mr-tl-year > span:first-child { font-family: var(--hf-mono); font-size: 12px; font-weight: 700; color: var(--hf-ink); letter-spacing: 0.04em; }
-.mr-tl-year-line { flex: 1; height: 1px; background: var(--hf-line); }
+.mr-tl {
+  display: flex;
+  flex-direction: column;
+}
+.mr-tl-year {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 4px 0 14px;
+}
+.mr-tl-group:first-child .mr-tl-year {
+  margin-top: 0;
+}
+.mr-tl-year > span:first-child {
+  font-family: var(--hf-mono);
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--hf-ink);
+  letter-spacing: 0.04em;
+}
+.mr-tl-year-line {
+  flex: 1;
+  height: 1px;
+  background: var(--hf-line);
+}
 
-.mr-tl-item { display: grid; grid-template-columns: 150px 18px 1fr; gap: 0 14px; }
-.mr-tl-aside { text-align: right; padding-top: 1px; }
-.mr-tl-date { font-family: var(--hf-mono); font-size: 12px; font-weight: 600; color: var(--hf-ink); white-space: nowrap; }
-.mr-tl-ago { font-size: 11px; color: var(--hf-ink-faint); margin-top: 2px; }
-.mr-tl-rail { display: flex; flex-direction: column; align-items: center; }
-.mr-tl-dot { width: 13px; height: 13px; border-radius: 50%; background: var(--hf-surface); border: 2.5px solid var(--hf-brand); margin-top: 3px; flex-shrink: 0; box-shadow: 0 0 0 3px var(--hf-bg); z-index: 1; }
-.mr-tl-group:first-child .mr-tl-item:first-child .mr-tl-dot { background: var(--hf-brand); }
-.mr-tl-line { width: 2px; flex: 1; background: var(--hf-line); margin-top: 2px; }
-.mr-tl-body { min-width: 0; padding-bottom: 22px; }
-.mr-tl-group:last-child .mr-tl-item:last-child .mr-tl-body { padding-bottom: 2px; }
-.mr-tl-date-inline { display: none; align-items: center; gap: 8px; white-space: nowrap; font-family: var(--hf-mono); font-size: 11px; text-transform: uppercase; letter-spacing: 0.03em; color: var(--hf-ink-faint); }
-.mr-tl-ago-inline { color: var(--hf-ink-faint); }
-.mr-tl-title { font-size: 16px; font-weight: 600; color: var(--hf-ink); letter-spacing: -0.014em; line-height: 1.25; display: flex; align-items: center; gap: 9px; flex-wrap: wrap; }
-.mr-tl-notes { margin: 8px 0 0; padding: 10px 13px; background: var(--hf-surface); border: 1px solid var(--hf-line-soft); border-left: 3px solid var(--hf-brand); border-radius: var(--hf-r-sm); font-size: 13.5px; color: var(--hf-ink-soft); line-height: 1.5; text-wrap: pretty; }
-.mr-tl-sameday { display: inline-flex; align-items: center; white-space: nowrap; padding: 1px 8px; border-radius: var(--hf-r-full); background: var(--hf-brand-bg); color: var(--hf-brand-2); font-family: var(--hf-sans); font-size: 10px; font-weight: 600; letter-spacing: 0.01em; }
-.mr-tl-sameday-wide { display: inline-flex; }
-.mr-tl-date-inline .mr-tl-sameday { text-transform: none; }
+.mr-tl-item {
+  display: grid;
+  grid-template-columns: 150px 18px 1fr;
+  gap: 0 14px;
+}
+.mr-tl-aside {
+  text-align: right;
+  padding-top: 1px;
+}
+.mr-tl-date {
+  font-family: var(--hf-mono);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--hf-ink);
+  white-space: nowrap;
+}
+.mr-tl-ago {
+  font-size: 11px;
+  color: var(--hf-ink-faint);
+  margin-top: 2px;
+}
+.mr-tl-rail {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+.mr-tl-dot {
+  width: 13px;
+  height: 13px;
+  border-radius: 50%;
+  background: var(--hf-surface);
+  border: 2.5px solid var(--hf-brand);
+  margin-top: 3px;
+  flex-shrink: 0;
+  box-shadow: 0 0 0 3px var(--hf-bg);
+  z-index: 1;
+}
+.mr-tl-group:first-child .mr-tl-item:first-child .mr-tl-dot {
+  background: var(--hf-brand);
+}
+.mr-tl-line {
+  width: 2px;
+  flex: 1;
+  background: var(--hf-line);
+  margin-top: 2px;
+}
+.mr-tl-body {
+  min-width: 0;
+  padding-bottom: 22px;
+}
+.mr-tl-group:last-child .mr-tl-item:last-child .mr-tl-body {
+  padding-bottom: 2px;
+}
+.mr-tl-date-inline {
+  display: none;
+  align-items: center;
+  gap: 8px;
+  white-space: nowrap;
+  font-family: var(--hf-mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--hf-ink-faint);
+}
+.mr-tl-ago-inline {
+  color: var(--hf-ink-faint);
+}
+.mr-tl-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--hf-ink);
+  letter-spacing: -0.014em;
+  line-height: 1.25;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  flex-wrap: wrap;
+}
+.mr-tl-notes {
+  margin: 8px 0 0;
+  padding: 10px 13px;
+  background: var(--hf-surface);
+  border: 1px solid var(--hf-line-soft);
+  border-left: 3px solid var(--hf-brand);
+  border-radius: var(--hf-r-sm);
+  font-size: 13.5px;
+  color: var(--hf-ink-soft);
+  line-height: 1.5;
+  text-wrap: pretty;
+}
+.mr-tl-sameday {
+  display: inline-flex;
+  align-items: center;
+  white-space: nowrap;
+  padding: 1px 8px;
+  border-radius: var(--hf-r-full);
+  background: var(--hf-brand-bg);
+  color: var(--hf-brand-2);
+  font-family: var(--hf-sans);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+.mr-tl-sameday-wide {
+  display: inline-flex;
+}
+.mr-tl-date-inline .mr-tl-sameday {
+  text-transform: none;
+}
 
 /* ============ TABLE ============ */
-.mr-table { border: 1px solid var(--hf-line); border-radius: var(--hf-r-lg); overflow: hidden; background: var(--hf-surface); }
-.mr-thead, .mr-trow { display: grid; grid-template-columns: 168px minmax(0,1.4fr) minmax(0,2.1fr) 104px; gap: 18px; align-items: center; padding: 0 18px; }
-.mr-thead { height: 38px; background: var(--hf-surface-2); border-bottom: 1px solid var(--hf-line); }
-.mr-th { font-family: var(--hf-mono); font-size: 10.5px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; color: var(--hf-ink-faint); }
-.mr-th-logged, .mr-td-logged { text-align: right; }
-.mr-trow-year { padding: 9px 18px 7px; background: var(--hf-bg); border-bottom: 1px solid var(--hf-line-soft); }
-.mr-trow-year span { font-family: var(--hf-mono); font-size: 11px; font-weight: 700; color: var(--hf-ink-soft); letter-spacing: 0.04em; }
-.mr-trow { min-height: 52px; padding-top: 11px; padding-bottom: 11px; border-bottom: 1px solid var(--hf-line-soft); }
-.mr-tbody:last-child .mr-trow:last-child { border-bottom: none; }
-.mr-trow:hover { background: var(--hf-surface-2); }
-.mr-td { font-size: 13.5px; color: var(--hf-ink); min-width: 0; }
-.mr-td-date { display: flex; flex-direction: column; gap: 2px; }
-.mr-td-date-main { font-family: var(--hf-mono); font-size: 12.5px; font-weight: 600; color: var(--hf-ink); }
-.mr-td-date-ago { font-size: 11px; color: var(--hf-ink-faint); }
-.mr-td-work { font-weight: 600; letter-spacing: -0.01em; display: flex; align-items: center; gap: 9px; flex-wrap: wrap; }
-.mr-td-notes { font-size: 13px; color: var(--hf-ink-soft); line-height: 1.5; text-wrap: pretty; }
-.mr-td-dim { color: var(--hf-ink-faint); }
-.mr-td-logged { font-family: var(--hf-mono); font-size: 11.5px; color: var(--hf-ink-faint); }
+.mr-table {
+  border: 1px solid var(--hf-line);
+  border-radius: var(--hf-r-lg);
+  overflow: hidden;
+  background: var(--hf-surface);
+}
+.mr-thead,
+.mr-trow {
+  display: grid;
+  grid-template-columns: 168px minmax(0, 1.4fr) minmax(0, 2.1fr) 104px;
+  gap: 18px;
+  align-items: center;
+  padding: 0 18px;
+}
+.mr-thead {
+  height: 38px;
+  background: var(--hf-surface-2);
+  border-bottom: 1px solid var(--hf-line);
+}
+.mr-th {
+  font-family: var(--hf-mono);
+  font-size: 10.5px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--hf-ink-faint);
+}
+.mr-th-logged,
+.mr-td-logged {
+  text-align: right;
+}
+.mr-trow-year {
+  padding: 9px 18px 7px;
+  background: var(--hf-bg);
+  border-bottom: 1px solid var(--hf-line-soft);
+}
+.mr-trow-year span {
+  font-family: var(--hf-mono);
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--hf-ink-soft);
+  letter-spacing: 0.04em;
+}
+.mr-trow {
+  min-height: 52px;
+  padding-top: 11px;
+  padding-bottom: 11px;
+  border-bottom: 1px solid var(--hf-line-soft);
+}
+.mr-tbody:last-child .mr-trow:last-child {
+  border-bottom: none;
+}
+.mr-trow:hover {
+  background: var(--hf-surface-2);
+}
+.mr-td {
+  font-size: 13.5px;
+  color: var(--hf-ink);
+  min-width: 0;
+}
+.mr-td-date {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.mr-td-date-main {
+  font-family: var(--hf-mono);
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--hf-ink);
+}
+.mr-td-date-ago {
+  font-size: 11px;
+  color: var(--hf-ink-faint);
+}
+.mr-td-work {
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  flex-wrap: wrap;
+}
+.mr-td-notes {
+  font-size: 13px;
+  color: var(--hf-ink-soft);
+  line-height: 1.5;
+  text-wrap: pretty;
+}
+.mr-td-dim {
+  color: var(--hf-ink-faint);
+}
+.mr-td-logged {
+  font-family: var(--hf-mono);
+  font-size: 11.5px;
+  color: var(--hf-ink-faint);
+}
 
 /* Empty → design/EmptyState + primitives.css */
 
 /* ============ ERROR / 403 / 404 ============ */
-.mr-error { display: flex; flex-direction: column; align-items: center; justify-content: center; text-align: center; gap: 11px; padding: 52px 24px; }
-.mr-error-art { width: 60px; height: 60px; border-radius: var(--hf-r-lg); display: flex; align-items: center; justify-content: center; background: var(--hf-surface-2); border: 1px solid var(--hf-line); color: var(--hf-ink-soft); }
-.mr-error-error .mr-error-art, .mr-error-forbidden .mr-error-art { background: var(--hf-bad-bg); border-color: var(--hf-bad-border); color: var(--hf-bad); }
-.mr-error-title { font-size: 18px; font-weight: 700; color: var(--hf-ink); letter-spacing: -0.02em; }
-.mr-error-sub { font-size: 13.5px; color: var(--hf-ink-soft); line-height: 1.55; max-width: 340px; }
-.mr-error .hf-btn { margin-top: 4px; }
+.mr-error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  gap: 11px;
+  padding: 52px 24px;
+}
+.mr-error-art {
+  width: 60px;
+  height: 60px;
+  border-radius: var(--hf-r-lg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--hf-surface-2);
+  border: 1px solid var(--hf-line);
+  color: var(--hf-ink-soft);
+}
+.mr-error-error .mr-error-art,
+.mr-error-forbidden .mr-error-art {
+  background: var(--hf-bad-bg);
+  border-color: var(--hf-bad-border);
+  color: var(--hf-bad);
+}
+.mr-error-title {
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--hf-ink);
+  letter-spacing: -0.02em;
+}
+.mr-error-sub {
+  font-size: 13.5px;
+  color: var(--hf-ink-soft);
+  line-height: 1.55;
+  max-width: 340px;
+}
+.mr-error .hf-btn {
+  margin-top: 4px;
+}
 
 /* ============ LOADING SKELETON ============ */
-@keyframes mr-shimmer { 0% { background-position: -200px 0; } 100% { background-position: 320px 0; } }
-.mr-skel { display: block; height: 12px; border-radius: var(--hf-r-sm); background: linear-gradient(90deg, var(--hf-line-soft) 0px, var(--hf-line) 40px, var(--hf-line-soft) 80px); background-size: 320px 100%; animation: mr-shimmer 1.1s linear infinite; }
-.mr-skel-w40 { width: 40%; } .mr-skel-w50 { width: 50%; } .mr-skel-w70 { width: 70%; } .mr-skel-w75 { width: 75%; } .mr-skel-w80 { width: 80%; } .mr-skel-w90 { width: 90%; }
-.mr-skel-block { width: 100%; height: 34px; border-radius: var(--hf-r); }
-.mr-skel-tl { display: flex; flex-direction: column; gap: 22px; }
-.mr-skel-item { display: grid; grid-template-columns: 18px 1fr; gap: 14px; }
-.mr-skel-dot { width: 13px; height: 13px; border-radius: 50%; background: var(--hf-line); margin-top: 3px; }
-.mr-skel-lines { display: flex; flex-direction: column; gap: 9px; }
-.mr-skel-table { border: 1px solid var(--hf-line); border-radius: var(--hf-r-lg); overflow: hidden; }
-.mr-skel-trow { display: grid; grid-template-columns: 168px 1.4fr 2.1fr 104px; gap: 18px; align-items: center; padding: 16px 18px; border-bottom: 1px solid var(--hf-line-soft); }
-.mr-skel-trow:last-child { border-bottom: none; }
+@keyframes mr-shimmer {
+  0% {
+    background-position: -200px 0;
+  }
+  100% {
+    background-position: 320px 0;
+  }
+}
+.mr-skel {
+  display: block;
+  height: 12px;
+  border-radius: var(--hf-r-sm);
+  background: linear-gradient(
+    90deg,
+    var(--hf-line-soft) 0px,
+    var(--hf-line) 40px,
+    var(--hf-line-soft) 80px
+  );
+  background-size: 320px 100%;
+  animation: mr-shimmer 1.1s linear infinite;
+}
+.mr-skel-w40 {
+  width: 40%;
+}
+.mr-skel-w50 {
+  width: 50%;
+}
+.mr-skel-w70 {
+  width: 70%;
+}
+.mr-skel-w75 {
+  width: 75%;
+}
+.mr-skel-w80 {
+  width: 80%;
+}
+.mr-skel-w90 {
+  width: 90%;
+}
+.mr-skel-block {
+  width: 100%;
+  height: 34px;
+  border-radius: var(--hf-r);
+}
+.mr-skel-tl {
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+}
+.mr-skel-item {
+  display: grid;
+  grid-template-columns: 18px 1fr;
+  gap: 14px;
+}
+.mr-skel-dot {
+  width: 13px;
+  height: 13px;
+  border-radius: 50%;
+  background: var(--hf-line);
+  margin-top: 3px;
+}
+.mr-skel-lines {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+}
+.mr-skel-table {
+  border: 1px solid var(--hf-line);
+  border-radius: var(--hf-r-lg);
+  overflow: hidden;
+}
+.mr-skel-trow {
+  display: grid;
+  grid-template-columns: 168px 1.4fr 2.1fr 104px;
+  gap: 18px;
+  align-items: center;
+  padding: 16px 18px;
+  border-bottom: 1px solid var(--hf-line-soft);
+}
+.mr-skel-trow:last-child {
+  border-bottom: none;
+}
 
 /* ============ FORM ============ */
-.mr-form { display: flex; flex-direction: column; min-height: 0; }
-.mr-form-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; padding: 18px 20px 12px; flex-shrink: 0; }
-.mr-form-title { font-size: 18px; font-weight: 700; letter-spacing: -0.02em; color: var(--hf-ink); }
-.mr-form-sub { font-family: var(--hf-mono); font-size: 11.5px; color: var(--hf-ink-faint); margin-top: 3px; }
-.mr-form-close { width: 30px; height: 30px; border-radius: 50%; background: var(--hf-surface-2); border: 1px solid var(--hf-line); display: flex; align-items: center; justify-content: center; color: var(--hf-ink-soft); flex-shrink: 0; }
-.mr-form-close:hover { background: var(--hf-line-soft); color: var(--hf-ink); }
-.mr-form-body { flex: 1; min-height: 0; overflow-y: auto; padding: 4px 20px 18px; display: flex; flex-direction: column; gap: 16px; }
-.mr-form-actions { display: flex; gap: 10px; justify-content: flex-end; padding: 14px 20px; border-top: 1px solid var(--hf-line); flex-shrink: 0; }
-.mr-form-actions .mr-btn-save { min-width: 130px; }
+.mr-form {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+.mr-form-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 18px 20px 12px;
+  flex-shrink: 0;
+}
+.mr-form-title {
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--hf-ink);
+}
+.mr-form-sub {
+  font-family: var(--hf-mono);
+  font-size: 11.5px;
+  color: var(--hf-ink-faint);
+  margin-top: 3px;
+}
+.mr-form-close {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  background: var(--hf-surface-2);
+  border: 1px solid var(--hf-line);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--hf-ink-soft);
+  flex-shrink: 0;
+}
+.mr-form-close:hover {
+  background: var(--hf-line-soft);
+  color: var(--hf-ink);
+}
+.mr-form-body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 4px 20px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.mr-form-actions {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+  padding: 14px 20px;
+  border-top: 1px solid var(--hf-line);
+  flex-shrink: 0;
+}
+.mr-form-actions .mr-btn-save {
+  min-width: 130px;
+}
 
-.mr-banner { display: flex; align-items: center; gap: 9px; padding: 10px 12px; border-radius: var(--hf-r); background: var(--hf-bad-bg); border: 1px solid var(--hf-bad-border); color: var(--hf-bad); font-size: 13px; font-weight: 500; }
+.mr-banner {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 10px 12px;
+  border-radius: var(--hf-r);
+  background: var(--hf-bad-bg);
+  border: 1px solid var(--hf-bad-border);
+  color: var(--hf-bad);
+  font-size: 13px;
+  font-weight: 500;
+}
 
 /* Field component inside MR forms keeps former label weight */
 .mr-form .hf-field-label,
@@ -266,12 +972,32 @@
 }
 
 /* MR form controls — exact former metrics (not hf-input geometry). */
-.mr-field { display: flex; flex-direction: column; gap: 6px; }
-.mr-field-top { display: flex; align-items: baseline; justify-content: space-between; }
-.mr-field-label { font-size: 12.5px; font-weight: 600; color: var(--hf-ink); }
-.mr-req { color: var(--hf-bad); }
-.mr-field-count { font-family: var(--hf-mono); font-size: 10.5px; color: var(--hf-ink-faint); }
-.mr-field-count.over { color: var(--hf-bad); }
+.mr-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.mr-field-top {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+}
+.mr-field-label {
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--hf-ink);
+}
+.mr-req {
+  color: var(--hf-bad);
+}
+.mr-field-count {
+  font-family: var(--hf-mono);
+  font-size: 10.5px;
+  color: var(--hf-ink-faint);
+}
+.mr-field-count.over {
+  color: var(--hf-bad);
+}
 .mr-input {
   width: 100%;
   background: var(--hf-surface);
@@ -283,116 +1009,418 @@
   color: var(--hf-ink);
   letter-spacing: -0.01em;
   outline: none;
-  transition: border-color 100ms, box-shadow 100ms;
+  transition:
+    border-color 100ms,
+    box-shadow 100ms;
 }
-.mr-input:focus { border-color: var(--hf-brand); box-shadow: 0 0 0 3px var(--hf-brand-bg); }
-.mr-input::placeholder { color: var(--hf-ink-faint); }
+.mr-input:focus {
+  border-color: var(--hf-brand);
+  box-shadow: 0 0 0 3px var(--hf-brand-bg);
+}
+.mr-input::placeholder {
+  color: var(--hf-ink-faint);
+}
 .mr-input.err,
-.mr-input.is-invalid { border-color: var(--hf-bad); }
+.mr-input.is-invalid {
+  border-color: var(--hf-bad);
+}
 .mr-input.err:focus,
-.mr-input.is-invalid:focus { box-shadow: 0 0 0 3px var(--hf-bad-bg); }
-.mr-input-date { font-family: var(--hf-mono); font-size: 14px; }
-.mr-textarea { min-height: 88px; line-height: 1.5; resize: vertical; }
-.mr-field-hint { font-size: 11.5px; color: var(--hf-ink-faint); line-height: 1.4; }
-.mr-field-err { display: flex; align-items: center; gap: 5px; font-size: 11.5px; color: var(--hf-bad); font-weight: 500; }
+.mr-input.is-invalid:focus {
+  box-shadow: 0 0 0 3px var(--hf-bad-bg);
+}
+.mr-input-date {
+  font-family: var(--hf-mono);
+  font-size: 14px;
+}
+.mr-textarea {
+  min-height: 88px;
+  line-height: 1.5;
+  resize: vertical;
+}
+.mr-field-hint {
+  font-size: 11.5px;
+  color: var(--hf-ink-faint);
+  line-height: 1.4;
+}
+.mr-field-err {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 11.5px;
+  color: var(--hf-bad);
+  font-weight: 500;
+}
 
-.mr-spinner { width: 14px; height: 14px; border-radius: 50%; border: 2px solid var(--hf-spinner-track); border-top-color: var(--hf-on-brand); animation: mr-spin 0.7s linear infinite; }
-@keyframes mr-spin { to { transform: rotate(360deg); } }
+.mr-spinner {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 2px solid var(--hf-spinner-track);
+  border-top-color: var(--hf-on-brand);
+  animation: mr-spin 0.7s linear infinite;
+}
+@keyframes mr-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
 
 /* inline form (two-pane side) */
-.mr-form-inline { background: var(--hf-surface); border: 1px solid var(--hf-line); border-radius: var(--hf-r-lg); box-shadow: var(--hf-shadow-1); }
-.mr-form-inline .mr-form-head { padding: 16px 16px 10px; }
-.mr-form-inline .mr-form-body { padding: 0 16px 14px; overflow: visible; }
-.mr-form-inline .mr-form-actions { padding: 12px 16px; }
-.mr-form-inline .mr-form-actions .mr-btn-save { width: 100%; }
+.mr-form-inline {
+  background: var(--hf-surface);
+  border: 1px solid var(--hf-line);
+  border-radius: var(--hf-r-lg);
+  box-shadow: var(--hf-shadow-1);
+}
+.mr-form-inline .mr-form-head {
+  padding: 16px 16px 10px;
+}
+.mr-form-inline .mr-form-body {
+  padding: 0 16px 14px;
+  overflow: visible;
+}
+.mr-form-inline .mr-form-actions {
+  padding: 12px 16px;
+}
+.mr-form-inline .mr-form-actions .mr-btn-save {
+  width: 100%;
+}
 
 /* ============ side summary card ============ */
-.mr-side-card { background: var(--hf-bg); border: 1px solid var(--hf-line); border-radius: var(--hf-r-lg); padding: 16px; display: flex; flex-direction: column; gap: 14px; }
-.mr-side-card-row { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
-.mr-side-stat { background: var(--hf-surface); border: 1px solid var(--hf-line); border-radius: var(--hf-r); padding: 10px 12px; }
-.mr-side-stat-val { font-size: 20px; font-weight: 700; color: var(--hf-ink); letter-spacing: -0.02em; line-height: 1; }
-.mr-side-stat-lbl { font-size: 10.5px; font-weight: 500; color: var(--hf-ink-soft); text-transform: uppercase; letter-spacing: 0.05em; margin-top: 5px; }
-.mr-side-meta { display: flex; flex-direction: column; gap: 0; }
-.mr-side-meta-row { display: flex; align-items: center; justify-content: space-between; padding: 8px 0; border-top: 1px solid var(--hf-line-soft); font-size: 12.5px; }
-.mr-side-meta-row:first-child { border-top: none; }
-.mr-side-meta-row span { color: var(--hf-ink-soft); }
-.mr-side-meta-row b { color: var(--hf-ink); font-weight: 600; white-space: nowrap; }
+.mr-side-card {
+  background: var(--hf-bg);
+  border: 1px solid var(--hf-line);
+  border-radius: var(--hf-r-lg);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.mr-side-card-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+.mr-side-stat {
+  background: var(--hf-surface);
+  border: 1px solid var(--hf-line);
+  border-radius: var(--hf-r);
+  padding: 10px 12px;
+}
+.mr-side-stat-val {
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--hf-ink);
+  letter-spacing: -0.02em;
+  line-height: 1;
+}
+.mr-side-stat-lbl {
+  font-size: 10.5px;
+  font-weight: 500;
+  color: var(--hf-ink-soft);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-top: 5px;
+}
+.mr-side-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+.mr-side-meta-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 0;
+  border-top: 1px solid var(--hf-line-soft);
+  font-size: 12.5px;
+}
+.mr-side-meta-row:first-child {
+  border-top: none;
+}
+.mr-side-meta-row span {
+  color: var(--hf-ink-soft);
+}
+.mr-side-meta-row b {
+  color: var(--hf-ink);
+  font-weight: 600;
+  white-space: nowrap;
+}
 
 /* ============ mobile sticky add bar ============ */
-.mr-addbar { display: none; flex-shrink: 0; padding: 10px 16px calc(10px + env(safe-area-inset-bottom, 0px)); background: var(--hf-surface); border-top: 1px solid var(--hf-line); }
-.mr-addbar-btn { width: 100%; padding: 13px; font-size: 15px; }
+.mr-addbar {
+  display: none;
+  flex-shrink: 0;
+  padding: 10px 16px calc(10px + env(safe-area-inset-bottom, 0px));
+  background: var(--hf-surface);
+  border-top: 1px solid var(--hf-line);
+}
+.mr-addbar-btn {
+  width: 100%;
+  padding: 13px;
+  font-size: 15px;
+}
 
 /* ============ overlays ============ */
-.mr-overlay { position: absolute; inset: 0; z-index: 60; overflow: hidden; }
-.mr-scrim { position: absolute; inset: 0; background: var(--hf-scrim); animation: mr-fade 240ms ease-out; }
-@keyframes mr-fade { from { opacity: 0; } }
+.mr-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 60;
+  overflow: hidden;
+}
+.mr-scrim {
+  position: absolute;
+  inset: 0;
+  background: var(--hf-scrim);
+  animation: mr-fade 240ms ease-out;
+}
+@keyframes mr-fade {
+  from {
+    opacity: 0;
+  }
+}
 
 /* modal */
-.mr-overlay-panel-modal { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); width: min(480px, calc(100% - 40px)); max-height: calc(100% - 48px); background: var(--hf-bg); border-radius: var(--hf-r-xl); box-shadow: var(--hf-shadow-modal); overflow: hidden; display: flex; flex-direction: column; animation: mr-pop 160ms cubic-bezier(.3,.7,.4,1); }
-@keyframes mr-pop { from { opacity: 0; transform: translate(-50%, -46%) scale(0.97); } }
+.mr-overlay-panel-modal {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: min(480px, calc(100% - 40px));
+  max-height: calc(100% - 48px);
+  background: var(--hf-bg);
+  border-radius: var(--hf-r-xl);
+  box-shadow: var(--hf-shadow-modal);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  animation: mr-pop 160ms cubic-bezier(0.3, 0.7, 0.4, 1);
+}
+@keyframes mr-pop {
+  from {
+    opacity: 0;
+    transform: translate(-50%, -46%) scale(0.97);
+  }
+}
 
 /* drawer */
-.mr-overlay-panel-drawer { position: absolute; top: 0; right: 0; bottom: 0; width: min(440px, 100%); background: var(--hf-bg); box-shadow: var(--hf-shadow-drawer); display: flex; flex-direction: column; will-change: transform; animation: mr-slide-r 360ms cubic-bezier(0.32, 0.72, 0, 1); }
-@keyframes mr-slide-r { from { transform: translateX(100%); } }
+.mr-overlay-panel-drawer {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: min(440px, 100%);
+  background: var(--hf-bg);
+  box-shadow: var(--hf-shadow-drawer);
+  display: flex;
+  flex-direction: column;
+  will-change: transform;
+  animation: mr-slide-r 360ms cubic-bezier(0.32, 0.72, 0, 1);
+}
+@keyframes mr-slide-r {
+  from {
+    transform: translateX(100%);
+  }
+}
 
 /* sheet (mobile) */
-.mr-overlay-panel-sheet { position: absolute; left: 0; right: 0; bottom: 0; max-height: 92%; background: var(--hf-bg); border-radius: var(--hf-r-xl) var(--hf-r-xl) 0 0; box-shadow: var(--hf-shadow-sheet); display: flex; flex-direction: column; will-change: transform; animation: mr-slide-u 380ms cubic-bezier(0.32, 0.72, 0, 1); }
-@keyframes mr-slide-u { from { transform: translateY(100%); } }
-.mr-sheet-grab { width: 38px; height: 5px; border-radius: var(--hf-r-full); background: var(--hf-line); margin: 9px auto 0; flex-shrink: 0; }
+.mr-overlay-panel-sheet {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  max-height: 92%;
+  background: var(--hf-bg);
+  border-radius: var(--hf-r-xl) var(--hf-r-xl) 0 0;
+  box-shadow: var(--hf-shadow-sheet);
+  display: flex;
+  flex-direction: column;
+  will-change: transform;
+  animation: mr-slide-u 380ms cubic-bezier(0.32, 0.72, 0, 1);
+}
+@keyframes mr-slide-u {
+  from {
+    transform: translateY(100%);
+  }
+}
+.mr-sheet-grab {
+  width: 38px;
+  height: 5px;
+  border-radius: var(--hf-r-full);
+  background: var(--hf-line);
+  margin: 9px auto 0;
+  flex-shrink: 0;
+}
 
 /* =====================================================================
    OVERVIEW TAB
    ===================================================================== */
 
-.mr-overview { display: flex; flex-direction: column; gap: 24px; }
+.mr-overview {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
 
 /* health summary strip */
-.mr-health-row { display: flex; flex-wrap: wrap; gap: 8px; }
-.mr-health-chip {
-  display: inline-flex; align-items: center; gap: 7px;
-  padding: 7px 13px; border-radius: var(--hf-r-full);
-  font-size: 13px; border: 1px solid transparent;
+.mr-health-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
 }
-.mr-health-chip-dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
-.mr-health-chip-val { font-weight: 700; }
-.mr-health-chip-lbl { opacity: 0.85; }
+.mr-health-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 7px 13px;
+  border-radius: var(--hf-r-full);
+  font-size: 13px;
+  border: 1px solid transparent;
+}
+.mr-health-chip-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.mr-health-chip-val {
+  font-weight: 700;
+}
+.mr-health-chip-lbl {
+  opacity: 0.85;
+}
 
-.mr-health-chip-overdue { background: var(--hf-bad-bg);  color: var(--hf-bad);          border-color: var(--hf-bad-border); }
-.mr-health-chip-overdue .mr-health-chip-dot { background: var(--hf-bad); }
-.mr-health-chip-soon    { background: var(--hf-warn-bg); color: var(--hf-warn-ink);      border-color: var(--hf-warn-border); }
-.mr-health-chip-soon    .mr-health-chip-dot { background: var(--hf-warn); }
-.mr-health-chip-ok      { background: var(--hf-ok-bg);   color: var(--hf-ok);            border-color: var(--hf-ok-border); }
-.mr-health-chip-ok      .mr-health-chip-dot { background: var(--hf-ok); }
+.mr-health-chip-overdue {
+  background: var(--hf-bad-bg);
+  color: var(--hf-bad);
+  border-color: var(--hf-bad-border);
+}
+.mr-health-chip-overdue .mr-health-chip-dot {
+  background: var(--hf-bad);
+}
+.mr-health-chip-soon {
+  background: var(--hf-warn-bg);
+  color: var(--hf-warn-ink);
+  border-color: var(--hf-warn-border);
+}
+.mr-health-chip-soon .mr-health-chip-dot {
+  background: var(--hf-warn);
+}
+.mr-health-chip-ok {
+  background: var(--hf-ok-bg);
+  color: var(--hf-ok);
+  border-color: var(--hf-ok-border);
+}
+.mr-health-chip-ok .mr-health-chip-dot {
+  background: var(--hf-ok);
+}
 
 /* recent activity */
-.mr-recent { display: flex; flex-direction: column; gap: 12px; }
-.mr-recent-head { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
-.mr-recent-viewall {
-  display: inline-flex; align-items: center; gap: 3px;
-  background: none; border: none; padding: 0;
-  font-size: 13px; font-weight: 600; color: var(--hf-brand);
+.mr-recent {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
-.mr-recent-viewall:hover { text-decoration: underline; }
+.mr-recent-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+.mr-recent-viewall {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--hf-brand);
+}
+.mr-recent-viewall:hover {
+  text-decoration: underline;
+}
 
-.mr-recent-list { display: flex; flex-direction: column; }
-.mr-recent-row { display: flex; gap: 13px; align-items: stretch; padding: 10px 0; border-bottom: 1px solid var(--hf-line); }
-.mr-recent-row:last-child { border-bottom: none; }
+.mr-recent-list {
+  display: flex;
+  flex-direction: column;
+}
+.mr-recent-row {
+  display: flex;
+  gap: 13px;
+  align-items: stretch;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--hf-line);
+}
+.mr-recent-row:last-child {
+  border-bottom: none;
+}
 
-.mr-recent-dot-col { display: flex; flex-direction: column; align-items: center; padding-top: 5px; width: 12px; flex-shrink: 0; }
-.mr-recent-dot { width: 9px; height: 9px; border-radius: 50%; background: var(--hf-brand-bg); border: 2px solid var(--hf-brand); flex-shrink: 0; }
-.mr-recent-line { flex: 1; width: 1px; background: var(--hf-line); margin-top: 4px; min-height: 10px; }
-.mr-recent-row:last-child .mr-recent-line { display: none; }
+.mr-recent-dot-col {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-top: 5px;
+  width: 12px;
+  flex-shrink: 0;
+}
+.mr-recent-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--hf-brand-bg);
+  border: 2px solid var(--hf-brand);
+  flex-shrink: 0;
+}
+.mr-recent-line {
+  flex: 1;
+  width: 1px;
+  background: var(--hf-line);
+  margin-top: 4px;
+  min-height: 10px;
+}
+.mr-recent-row:last-child .mr-recent-line {
+  display: none;
+}
 
-.mr-recent-body { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 3px; }
-.mr-recent-title-row { display: flex; align-items: center; gap: 7px; flex-wrap: wrap; }
-.mr-recent-title { font-size: 13.5px; font-weight: 600; color: var(--hf-ink); }
-.mr-recent-meta { font-size: 12px; color: var(--hf-ink-soft); }
-.mr-recent-sep { margin: 0 3px; color: var(--hf-line); }
-.mr-recent-ago { color: var(--hf-ink-faint); }
+.mr-recent-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+.mr-recent-title-row {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  flex-wrap: wrap;
+}
+.mr-recent-title {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--hf-ink);
+}
+.mr-recent-meta {
+  font-size: 12px;
+  color: var(--hf-ink-soft);
+}
+.mr-recent-sep {
+  margin: 0 3px;
+  color: var(--hf-line);
+}
+.mr-recent-ago {
+  color: var(--hf-ink-faint);
+}
 
 .mr-recent-nil {
-  display: flex; align-items: center; gap: 8px;
-  font-size: 13px; color: var(--hf-ink-faint); padding: 14px 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--hf-ink-faint);
+  padding: 14px 0;
 }
 
 /* =====================================================================
@@ -400,138 +1428,420 @@
    ===================================================================== */
 
 /* section wrapper */
-.mr-schedule { display: flex; flex-direction: column; gap: 12px; }
-.mr-schedule-head {
-  display: flex; align-items: center; justify-content: space-between; gap: 12px;
+.mr-schedule {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
-.mr-schedule-head-left { display: flex; align-items: center; gap: 10px; }
-.mr-schedule-add-btn { padding: 7px 12px; font-size: 12.5px; }
+.mr-schedule-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.mr-schedule-head-left {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.mr-schedule-add-btn {
+  padding: 7px 12px;
+  font-size: 12.5px;
+}
 
 /* task list */
-.mr-task-list { display: flex; flex-direction: column; gap: 6px; }
+.mr-task-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
 
 /* task card */
 .mr-task-card {
-  display: flex; align-items: center; justify-content: space-between; gap: 12px;
-  padding: 12px 14px; border-radius: var(--hf-r-lg);
-  background: var(--hf-surface); border: 1px solid var(--hf-line);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: var(--hf-r-lg);
+  background: var(--hf-surface);
+  border: 1px solid var(--hf-line);
   transition: border-color 100ms;
 }
-.mr-task-card:hover { border-color: var(--hf-line-strong); }
+.mr-task-card:hover {
+  border-color: var(--hf-line-strong);
+}
 .mr-task-card[data-status="overdue"] {
-  background: linear-gradient(to right, var(--hf-bad-bg) 0%, var(--hf-bad-bg) 3px, var(--hf-surface) 3px);
+  background: linear-gradient(
+    to right,
+    var(--hf-bad-bg) 0%,
+    var(--hf-bad-bg) 3px,
+    var(--hf-surface) 3px
+  );
   border-color: var(--hf-bad-border);
 }
 .mr-task-card[data-status="soon"] {
-  background: linear-gradient(to right, var(--hf-warn-bg) 0%, var(--hf-warn-bg) 3px, var(--hf-surface) 3px);
+  background: linear-gradient(
+    to right,
+    var(--hf-warn-bg) 0%,
+    var(--hf-warn-bg) 3px,
+    var(--hf-surface) 3px
+  );
   border-color: var(--hf-warn-border);
 }
 
-.mr-task-card-main { display: flex; align-items: center; gap: 11px; min-width: 0; flex: 1; }
+.mr-task-card-main {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  min-width: 0;
+  flex: 1;
+}
 .mr-task-dot {
-  width: 9px; height: 9px; border-radius: 50%; flex-shrink: 0;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  flex-shrink: 0;
   background: var(--hf-line);
 }
-.mr-task-dot[data-status="overdue"] { background: var(--hf-bad); }
-.mr-task-dot[data-status="soon"]    { background: var(--hf-warn); }
-.mr-task-dot[data-status="ok"]      { background: var(--hf-ok); }
+.mr-task-dot[data-status="overdue"] {
+  background: var(--hf-bad);
+}
+.mr-task-dot[data-status="soon"] {
+  background: var(--hf-warn);
+}
+.mr-task-dot[data-status="ok"] {
+  background: var(--hf-ok);
+}
 
-.mr-task-info { min-width: 0; }
-.mr-task-title { font-size: 14px; font-weight: 600; color: var(--hf-ink); letter-spacing: -0.01em; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.mr-task-interval { font-size: 11.5px; color: var(--hf-ink-soft); margin-top: 2px; }
+.mr-task-info {
+  min-width: 0;
+}
+.mr-task-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--hf-ink);
+  letter-spacing: -0.01em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.mr-task-interval {
+  font-size: 11.5px;
+  color: var(--hf-ink-soft);
+  margin-top: 2px;
+}
 
-.mr-task-card-right { display: flex; align-items: center; gap: 8px; flex-shrink: 0; }
+.mr-task-card-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
 
 /* due badge */
 .mr-due-badge {
-  display: inline-flex; align-items: center; gap: 5px;
-  padding: 4px 9px; border-radius: var(--hf-r-full);
-  font-size: 11.5px; font-weight: 500; white-space: nowrap;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 9px;
+  border-radius: var(--hf-r-full);
+  font-size: 11.5px;
+  font-weight: 500;
+  white-space: nowrap;
   border: 1px solid transparent;
 }
-.mr-due-badge-overdue { background: var(--hf-bad-bg);  color: var(--hf-bad);             border-color: var(--hf-bad-border); }
-.mr-due-badge-soon    { background: var(--hf-warn-bg); color: var(--hf-warn-ink);         border-color: var(--hf-warn-border);  }
-.mr-due-badge-ok      { background: var(--hf-ok-bg);   color: var(--hf-ok);               border-color: var(--hf-ok-border);}
+.mr-due-badge-overdue {
+  background: var(--hf-bad-bg);
+  color: var(--hf-bad);
+  border-color: var(--hf-bad-border);
+}
+.mr-due-badge-soon {
+  background: var(--hf-warn-bg);
+  color: var(--hf-warn-ink);
+  border-color: var(--hf-warn-border);
+}
+.mr-due-badge-ok {
+  background: var(--hf-ok-bg);
+  color: var(--hf-ok);
+  border-color: var(--hf-ok-border);
+}
 
 /* task actions */
-.mr-task-actions { display: flex; align-items: center; gap: 6px; }
-.mr-task-log-btn { padding: 7px 12px; font-size: 12.5px; font-weight: 600; }
+.mr-task-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.mr-task-log-btn {
+  padding: 7px 12px;
+  font-size: 12.5px;
+  font-weight: 600;
+}
 .mr-task-del-btn {
-  width: 28px; height: 28px; border-radius: var(--hf-r-sm); flex-shrink: 0;
-  background: none; border: 1px solid transparent;
-  display: flex; align-items: center; justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: var(--hf-r-sm);
+  flex-shrink: 0;
+  background: none;
+  border: 1px solid transparent;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   color: var(--hf-ink-faint);
 }
-.mr-task-del-btn:hover { background: var(--hf-bad-bg); border-color: var(--hf-bad-border); color: var(--hf-bad); }
+.mr-task-del-btn:hover {
+  background: var(--hf-bad-bg);
+  border-color: var(--hf-bad-border);
+  color: var(--hf-bad);
+}
 .mr-task-edit-btn {
-  width: 28px; height: 28px; border-radius: var(--hf-r-sm); flex-shrink: 0;
-  background: none; border: 1px solid transparent;
-  display: flex; align-items: center; justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: var(--hf-r-sm);
+  flex-shrink: 0;
+  background: none;
+  border: 1px solid transparent;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   color: var(--hf-ink-faint);
 }
-.mr-task-edit-btn:hover { background: var(--hf-surface-2); border-color: var(--hf-line); color: var(--hf-ink); }
+.mr-task-edit-btn:hover {
+  background: var(--hf-surface-2);
+  border-color: var(--hf-line);
+  color: var(--hf-ink);
+}
+
+/* record actions */
+.mr-tl-head-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+}
+.mr-record-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+.mr-record-edit-btn,
+.mr-record-del-btn {
+  width: 26px;
+  height: 26px;
+  border-radius: var(--hf-r-sm);
+  flex-shrink: 0;
+  background: none;
+  border: 1px solid transparent;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--hf-ink-faint);
+  cursor: pointer;
+}
+.mr-record-edit-btn:hover {
+  background: var(--hf-surface-2);
+  border-color: var(--hf-line);
+  color: var(--hf-ink);
+}
+.mr-record-del-btn:hover {
+  background: var(--hf-bad-bg);
+  border-color: var(--hf-bad-border);
+  color: var(--hf-bad);
+}
+
+/* confirm dialog */
+.mr-confirm-dialog {
+  padding: 22px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.mr-confirm-dialog-title {
+  font-size: 17px;
+  font-weight: 700;
+  color: var(--hf-ink);
+  letter-spacing: -0.01em;
+}
+.mr-confirm-dialog-desc {
+  font-size: 13.5px;
+  color: var(--hf-ink-soft);
+  line-height: 1.5;
+}
+.mr-confirm-dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 8px;
+}
 
 /* delete confirm */
-.mr-task-confirm { display: flex; align-items: center; gap: 7px; }
-.mr-task-confirm-txt { font-size: 12.5px; font-weight: 500; color: var(--hf-ink); white-space: nowrap; }
-.mr-task-confirm-yes { padding: 6px 11px; font-size: 12.5px; background: var(--hf-bad); color: var(--hf-on-brand); border-color: var(--hf-bad); font-weight: 600; }
-.mr-task-confirm-yes:hover { background: var(--hf-bad-2); border-color: var(--hf-bad-2); }
-.mr-task-confirm-no { padding: 6px 11px; font-size: 12.5px; }
+.mr-task-confirm {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+.mr-task-confirm-txt {
+  font-size: 12.5px;
+  font-weight: 500;
+  color: var(--hf-ink);
+  white-space: nowrap;
+}
+.mr-task-confirm-yes {
+  padding: 6px 11px;
+  font-size: 12.5px;
+  background: var(--hf-bad);
+  color: var(--hf-on-brand);
+  border-color: var(--hf-bad);
+  font-weight: 600;
+}
+.mr-task-confirm-yes:hover {
+  background: var(--hf-bad-2);
+  border-color: var(--hf-bad-2);
+}
+.mr-task-confirm-no {
+  padding: 6px 11px;
+  font-size: 12.5px;
+}
 
 /* task empty state */
 .mr-task-empty {
-  display: flex; align-items: center; gap: 9px;
-  padding: 14px 16px; border-radius: var(--hf-r-lg);
-  background: var(--hf-surface-2); border: 1px dashed var(--hf-line);
-  font-size: 13px; color: var(--hf-ink-soft); line-height: 1.4;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 14px 16px;
+  border-radius: var(--hf-r-lg);
+  background: var(--hf-surface-2);
+  border: 1px dashed var(--hf-line);
+  font-size: 13px;
+  color: var(--hf-ink-soft);
+  line-height: 1.4;
 }
-.mr-task-empty-link { background: none; border: none; padding: 0; color: var(--hf-brand); font-weight: 600; font-size: 13px; text-decoration: underline; text-decoration-color: transparent; }
-.mr-task-empty-link:hover { text-decoration-color: var(--hf-brand); }
+.mr-task-empty-link {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--hf-brand);
+  font-weight: 600;
+  font-size: 13px;
+  text-decoration: underline;
+  text-decoration-color: transparent;
+}
+.mr-task-empty-link:hover {
+  text-decoration-color: var(--hf-brand);
+}
 
 /* task loading skeleton */
-.mr-task-skel { display: flex; flex-direction: column; gap: 8px; }
-.mr-task-skel-row {
-  display: flex; align-items: center; gap: 10px; padding: 11px 14px;
-  border-radius: var(--hf-r-lg); background: var(--hf-surface); border: 1px solid var(--hf-line);
+.mr-task-skel {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
-.mr-task-skel-row .mr-skel-dot { flex-shrink: 0; }
-.mr-task-skel-row .mr-skel { flex: 1; }
-.mr-task-skel-row .mr-skel:last-child { flex: 0; }
+.mr-task-skel-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 11px 14px;
+  border-radius: var(--hf-r-lg);
+  background: var(--hf-surface);
+  border: 1px solid var(--hf-line);
+}
+.mr-task-skel-row .mr-skel-dot {
+  flex-shrink: 0;
+}
+.mr-task-skel-row .mr-skel {
+  flex: 1;
+}
+.mr-task-skel-row .mr-skel:last-child {
+  flex: 0;
+}
 
 /* task badge on timeline / table records */
 .mr-tl-task-badge {
-  display: inline-flex; align-items: center; gap: 4px;
-  padding: 1px 7px; border-radius: var(--hf-r-full);
-  background: var(--hf-brand-bg); color: var(--hf-brand-2);
-  font-size: 10.5px; font-weight: 600; white-space: nowrap;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 1px 7px;
+  border-radius: var(--hf-r-full);
+  background: var(--hf-brand-bg);
+  color: var(--hf-brand-2);
+  font-size: 10.5px;
+  font-weight: 600;
+  white-space: nowrap;
   font-family: var(--hf-sans);
 }
 
 /* interval input row in create task form */
-.mr-interval-row { display: flex; align-items: center; gap: 10px; }
-.mr-interval-num { width: 76px; flex-shrink: 0; text-align: center; font-family: var(--hf-mono); }
+.mr-interval-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.mr-interval-num {
+  width: 76px;
+  flex-shrink: 0;
+  text-align: center;
+  font-family: var(--hf-mono);
+}
 .mr-unit-seg {
-  flex: 1; display: flex; gap: 2px; background: var(--hf-surface-2);
-  border: 1px solid var(--hf-line); border-radius: var(--hf-r); padding: 3px;
+  flex: 1;
+  display: flex;
+  gap: 2px;
+  background: var(--hf-surface-2);
+  border: 1px solid var(--hf-line);
+  border-radius: var(--hf-r);
+  padding: 3px;
 }
 .mr-unit-btn {
-  flex: 1; display: inline-flex; align-items: center; justify-content: center;
-  padding: 6px 4px; border-radius: var(--hf-r-sm); border: none; background: none;
-  font-size: 12.5px; font-weight: 500; color: var(--hf-ink-soft);
+  flex: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 4px;
+  border-radius: var(--hf-r-sm);
+  border: none;
+  background: none;
+  font-size: 12.5px;
+  font-weight: 500;
+  color: var(--hf-ink-soft);
 }
-.mr-unit-btn.active { background: var(--hf-surface); color: var(--hf-ink); font-weight: 600; box-shadow: var(--hf-shadow-1); }
+.mr-unit-btn.active {
+  background: var(--hf-surface);
+  color: var(--hf-ink);
+  font-weight: 600;
+  box-shadow: var(--hf-shadow-1);
+}
 
 /* select element */
-.mr-select { appearance: none; background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23999' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E"); background-repeat: no-repeat; background-position: right 12px center; padding-right: 34px; cursor: pointer; }
+.mr-select {
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23999' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
+  padding-right: 34px;
+  cursor: pointer;
+}
 
 /* =====================================================================
    RESPONSIVE — tasks
    ===================================================================== */
 @container hfapp (max-width: 600px) {
-  .mr-task-card { flex-direction: column; align-items: flex-start; gap: 10px; }
-  .mr-task-card-right { width: 100%; justify-content: space-between; }
-  .mr-interval-row { flex-wrap: wrap; }
-  .mr-unit-seg { min-width: 0; }
+  .mr-task-card {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 10px;
+  }
+  .mr-task-card-right {
+    width: 100%;
+    justify-content: space-between;
+  }
+  .mr-interval-row {
+    flex-wrap: wrap;
+  }
+  .mr-unit-seg {
+    min-width: 0;
+  }
 }
 
 /* =====================================================================
@@ -540,45 +1850,108 @@
 
 /* TABLET 601–1000 */
 @container hfapp (max-width: 1000px) {
-  .mr-twopane-grid { grid-template-columns: minmax(0,1fr) 320px; }
-  .mr-hero-band { padding: 20px 24px 18px; }
-  .mr-twopane-main { padding: 20px 24px 48px; }
-  .mr-focus-wrap { padding: 24px 24px 56px; }
-  .mr-detail-inner { padding: 22px 24px 56px; }
-  .mr-rail { width: 280px; }
-  .mr-hero-name { font-size: 23px; }
-  .mr-tl-item { grid-template-columns: 132px 18px 1fr; }
+  .mr-twopane-grid {
+    grid-template-columns: minmax(0, 1fr) 320px;
+  }
+  .mr-hero-band {
+    padding: 20px 24px 18px;
+  }
+  .mr-twopane-main {
+    padding: 20px 24px 48px;
+  }
+  .mr-focus-wrap {
+    padding: 24px 24px 56px;
+  }
+  .mr-detail-inner {
+    padding: 22px 24px 56px;
+  }
+  .mr-rail {
+    width: 280px;
+  }
+  .mr-hero-name {
+    font-size: 23px;
+  }
+  .mr-tl-item {
+    grid-template-columns: 132px 18px 1fr;
+  }
 }
 
 /* MOBILE <=600 */
 @container hfapp (max-width: 600px) {
-  .mr-body { flex-direction: column; }
-  .mr-rail { display: none; }              /* rail collapses to the detail */
-  .mr-detail-inner, .mr-focus-wrap { padding: 16px 16px 24px; gap: 16px; max-width: none; }
+  .mr-body {
+    flex-direction: column;
+  }
+  .mr-rail {
+    display: none;
+  } /* rail collapses to the detail */
+  .mr-detail-inner,
+  .mr-focus-wrap {
+    padding: 16px 16px 24px;
+    gap: 16px;
+    max-width: none;
+  }
 
-  .mr-hero { gap: 13px; }
-  .mr-hero-name { font-size: 20px; }
-  .mr-hero-add { display: none; }          /* sticky add bar takes over */
+  .mr-hero {
+    gap: 13px;
+  }
+  .mr-hero-name {
+    font-size: 20px;
+  }
+  .mr-hero-add {
+    display: none;
+  } /* sticky add bar takes over */
 
-  .mr-hero-band { padding: 16px 16px 14px; }
-  .mr-twopane-grid { display: block; }
-  .mr-twopane-main { padding: 16px 16px 24px; gap: 16px; }
+  .mr-hero-band {
+    padding: 16px 16px 14px;
+  }
+  .mr-twopane-grid {
+    display: block;
+  }
+  .mr-twopane-main {
+    padding: 16px 16px 24px;
+    gap: 16px;
+  }
 
   /* timeline: drop the date aside, show inline date above the title */
-  .mr-tl-item { grid-template-columns: 18px 1fr; }
-  .mr-tl-aside { display: none; }
-  .mr-tl-date-inline { display: flex; margin-bottom: 3px; }
-  .mr-tl-sameday-wide { display: none; }
-  .mr-tl-title { font-size: 15.5px; }
+  .mr-tl-item {
+    grid-template-columns: 18px 1fr;
+  }
+  .mr-tl-aside {
+    display: none;
+  }
+  .mr-tl-date-inline {
+    display: flex;
+    margin-bottom: 3px;
+  }
+  .mr-tl-sameday-wide {
+    display: none;
+  }
+  .mr-tl-title {
+    font-size: 15.5px;
+  }
 
-  .mr-addbar { display: block; }
+  .mr-addbar {
+    display: block;
+  }
 
-  .mr-hist-head { gap: 8px; }
-  .mr-root .hf-empty { padding: 40px 20px; min-height: 0; }
+  .mr-hist-head {
+    gap: 8px;
+  }
+  .mr-root .hf-empty {
+    padding: 40px 20px;
+    min-height: 0;
+  }
 }
 
 /* honour reduced motion */
 @media (prefers-reduced-motion: reduce) {
-  .mr-scrim, .mr-overlay-panel-modal, .mr-overlay-panel-drawer, .mr-overlay-panel-sheet { animation: none; }
-  .mr-skel { animation: none; }
+  .mr-scrim,
+  .mr-overlay-panel-modal,
+  .mr-overlay-panel-drawer,
+  .mr-overlay-panel-sheet {
+    animation: none;
+  }
+  .mr-skel {
+    animation: none;
+  }
 }

--- a/docs/reference/data-model.md
+++ b/docs/reference/data-model.md
@@ -88,9 +88,25 @@ The public shape and validation rules live in the [OpenAPI spec](openapi.json)
 
 - **`ownerId`** is copied from the target asset at creation and is not exposed
   in API responses.
+- **`revision`** is an internal optimistic-concurrency counter initialized to `0` and incremented
+  by each successful correction; it is not exposed in API responses.
 - **`performedAt`** is stored as a timezone-free `YYYY-MM-DD` calendar date.
   It is never converted to a timestamp for persistence or display.
 - Archived assets retain readable history but cannot receive new records.
+
+## Maintenance Task
+
+The public shape and validation rules live in the [OpenAPI spec](openapi.json)
+(`MaintenanceTask`, `CreateMaintenanceTaskBody`, `UpdateMaintenanceTaskBody`). Domain-only details:
+
+- **`scheduleSeedDate`** is an immutable date-only creation baseline. It is the supplied
+  `lastCompletedDate` or the UTC calendar date at creation when no completion was supplied; it is
+  never exposed in API responses or replaced by the current date during a later edit.
+- **`initialLastCompletedDate`** preserves the nullable completion value supplied at creation so
+  record deletion can restore the original uncompleted state. It is not exposed in API responses.
+- **`revision`** is an internal per-task optimistic-concurrency counter. Task edits, record
+  corrections that change derived task state, and task deletion increment it atomically and carry
+  the resulting value on their task events.
 
 ## Activity Entry
 
@@ -100,14 +116,19 @@ details:
 
 - **`ownerId`** scopes the entry to the owning user and is never exposed in API
   responses.
-- **`actorId`** is stored separately from `ownerId` for future delegation/team
-  attribution. In v1 they are the same user and the API does not display actor
-  copy.
+- **`actorId`** is stored separately from `ownerId` for delegation/team attribution. For shared
+  assets they may differ, and the API exposes the actor id plus the display-name snapshot carried
+  by the event; telemetry never writes the display name.
 - **Asset snapshots** (`asset_id`, `asset_name`, `asset_type`) are copied from
   the enriched event payload. Entries remain readable after an asset is renamed,
   archived, or after a task is deleted.
 - **`source_event_id`** is unique. The queue consumer inserts entries
   idempotently from this id so at-least-once delivery cannot duplicate history.
+- **Correction audit payloads** are retained in an internal `audit_snapshot_json` value for
+  `maintenance_record_updated` and `maintenance_record_deleted` entries. The payload contains the
+  normalized before/after or deleted record snapshot, including notes, with the original record
+  `createdAt`; the public `GET /api/activity` read model remains compact and never exposes this
+  payload, `taskId`, notes, or prior values.
 - Entries are immutable and append-only. There is no edit/delete history path.
 
 ## Team
@@ -131,23 +152,31 @@ Field shapes and validation rules live in the [OpenAPI spec](openapi.json)
 
 Aggregates raise events when something significant happens. Today:
 
-| Event                        | Raised when                                       | Carries                                                                                                                                                                                     |
-| ---------------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `AssetCreated`               | an asset is created                               | event id, asset/owner/actor, asset snapshot, type, optional year, and History `activityEntryType` conclusion                                                                                |
-| `MaintenanceRecordCreated`   | a maintenance record is created                   | event id, record/asset/owner/actor, asset snapshot, title, performed date, linked task id, and History `activityEntryType` conclusion                                                       |
-| `MaintenanceTaskCreated`     | a maintenance task is scheduled                   | event id, task/asset/owner/actor, asset snapshot, title, interval, resulting **`nextDue`**, and History `activityEntryType` conclusion                                                      |
-| `MaintenanceTaskUpdated`     | a task's title or interval is edited              | event id, task/asset/owner/actor, asset snapshot, title, interval, resulting **`nextDue`**, and History `activityEntryType` conclusion; published only when the edit changes a stored value |
-| `MaintenanceTaskAdvanced`    | a task is completed by a record                   | event id, task/record/asset/owner/actor, asset snapshot, title, performed date, resulting **`nextDue`**, and History `activityEntryType` conclusion                                         |
-| `MaintenanceTaskDeleted`     | a maintenance task is removed                     | event id, task/asset/owner/actor, asset snapshot, title, and History `activityEntryType` conclusion                                                                                         |
-| `NotificationEmailUpdated`   | a user sets/changes their contact email           | event id and `userId` only (no address — PII stays out of the event)                                                                                                                        |
-| `NotificationEmailVerified`  | a user's contact email becomes verified           | event id and `userId` only (no address)                                                                                                                                                     |
-| `NotificationEmailRemoved`   | a user clears their contact email                 | event id and `userId` only (no address)                                                                                                                                                     |
-| `MaintenanceReminderCreated` | a due-soon reminder is created                    | event id, notification/task/asset/owner ids, notification type, system actor, and lead-days conclusion                                                                                      |
-| `ReminderEmailDispatched`    | an aggregated reminder email decision is recorded | event id, email batch id, owner id, result, suppress reason, and covered notification count; no email address or reminder copy                                                              |
-| `TeamCreated`                | a team is created                                 | event id, team/owner/actor, and team name                                                                                                                                                   |
-| `AssetSharedToTeam`          | an asset is shared to a team                      | event id, asset/owner/actor, asset name, team id + name                                                                                                                                     |
-| `AssetUnsharedFromTeam`      | an asset is returned to personal                  | event id, asset/owner/actor, asset name, team id + name (of the team it left)                                                                                                               |
-| `AssetEdited`                | an asset's name and/or metadata is edited         | event id, asset/owner/actor, new and previous name, asset type, and `nameChanged`/`metadataChanged` flags                                                                                   |
+| Event                        | Raised when                                         | Carries                                                                                                                                                                                                       |
+| ---------------------------- | --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `AssetCreated`               | an asset is created                                 | event id, asset/owner/actor, asset snapshot, type, optional year, and History `activityEntryType` conclusion                                                                                                  |
+| `MaintenanceRecordCreated`   | a maintenance record is created                     | event id, record/asset/owner/actor, asset snapshot, title, performed date, linked task id, and History `activityEntryType` conclusion                                                                         |
+| `MaintenanceRecordUpdated`   | a maintenance record's title, date, or notes change | event id, record/asset/owner/actor snapshots, `createdAt`, resulting `recordRevision`, immutable linked task id, normalized before-and-after title/date/notes, and History `activityEntryType` conclusion     |
+| `MaintenanceRecordDeleted`   | a maintenance record is hard-deleted                | event id, record/asset/owner/actor snapshots, `createdAt`, deleted-event `recordRevision`, immutable linked task id, normalized deleted title/date/notes snapshot, and History `activityEntryType` conclusion |
+| `MaintenanceTaskCreated`     | a maintenance task is scheduled                     | event id, task/asset/owner/actor, asset snapshot, title, interval, resulting **`nextDue`**, and History `activityEntryType` conclusion                                                                        |
+| `MaintenanceTaskUpdated`     | a task's title or interval is edited                | event id, task/asset/owner/actor, asset snapshot, title, interval, resulting **`nextDue`**, and History `activityEntryType` conclusion; published only when the edit changes a stored value                   |
+| `MaintenanceTaskAdvanced`    | a task is completed by a record                     | event id, task/record/asset/owner/actor, asset snapshot, title, performed date, resulting **`nextDue`**, and History `activityEntryType` conclusion                                                           |
+| `MaintenanceTaskReconciled`  | a linked record correction changes task schedule    | event id, task/record/asset/owner/actor, asset snapshot, title, resulting `lastCompletedDate`/`nextDue`, and no duplicate completion History conclusion                                                       |
+| `MaintenanceTaskDeleted`     | a maintenance task is removed                       | event id, task/asset/owner/actor, asset snapshot, title, and History `activityEntryType` conclusion                                                                                                           |
+| `NotificationEmailUpdated`   | a user sets/changes their contact email             | event id and `userId` only (no address — PII stays out of the event)                                                                                                                                          |
+| `NotificationEmailVerified`  | a user's contact email becomes verified             | event id and `userId` only (no address)                                                                                                                                                                       |
+| `NotificationEmailRemoved`   | a user clears their contact email                   | event id and `userId` only (no address)                                                                                                                                                                       |
+| `MaintenanceReminderCreated` | a due-soon reminder is created                      | event id, notification/task/asset/owner ids, notification type, system actor, and lead-days conclusion                                                                                                        |
+| `ReminderEmailDispatched`    | an aggregated reminder email decision is recorded   | event id, email batch id, owner id, result (`sent` / `suppressed` / `failed` / `unknown`), suppress reason, and covered notification count; no email address or reminder copy                                 |
+| `TeamCreated`                | a team is created                                   | event id, team/owner/actor, and team name                                                                                                                                                                     |
+| `AssetSharedToTeam`          | an asset is shared to a team                        | event id, asset/owner/actor, asset name, team id + name                                                                                                                                                       |
+| `AssetUnsharedFromTeam`      | an asset is returned to personal                    | event id, asset/owner/actor, asset name, team id + name (of the team it left)                                                                                                                                 |
+| `AssetEdited`                | an asset's name and/or metadata is edited           | event id, asset/owner/actor, new and previous name, asset type, and `nameChanged`/`metadataChanged` flags                                                                                                     |
+
+`MaintenanceTaskCreated` carries `taskRevision = 0`. Every later task mutation carries the
+resulting revision after incrementing the prior value; `MaintenanceTaskDeleted` carries
+`priorRevision + 1` immediately before deleting the task row. `MaintenanceTaskReconciled` carries
+the resulting task revision but is not an Activity History event.
 
 Events are published after persistence through the in-memory event bus for
 telemetry. Tracked activity events are also written to an outbox in the same D1
@@ -184,7 +213,10 @@ it renders even after the source task is deleted or the asset archived.
   by source `maintenance_task_id`, with `status` (`pending` / `fired` /
   `canceled` / `superseded`), the `next_due` snapshot, the derived `fire_at`
   (`next_due − 7-day lead`, date-only), and `last_event_id` /
-  `last_event_occurred_at` for dedupe and order resolution. A partial unique
+  `last_event_occurred_at` / `last_task_revision` for dedupe and
+  `(taskRevision, kind, lowercase(eventId))` order
+  resolution. `last_event_id` and `last_task_revision` are provenance snapshots only; the
+  `notification_task_heads` row is the sole ordering authority. A partial unique
   index enforces at most one `pending` reminder per task, and a task-cycle
   unique index makes the one-time launch bootstrap idempotent on
   `(maintenance_task_id, next_due)`.
@@ -196,40 +228,74 @@ it renders even after the source task is deleted or the asset archived.
   the owner/sweep email aggregate. `ownerId` and `actorId` are never exposed in
   API responses; `actorId` is `"system"` and reserved for future delegation.
 - **`email_batches`** — one aggregated reminder email per owner per sweep, with
-  `status` (`pending` / `sent` / `suppressed` / `failed`), `suppress_reason`, and
-  the covered `notification_count`. The outbound consumer is idempotent on the
-  batch id.
+  `sweep_run_id`, `status` (`pending` / `sending` / `sent` / `suppressed` / `failed` / `unknown`),
+  nullable `claim_token`, nullable `lease_expires_at`, nullable `next_attempt_at`, and a
+  `retry_count` capped at three retries after the initial attempt. A claim token is unique per
+  `sending` attempt and is cleared when a claim returns to `pending` or reaches a terminal state;
+  provider-result and lease-reaper writes compare the stored token and unexpired lease in the same
+  conditional update. `suppress_reason`, and the covered `notification_count` are also stored. The
+  outbound consumer is idempotent on the batch id; `unknown` means the provider outcome may have
+  been accepted and must not be retried automatically.
 - **`notification_email_outbox`** — producer-side transactional outbox for
   reminder email jobs. The sweep writes this in the same D1 batch as
   `notifications`, fired reminder status updates, and `email_batches`; a later
-  queue relay moves pending rows to the outbound reminder-email queue.
-- **`notification_ingested_events`** — dedupe/order markers keyed by source
-  `event_id`, so at-least-once redelivery of a `MaintenanceTask*` event is a
-  no-op.
+  queue relay moves pending rows to the outbound reminder-email queue. Relay rows use
+  `pending` / `sending` / `sent` / `failed`, a claim token and lease, and durable attempt count;
+  confirmed pre-publication exhaustion sets both the outbox and `email_batches` to `failed`, while
+  an unknown publication sets the outbox to `failed` and the batch to `unknown`; each terminal
+  batch transition emits exactly one `ReminderEmailDispatched` observation.
+- **`notification_ingested_events`** — dedupe markers keyed by source `event_id`; ordering is
+  owned by `notification_task_heads`, while the scheduled reminder retains only event/revision
+  provenance for diagnostics.
+- **`notification_task_heads`** — one order/terminal marker per source task, storing the latest
+  `task_revision`, marker `kind` (`legacy` / `bootstrap` / `real` / `terminal-delete`), canonical
+  `event_id`, `current_next_due`, and status (`active` / `deleted`); this prevents an older event
+  from reactivating a task after deletion, including when a legacy delete arrives after bootstrap.
 - **`notification_dead_letters`** — durable copies of messages exhausted on the
-  notification queues / DLQs, so a permanently failing job is persisted, not
-  dropped.
+  notification queues / DLQs, keyed uniquely by `(queue, queue_message_id)` so a permanently
+  failing message is persisted once, not dropped or duplicated on redelivery. Existing rows use
+  `legacy:<id>` until replayed.
+- **`notification_sweep_runs`** — one durable row per deterministic cron `sweepRunId`, storing
+  non-null `id` (primary key), `cron_name`, `scheduled_time_epoch_ms`, status `running` /
+  `completed`, and created/completed timestamps, used to make a retried scheduled invocation reuse
+  its reminder claims and email batches. `(cron_name, scheduled_time_epoch_ms)` is unique.
+- **`notification_sweep_items`** — one non-null `(sweep_run_id, reminder_id)` primary-key claim row
+  per reminder in a sweep, with foreign keys to `notification_sweep_runs` and
+  `scheduled_reminders`, non-null `owner_id`, `claimed_at`, and `email_batch_id` referencing
+  `email_batches`. Every committed item has exactly one batch, including a `suppressed` batch when
+  no verified email exists, and the item's owner matches the batch owner.
+- **`notification_migration_anomalies`** — unresolved bootstrap repair rows; any non-null
+  `resolved_at` marks an operator-confirmed repair, and unresolved rows block deployment.
+- **`maintenance_write_gate`** — a singleton operational row used only during the seed/revision
+  migration rollout; `frozen` blocks maintenance writes while reads remain available, and `open`
+  is the normal state. It is not exposed through the API.
 
 ## Storage mapping
 
-| Domain concept        | D1 table                                     | Notes                                                                  |
-| --------------------- | -------------------------------------------- | ---------------------------------------------------------------------- |
-| `User`                | `users`                                      |                                                                        |
-| `Asset`               | `assets`                                     | `metadata` is a JSON string column                                     |
-| `Team`                | `teams` + `team_members`                     | unique index on `team_members.user_id` enforces one team per user      |
-| `MaintenanceRecord`   | `maintenance_records`                        | `performed_at` is a date-only text column                              |
-| `ActivityEntry`       | `activity_entries`                           | append-only history projection, ordered by `occurred_at` then `id`     |
-| Activity outbox       | `activity_event_outbox`                      | producer-side transactional outbox for the activity-history queue      |
-| Verification tokens   | `email_verification_tokens`                  | hashed, single-use, 24h TTL, scoped by `(user, email, purpose)`        |
-| Verification sends    | `email_verification_sends`                   | per-send audit rows backing the cooldown / per-address / per-user caps |
-| Scheduled reminders   | `scheduled_reminders`                        | notifications' own cancelable schedule, keyed by source task           |
-| Notifications         | `notifications`                              | durable in-app inbox; one per `(task, cycle)`                          |
-| Email batches         | `email_batches`                              | one aggregated reminder email per owner per sweep                      |
-| Reminder email outbox | `notification_email_outbox`                  | producer-side transactional outbox for aggregated reminder email jobs  |
-| Notification events   | `notification_ingested_events`               | inbound event dedupe/order markers                                     |
-| Notification DLQ      | `notification_dead_letters`                  | durable copy of exhausted notification-queue messages                  |
-| Queue dead letters    | `dead_letters`                               | durable copy of malformed or exhausted activity queue messages         |
-| Auth (Better Auth)    | `user`, `session`, `account`, `verification` | **singular** names; auth infra, separate from the domain `users` table |
+| Domain concept                   | D1 table                                     | Notes                                                                                                                                                                                  |
+| -------------------------------- | -------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `User`                           | `users`                                      |                                                                                                                                                                                        |
+| `Asset`                          | `assets`                                     | `metadata` is a JSON string column                                                                                                                                                     |
+| `Team`                           | `teams` + `team_members`                     | unique index on `team_members.user_id` enforces one team per user                                                                                                                      |
+| `MaintenanceRecord`              | `maintenance_records`                        | `performed_at` is a date-only text column; correction endpoints cannot change `task_id`, while task deletion explicitly unlinks it to null; `revision` supports correction concurrency |
+| `MaintenanceTask`                | `maintenance_tasks`                          | Stores mutable `last_completed_date`/`next_due` plus immutable `schedule_seed_date` and nullable `initial_last_completed_date` used to rebuild a task after linked-record corrections  |
+| `ActivityEntry`                  | `activity_entries`                           | append-only history projection, ordered by `occurred_at` then `id`                                                                                                                     |
+| Activity outbox                  | `activity_event_outbox`                      | producer-side transactional outbox for the activity-history queue                                                                                                                      |
+| Verification tokens              | `email_verification_tokens`                  | hashed, single-use, 24h TTL, scoped by `(user, email, purpose)`                                                                                                                        |
+| Verification sends               | `email_verification_sends`                   | per-send audit rows backing the cooldown / per-address / per-user caps                                                                                                                 |
+| Scheduled reminders              | `scheduled_reminders`                        | notifications' own cancelable schedule, keyed by source task                                                                                                                           |
+| Notifications                    | `notifications`                              | durable in-app inbox; one per `(task, cycle)`                                                                                                                                          |
+| Email batches                    | `email_batches`                              | one aggregated reminder email per owner per sweep                                                                                                                                      |
+| Reminder email outbox            | `notification_email_outbox`                  | producer-side transactional outbox for aggregated reminder email jobs                                                                                                                  |
+| Notification sweep runs          | `notification_sweep_runs`                    | deterministic cron-run identity for idempotent reminder claims                                                                                                                         |
+| Notification sweep items         | `notification_sweep_items`                   | durable reminder-to-sweep claim association                                                                                                                                            |
+| Notification events              | `notification_ingested_events`               | inbound event dedupe/order markers                                                                                                                                                     |
+| Notification task heads          | `notification_task_heads`                    | latest per-task revision and terminal deletion marker                                                                                                                                  |
+| Notification migration anomalies | `notification_migration_anomalies`           | unresolved bootstrap repairs block deployment                                                                                                                                          |
+| Maintenance write gate           | `maintenance_write_gate`                     | singleton migration quiescence control, not an API entity                                                                                                                              |
+| Notification DLQ                 | `notification_dead_letters`                  | durable copy of exhausted notification-queue messages                                                                                                                                  |
+| Queue dead letters               | `dead_letters`                               | durable copy of malformed or exhausted activity queue messages                                                                                                                         |
+| Auth (Better Auth)               | `user`, `session`, `account`, `verification` | **singular** names; auth infra, separate from the domain `users` table                                                                                                                 |
 
 Timestamps are stored as ISO-8601 strings. Schema lives in
 [`/migrations`](../../migrations) and is applied with

--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -572,6 +572,30 @@
           "maintenanceRecords"
         ]
       },
+      "UpdateMaintenanceRecordBody": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 100,
+            "example": "Changed synthetic oil"
+          },
+          "performedAt": {
+            "type": "string",
+            "format": "date",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+            "example": "2026-06-09"
+          },
+          "notes": {
+            "type": "string",
+            "nullable": true,
+            "maxLength": 1000,
+            "example": "Used 7 quarts of 5W-20 synthetic oil."
+          }
+        },
+        "additionalProperties": false
+      },
       "MaintenanceTask": {
         "type": "object",
         "properties": {
@@ -1002,6 +1026,8 @@
             "enum": [
               "asset_added",
               "maintenance_logged",
+              "maintenance_record_updated",
+              "maintenance_record_deleted",
               "task_completed",
               "task_scheduled",
               "task_updated",
@@ -1116,6 +1142,8 @@
             "enum": [
               "asset_added",
               "maintenance_logged",
+              "maintenance_record_updated",
+              "maintenance_record_deleted",
               "task_completed",
               "task_scheduled",
               "task_updated",
@@ -2002,6 +2030,213 @@
         }
       }
     },
+    "/api/assets/{assetId}/maintenance-records/{recordId}": {
+      "patch": {
+        "tags": [
+          "Maintenance"
+        ],
+        "summary": "Edit a maintenance record",
+        "description": "Updates title, performedAt, and/or notes. Empty string notes clears the notes. If the record is linked to a task, the task schedule is reconciled. CAS concurrency check retries on conflict. A no-op edit returns 200 with the unchanged record.",
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "195d0ef0-47f5-439f-abfd-29f892c9a040"
+            },
+            "required": true,
+            "name": "assetId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "e914b960-772f-46a7-b6fb-f333dcfc7fc9"
+            },
+            "required": true,
+            "name": "recordId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateMaintenanceRecordBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated maintenance record",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MaintenanceRecord"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The asset belongs to another user",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No such record or asset",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The asset is archived or concurrent conflict exceeded retries",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Maintenance writes are temporarily frozen",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Maintenance"
+        ],
+        "summary": "Delete a maintenance record",
+        "description": "Permanently deletes the maintenance record. If linked to a task, the task schedule is reconciled to the surviving records or initial baseline.",
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "195d0ef0-47f5-439f-abfd-29f892c9a040"
+            },
+            "required": true,
+            "name": "assetId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "e914b960-772f-46a7-b6fb-f333dcfc7fc9"
+            },
+            "required": true,
+            "name": "recordId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Maintenance record deleted"
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The asset belongs to another user",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No such record or asset",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The asset is archived or concurrent conflict exceeded retries",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Maintenance writes are temporarily frozen",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/assets/{assetId}/maintenance-tasks": {
       "post": {
         "tags": [
@@ -2387,6 +2622,8 @@
               "enum": [
                 "asset_added",
                 "maintenance_logged",
+                "maintenance_record_updated",
+                "maintenance_record_deleted",
                 "task_completed",
                 "task_scheduled",
                 "task_updated",

--- a/docs/specs/SPECS.md
+++ b/docs/specs/SPECS.md
@@ -40,8 +40,8 @@ relevant cross-cutting specs rather than re-describing the behavior.
 | [dashboard.md](./features/dashboard.md)                       | Home          | in-progress |
 | [activity-history.md](./features/activity-history.md)         | History       | in-progress |
 | [notifications.md](./features/notifications.md)               | Notifications | active      |
-| [maintenance-record.md](./features/maintenance-record.md)     | Maintenance   | draft       |
-| [maintenance-task.md](./features/maintenance-task.md)         | Maintenance   | active      |
+| [maintenance-record.md](./features/maintenance-record.md)     | Maintenance   | in-progress |
+| [maintenance-task.md](./features/maintenance-task.md)         | Maintenance   | in-progress |
 | [marketing-home.md](./features/marketing-home.md)             | Marketing     | active      |
 | [user-profile.md](./features/user-profile.md)                 | Identity      | active      |
 | [email-verification.md](./features/email-verification.md)     | Identity      | active      |

--- a/docs/specs/cross-cutting/error-handling.md
+++ b/docs/specs/cross-cutting/error-handling.md
@@ -21,15 +21,15 @@ Errors flow from the domain outward through a typed hierarchy. Use cases express
 
 **Domain error types (`packages/shared/src/errors.ts`):**
 
-| Subclass               | HTTP status | Meaning                                                      |
-| ---------------------- | ----------- | ------------------------------------------------------------ |
-| `NotFoundError`        | 404         | Entity does not exist or is not visible to the requester     |
-| `UnauthorizedError`    | 401         | No valid session                                             |
-| `ForbiddenError`       | 403         | Session is valid but requester lacks access to this resource |
-| `ValidationError`      | 422         | Input failed a domain rule; carries an optional `field` name |
-| `ConflictError`        | 409         | Operation would violate a uniqueness or state constraint     |
-| `TooManyRequestsError` | 429         | Caller exceeded a rate limit and should retry later          |
-| `InvariantError`       | 500         | Internal invariant violated; a bug, not a user error         |
+| Subclass               | HTTP status | Meaning                                                                               |
+| ---------------------- | ----------- | ------------------------------------------------------------------------------------- |
+| `NotFoundError`        | 404         | Entity does not exist, or an explicitly documented nested foreign reference is hidden |
+| `UnauthorizedError`    | 401         | No valid session                                                                      |
+| `ForbiddenError`       | 403         | Session is valid but requester lacks access to an existing direct resource            |
+| `ValidationError`      | 422         | Input failed a domain rule; carries an optional `field` name                          |
+| `ConflictError`        | 409         | Operation would violate a uniqueness or state constraint                              |
+| `TooManyRequestsError` | 429         | Caller exceeded a rate limit and should retry later                                   |
+| `InvariantError`       | 500         | Internal invariant violated; a bug, not a user error                                  |
 
 **Backend flow:**
 

--- a/docs/specs/cross-cutting/permissions.md
+++ b/docs/specs/cross-cutting/permissions.md
@@ -62,8 +62,9 @@ the requester to match that field.
 `asset.ownerId === requesterId`. A team member who can see a shared asset but
 does not own it receives 403 when attempting to change sharing.
 
-Note: the 403 vs 404 response for exists-but-forbidden access has not been
-explicitly decided. See Known Issues. This app currently returns 403.
+This is the canonical behavior for direct single-resource requests. A feature may
+define a narrower 404 exception for a foreign-reference validation inside another
+request, but it must document that exception explicitly.
 
 ---
 
@@ -84,8 +85,9 @@ Every feature spec must document:
 
 ## Exceptions
 
-| Feature | Deviation | Reason |
-| ------- | --------- | ------ |
+| Feature                                                                     | Deviation                          | Reason                                                                                                                                                |
+| --------------------------------------------------------------------------- | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Maintenance-record creation with an inaccessible `taskId` foreign reference | 404 instead of direct-resource 403 | The task id is validated as a nested foreign reference without revealing whether the task exists on another asset; direct task requests still use 403 |
 
 ---
 
@@ -107,18 +109,19 @@ Every feature spec must document:
 
 ## Known Issues
 
-- **403 vs 404 on wrong-owner single-resource access has not been decided.** The
-  current code returns 403, which reveals that the entity exists but the
-  requester cannot access it. An alternative is to return 404 unconditionally to
-  avoid leaking existence. **Planned:** make a deliberate call, document the
-  rationale here, and update the Canonical Behavior section accordingly. Tracked
-  in [#52](https://github.com/snaveevans/pineapple/issues/52).
+- **403 vs 404 on wrong-owner single-resource access is settled for the current
+  contract:** direct requests return 403, while only explicitly documented nested
+  foreign-reference checks may return 404. Broader callers that still need a
+  different privacy policy remain tracked in [#52](https://github.com/snaveevans/pineapple/issues/52),
+  but must not reintroduce ambiguity into feature specs.
 - **Different enforcement mechanisms for collections vs single resources.**
   Collections filter at the repo-query level; single resources check post-fetch
   at the use-case level. Both enforce the same invariant but in different places.
 - **Asset deletion is not yet implemented.** When added, it should remain
   asset-owner-only (team members may edit shared assets but not delete them).
-- **Archived resource visibility is inconsistent.** Collection queries filter out
-  archived assets, but single-resource access by ID does not exclude archived
-  entities. **Planned:** define the access policy for archived resources and
-  apply it consistently.
+- **Archived resource visibility is operation-specific.** Collections and reads
+  may include archived assets where a feature needs historical data; each feature
+  must explicitly define whether create, edit, and delete are allowed. Maintenance
+  tasks allow edits/deletes of existing tasks but reject new tasks, while
+  maintenance records allow edits/deletes on active accessible assets and reject
+  edits/deletes and new records on archived assets with 409.

--- a/docs/specs/cross-cutting/schema-migrations.md
+++ b/docs/specs/cross-cutting/schema-migrations.md
@@ -161,8 +161,9 @@ Every feature that changes the database must:
 
 ## Exceptions
 
-| Feature | Deviation | Reason |
-| ------- | --------- | ------ |
+| Feature                                                                                  | Deviation                                                                                 | Reason                                                                                                                                                                                                                                                                                |
+| ---------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Activity History type-constraint widening (`0019_activity_history_correction_types.sql`) | Rebuilds `activity_entries` and drops only the copied old table inside the same migration | SQLite cannot alter a `CHECK` constraint in place; the rebuild is an expand-safe constraint widening only when every column, row, foreign key, unique constraint, and index is copied and pre/post counts are validated. It does not remove an old shape or contract an unused field. |
 
 ## Anti-Patterns
 

--- a/docs/specs/features/activity-history.md
+++ b/docs/specs/features/activity-history.md
@@ -100,20 +100,24 @@ defines the API capability and behavior.
   that **I know whether a teammate or I logged it**
 - As a **user whose shared asset is later unshared**, I **stop seeing that asset's
   activity in my feed** so that **the feed only ever shows assets I can currently access**
+- As a **user who corrects a maintenance record**, I can **see the correction as a new immutable entry** so that **History never rewrites the original action**
+- As a **user who deletes a maintenance record**, I can **see that deletion in History even though the record is gone from maintenance history** so that **the action trail remains complete**
 
 ## What Counts as Activity
 
-Each tracked action becomes exactly one history entry. The six entry types and the
-existing domain events that drive them:
+Each tracked action becomes exactly one history entry. The following eight entry types are
+exhaustive for v1, and the table defines the existing domain event that drives each one:
 
-| Entry type           | User action                                 | Source domain event(s)                                                                                                                |
-| -------------------- | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `asset_added`        | Added an asset                              | `AssetCreated`                                                                                                                        |
-| `maintenance_logged` | Logged maintenance with no task advancement | `MaintenanceRecordCreated` whose producer-owned `activityEntryType` is `maintenance_logged`                                           |
-| `task_completed`     | Completed a scheduled task by logging work  | `MaintenanceTaskAdvanced`; the paired `MaintenanceRecordCreated` carries `activityEntryType: null`, so the pair is one entry, not two |
-| `task_scheduled`     | Scheduled a maintenance task                | `MaintenanceTaskCreated`                                                                                                              |
-| `task_updated`       | Edited a scheduled task's title or interval | `MaintenanceTaskUpdated`; published only when the edit changes a stored value ([maintenance-task.md](./maintenance-task.md))          |
-| `task_deleted`       | Removed a maintenance task                  | `MaintenanceTaskDeleted`                                                                                                              |
+| Entry type                   | User action                                 | Source domain event(s)                                                                                                                |
+| ---------------------------- | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `asset_added`                | Added an asset                              | `AssetCreated`                                                                                                                        |
+| `maintenance_logged`         | Logged maintenance with no task advancement | `MaintenanceRecordCreated` whose producer-owned `activityEntryType` is `maintenance_logged`                                           |
+| `maintenance_record_updated` | Corrected a maintenance record              | `MaintenanceRecordUpdated`; carries the current record snapshot and the prior values needed to explain the correction                 |
+| `maintenance_record_deleted` | Deleted a maintenance record                | `MaintenanceRecordDeleted`; carries the deleted record snapshot so the row renders after hard deletion                                |
+| `task_completed`             | Completed a scheduled task by logging work  | `MaintenanceTaskAdvanced`; the paired `MaintenanceRecordCreated` carries `activityEntryType: null`, so the pair is one entry, not two |
+| `task_scheduled`             | Scheduled a maintenance task                | `MaintenanceTaskCreated`                                                                                                              |
+| `task_updated`               | Edited a scheduled task's title or interval | `MaintenanceTaskUpdated`; published only when the edit changes a stored value ([maintenance-task.md](./maintenance-task.md))          |
+| `task_deleted`               | Removed a maintenance task                  | `MaintenanceTaskDeleted`                                                                                                              |
 
 Not tracked in v1: asset archive/unarchive (no domain event exists), profile/account
 changes, and sign-in events. See Out of Scope.
@@ -158,15 +162,16 @@ These are behavioral guarantees, not storage prescriptions:
 
 ## Delivery Plan
 
-| Slice | Scope                                                                                                                                                                                                          | Issue                                                    | Depends on                  |
-| ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- | --------------------------- |
-| `S1`  | Base activity history — durable log + queue consumer, `GET /api/activity`, entries, server-side filtering, cursor pagination, the `/app/history` page. Shipped on `main` (see Flags: `S1` box reconciliation). | —                                                        | —                           |
-| `S2`  | Shared-asset activity + actor attribution — feed spans owned + team-shared assets, entries expose the acting user, full shared-asset history. Delivers teams-foundation `S3`.                                  | [#73](https://github.com/snaveevans/pineapple/issues/73) | `S1`, teams-foundation `S2` |
-| `S3`  | `task_updated` entry type — a maintenance task edit produces a History entry. Delivers maintenance-task `S2`.                                                                                                  | #180                                                     | `S1`                        |
+| Slice | Scope                                                                                                                                                                                                          | Issue                                                      | Depends on                  |
+| ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- | --------------------------- |
+| `S1`  | Base activity history — durable log + queue consumer, `GET /api/activity`, entries, server-side filtering, cursor pagination, the `/app/history` page. Shipped on `main` (see Flags: `S1` box reconciliation). | —                                                          | —                           |
+| `S2`  | Shared-asset activity + actor attribution — feed spans owned + team-shared assets, entries expose the acting user, full shared-asset history. Delivers teams-foundation `S3`.                                  | [#73](https://github.com/snaveevans/pineapple/issues/73)   | `S1`, teams-foundation `S2` |
+| `S3`  | `task_updated` entry type — a maintenance task edit produces a History entry. Delivers maintenance-task `S2`.                                                                                                  | #180                                                       | `S1`                        |
+| `S4`  | `maintenance_record_updated` and `maintenance_record_deleted` entries from immutable correction events.                                                                                                        | [#181](https://github.com/snaveevans/pineapple/issues/181) | `S1`                        |
 
 ## API Requirements
 
-_Each criterion below carries exactly one slice tag (`S1` or `S2`) from the Delivery Plan above._
+_Each criterion below carries exactly one slice tag (`S1` through `S4`) from the Delivery Plan above._
 
 ### Read model
 
@@ -186,7 +191,8 @@ _Each criterion below carries exactly one slice tag (`S1` or `S2`) from the Deli
 - [ ] `S1` Entries are returned newest first by `occurredAt`, with a stable secondary
       tiebreak (e.g. entry id) so equal timestamps have a deterministic order
 - [ ] `S1` Each entry includes: a stable `id`, an entry `type` (one of `asset_added`,
-      `maintenance_logged`, `task_completed`, `task_scheduled`, `task_deleted`),
+      `maintenance_logged`, `maintenance_record_updated`, `maintenance_record_deleted`,
+      `task_completed`, `task_scheduled`, `task_updated`, `task_deleted`),
       `occurredAt`, and an asset snapshot (`id`, `name`, `type`) sufficient to render
       the row without an additional lookup
 - [x] `S2` Each entry additionally carries an **actor** attribution (a stable acting-user
@@ -195,9 +201,11 @@ _Each criterion below carries exactly one slice tag (`S1` or `S2`) from the Deli
       a teammate's (e.g. render "you" when the actor is the caller, otherwise the
       actor's display name); it exposes a display name and a stable id only — never
       the actor's email or auth-provider identifiers
-- [ ] `S1` Maintenance-related entries (`maintenance_logged`, `task_completed`,
-      `task_scheduled`, `task_deleted`) include the relevant title snapshot, and
-      `maintenance_logged` / `task_completed` include the `performedAt` date
+- [ ] `S1` Maintenance-related entries (`maintenance_logged`, `maintenance_record_updated`,
+      `maintenance_record_deleted`, `task_completed`, `task_scheduled`, `task_updated`,
+      `task_deleted`) include
+      the relevant title snapshot, and `maintenance_logged` / `maintenance_record_updated` /
+      `maintenance_record_deleted` / `task_completed` include the `performedAt` date
 - [ ] `S1` Completing a scheduled task by logging work produces exactly one
       `task_completed` entry; it never also produces a separate `maintenance_logged`
       entry for the same record
@@ -208,6 +216,9 @@ _Each criterion below carries exactly one slice tag (`S1` or `S2`) from the Deli
 - [x] `S3` `task_updated` is a valid entry `type`, sourced from `MaintenanceTaskUpdated`;
       an entry includes the task's post-edit title snapshot and follows the same entry
       shape as the other maintenance entry types
+- [ ] `S4` `maintenance_record_updated` is a valid entry `type`, sourced from `MaintenanceRecordUpdated`, and carries the current record title and performed date; its durable projection also retains `auditSnapshot = { recordId, taskId, createdAt, before: { title, performedAt, notes }, after: { title, performedAt, notes } }`, where `createdAt` is the original record creation timestamp and blank notes are `null`
+- [ ] `S4` `maintenance_record_deleted` is a valid entry `type`, sourced from `MaintenanceRecordDeleted`, and carries the deleted record title and performed date; its durable projection also retains `auditSnapshot = { recordId, taskId, createdAt, deleted: { title, performedAt, notes } }`, where `createdAt` is the original record creation timestamp and blank notes are `null`
+- [ ] `S4` `auditSnapshot` is internal nullable storage only; `GET /api/activity` never returns it, `taskId`, notes, or before/after/deleted values
 - [x] `S2` For a shared asset, the caller sees its **entire** activity history — including
       entries recorded before the asset was shared or before the caller joined the team
       — matching how a shared asset's maintenance records follow the asset. Sharing
@@ -237,7 +248,7 @@ _Each criterion below carries exactly one slice tag (`S1` or `S2`) from the Deli
       error and not a leak of existence)
 - [ ] `S1` v1 supports a single value per filter dimension (one type and/or one asset);
       multi-select and date ranges are out of scope
-- [ ] `S1` The web UI may narrow the already-loaded entries by title or asset name for
+- [ ] `S1` The web UI narrows the already-loaded entries by title or asset name for
       quick scanning, but this is not an API filter and does not search unloaded pages
 
 ### Pagination
@@ -246,11 +257,11 @@ _Each criterion below carries exactly one slice tag (`S1` or `S2`) from the Deli
       entries exist and a null/absent cursor when the caller has reached the end
 - [ ] `S1` The client requests the next page by passing the returned cursor; the cursor is
       opaque to the client
-- [ ] `S1` Cursor-page responses may return empty `availableFilters`; the client preserves
+- [ ] `S1` Cursor-page responses return empty `availableFilters`; the client preserves
       the first page's facets while loading older entries
 - [ ] `S1` A bounded page size applies (default and maximum defined at the Zod edge; the
-      maximum keeps a single response within Analytics Engine / Worker limits and a
-      reasonable payload size)
+      default is **20** and the maximum is **50**; values outside `1..50` return 422. The maximum
+      keeps a single response within Analytics Engine / Worker limits and a reasonable payload size
 - [ ] `S1` Active filters are preserved across pages (the cursor is valid only within the
       same filter set, or the filter params are re-sent alongside the cursor)
 
@@ -274,7 +285,7 @@ write-side ownership or 403-on-modify path.
 **Validation (Zod HTTP edge, per ADR-0007):** Query parameters are validated at the
 HTTP edge and drive the generated OpenAPI contract:
 
-- `type` — optional; must be one of the six entry-type enum values
+- `type` — optional; must be one of the eight entry-type enum values
 - `assetId` — optional; must be a UUID
 - `cursor` — optional; opaque string
 - `limit` — optional; integer within the supported range, with a default applied when
@@ -306,6 +317,8 @@ only and does not order the feed.
 | `cursor` is malformed or no longer valid for the filter set   | 422 validation error                                                                                                          |
 | Completing a scheduled task by logging work                   | Exactly one `task_completed` entry; never a duplicate `maintenance_logged` entry for the same record                          |
 | Logging ad-hoc maintenance (no `taskId`)                      | One `maintenance_logged` entry                                                                                                |
+| A maintenance record is edited                                | One `maintenance_record_updated` entry with the current record snapshot; the original entry remains immutable                 |
+| A maintenance record is hard-deleted                          | One `maintenance_record_deleted` entry with the deleted record snapshot; the record is still renderable in History            |
 | A task referenced by an entry is later deleted                | The entry remains and renders from its snapshot                                                                               |
 | An asset referenced by entries is later archived              | Entries remain; the asset still appears in the asset filter facet                                                             |
 | Two actions share the same `occurredAt`                       | Deterministic order via the secondary tiebreak; no flicker or duplication across pages                                        |
@@ -325,7 +338,8 @@ telemetry (telemetry.md anti-pattern), so the mapping must land with the route.
 
 **Domain events:** None new. History does not publish a domain event — reads do not
 produce events, and the feature emits nothing. It **consumes** the existing events
-(`AssetCreated`, `MaintenanceRecordCreated`, `MaintenanceTaskCreated`,
+(`AssetCreated`, `MaintenanceRecordCreated`, `MaintenanceRecordUpdated`,
+`MaintenanceRecordDeleted`, `MaintenanceTaskCreated`, `MaintenanceTaskUpdated`,
 `MaintenanceTaskAdvanced`, `MaintenanceTaskDeleted`), persisting one entry per action to
 its own durable store. Those events are enriched per
 [ADR-0010](../../decisions/0010-smart-events-for-durable-consumers.md) so the consumer
@@ -366,13 +380,16 @@ is **idempotent**: it writes each entry under a unique constraint on the source 
 (insert-or-ignore), so an at-least-once redelivery can never create a duplicate. A message
 that exhausts its retries lands in the queue's dead-letter queue and is persisted durably (a
 `dead_letters` record) rather than left to expire, so a poison event is captured for manual,
-idempotent-safe replay — not silently lost. Net effect:
+idempotent-safe replay — not silently lost. The dead-letter row is keyed by the queue name and the
+stable Cloudflare queue `message.id`; persistence uses insert-or-ignore on that pair and never
+uses a newly generated random id as the dedupe key. If D1 is unavailable, the consumer throws and
+leaves the message eligible for another queue delivery. Net effect:
 every action appears in History exactly once, capture never blocks or fails the user's
 action, and there is no silent-gap trade-off. Built this way from the start — no best-effort
 interim.
 
 **DECISION — Smart Events; History is a pure projection ([ADR-0010](../../decisions/0010-smart-events-for-durable-consumers.md)):**
-The six tracked events are enriched to carry the state and producer-owned conclusions a
+The eight tracked events are enriched to carry the state and producer-owned conclusions a
 durable consumer needs, and the History consumer writes each entry **directly from the
 event** — no read-back to D1:
 
@@ -380,10 +397,19 @@ event** — no read-back to D1:
   name is cross-aggregate, so the use case — which already loads the asset — supplies it
   when the event is published; it is never read inside an aggregate (ADR-0003).
 - Each maintenance event carries its own descriptive `title`
-  (`MaintenanceRecordCreated`, `MaintenanceTaskCreated`, `MaintenanceTaskUpdated`,
-  `MaintenanceTaskAdvanced`, `MaintenanceTaskDeleted`). Carrying `title` on
+  (`MaintenanceRecordCreated`, `MaintenanceRecordUpdated`, `MaintenanceRecordDeleted`,
+  `MaintenanceTaskCreated`, `MaintenanceTaskUpdated`, `MaintenanceTaskAdvanced`,
+  `MaintenanceTaskDeleted`). Carrying `title` on
   `MaintenanceTaskDeleted` is what lets a `task_deleted` entry render after the task row
   is gone (`DELETE FROM maintenance_tasks`).
+- `MaintenanceRecordUpdated` and `MaintenanceRecordDeleted` also carry the asset snapshot,
+  actor display-name snapshot, immutable record identity, and the complete normalized audit
+  snapshot described in the S4 requirements. The projection writes the compact title/date fields
+  used by the History API plus the private audit snapshot; it never reads the record back.
+- Asset and actor snapshots are captured from the successfully authorized mutation context at the
+  commit that creates the event. If the actor has no profile display name, the event carries the
+  deterministic display-name fallback `"Unknown"`; later asset renames or actor-name changes never
+  rewrite the entry.
 - Each tracked event carries a producer-owned `activityEntryType` conclusion. For
   static one-to-one mappings this is the event's fixed activity type; for
   `MaintenanceRecordCreated` it is `maintenance_logged` when the record itself should
@@ -398,6 +424,9 @@ event** — no read-back to D1:
 
 This holds ADR-0009's line: events carry domain state and conclusions, never presentation
 copy — the client still formats relative dates and labels.
+
+`MaintenanceTaskReconciled` is explicitly not one of the eight History events. It is a notification
+and scheduling conclusion only and never creates a History row.
 
 Telemetry handlers stay **thin selective readers**: the enriched fields are not added to
 their Analytics Engine writes, so the telemetry data-point contracts and their `v1` schema
@@ -419,10 +448,46 @@ below. This resolves the previously reserved actor-vs-owner field.
 **FOLLOW-UP — Reference docs at implementation time:** Adding the durable store
 introduces a new table and a new branded id (an activity-entry id). Update
 [data-model.md](../../reference/data-model.md) (storage mapping, branded value
-objects, the consumer, the enriched event payloads (all six tracked events per
+objects, the consumer, the enriched event payloads (all eight tracked events per
 ADR-0010), and the currently stale domain-events table) and add the web screen to
 [`docs/web/FEATURES.md`](../../web/FEATURES.md) when built. Regenerate the OpenAPI
 document from the new Zod route spec.
+
+The #181 migration is the planned `0019_activity_history_correction_types.sql`. Because SQLite
+stores the allowed type list in a table `CHECK`, this migration creates `activity_entries_new` with
+the complete eight-value type list and nullable `audit_snapshot_json TEXT`, copies every existing
+column and row unchanged, verifies equal row counts and preserved `source_event_id` uniqueness,
+foreign keys, and all three owner/type/asset indexes, then swaps the tables in one migration
+transaction. If any copy, count, uniqueness, foreign-key, or index preservation check fails, the
+migration aborts and the table swap rolls back; it does not record a warning and continue. Existing entries retain `audit_snapshot_json = NULL`; only correction entries
+populate it. The JSON is exactly one of:
+
+```json
+{
+  "recordId": "...",
+  "taskId": "...",
+  "createdAt": "...",
+  "before": { "title": "...", "performedAt": "YYYY-MM-DD", "notes": null },
+  "after": { "title": "...", "performedAt": "YYYY-MM-DD", "notes": null }
+}
+```
+
+or:
+
+```json
+{
+  "recordId": "...",
+  "taskId": null,
+  "createdAt": "...",
+  "deleted": { "title": "...", "performedAt": "YYYY-MM-DD", "notes": null }
+}
+```
+
+The formal shape is `taskId: string | null`; the updated form shows a linked record and the deleted
+form shows the valid unlinked case. The projection requires `json_valid(audit_snapshot_json) = 1`,
+validates the exact per-type object shape (no additional keys), stores no snapshot for any other
+type, and uses the record's current nullable link at event time. The API schema never selects this
+column.
 
 ## Out of Scope
 
@@ -448,7 +513,5 @@ document from the new Zod route spec.
 
 ## Open Questions
 
-- [ ] Exact page size (default and maximum) and cursor encoding — implementer's call
-      within the bounds above — engineering — resolve during implementation
 - [ ] Whether the asset filter facet should visually distinguish archived assets from
       active ones — design — resolve during web design

--- a/docs/specs/features/maintenance-record.md
+++ b/docs/specs/features/maintenance-record.md
@@ -7,103 +7,178 @@ metadata:
 
 # Maintenance Record
 
-**Status:** draft
+**Status:** in-progress
 **Owner:** [unknown - assign on review]
-**Last Updated:** 2026-06-04
-**Related Specs:** [authentication.md](../cross-cutting/authentication.md), [validation.md](../cross-cutting/validation.md), [error-handling.md](../cross-cutting/error-handling.md), [loading-states.md](../cross-cutting/loading-states.md), [permissions.md](../cross-cutting/permissions.md), [telemetry.md](../cross-cutting/telemetry.md), [dashboard.md](./dashboard.md), [maintenance-task.md](./maintenance-task.md)
+**Last Updated:** 2026-08-21
+**Related Specs:** [authentication.md](../cross-cutting/authentication.md), [validation.md](../cross-cutting/validation.md), [error-handling.md](../cross-cutting/error-handling.md), [loading-states.md](../cross-cutting/loading-states.md), [permissions.md](../cross-cutting/permissions.md), [telemetry.md](../cross-cutting/telemetry.md), [dashboard.md](./dashboard.md), [maintenance-task.md](./maintenance-task.md), [activity-history.md](./activity-history.md)
 
 ---
 
 ## Summary
 
-The Maintenance Record feature lets an authenticated user create dated maintenance log entries for an asset and view that asset's maintenance history. Records capture what was done, when it was done, and optional notes so the user can later answer questions like "when did I last change this?" without introducing service schedules, reminders, structured maintenance tasks, or component analytics.
+The Maintenance Record feature lets an authenticated user create, correct, delete, and view dated maintenance log entries for an asset. Records capture what was done, when it was done, and optional notes so the user can later answer questions like "when did I last change this?". When a record is linked to a recurring task, correcting or deleting the record also restores that task's schedule from its original seed and the remaining linked records; it never treats a correction as newly completed work.
 
 ## User Stories
 
-- As an **authenticated owner-operator**, I can **record completed maintenance on one of my assets** so that **I have a durable history of work I performed**
+- As an **authenticated user**, I can **record completed maintenance on an asset I can access** so that **the fleet has a durable history of work performed**
 - As **DIYer Dale**, I can **record a home air-filter change** so that **I can later see when I last changed it**
 - As **DIYer Dale**, I can **record a propane tank replacement on my toy hauler trailer** so that **I can later compare replacement history manually**
 - As **DIYer Dale**, I can **record a sprinkler replacement with location details in notes** so that **I can later spot repeated problems by reviewing the history**
 - As **DIYer Dale**, I can **record when I added water softener pellets** so that **I can later see my replenishment history**
-- As an **authenticated owner-operator**, I can **view maintenance records for an asset in reverse chronological order** so that **the most recent work is easiest to find**
+- As an **authenticated user**, I can **view maintenance records for an asset I can access in reverse chronological order** so that **the most recent work is easiest to find**
 - As a **user entering a maintenance record**, I can **see clear validation errors** so that **I know exactly what must be corrected before saving**
+- As an **authenticated user with access to an asset**, I can **edit a record's title, performed date, or notes** so that **I can correct a mistake without deleting the history entry**
+- As an **authenticated user with access to an asset**, I can **delete an incorrect maintenance record** so that **the maintenance history and any linked task schedule no longer rely on false data**
+- As a **user correcting a linked record**, I can **see the linked task's schedule recomputed from the surviving evidence** so that **a correction does not leave the next due date stale or silently shifted**
+- As a **user reviewing Activity History**, I can **see record corrections and deletions as additional immutable entries** so that **the action trail is preserved without rewriting prior events**
 
 ## Acceptance Criteria
 
-- [ ] A maintenance record is always tied to an existing asset owned by the authenticated user
-- [ ] The API never accepts `ownerId` in the request body; ownership is derived from the authenticated session
-- [ ] The create use case checks that the target asset exists and belongs to the authenticated user before creating the record
-- [ ] The list use case returns only records for an asset owned by the authenticated user
-- [ ] `POST /api/assets/{assetId}/maintenance-records` accepts `{ title, performedAt, notes?, taskId? }` and returns the full created maintenance record with status 201; `taskId` behavior is defined in [maintenance-task.md](./maintenance-task.md)
-- [ ] `GET /api/assets/{assetId}/maintenance-records` returns `{ maintenanceRecords: [...] }` with status 200
-- [ ] Maintenance record responses contain `id`, `assetId`, `title`, `performedAt`, nullable `notes`, nullable `taskId`, and `createdAt`; `ownerId` is never exposed
-- [ ] The user can start maintenance record creation from an asset detail page
-- [ ] The maintenance record form requires a **Title** field describing the work performed
-- [ ] Title is limited to 100 characters
-- [ ] The maintenance record form requires a **Performed date** field
-- [ ] The maintenance record form includes optional **Notes** for free-form details such as component location, observed condition, cost, vendor, quantity, or replacement context
-- [ ] Notes are limited to 1000 characters
-- [ ] The performed date must be today or earlier; future dates are rejected with a field-level validation error
-- [ ] Performed date is treated as date-only data in `YYYY-MM-DD` format, not as a user-local timestamp
-- [ ] The API uses the current UTC calendar date as the authoritative definition of today
-- [ ] An archived asset's maintenance history remains readable, but creating a new record for it returns 409
-- [ ] Submitting with missing or invalid required fields shows an error banner and field-level errors
-- [ ] Editing a field that has an error clears that field's error immediately
-- [ ] Save button shows "Saving..." and is disabled while save is in flight
-- [ ] On successful save, the asset's maintenance history includes the newly created record
-- [ ] On successful save, the user remains in or returns to the asset context where the record can be seen
-- [ ] The asset maintenance history shows records newest first by performed date
-- [ ] If two records have the same performed date, the most recently created record appears first
-- [ ] An asset with no maintenance records shows an empty state with an action to add the first record
-- [ ] A 401 response from the API redirects to `/login` through the API client layer
-- [ ] A 403 response is shown as an access-denied error if the asset exists but belongs to another user
-- [ ] A 404 response is shown as a not-found error if the asset does not exist
-- [ ] A non-401 API error shows a banner with the server error message; if the API identifies a specific field, the error is mapped to that field
-- [ ] Creating a maintenance record publishes a `MaintenanceRecordCreated` domain event
+- [ ] `S1` A maintenance record is always tied to an existing asset the requester can access
+- [ ] `S1` The API never accepts `ownerId` in the request body; record ownership is derived from the target asset, while the authenticated session supplies the actor/requester
+- [ ] `S1` The create use case checks that the target asset exists and the requester can access it before creating the record
+- [ ] `S1` The list use case returns only records for an asset the requester can access
+- [ ] `S1` `POST /api/assets/{assetId}/maintenance-records` accepts `{ title, performedAt, notes?, taskId? }` and returns the full created maintenance record with status 201; `taskId` behavior is defined in [maintenance-task.md](./maintenance-task.md)
+- [ ] `S1` `GET /api/assets/{assetId}/maintenance-records` returns `{ maintenanceRecords: [...] }` with status 200
+- [ ] `S1` Maintenance record responses contain `id`, `assetId`, `title`, `performedAt`, nullable `notes`, nullable `taskId`, and `createdAt`; `ownerId` is never exposed
+- [ ] `S1` The user can start maintenance record creation from an asset detail page
+- [ ] `S1` The maintenance record form requires a **Title** field describing the work performed
+- [ ] `S1` Title is limited to 100 characters
+- [ ] `S1` The maintenance record form requires a **Performed date** field
+- [ ] `S1` The maintenance record form includes optional **Notes** for free-form details such as component location, observed condition, cost, vendor, quantity, or replacement context
+- [ ] `S1` Notes are limited to 1000 characters
+- [ ] `S1` The performed date must be today or earlier; future dates are rejected with a field-level validation error
+- [ ] `S1` Performed date is treated as date-only data in `YYYY-MM-DD` format, not as a user-local timestamp
+- [ ] `S1` The API uses the current UTC calendar date as the authoritative definition of today
+- [ ] `S1` An archived asset's maintenance history remains readable, but creating a new record for it returns 409
+- [ ] `S1` Submitting with missing or invalid required fields shows an error banner and field-level errors
+- [ ] `S1` Editing a field that has an error clears that field's error immediately
+- [ ] `S1` Save button shows "Saving..." and is disabled while save is in flight
+- [ ] `S1` On successful save, the asset's maintenance history includes the newly created record
+- [ ] `S1` On successful save, the user stays on `/app/assets/{assetId}/maintenance`; the record list refreshes and the newly created record is visible
+- [ ] `S1` The asset maintenance history shows records newest first by performed date
+- [ ] `S1` If two records have the same performed date, the most recently created record appears first
+- [ ] `S1` An asset with no maintenance records shows an empty state with an action to add the first record
+- [ ] `S1` A 401 response from the API redirects to `/login` through the API client layer
+- [ ] `S1` A 403 response is shown as an access-denied error if the asset exists but the requester cannot access it
+- [ ] `S1` A 404 response is shown as a not-found error if the asset does not exist
+- [ ] `S1` A non-401 API error shows a banner with the server error message; if the API identifies a specific field, the error is mapped to that field
+- [ ] `S1` Creating a maintenance record publishes a `MaintenanceRecordCreated` domain event
+
+### Record editing
+
+- [ ] `S2` `PATCH /api/assets/{assetId}/maintenance-records/{recordId}` accepts one or more of `title`, `performedAt`, and `notes`, and returns the updated record with status 200
+- [ ] `S2` The edit request never accepts or changes `taskId`, `assetId`, `ownerId`, or `createdAt`
+- [ ] `S2` At least one editable field must be present; an empty edit body returns 422
+- [ ] `S2` Omitted editable fields remain unchanged; blank or explicit `null` `notes` normalizes to `null`; forbidden keys (`taskId`, `assetId`, `ownerId`, or `createdAt`) and every other unknown key return 422 instead of being silently stripped
+- [ ] `S2` Edited title, performed date, and notes use the same validation and normalization rules as record creation
+- [ ] `S2` A missing record or a record whose asset does not match the `{assetId}` path returns 404; otherwise editing requires current access to the record's asset, with inaccessible assets returning 403 and archived assets returning 409
+- [ ] `S2` Editing a record on an archived asset returns 409; archived history is readable but correction is blocked
+- [ ] `S2` Each record has an internal optimistic `revision` initialized to `0`; edits and deletes conditionally advance it, and the field is never accepted or returned by the API
+- [ ] `S2` Editing only title or notes does not change a linked task's schedule
+- [ ] `S2` Editing `performedAt` recomputes a linked task from the normalized edited record plus all other records still linked to the task, using its immutable schedule seed as defined in [maintenance-task.md](./maintenance-task.md)
+- [ ] `S2` An edit that produces no value changes at the record revision CAS linearization point returns the current record with status 200 and publishes no update event; if the revision changes before that point, the operation retries against fresh state instead of returning a stale no-op
+- [ ] `S2` A successful edit publishes exactly one `MaintenanceRecordUpdated` event containing the full normalized before-and-after record snapshots needed by History and durable consumers; it never publishes `MaintenanceRecordCreated`, `MaintenanceTaskAdvanced`, or `MaintenanceTaskUpdated`
+- [ ] `S2` The asset maintenance page exposes an edit action with a prefilled form and refreshes the record list and linked task after success
+
+### Record deletion
+
+- [ ] `S3` `DELETE /api/assets/{assetId}/maintenance-records/{recordId}` hard-deletes the record and returns 204
+- [ ] `S3` DELETE uses the same lookup precedence as PATCH: a missing record or record/asset path mismatch returns 404; an existing record on an inaccessible asset returns 403; an accessible archived asset returns 409, with access checked before archived state is revealed
+- [ ] `S3` Deleting a record on an archived asset returns 409; archived history is readable but deletion is blocked
+- [ ] `S3` Deleting a record never deletes or mutates other records
+- [ ] `S3` Deleting a linked record recomputes the task from all records still linked to the task, excluding the deleted record, using its immutable schedule seed as defined in [maintenance-task.md](./maintenance-task.md)
+- [ ] `S3` A successful deletion publishes exactly one `MaintenanceRecordDeleted` event containing the full normalized deleted-record snapshot needed by History; it never publishes `MaintenanceRecordCreated`, `MaintenanceTaskAdvanced`, or `MaintenanceTaskUpdated`
+- [ ] `S3` The asset maintenance page requires confirmation before deletion, shows a pending state, removes the record after success, and refreshes any linked task
+- [ ] `S3` Record persistence, linked-task reconciliation, implicit task-deletion unlinks, and producer-side outbox events commit atomically; task-affecting mutations use the task and record optimistic revisions, conditionally require every expected row update/delete to affect its snapshotted row count, attempt once and retry the complete operation up to three additional times against the latest state, and return 409 with no partial mutation after the fourth conflict
+
+### Correction history
+
+- [ ] `S2` A record edit creates an immutable `maintenance_record_updated` Activity History entry; the existing entry is not rewritten, and the durable projection retains the full normalized before-and-after snapshot including notes
+- [ ] `S3` A record deletion creates an immutable `maintenance_record_deleted` Activity History entry; the deleted record is absent from the maintenance-record list but remains represented in History, and the durable projection retains the full normalized deleted snapshot including notes
+- [ ] `S2` The asset-page edit flow exposes loading, success, validation, 401, 403, 404, 409, and frozen-write 503 states; archived assets do not render correction controls
+- [ ] `S3` The asset-page delete flow exposes confirmation, loading, success, retryable failure, 401, 403, 404, 409, and frozen-write 503 states; repeated deletion returns 404 and produces no second event
+
+## Delivery Plan
+
+| Slice | Scope                                                                                                                        | Issue                                                      | Depends on |
+| ----- | ---------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- | ---------- |
+| `S1`  | Existing record creation/listing and asset-page history. Shipped on `main`; acceptance boxes need brownfield reconciliation. | -                                                          | -          |
+| `S2`  | Edit record title, notes, or performed date; reconcile linked task schedule; publish correction events.                      | [#181](https://github.com/snaveevans/pineapple/issues/181) | `S1`       |
+| `S3`  | Delete records; preserve immutable History snapshots; add asset-page edit/delete controls.                                   | [#181](https://github.com/snaveevans/pineapple/issues/181) | `S2`       |
 
 ## Validation & Ownership
 
 **Authentication:** This feature is available only to authenticated users. API requests use the resolved `User.id` as `requesterId`.
 
-**Permissions:** Maintenance records are owned through the asset they belong to. A user can create and list maintenance records only for assets they own. The client cannot supply `ownerId`.
+**Permissions:** Maintenance records are owned through the asset they belong to. A user can create, list, edit, and delete maintenance records for active assets they can access: assets they own and assets shared with their team. Archived asset history remains readable, but archived records are not mutable in this slice. The record owner remains the asset owner, while `actorId` identifies the user who performed the mutation. The client cannot supply `ownerId`.
 
-**HTTP validation:** Inputs are validated at the Zod HTTP edge in `apps/api/src/api/schemas/maintenanceRecordSchemas.ts` and drive the generated OpenAPI contract. The schema requires `title` and `performedAt`, allows optional `notes`, enforces title length <= 100 characters, enforces notes length <= 1000 characters, validates `assetId` as a UUID, and rejects malformed calendar dates. The domain performs the authoritative current-UTC-date comparison.
+**HTTP validation:** Inputs are validated at the Zod HTTP edge in `apps/api/src/api/schemas/maintenanceRecordSchemas.ts` and drive the generated OpenAPI contract. The create schema requires `title` and `performedAt`, allows optional `notes` and `taskId`, enforces title length <= 100 characters, enforces notes length <= 1000 characters, validates path ids as UUIDs, and rejects malformed calendar dates. The edit schema allows only `title`, `performedAt`, and `notes`, requires at least one field, and never accepts `taskId`. The domain performs the authoritative current-UTC-date comparison.
 
-**Domain validation:** Domain construction trims title and notes, converts blank notes to `null`, and preserves these invariants: a maintenance record has an asset ID, owner ID derived from the session context, non-empty title of 100 characters or fewer, date-only performed date of today or earlier, nullable notes of 1000 characters or fewer, and a UTC creation timestamp.
+**Create lookup precedence when `taskId` is supplied:** resolve and authorize the path asset first (missing asset 404, inaccessible asset 403, archived path asset 409); then resolve the referenced task (missing task 404). If the task belongs to a different asset, check access to that task's parent asset: an inaccessible foreign task returns 404 and an accessible foreign task returns 422 with a `taskId` field error, regardless of whether that foreign asset is archived. A same-asset task proceeds with the already-authorized asset. This nested foreign-reference exception is recorded in [permissions.md](../cross-cutting/permissions.md); direct task requests remain 403 for an existing inaccessible task.
 
-**Date-only mitigation:** Until a cross-cutting time spec exists, this feature treats `performedAt` as a timezone-free calendar date string in `YYYY-MM-DD` format across the UI, API, domain, and D1 persistence. The implementation should compare dates lexicographically against today's `YYYY-MM-DD` value and must not parse `performedAt` through `Date` for validation, storage, or display. The stored maintenance date is not "in UTC"; it is a date-only value with no time zone. Generated timestamps such as `createdAt`, domain event time, and request telemetry time are UTC instants. Event telemetry may convert `performedAt` to UTC midnight only at the telemetry boundary because Analytics Engine doubles require a number.
+**Domain validation:** Domain construction and edit validation trim title and notes, convert blank notes to `null`, and preserve these invariants: a maintenance record has an asset ID, owner ID derived from the target asset, actor/requester ID derived from the session context, non-empty title of 100 characters or fewer, date-only performed date of today or earlier, nullable notes of 1000 characters or fewer, a task link that correction endpoints cannot change, an internal optimistic revision, and a UTC creation timestamp. Task deletion explicitly unlinks every linked record by setting its `taskId` to null and incrementing its record revision; no other operation changes the link. A record deletion has no replacement record state; its deleted snapshot is carried by the domain event.
+
+**Linked-task reconciliation:** When a linked record is edited, the application applies the normalized edit first and recomputes from that record plus all other records still linked to the task. When a record is deleted, recomputation excludes the deleted record. The task's immutable creation seed, initial completion state, and optimistic revision are internal fields and are not exposed in the maintenance-task API. The record's own optimistic revision is likewise internal. The exact formula and event boundary are defined in [maintenance-task.md](./maintenance-task.md); the record mutation and task update commit in one producer-side transaction. A task-affecting mutation reads the current task and record revisions, conditionally writes the resulting record/task state with each revision incremented by one, and retries the complete operation against fresh state after the initial attempt loses a race, up to three additional attempts. The fourth conflict returns 409 with the record, task, and outbox transaction rolled back; validation, 404, archive, and no-op outcomes are not retried. If task deletion wins a race, its required unlink is the current state used by the retry; a later record correction updates the now-unlinked record without reconciling a deleted task. If another correction deletes the record first, a competing edit retries and returns 404; if two edits race, their normalized PATCH operations serialize and the later successful operation wins. If an edit commits before delete, deletion uses the edited snapshot; if delete commits first, an edit retry returns 404; two deletes serialize with one 204/event and one 404/no event.
+
+**Persistence migration:** Add the record `revision`, an internal `legacy_revision_pending DEFAULT 1` discriminator, and the Activity History correction-audit payload through the expand/contract policy in [schema-migrations.md](../cross-cutting/schema-migrations.md). The new writer explicitly supplies `revision` and `legacy_revision_pending = 0`. The expansion includes an `AFTER INSERT` compatibility trigger that fills `revision = 0` only when `legacy_revision_pending = 1`, then sets the discriminator to `0`; it has no UPDATE trigger and never overwrites a backfilled or incremented revision. Existing records receive the same value idempotently before correction code is promoted. The durable History projection adds its internal audit snapshot storage without changing existing entries. The pre-deploy validation query must report zero rows with a null record revision, and the deploy workflow must stop before Worker deployment when the count is nonzero. The trigger is removed only in a later contract migration after the new writer is live.
+
+**Date-only mitigation:** Until a cross-cutting time spec exists, this feature treats `performedAt` as a timezone-free calendar date string in `YYYY-MM-DD` format across the UI, API, domain, and D1 persistence. The implementation must compare dates lexicographically against today's `YYYY-MM-DD` value and must not parse `performedAt` through `Date` for validation, storage, or display. The stored maintenance date is not "in UTC"; it is a date-only value with no time zone. Generated timestamps such as `createdAt`, domain event time, and request telemetry time are UTC instants. Event telemetry may convert `performedAt` to UTC midnight only at the telemetry boundary because Analytics Engine doubles require a number.
 
 **Field errors:** Validation errors map back to `title`, `performedAt`, and `notes` when the backend includes a known `field` value.
 
 ## Edge Cases & Error States
 
-| Scenario                                            | Expected Behavior                                                           |
-| --------------------------------------------------- | --------------------------------------------------------------------------- |
-| Asset has no maintenance records                    | Empty state shown with an add action                                        |
-| Title is empty                                      | Save blocked; title field shows a required-field error                      |
-| Title is over 100 characters                        | Save blocked; title field shows a max-length error                          |
-| Performed date is empty                             | Save blocked; performed date field shows a required-field error             |
-| Performed date is in the future                     | Save blocked; performed date field shows a "must be today or earlier" error |
-| Notes is empty or whitespace-only                   | Accepted and normalized to `null`                                           |
-| Notes is over 1000 characters                       | Save blocked; notes field shows a max-length error                          |
-| Notes contains component details                    | Accepted as free text; no structured component/location fields are created  |
-| Asset is archived and history is requested          | Existing maintenance history is returned                                    |
-| Asset is archived and record creation is attempted  | Creation rejected with 409                                                  |
-| User submits and the API returns 422 with a field   | Banner shown and the server message is pinned to the matching form field    |
-| User submits and the API returns 422 without field  | Banner shown; no field highlighted                                          |
-| User submits and the API returns 401                | Redirect to `/login` (replace history entry)                                |
-| User submits or views another user's asset          | 403 access-denied treatment                                                 |
-| User submits or views a missing asset               | 404 not-found treatment                                                     |
-| Maintenance history request fails                   | Error state shown with retry action                                         |
-| Maintenance history request is pending              | Loading state shown; history area is not blank                              |
-| User edits a field after a failed submit            | Field error clears and mutation error state resets                          |
-| User records two entries on the same performed date | Both records are shown; newest created entry sorts first within that date   |
+| Scenario                                                                      | Expected Behavior                                                                                                                                   |
+| ----------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Asset has no maintenance records                                              | Empty state shown with an add action                                                                                                                |
+| Title is empty                                                                | Save blocked; title field shows a required-field error                                                                                              |
+| Title is over 100 characters                                                  | Save blocked; title field shows a max-length error                                                                                                  |
+| Performed date is empty                                                       | Save blocked; performed date field shows a required-field error                                                                                     |
+| Performed date is in the future                                               | Save blocked; performed date field shows a "must be today or earlier" error                                                                         |
+| Notes is empty or whitespace-only                                             | Accepted and normalized to `null`                                                                                                                   |
+| Notes is over 1000 characters                                                 | Save blocked; notes field shows a max-length error                                                                                                  |
+| Notes contains component details                                              | Accepted as free text; no structured component/location fields are created                                                                          |
+| Asset is archived and history is requested                                    | Existing maintenance history is returned                                                                                                            |
+| Asset is archived and record creation is attempted                            | Creation rejected with 409                                                                                                                          |
+| User submits and the API returns 422 with a field                             | Banner shown and the server message is pinned to the matching form field                                                                            |
+| User submits and the API returns 422 without field                            | Banner shown; no field highlighted                                                                                                                  |
+| User submits and the API returns 401                                          | Redirect to `/login` (replace history entry)                                                                                                        |
+| User submits or views another user's asset                                    | 403 access-denied treatment                                                                                                                         |
+| User submits or views a missing asset                                         | 404 not-found treatment                                                                                                                             |
+| Maintenance history request fails                                             | Error state shown with retry action                                                                                                                 |
+| Maintenance history request is pending                                        | Loading state shown; history area is not blank                                                                                                      |
+| User edits a field after a failed submit                                      | Field error clears and mutation error state resets                                                                                                  |
+| User records two entries on the same performed date                           | Both records are shown; newest created entry sorts first within that date                                                                           |
+| User edits only a record title or notes                                       | Record updates; linked task state and reminder schedule are unchanged                                                                               |
+| User edits a linked record to an earlier date                                 | Task uses the latest surviving completion, unless an original completion seed is later                                                              |
+| User edits the latest linked record to a later date                           | Task `lastCompletedDate` and `nextDue` move to the edited date plus interval                                                                        |
+| User deletes a non-latest linked record                                       | Record is removed; task schedule remains based on the latest surviving date                                                                         |
+| User deletes the latest linked record                                         | Task rewinds to the latest remaining completion or its original seed                                                                                |
+| User deletes the only linked record on a task with no initial completion date | `lastCompletedDate` becomes null; `nextDue` returns to the task creation seed                                                                       |
+| User attempts to change a record's task link                                  | 422; task linkage is immutable in this slice                                                                                                        |
+| PATCH omits a field                                                           | Existing value remains unchanged                                                                                                                    |
+| PATCH sends blank or null `notes`                                             | Notes are cleared to `null`                                                                                                                         |
+| PATCH sends a forbidden key                                                   | 422; no mutation is applied                                                                                                                         |
+| Record belongs to a different asset than the path                             | 404; no access or archive state is revealed                                                                                                         |
+| Record id is missing for PATCH or DELETE                                      | 404; no mutation or event is produced                                                                                                               |
+| User edits or deletes a record on a shared asset                              | Mutation succeeds under the same access rule as record creation                                                                                     |
+| User edits or deletes a record on an archived asset                           | 409; existing history remains readable and unchanged                                                                                                |
+| Record edit/delete succeeds                                                   | Maintenance list and affected task are refreshed; History gains an entry                                                                            |
+| Record edit/delete fails after validation                                     | No record, task, or outbox state is partially changed                                                                                               |
+| DELETE is repeated after successful deletion                                  | 404; no second event or task mutation is produced                                                                                                   |
+| Concurrent task-affecting mutation loses its revision race                    | Retry against current state; after the bounded limit, return 409 with no partial record, task, or outbox change                                     |
+| Runtime reads a task with a null schedule seed after rollout                  | Emit an observable invariant failure and return 500; never synthesize a current-date seed or partially mutate the request                           |
+| Runtime reads a record with a null revision after rollout                     | Emit an observable invariant failure and return 500; do not apply a correction or write an outbox event                                             |
+| Record edit races with record deletion                                        | The first committed operation wins; the second retries against the latest row and returns either the resulting 204 or 404 without a duplicate event |
 
 ## Telemetry
 
-**Request telemetry:** `POST /api/assets/{assetId}/maintenance-records` maps to the `CreateMaintenanceRecord` operation via `createTechnicalTelemetryMiddleware`. `GET /api/assets/{assetId}/maintenance-records` maps to the `ListMaintenanceRecords` operation. Both route patterns must be added to the operation name mapping in `technicalTelemetry.ts`; see [telemetry.md](../cross-cutting/telemetry.md) for the full request data point shape.
+**Request telemetry:** `POST /api/assets/{assetId}/maintenance-records` maps to `CreateMaintenanceRecord`, `GET /api/assets/{assetId}/maintenance-records` maps to `ListMaintenanceRecords`, `PATCH /api/assets/{assetId}/maintenance-records/{recordId}` maps to `UpdateMaintenanceRecord`, and `DELETE /api/assets/{assetId}/maintenance-records/{recordId}` maps to `DeleteMaintenanceRecord` via `createTechnicalTelemetryMiddleware`. All route patterns must be added to the operation name mapping in `technicalTelemetry.ts`; see [telemetry.md](../cross-cutting/telemetry.md) for the full request data point shape.
 
 **Domain event:** On successful maintenance record creation, a `MaintenanceRecordCreated` event is published to the event bus and captured by a maintenance-record telemetry handler (planned dataset: `pineapple_maintenance_domain_events`, binding: `MAINTENANCE_DOMAIN_TELEMETRY`). The event must not include user-entered title or notes in telemetry blobs.
+
+**Correction events:** A successful edit publishes exactly one `MaintenanceRecordUpdated` event with `recordId`, `assetId`, `ownerId`, `actorId`, actor display-name snapshot, asset snapshot, `createdAt` (the original record creation timestamp), resulting `recordRevision`, the current nullable `taskId` (correction endpoints cannot change it; a prior task deletion may have unlinked it), normalized `before` and `after` values for `title`, `performedAt`, and `notes`, and the `maintenance_record_updated` History conclusion. A successful hard delete publishes exactly one `MaintenanceRecordDeleted` event with the same identity and snapshots plus `recordRevision = prior record revision + 1` captured before row removal, the full normalized deleted-record snapshot, and the `maintenance_record_deleted` History conclusion. Neither correction event is a completion event; corrections never publish `MaintenanceRecordCreated`, `MaintenanceTaskAdvanced`, or `MaintenanceTaskUpdated`. When a linked task's derived schedule changes because of either mutation, the application also publishes one `MaintenanceTaskReconciled` Smart Event defined in [maintenance-task.md](./maintenance-task.md). The events are written to the producer-side outbox in the same D1 batch as the record and task changes. Telemetry handlers write ids, enums, dates, and change flags only; user-entered title and notes remain out of Analytics Engine.
 
 **MaintenanceRecordCreated data point contract:**
 
@@ -125,17 +200,19 @@ The Maintenance Record feature lets an authenticated user create dated maintenan
 
 ## Flags
 
-**REVIEW NEEDED - Dashboard entry path belongs with dashboard design:** Creation must be available from the asset detail page. A dashboard entry path is desired, but the exact interaction and placement should be resolved in the dashboard spec after design review.
+**REVIEW NEEDED - `S1` boxes describe shipped create/list behavior but have not been reconciled with tests on `main`:** The existing record creation and history flows are live. A brownfield pass should tick each `S1` box a test actually covers and split or correct any that are not true. The new `S2`/`S3` boxes belong to #181.
 
-**NOT SPECIFIED - Navigation after successful creation:** The user should remain in or return to the asset context, but the exact presentation is not specified: inline form, modal, drawer, or separate route.
+**REVIEW NEEDED - Dashboard entry path belongs with dashboard design:** Creation must be available from the asset detail page. A dashboard entry path is desired, but the exact interaction and placement should be resolved in the dashboard spec after design review. Record correction controls are intentionally asset-page-only in this slice.
+
+**DECISION - Navigation after successful creation:** The user stays on `/app/assets/{assetId}/maintenance`; the record list refreshes and shows the newly created record.
 
 **FOLLOW-UP NEEDED - Cross-cutting time spec:** This feature uses a local mitigation for date-only maintenance records. A future cross-cutting time spec should define project-wide rules for date-only fields, timestamps, user time zones, server clock comparisons, and telemetry conversions.
 
 ## Out of Scope
 
-- Editing maintenance records
-- Deleting maintenance records
-- Service schedules, reminders, recurrence rules, and next-due dates (scheduling is defined in [maintenance-task.md](./maintenance-task.md))
+- Changing a record's linked `taskId`; relinking is a separate product decision
+- Direct task rescheduling, snooze, or reminder controls; rescheduling is tracked in [#235](https://github.com/snaveevans/pineapple/issues/235) and snooze in [#236](https://github.com/snaveevans/pineapple/issues/236)
+- Service-schedule creation, recurrence-rule editing, and task interval editing (those behaviors are defined in [maintenance-task.md](./maintenance-task.md))
 - Structured maintenance task/category management
 - Structured component or location tracking for repeated failures
 - Structured quantity, cost, vendor, mileage, odometer, or attachment fields

--- a/docs/specs/features/maintenance-task.md
+++ b/docs/specs/features/maintenance-task.md
@@ -7,28 +7,29 @@ metadata:
 
 # Maintenance Task
 
-**Status:** active
+**Status:** in-progress
 **Owner:** product and engineering
-**Last Updated:** 2026-08-17
+**Last Updated:** 2026-08-21
 **Related Specs:** [authentication.md](../cross-cutting/authentication.md), [validation.md](../cross-cutting/validation.md), [error-handling.md](../cross-cutting/error-handling.md), [loading-states.md](../cross-cutting/loading-states.md), [permissions.md](../cross-cutting/permissions.md), [telemetry.md](../cross-cutting/telemetry.md), [maintenance-record.md](./maintenance-record.md), [dashboard.md](./dashboard.md), [activity-history.md](./activity-history.md)
 
 ---
 
 ## Summary
 
-The Maintenance Task feature lets an authenticated owner-operator define scheduled maintenance work for an asset — specifying what to do and how often (time-based interval) — so they always know when maintenance is next due. When a maintenance record is linked to a task at logging time, the task's next-due date automatically advances based on when the work was performed. Tasks are the scheduling counterpart to the Maintenance Record log: records capture what _was_ done; tasks capture what _should_ be done and when.
+The Maintenance Task feature lets an authenticated owner-operator define scheduled maintenance work for an asset — specifying what to do and how often (time-based interval) — so they always know when maintenance is next due. When a maintenance record is linked to a task at logging time, the task's next-due date automatically advances based on when the work was performed. If a linked record is later corrected or deleted, the task recomputes its completion state from an immutable creation seed and the remaining linked records. Tasks created after the schedule-seed migration restore from their original seed; legacy tasks restore from their deterministic backfilled baseline because historical provenance cannot be recovered. Tasks are the scheduling counterpart to the Maintenance Record log: records capture what _was_ done; tasks capture what _should_ be done and when.
 
 ## User Stories
 
-- As an **authenticated owner-operator**, I can **create a time-based maintenance task for one of my assets** so that **I know what recurring maintenance is scheduled and when it's next due**
+- As an **authenticated user**, I can **create a time-based maintenance task for an asset I can access** so that **I know what recurring maintenance is scheduled and when it's next due**
 - As **DIYer Dale**, I can **seed a new task with a last-completed date** so that **the next-due date reflects reality from the moment I create the task**
 - As **DIYer Dale**, I can **create a "replace furnace filter every 2 months" task for my house without a last-completed date** so that **the system starts counting from today**
-- As an **authenticated owner-operator**, I can **list the maintenance tasks for one of my assets** so that **I can see all scheduled work and when each item is next due**
+- As an **authenticated user**, I can **list the maintenance tasks for an asset I can access** so that **I can see all scheduled work and when each item is next due**
 - As **DIYer Dale**, I can **link a maintenance record to a task when logging completed work** so that **the task's next-due date advances automatically to reflect the work I just performed**
 - As **DIYer Dale**, I can **use a task's dedicated "Log maintenance" flow** so that **the record is pre-linked to the task without extra steps**
-- As an **authenticated owner-operator**, I can **delete a maintenance task** so that **stale or incorrect tasks don't clutter my asset**
+- As an **authenticated user**, I can **delete a maintenance task on an asset I can access** so that **stale or incorrect tasks don't clutter the asset**
 - As a **user who deletes a task**, my **existing maintenance records are preserved** so that **my historical maintenance log is not lost**
-- As an **authenticated owner-operator**, I can **edit a task's title or interval** so that **I can correct a mistake without losing `lastCompletedDate` or churning the task's history the way delete-and-recreate does**
+- As an **authenticated user**, I can **edit a task's title or interval on an asset I can access** so that **I can correct a mistake without losing `lastCompletedDate` or churning the task's history the way delete-and-recreate does**
+- As an **authenticated user correcting or deleting a linked record**, I can **trust the task's `lastCompletedDate` and `nextDue` to reflect the remaining evidence** so that **a record correction cannot leave the recurring schedule stale**
 
 ## Acceptance Criteria
 
@@ -39,9 +40,9 @@ tagged boxes are all `[x]`." See docs/specs/SPECS.md. -->
 
 ### Task creation
 
-- [x] `S1` A maintenance task is always tied to an existing asset owned by the authenticated user
+- [x] `S1` A maintenance task is always tied to an existing asset the authenticated requester can access
 - [x] `S1` `POST /api/assets/{assetId}/maintenance-tasks` accepts `{ title, intervalValue, intervalUnit, lastCompletedDate? }` and returns the full created task with status 201
-- [x] `S1` `ownerId` is never accepted in the request body; it is derived from the authenticated session
+- [x] `S1` `ownerId` is never accepted in the request body; it is derived from the target asset, while the authenticated session supplies the actor/requester
 - [x] `S1` `title` is required and limited to 100 characters
 - [x] `S1` `intervalValue` is required and must be a positive integer (≥ 1)
 - [x] `S1` `intervalUnit` is required and must be one of `"day" | "week" | "month" | "year"`
@@ -49,12 +50,12 @@ tagged boxes are all `[x]`." See docs/specs/SPECS.md. -->
 - [x] `S1` When `lastCompletedDate` is provided, `nextDue = lastCompletedDate + interval` (calendar-based arithmetic)
 - [x] `S1` When `lastCompletedDate` is omitted, `nextDue = today (UTC calendar date) + interval`
 - [x] `S1` Creating a task for an archived asset returns 409
-- [x] `S1` The create use case checks that the target asset exists and belongs to the authenticated user before creating the task
+- [x] `S1` The create use case checks that the target asset exists and the requester can access it before creating the task; the task's `ownerId` remains the asset owner
 
 ### Task list
 
 - [x] `S1` `GET /api/assets/{assetId}/maintenance-tasks` returns `{ maintenanceTasks: [...] }` with status 200
-- [x] `S1` The list use case returns only tasks for an asset owned by the authenticated user
+- [x] `S1` The list use case returns only tasks for an asset the authenticated requester can access
 - [x] `S1` Each task in the response includes `id`, `assetId`, `title`, `intervalValue`, `intervalUnit`, `lastCompletedDate` (nullable), `nextDue`, and `createdAt`; `ownerId` is never exposed
 - [x] `S1` Tasks are returned in ascending `nextDue` order (soonest due first)
 - [x] `S1` The dashboard's cross-asset queue is exposed through [dashboard.md](./dashboard.md), not by requiring the web app to call this asset-scoped endpoint once per asset
@@ -63,23 +64,24 @@ tagged boxes are all `[x]`." See docs/specs/SPECS.md. -->
 
 - [x] `S1` `DELETE /api/assets/{assetId}/maintenance-tasks/{taskId}` returns 204 on success
 - [x] `S1` Deleting a task that doesn't exist returns 404
-- [x] `S1` Deleting a task that belongs to another user returns 403
+- [x] `S1` Deleting a task whose asset the requester cannot access returns 403
 - [x] `S1` Existing maintenance records previously linked to the deleted task are preserved with their `taskId` set to null
+- [x] `S2` Deleting an existing task on an archived asset is permitted; archival blocks new maintenance activity, not mutation of an existing task
 
 ### Task edit
 
 - [x] `S2` `PATCH /api/assets/{assetId}/maintenance-tasks/{taskId}` accepts `{ title?, intervalValue?, intervalUnit? }` and returns the full updated task with status 200
 - [x] `S2` At least one of `title`, `intervalValue`, `intervalUnit` must be present in the request body; a body with none of them returns 422
 - [x] `S2` `lastCompletedDate` and `nextDue` are not fields on this endpoint's request schema; the endpoint never accepts a direct override of either — `nextDue` is always derived (see recompute rule below)
-- [x] `S2` `ownerId` is never accepted in the request body; it is derived from the authenticated session
+- [x] `S2` `ownerId` is never accepted in the request body; it remains the target asset owner, while the authenticated session supplies the actor/requester
 - [x] `S2` When provided, `title` follows the same validation as task creation (non-empty after trim, ≤100 characters)
 - [x] `S2` When provided, `intervalValue` follows the same validation as task creation (positive integer ≥ 1)
 - [x] `S2` When provided, `intervalUnit` follows the same validation as task creation (one of `day | week | month | year`)
 - [x] `S2` A field omitted from the request body keeps its current stored value
-- [x] `S2` When the resulting `intervalValue` and/or `intervalUnit` differ from the task's current stored values, `nextDue` is recomputed as `(lastCompletedDate ?? todayUtc) + interval`, using the resulting `intervalValue`/`intervalUnit` and the same calendar arithmetic as task creation
+- [ ] `S4` When the resulting `intervalValue` and/or `intervalUnit` differ from the task's current stored values, `nextDue` is recomputed as `(lastCompletedDate ?? scheduleSeedDate) + interval`, using the resulting `intervalValue`/`intervalUnit` and the same calendar arithmetic as task creation
 - [x] `S2` When the resulting `intervalValue` and `intervalUnit` are unchanged from the task's current stored values — whether omitted from the request or resent unchanged — `lastCompletedDate` and `nextDue` are left unchanged; this holds even for a title-only edit on a task with no `lastCompletedDate`, where recomputing from `todayUtc` would otherwise silently push the schedule out
-- [x] `S2` When the requested `title`, `intervalValue`, and `intervalUnit` (after applying only the provided fields) are identical to the task's current stored values, the edit is a no-op: the task is returned unchanged with status 200, and no `MaintenanceTaskUpdated` event is published
-- [x] `S2` Editing a task on an archived asset is permitted — asset archival blocks new maintenance activity (creating tasks or records), not correction of an existing task's metadata
+- [x] `S2` When the requested `title`, `intervalValue`, and `intervalUnit` (after applying only the provided fields) are identical to the task's current stored values at the optimistic-CAS linearization point, the edit is a no-op: the task is returned unchanged with status 200, and no `MaintenanceTaskUpdated` event is published; if the revision changes before that point, the operation retries against fresh state instead of returning a stale no-op
+- [x] `S2` Editing or deleting a task on an archived asset is permitted — asset archival blocks new maintenance activity (creating tasks or records), not mutation of an existing task
 - [x] `S2` Editing a task that doesn't exist returns 404
 - [x] `S2` Editing a task that exists but belongs to a different asset than the path `assetId` returns 404
 - [x] `S2` Editing a task whose asset the requester cannot access returns 403
@@ -87,92 +89,130 @@ tagged boxes are all `[x]`." See docs/specs/SPECS.md. -->
 - [x] `S2` A successful edit that changes `title`, `intervalValue`, or `intervalUnit` publishes a `MaintenanceTaskUpdated` domain event carrying the resulting `nextDue` as a producer-owned conclusion (ADR-0010), so the notifications scheduler reschedules the pending reminder via its existing supersede path without reading task storage back
 - [x] `S3` An editable task exposes an edit action that opens a form prefilled with its title and interval; the form never offers `lastCompletedDate` or `nextDue`
 - [x] `S3` Saving the task submits the edit endpoint, updates the displayed task in place, and shows the existing access-denied / not-found treatment for 403/404 responses
+- [ ] `S4` Task writes blocked by `maintenance_write_gate = frozen` return 503 with `maintenance_write_frozen`; the UI leaves the current data intact and shows a retryable state for the user
 
 ### Record-task linking (change to existing maintenance-record endpoint)
 
 - [x] `S1` `POST /api/assets/{assetId}/maintenance-records` accepts an optional `taskId` field in the request body
-- [x] `S1` When `taskId` is provided, it must reference a maintenance task belonging to the same asset; a task from a different asset returns 422
-- [x] `S1` When `taskId` references a task owned by a different user, 404 is returned (existence is not revealed)
+- [x] `S1` When `taskId` is provided, an accessible task from a different asset returns 422; an inaccessible foreign task returns 404, and a missing task returns 404
+- [x] `S1` When `taskId` references a task on an asset the requester cannot access, 404 is returned (existence is not revealed); this is a foreign-reference validation exception, not a direct child-resource request, which follows the canonical 403 rule
 - [x] `S1` Maintenance record responses include a nullable `taskId` field
 - [x] `S1` When a linked record's `performedAt` is strictly greater than the task's current `lastCompletedDate` (or the task has no `lastCompletedDate`), the task's `lastCompletedDate` updates to `record.performedAt` and `nextDue` advances accordingly
 - [x] `S1` When a linked record's `performedAt` is earlier than the task's current `lastCompletedDate`, `lastCompletedDate` and `nextDue` are unchanged — linking an older record never regresses the next-due date
-- [x] `S1` Linking a record to a task for an archived asset returns 409 (the existing archived-asset rule for record creation applies)
+- [x] `S1` Linking a record to a task for an archived path asset returns 409; an accessible foreign task returns 422 and an inaccessible foreign task returns 404 regardless of the foreign asset's archived state
+
+### Record correction reconciliation
+
+- [ ] `S4` A task stores an immutable internal `scheduleSeedDate`, set at creation to the supplied `lastCompletedDate` or today's UTC date when no completion date was supplied; it is not exposed in the API response
+- [ ] `S4` A task preserves an internal nullable `initialLastCompletedDate` alongside `scheduleSeedDate`, so removing all linked records can restore both the original schedule and the original nullable completion state; neither field is exposed in the API response
+- [ ] `S4` A new task starts with internal `revision = 0` and its create event carries `taskRevision = 0`; each later successful task-affecting mutation commits at prior revision + 1, including a title-only task edit
+- [ ] `S4` Task deletion carries `taskRevision = prior revision + 1` on `MaintenanceTaskDeleted` immediately before removing the task row; the event revision remains available to durable consumers after deletion
+- [ ] `S4` Task deletion snapshots every linked record id and revision, conditionally sets each linked record's `taskId` to `null` while incrementing that record's revision by one, and conditionally deletes the task at its expected revision in the same D1 transaction; a row-count mismatch on either the unlink or task delete is a conflict that retries the complete operation, never a partial success
+- [ ] `S4` Existing tasks are backfilled by an idempotent deterministic migration: `scheduleSeedDate` is set from the stored `lastCompletedDate`, or the UTC calendar date of `createdAt` when that value is null; `initialLastCompletedDate` is set from the stored `lastCompletedDate`; `revision` is set to `0`; a validation query reports any remaining null seed or revision values, rerunning the migration is safe, and the new runtime does not silently synthesize a seed for an incomplete row
+- [ ] `S4` Legacy rows use the current stored state as their baseline even when the original provenance is unknowable: a non-null stored `lastCompletedDate` becomes both the seed and the preserved initial completion, while a null stored value uses the creation date seed and a null initial completion
+- [ ] `S4` The legacy backfill is documented as unable to recover an original manually supplied seed, or distinguish a linked-record completion from an original completion, when that provenance was replaced or absent before this feature shipped; legacy rows therefore do not receive historical rewind guarantees beyond the deterministic baseline
+- [ ] `S4` After a linked record edit or deletion, `lastCompletedDate` is the latest date among the original completion seed and the remaining linked records; it is null only when neither exists
+- [ ] `S4` After a linked record edit or deletion, `nextDue` is `addInterval(lastCompletedDate, interval)` when `lastCompletedDate` is non-null, otherwise `addInterval(scheduleSeedDate, interval)`
+- [ ] `S4` A linked record older than the original completion seed does not regress `lastCompletedDate` or `nextDue`; when a task has no original completion seed, `lastCompletedDate` is the latest remaining linked record date, including when that date is earlier than `scheduleSeedDate`
+- [ ] `S4` Editing only a linked record's title or notes does not change the task schedule
+- [ ] `S4` Editing a linked record's performed date recomputes from the normalized edited record plus all other linked records, while deletion recomputes from all linked records except the deleted record, in one atomic application operation
+- [ ] `S4` A change to either derived `lastCompletedDate` or `nextDue` caused by record correction publishes a `MaintenanceTaskReconciled` Smart Event carrying both resulting values, the source record id/use case, and the asset/task snapshot required by durable consumers
+- [ ] `S4` Every mutation that changes stored task state increments an internal per-task `revision` in the same transaction and carries the resulting revision on its task event; this covers task creation (`0`), record creation that advances a task, task edits (including title-only edits), record corrections that change derived task state, and task deletion
+- [ ] `S4` `MaintenanceTaskReconciled` uses the existing notification supersede/reschedule path without requiring the notifications consumer to read maintenance-task storage back; when `nextDue` is unchanged, ingestion creates no new cycle or fire-status change and, if the winning cycle is pending, replaces its snapshot and order marker, otherwise leaves the cycle row unchanged
+- [ ] `S4` A record correction that leaves both derived `lastCompletedDate` and `nextDue` unchanged does not publish a task reconciliation event, although the record update/delete event is still published; the record mutation still uses its own revision CAS
+- [ ] `S4` A record correction never publishes `MaintenanceTaskAdvanced`, `MaintenanceRecordCreated`, `MaintenanceTaskUpdated`, or a new `task_completed` History entry
+- [ ] `S4` If reconciliation returns a previously seen `nextDue`, notifications reuses or reactivates an unfired cycle and never creates a duplicate notification for a cycle that already fired
 
 ### General
 
 - [x] `S1` A 401 response from the API redirects to `/login` through the API client layer
-- [x] `S1` A 403 response from asset or task ownership checks is shown as an access-denied error
+- [x] `S1` A 403 response from asset-access checks is shown as an access-denied error
 - [x] `S1` A 404 response is shown as a not-found error when the asset or task does not exist
 - [x] `S3` A 403/404 response from a task edit is shown using the same access-denied / not-found treatment as the rest of this feature
 
 ## Delivery Plan
 
-| Slice | Scope                                                                                                                                   | Issue | Depends on |
-| ----- | --------------------------------------------------------------------------------------------------------------------------------------- | ----- | ---------- |
-| `S1`  | Task creation, listing, deletion, and record-task linking (already shipped)                                                             | —     | —          |
-| `S2`  | Task-edit backend: `PATCH` for `title`/`intervalValue`/`intervalUnit`, recomputed `nextDue`, and a `MaintenanceTaskUpdated` Smart Event | #180  | `S1`       |
-| `S3`  | Task-edit UI: prefilled title/interval form that updates the task in place without exposing schedule baselines                          | #180  | `S2`       |
+| Slice | Scope                                                                                                                                   | Issue                                                      | Depends on |
+| ----- | --------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- | ---------- |
+| `S1`  | Task creation, listing, deletion, and record-task linking (already shipped)                                                             | —                                                          | —          |
+| `S2`  | Task-edit backend: `PATCH` for `title`/`intervalValue`/`intervalUnit`, recomputed `nextDue`, and a `MaintenanceTaskUpdated` Smart Event | #180                                                       | `S1`       |
+| `S3`  | Task-edit UI: prefilled title/interval form that updates the task in place without exposing schedule baselines                          | #180                                                       | `S2`       |
+| `S4`  | Record edit/delete reconciliation: immutable schedule seed, task recomputation, correction events, and notification rescheduling        | [#181](https://github.com/snaveevans/pineapple/issues/181) | `S1`, `S2` |
 
 ## Validation & Ownership
 
-**Authentication:** This feature is available only to authenticated users. API requests use the resolved `User.id` as `ownerId`.
+**Authentication:** This feature is available only to authenticated users. API requests use the resolved `User.id` as `requesterId`; `ownerId` remains the asset owner's domain id.
 
-**Permissions:** Tasks are owned through the asset they belong to. A user can create, list, delete, and edit tasks only for assets they own or that are shared with their team (same access rule as create/delete — see `canAccessAsset`). The client cannot supply `ownerId`.
+**Permissions:** Tasks are owned through the asset they belong to. A user can list, edit, and delete existing tasks for assets they own or that are shared with their team, including archived assets; creating a task is limited to active assets. The client cannot supply `ownerId`. Direct requests for an existing inaccessible task return 403; the `taskId` foreign-reference check during record creation is the explicit 404 exception documented above.
 
-**HTTP validation:** Inputs are validated at the Zod HTTP edge in `apps/api/src/api/schemas/maintenanceTaskSchemas.ts`. Required fields (create): `title` (string, max 100 chars), `intervalValue` (positive integer), `intervalUnit` (enum: `day | week | month | year`). Optional (create): `lastCompletedDate` (YYYY-MM-DD, today or earlier). For maintenance record creation, `taskId` is optional (UUID). The edit (`PATCH`) schema makes `title`, `intervalValue`, and `intervalUnit` all optional but validated with the same per-field rules as create when present, and refines that at least one of the three must be supplied; it declares no `lastCompletedDate` or `nextDue` field at all, so either key in a request body is silently stripped by Zod's default unknown-key handling rather than rejected or applied.
+**HTTP validation:** Inputs are validated at the Zod HTTP edge in `apps/api/src/api/schemas/maintenanceTaskSchemas.ts`. Required fields (create): `title` (string, max 100 chars), `intervalValue` (positive integer), `intervalUnit` (enum: `day | week | month | year`). Optional (create): `lastCompletedDate` (YYYY-MM-DD, today or earlier). For maintenance record creation, `taskId` is optional (UUID). The edit (`PATCH`) schema makes `title`, `intervalValue`, and `intervalUnit` all optional but validated with the same per-field rules as create when present, and refines that at least one of the three must be supplied. The schema is strict: `lastCompletedDate`, `nextDue`, `ownerId`, `assetId`, `createdAt`, and every other unknown key return 422 rather than being stripped or applied.
 
-**Domain validation:** Domain construction trims title and preserves these invariants: non-empty title of at most 100 characters; positive integer interval value; valid interval unit; date-only `lastCompletedDate` of today or earlier when provided; `nextDue` always present and derived from `lastCompletedDate` (or today's UTC calendar date) + interval. Editing reuses the same invariants — an edit cannot leave the task in a state creation itself couldn't produce.
+**Domain validation:** Domain construction trims title and preserves these invariants: non-empty title of at most 100 characters; positive integer interval value; valid interval unit; date-only `lastCompletedDate` of today or earlier when provided; immutable internal `scheduleSeedDate`; nullable internal `initialLastCompletedDate`; and `nextDue` always present. At creation, `scheduleSeedDate` is the supplied `lastCompletedDate` or today's UTC calendar date when no completion date is supplied, while `initialLastCompletedDate` is the supplied value or null. Editing and record reconciliation reuse the same invariants — an edit cannot leave the task in a state creation itself couldn't produce. Archive state is checked by operation: create rejects archived assets with 409, while edits and deletes of existing tasks remain permitted.
 
 **Next-due arithmetic:** Interval arithmetic is calendar-based. "2 months from 2026-01-31" yields "2026-03-31"; if the resulting day exceeds the month length, clamp to the last day of that month. The implementation must not parse date strings through `Date` for calendar arithmetic; use manual calendar math or a WinterCG-compatible date library. Editing must reuse this same `addInterval` implementation, not a second one.
 
-**Edit recompute rule:** An edit whose resulting `intervalValue`/`intervalUnit` differ from the task's current stored values recomputes `nextDue = addInterval(lastCompletedDate ?? todayUtc, resultingIntervalValue, resultingIntervalUnit)` — the identical formula task creation uses, just with the task's current `lastCompletedDate` (if any) as the baseline instead of a client-supplied one. The recompute is gated on the _resulting_ value actually differing from what's stored, not merely on whether the request includes the field — a client that resends the current interval alongside a title change (e.g. a form that always submits its full state) must not shift `nextDue` as a side effect. This matters most for a task with no `lastCompletedDate`, where the baseline would otherwise silently move from the task's original creation date to "today."
+**Edit recompute rule:** An edit whose resulting `intervalValue`/`intervalUnit` differ from the task's current stored values recomputes `nextDue = addInterval(lastCompletedDate ?? scheduleSeedDate, resultingIntervalValue, resultingIntervalUnit)` — the identical formula task creation uses, just with the task's current `lastCompletedDate` (if any) as the baseline instead of a client-supplied one. The recompute is gated on the _resulting_ value actually differing from what's stored, not merely on whether the request includes the field — a client that resends the current interval alongside a title change (e.g. a form that always submits its full state) must not shift `nextDue` as a side effect. This keeps an uncompleted task anchored to its creation seed instead of silently moving the schedule forward as time passes.
 
-**Date-only mitigation:** Same convention as [maintenance-record.md](./maintenance-record.md). `lastCompletedDate` and `nextDue` are timezone-free YYYY-MM-DD strings across the API, domain, and D1 persistence. Today's UTC calendar date is authoritative for seeding, comparisons, and edit recomputation.
+**Task mutation concurrency:** Task interval edits, record corrections, and task deletion use optimistic concurrency on an internal per-task `revision`, initialized to `0`. The application reads the task and related records, computes the complete resulting state, and conditionally commits the task mutation, record mutation/unlink, and outbox rows only when the read revision is still current. A failed conditional write retries the complete operation against fresh state after the initial attempt, up to three additional attempts; the fourth conflict returns 409 and rolls back the entire operation. Validation, 404, archive, and no-op outcomes are not retried. The resulting revision is carried on the task event so notification and other durable consumers order events by `(taskRevision, kind, lowercase(eventId))` rather than arrival order. If task deletion wins a race with a record correction, the task's record links are null in the retry's current state and the correction proceeds as an unlinked-record edit without producing a task reconciliation event. If an interval edit and record correction race, the later retry applies its change to the latest task interval and completion state, so neither committed change is lost. If task edit commits before task deletion, deletion reads that edit and emits the terminal delete at the next revision; if deletion commits first, the edit retry returns 404. If record deletion wins before a correction retry, the correction returns 404; if task deletion wins first, the record correction follows the unlinked-record rule.
+
+**Record-correction recompute rule:** When a linked record is edited, the application applies the normalized edit and loads that edited record plus all other records still linked to the task. When a record is deleted, the deleted record is excluded and all other linked records are loaded. `lastCompletedDate` becomes the latest of the immutable initial completion date, if one was supplied at task creation, and the post-mutation linked records' `performedAt` values. If neither exists, `lastCompletedDate` is null. `nextDue` is then `addInterval(lastCompletedDate, interval)` when `lastCompletedDate` is non-null, or `addInterval(scheduleSeedDate, interval)` when it is null. A linked record older than an initial completion date is retained as history but does not regress the task. When no initial completion date exists, the latest remaining linked record date is the task's `lastCompletedDate`, even when it is earlier than `scheduleSeedDate`.
+
+**Date-only mitigation:** Same convention as [maintenance-record.md](./maintenance-record.md). `scheduleSeedDate`, `lastCompletedDate`, and `nextDue` are timezone-free YYYY-MM-DD strings across the API, domain, and D1 persistence. Today's UTC calendar date is authoritative for initial seeding and comparisons; record reconciliation never uses the current date as a fallback when a task's stored seed is available.
 
 **Field errors:** Validation errors map back to `title`, `intervalValue`, `intervalUnit`, and `lastCompletedDate` when the backend includes a known `field` value.
 
 ## Edge Cases & Error States
 
-| Scenario                                                                       | Expected Behavior                                                                            |
-| ------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------- |
-| Asset has no maintenance tasks                                                 | List returns `{ maintenanceTasks: [] }`                                                      |
-| `title` is empty                                                               | 422; title field shows required-field error                                                  |
-| `title` is over 100 characters                                                 | 422; title field shows max-length error                                                      |
-| `intervalValue` is 0 or negative                                               | 422; intervalValue field shows must-be-positive error                                        |
-| `intervalValue` is not an integer                                              | 422; intervalValue field shows type error                                                    |
-| `intervalUnit` is not a valid enum value                                       | 422; intervalUnit field shows invalid-value error                                            |
-| `lastCompletedDate` is in the future                                           | 422; lastCompletedDate field shows "must be today or earlier" error                          |
-| `lastCompletedDate` is malformed                                               | 422; lastCompletedDate field shows format error                                              |
-| `lastCompletedDate` omitted                                                    | `nextDue` seeded as today (UTC calendar date) + interval                                     |
-| Asset is archived; task creation attempted                                     | 409                                                                                          |
-| Asset is archived; task list requested                                         | Existing task list is returned normally                                                      |
-| Asset is archived; record with `taskId` provided                               | 409 (archived-asset rule on record creation applies)                                         |
-| Linked record's `performedAt` equals task's `lastCompletedDate`                | `lastCompletedDate` and `nextDue` unchanged                                                  |
-| Linked record's `performedAt` is older than task's `lastCompletedDate`         | `lastCompletedDate` and `nextDue` unchanged                                                  |
-| `taskId` in record creation belongs to a different asset (same user)           | 422; taskId field shows "task does not belong to this asset"                                 |
-| `taskId` in record creation belongs to another user's task                     | 404                                                                                          |
-| `taskId` in record creation references a non-existent task                     | 404                                                                                          |
-| Task is deleted while it has linked records                                    | 204; linked records preserved with `taskId` set to null                                      |
-| Deleting a task that doesn't exist                                             | 404                                                                                          |
-| Deleting another user's task                                                   | 403                                                                                          |
-| User lists tasks for another user's asset                                      | 403                                                                                          |
-| User lists tasks for a non-existent asset                                      | 404                                                                                          |
-| PATCH body has none of `title`, `intervalValue`, `intervalUnit`                | 422; banner shown, no field highlighted                                                      |
-| PATCH `title` present but empty/whitespace-only                                | 422; title field shows required-field error                                                  |
-| PATCH `title` exceeds 100 characters                                           | 422; title field shows max-length error                                                      |
-| PATCH `intervalValue` is 0, negative, or non-integer                           | 422; intervalValue field shows validation error                                              |
-| PATCH `intervalUnit` is not `day`/`week`/`month`/`year`                        | 422; intervalUnit field shows invalid-value error                                            |
-| PATCH body includes `lastCompletedDate` or `nextDue`                           | Silently ignored (not part of the schema); `nextDue` is still derived per the recompute rule |
-| Edit changes only `title`                                                      | `lastCompletedDate` and `nextDue` unchanged; `MaintenanceTaskUpdated` published              |
-| Edit changes `intervalValue`/`intervalUnit`, task has a `lastCompletedDate`    | `nextDue` recomputed from `lastCompletedDate` + resulting interval                           |
-| Edit changes `intervalValue`/`intervalUnit`, task has no `lastCompletedDate`   | `nextDue` recomputed from today's UTC date + resulting interval                              |
-| Edit request's resulting values exactly match the task's current stored values | 200 with unchanged task; no `MaintenanceTaskUpdated` event published                         |
-| Editing a task that doesn't exist                                              | 404                                                                                          |
-| Editing a task that belongs to a different asset than the path `assetId`       | 404                                                                                          |
-| Editing a task whose asset the requester cannot access                         | 403                                                                                          |
-| Editing a task on an archived asset                                            | Permitted; 200                                                                               |
-| 422 response with a known field name                                           | Banner shown; server error message pinned to the matching form field                         |
-| 422 response without a field name                                              | Banner shown; no field highlighted                                                           |
+| Scenario                                                                          | Expected Behavior                                                                                                                                                                    |
+| --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Asset has no maintenance tasks                                                    | List returns `{ maintenanceTasks: [] }`                                                                                                                                              |
+| `title` is empty                                                                  | 422; title field shows required-field error                                                                                                                                          |
+| `title` is over 100 characters                                                    | 422; title field shows max-length error                                                                                                                                              |
+| `intervalValue` is 0 or negative                                                  | 422; intervalValue field shows must-be-positive error                                                                                                                                |
+| `intervalValue` is not an integer                                                 | 422; intervalValue field shows type error                                                                                                                                            |
+| `intervalUnit` is not a valid enum value                                          | 422; intervalUnit field shows invalid-value error                                                                                                                                    |
+| `lastCompletedDate` is in the future                                              | 422; lastCompletedDate field shows "must be today or earlier" error                                                                                                                  |
+| `lastCompletedDate` is malformed                                                  | 422; lastCompletedDate field shows format error                                                                                                                                      |
+| `lastCompletedDate` omitted                                                       | `nextDue` seeded as today (UTC calendar date) + interval                                                                                                                             |
+| Asset is archived; task creation attempted                                        | 409                                                                                                                                                                                  |
+| Asset is archived; task list requested                                            | Existing task list is returned normally                                                                                                                                              |
+| Asset is archived; existing task edited or deleted                                | Mutation is permitted; archival blocks only new tasks/records and record corrections                                                                                                 |
+| Asset is archived; record with `taskId` provided                                  | 409 (archived-asset rule on record creation applies)                                                                                                                                 |
+| Linked record's `performedAt` equals task's `lastCompletedDate`                   | `lastCompletedDate` and `nextDue` unchanged                                                                                                                                          |
+| Linked record's `performedAt` is older than task's `lastCompletedDate`            | `lastCompletedDate` and `nextDue` unchanged                                                                                                                                          |
+| `taskId` in record creation belongs to a different asset (same user)              | 422; taskId field shows "task does not belong to this asset"                                                                                                                         |
+| `taskId` in record creation references a task on an inaccessible asset            | 404; deliberate foreign-reference exception to direct-resource 403                                                                                                                   |
+| `taskId` in record creation references a non-existent task                        | 404                                                                                                                                                                                  |
+| Task is deleted while it has linked records                                       | 204; linked records preserved with `taskId` set to null                                                                                                                              |
+| Deleting a task that doesn't exist                                                | 404                                                                                                                                                                                  |
+| Deleting a task on an inaccessible asset                                          | 403                                                                                                                                                                                  |
+| User lists tasks for an inaccessible asset                                        | 403                                                                                                                                                                                  |
+| User lists tasks for a non-existent asset                                         | 404                                                                                                                                                                                  |
+| PATCH body has none of `title`, `intervalValue`, `intervalUnit`                   | 422; banner shown, no field highlighted                                                                                                                                              |
+| PATCH `title` present but empty/whitespace-only                                   | 422; title field shows required-field error                                                                                                                                          |
+| PATCH `title` exceeds 100 characters                                              | 422; title field shows max-length error                                                                                                                                              |
+| PATCH `intervalValue` is 0, negative, or non-integer                              | 422; intervalValue field shows validation error                                                                                                                                      |
+| PATCH `intervalUnit` is not `day`/`week`/`month`/`year`                           | 422; intervalUnit field shows invalid-value error                                                                                                                                    |
+| PATCH body includes `lastCompletedDate`, `nextDue`, or any unknown key            | 422; no mutation or event is produced                                                                                                                                                |
+| Edit changes only `title`                                                         | `lastCompletedDate` and `nextDue` unchanged; `MaintenanceTaskUpdated` published                                                                                                      |
+| Edit changes `intervalValue`/`intervalUnit`, task has a `lastCompletedDate`       | `nextDue` recomputed from `lastCompletedDate` + resulting interval                                                                                                                   |
+| Edit changes `intervalValue`/`intervalUnit`, task has no `lastCompletedDate`      | `nextDue` recomputed from `scheduleSeedDate` + resulting interval                                                                                                                    |
+| Edit request's resulting values exactly match the task's current stored values    | 200 with unchanged task; no `MaintenanceTaskUpdated` event published                                                                                                                 |
+| Editing a task that doesn't exist                                                 | 404                                                                                                                                                                                  |
+| Editing a task that belongs to a different asset than the path `assetId`          | 404                                                                                                                                                                                  |
+| Editing a task whose asset the requester cannot access                            | 403                                                                                                                                                                                  |
+| Editing a task on an archived asset                                               | Permitted; 200                                                                                                                                                                       |
+| Edit changes only a linked record's title or notes                                | Task schedule unchanged; record update event only                                                                                                                                    |
+| Edit changes a linked record's performed date                                     | Task recomputed from initial completion seed plus all remaining linked records                                                                                                       |
+| Delete removes a non-latest linked record                                         | Task keeps the latest surviving completion and next due date                                                                                                                         |
+| Delete removes the latest linked record                                           | Task rewinds to the latest remaining completion or its original seed                                                                                                                 |
+| Delete removes the only linked record from a task with no initial completion date | `lastCompletedDate` becomes null; `nextDue` uses `scheduleSeedDate`                                                                                                                  |
+| Record correction leaves the task schedule unchanged                              | No `MaintenanceTaskReconciled` event; record correction event still publishes                                                                                                        |
+| A task predates the schedule-seed migration                                       | Deterministic seed, initial completion, and revision are backfilled from current state; a linked record becomes an indistinguishable legacy baseline and is not historically rewound |
+| Runtime reads a null seed or revision after rollout                               | Invariant failure is logged/observable and returns 500; no current-date fallback or partial mutation                                                                                 |
+| Task edit races with task deletion                                                | The first committed operation wins its revision; the second retries against it, then either deletes the latest task or returns 404 after deletion                                    |
+| 422 response with a known field name                                              | Banner shown; server error message pinned to the matching form field                                                                                                                 |
+| 422 response without a field name                                                 | Banner shown; no field highlighted                                                                                                                                                   |
 
 ## Telemetry
 
@@ -185,9 +225,9 @@ tagged boxes are all `[x]`." See docs/specs/SPECS.md. -->
 
 All four route patterns must be added to the operation name mapping in `technicalTelemetry.ts`. See [telemetry.md](../cross-cutting/telemetry.md) for the full request data point shape. The existing `POST /api/assets/{assetId}/maintenance-records` operation name (`CreateMaintenanceRecord`) is unchanged when `taskId` is added to the body.
 
-**Domain events:** Four events are published to dataset `pineapple_maintenance_task_domain_events` (binding: `MAINTENANCE_TASK_DOMAIN_TELEMETRY`). None may include user-entered title text in telemetry blobs.
+**Domain events:** Five events are published to dataset `pineapple_maintenance_task_domain_events` (binding: `MAINTENANCE_TASK_DOMAIN_TELEMETRY`). None may include user-entered title text in telemetry blobs.
 
-**Enriched event payload vs. telemetry blobs (Smart Events, [ADR-0010](../../decisions/0010-smart-events-for-durable-consumers.md)):** The blob tables below are the _thin telemetry projection_ written to Analytics Engine (IDs and enums only, no PII). The _event payload_ carried on the bus/queue to durable consumers is richer — it additionally carries the asset snapshot (`name`, `type`), the task `title`, the History `activityEntryType` conclusion, and, for `MaintenanceTaskCreated`, `MaintenanceTaskUpdated`, and `MaintenanceTaskAdvanced`, the resulting **`nextDue`** as a producer-owned conclusion. `nextDue` is required so the [notifications](./notifications.md) durable scheduler can schedule/reschedule a reminder **without reading maintenance-task storage back** (ADR-0010); `MaintenanceTaskDeleted` needs no `nextDue` (its consumer cancels). These payload fields are **not** added to the telemetry blobs, which stay PII-free. The full payload contract lives in [data-model.md](../../reference/data-model.md) (domain-events table). Implementation must populate `nextDue` where these events are constructed in the application layer, using the task's `nextDue` after creation, update, or advancement.
+**Enriched event payload vs. telemetry blobs (Smart Events, [ADR-0010](../../decisions/0010-smart-events-for-durable-consumers.md)):** The blob tables below are the _thin telemetry projection_ written to Analytics Engine (IDs and enums only, no PII). The _event payload_ carried on the bus/queue to durable consumers is richer — it additionally carries `kind = real`, the asset snapshot (`name`, `type`), the task `title`, the History `activityEntryType` conclusion, the resulting internal **`taskRevision`**, and, for `MaintenanceTaskCreated`, `MaintenanceTaskUpdated`, `MaintenanceTaskAdvanced`, and `MaintenanceTaskReconciled`, the resulting **`lastCompletedDate`** and **`nextDue`** as producer-owned conclusions. `MaintenanceTaskReconciled.activityEntryType` is always `null`; it is a notification/scheduling conclusion and History ignores it. `nextDue` is required so the [notifications](./notifications.md) durable scheduler can schedule/reschedule a reminder **without reading maintenance-task storage back** (ADR-0010); `MaintenanceTaskDeleted` needs no `nextDue` (its consumer cancels). These payload fields are **not** added to the telemetry blobs, which stay PII-free. The full payload contract lives in [data-model.md](../../reference/data-model.md) (domain-events table). Implementation must populate the schedule conclusions where these events are constructed in the application layer, using the task state after creation, update, advancement, or record reconciliation.
 
 ### `MaintenanceTaskCreated` — on successful task creation
 
@@ -229,6 +269,12 @@ Published only when the edit's resulting values differ from the task's current s
 
 ### `MaintenanceTaskDeleted` — on successful task deletion
 
+The domain event (separate from the telemetry data point below) carries the task snapshot,
+`taskRevision = prior revision + 1`, and the ordered `unlinkedRecordIds` captured by the same
+transaction. The implicit record unlinks increment each record revision but do not emit
+`MaintenanceRecordUpdated` correction events; the task-deletion event is the single user action
+and the record rows remain preserved with `taskId = null`.
+
 | Field        | Name                  | Value                            |
 | ------------ | --------------------- | -------------------------------- |
 | `indexes[0]` | —                     | `owner_id`                       |
@@ -265,6 +311,161 @@ Published only when `record.performedAt > task.lastCompletedDate` (i.e. when `ne
 | `doubles[1]` | `event_time_ms`         | Event timestamp (ms since epoch)                      |
 | `doubles[2]` | `performed_date_ms`     | `record.performedAt` at UTC midnight (ms since epoch) |
 
+### `MaintenanceTaskReconciled` - when a record edit or deletion changes task schedule
+
+Published only when linked-record correction changes the task's derived `lastCompletedDate` or
+`nextDue`. It is not a completion event and does not create a `task_completed` History entry.
+
+| Field        | Name                     | Value                                                           |
+| ------------ | ------------------------ | --------------------------------------------------------------- |
+| `indexes[0]` | -                        | `owner_id`                                                      |
+| `blobs[0]`   | `event_type`             | `"MaintenanceTaskReconciled"`                                   |
+| `blobs[1]`   | `aggregate_type`         | `"MaintenanceTask"`                                             |
+| `blobs[2]`   | `maintenance_task_id`    | Task UUID                                                       |
+| `blobs[3]`   | `asset_id`               | Asset UUID                                                      |
+| `blobs[4]`   | `owner_id`               | Owner UUID                                                      |
+| `blobs[5]`   | `actor_id`               | Actor UUID                                                      |
+| `blobs[6]`   | `maintenance_record_id`  | Source record UUID                                              |
+| `blobs[7]`   | `source_use_case`        | `"UpdateMaintenanceRecord"` or `"DeleteMaintenanceRecord"`      |
+| `blobs[8]`   | `schema_version`         | `"v1"`                                                          |
+| `blobs[9]`   | `result`                 | `"success"`                                                     |
+| `doubles[0]` | `count`                  | Always `1`                                                      |
+| `doubles[1]` | `event_time_ms`          | Event timestamp (ms since epoch)                                |
+| `doubles[2]` | `last_completed_date_ms` | Resulting `lastCompletedDate` at UTC midnight, or `0` when null |
+
+## Implementation Requirements
+
+- Add the immutable schedule fields, task `revision`, record `revision`, and internal `legacy_baseline_pending` and `legacy_revision_pending` discriminators through the expand/contract migration policy in [schema-migrations.md](../cross-cutting/schema-migrations.md): introduce nullable columns with both discriminators `DEFAULT 1` plus `AFTER INSERT` compatibility triggers for rows inserted by the still-running old Worker. The new writer explicitly supplies all new fields and both discriminators as `0`. The task trigger runs only when `legacy_baseline_pending = 1`, fills (`scheduleSeedDate = COALESCE(lastCompletedDate, date(createdAt))`, `initialLastCompletedDate = lastCompletedDate`, `revision = 0`), then sets the discriminator to `0`; the record trigger does the same for `revision = 0` and `legacy_revision_pending`. Neither trigger has an UPDATE path or overwrites a backfilled seed, a deliberately null `initialLastCompletedDate`, or a non-null revision. The backfill sets both discriminators to `0` for existing rows after populating them. Then run the deterministic idempotent backfill and the exact seven-column validation query below. The deploy workflow must stop before `wrangler deploy` unless every gate count is zero; the triggers remain until the new writer is live and are removed only in a later contract migration. A failed or interrupted backfill blocks promotion, is visible through this query, and is safe to rerun; application code must not invent a new current-date seed at runtime. A task with no initial completion date is still seeded and is not a null-seed task.
+- Reconciliation must load the linked records needed to derive the task state and persist the record, task, and producer-side outbox rows atomically.
+- The record correction use cases must not make notification or History consumers read maintenance-task or maintenance-record storage back; Smart Event payloads carry the required snapshots and schedule conclusions.
+- The migration sequence is fixed and uses new files only: `0017_maintenance_seed_revision_expand.sql` adds the nullable task/record columns, `DEFAULT 1` legacy discriminators, insert compatibility triggers, and the singleton `maintenance_write_gate`; `0018_maintenance_seed_revision_backfill.sql` performs the deterministic existing-row backfill and leaves the triggers installed; `0019_activity_history_correction_types.sql` widens the History constraint and adds `audit_snapshot_json` using the approved SQLite rebuild in [schema-migrations.md](../cross-cutting/schema-migrations.md); `0020_notification_heads_email_claims.sql` adds notification task heads, sweep-run identity/items, email batch and outbox claim/retry columns, rebuilds `notification_email_outbox` to permit `pending | sending | sent | failed` while preserving existing rows/keys/indexes, adds the notification DLQ key, anomaly storage, and the required indexes; `0021_notification_scheduler_bootstrap.sql` performs the idempotent head/cycle bootstrap. If another migration lands first, preserve this order and use the next available sequential numbers rather than editing an applied file.
+- The migration/deploy command sequence is: `pnpm --filter @snaveevans/pineapple-api wrangler d1 migrations apply pineapple --remote`; then `pnpm --filter @snaveevans/pineapple-api wrangler d1 execute pineapple --remote --command "$MAINTENANCE_SCHEMA_VALIDATION_SQL" --json`; then `pnpm --filter @snaveevans/pineapple-api wrangler d1 execute pineapple --remote --command "$NOTIFICATION_BOOTSTRAP_VALIDATION_SQL" --json`; `pnpm --filter @snaveevans/pineapple-api wrangler deploy` is permitted only after both validation commands pass. The workflow parses each single result row and exits nonzero for malformed output, any null task seed/revision, any null record revision, any pending compatibility flag, any unresolved notification migration anomaly, any invalid active head, any incomplete sweep run, any new correction entry with a null/invalid audit snapshot, or any migration command failure. The activity rebuild itself aborts and rolls back on any row-count/index/FK preservation mismatch. The validation runs after migrations and before queue reconciliation or Worker deployment.
+- `MAINTENANCE_SCHEMA_VALIDATION_SQL` is exactly:
+
+  ```sql
+  SELECT
+    (SELECT COUNT(*) FROM maintenance_tasks WHERE schedule_seed_date IS NULL OR revision IS NULL) AS invalid_tasks,
+    (SELECT COUNT(*) FROM maintenance_records WHERE revision IS NULL) AS invalid_records,
+    (SELECT COUNT(*) FROM maintenance_tasks WHERE legacy_baseline_pending IS NULL OR legacy_baseline_pending <> 0) AS pending_task_compatibility_flags,
+    (SELECT COUNT(*) FROM maintenance_records WHERE legacy_revision_pending IS NULL OR legacy_revision_pending <> 0) AS pending_record_compatibility_flags,
+    (SELECT COUNT(*) FROM notification_migration_anomalies WHERE resolved_at IS NULL) AS notification_anomalies,
+    (SELECT COUNT(*) FROM activity_entries WHERE type IN ('maintenance_record_updated', 'maintenance_record_deleted') AND (
+      json_valid(audit_snapshot_json) <> 1 OR
+      COALESCE(json_type(audit_snapshot_json), 'missing') <> 'object' OR
+      COALESCE(json_type(audit_snapshot_json, '$.recordId'), 'missing') <> 'text' OR
+      (json_type(audit_snapshot_json, '$.recordId') = 'text' AND (
+        length(json_extract(audit_snapshot_json, '$.recordId')) <> 36 OR
+        substr(json_extract(audit_snapshot_json, '$.recordId'), 9, 1) <> '-' OR
+        substr(json_extract(audit_snapshot_json, '$.recordId'), 14, 1) <> '-' OR
+        substr(json_extract(audit_snapshot_json, '$.recordId'), 19, 1) <> '-' OR
+        substr(json_extract(audit_snapshot_json, '$.recordId'), 24, 1) <> '-' OR
+        substr(json_extract(audit_snapshot_json, '$.recordId'), 1, 8) GLOB '*[^0-9A-Fa-f]*' OR
+        substr(json_extract(audit_snapshot_json, '$.recordId'), 10, 4) GLOB '*[^0-9A-Fa-f]*' OR
+        substr(json_extract(audit_snapshot_json, '$.recordId'), 15, 4) GLOB '*[^0-9A-Fa-f]*' OR
+        substr(json_extract(audit_snapshot_json, '$.recordId'), 20, 4) GLOB '*[^0-9A-Fa-f]*' OR
+        substr(json_extract(audit_snapshot_json, '$.recordId'), 25, 12) GLOB '*[^0-9A-Fa-f]*')) OR
+      COALESCE(json_type(audit_snapshot_json, '$.taskId'), 'missing') NOT IN ('text', 'null') OR
+      (json_type(audit_snapshot_json, '$.taskId') = 'text' AND (
+        length(json_extract(audit_snapshot_json, '$.taskId')) <> 36 OR
+        substr(json_extract(audit_snapshot_json, '$.taskId'), 9, 1) <> '-' OR
+        substr(json_extract(audit_snapshot_json, '$.taskId'), 14, 1) <> '-' OR
+        substr(json_extract(audit_snapshot_json, '$.taskId'), 19, 1) <> '-' OR
+        substr(json_extract(audit_snapshot_json, '$.taskId'), 24, 1) <> '-' OR
+        substr(json_extract(audit_snapshot_json, '$.taskId'), 1, 8) GLOB '*[^0-9A-Fa-f]*' OR
+        substr(json_extract(audit_snapshot_json, '$.taskId'), 10, 4) GLOB '*[^0-9A-Fa-f]*' OR
+        substr(json_extract(audit_snapshot_json, '$.taskId'), 15, 4) GLOB '*[^0-9A-Fa-f]*' OR
+        substr(json_extract(audit_snapshot_json, '$.taskId'), 20, 4) GLOB '*[^0-9A-Fa-f]*' OR
+        substr(json_extract(audit_snapshot_json, '$.taskId'), 25, 12) GLOB '*[^0-9A-Fa-f]*')) OR
+      COALESCE(json_type(audit_snapshot_json, '$.createdAt'), 'missing') <> 'text' OR
+      (json_type(audit_snapshot_json, '$.createdAt') = 'text' AND (
+        length(json_extract(audit_snapshot_json, '$.createdAt')) <> 24 OR
+        json_extract(audit_snapshot_json, '$.createdAt') NOT GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T[0-9][0-9]:[0-9][0-9]:[0-9][0-9].[0-9][0-9][0-9]Z' OR
+        COALESCE(strftime('%Y-%m-%dT%H:%M:%fZ', json_extract(audit_snapshot_json, '$.createdAt')), 'invalid') <> json_extract(audit_snapshot_json, '$.createdAt')) OR
+      EXISTS (SELECT 1 FROM json_each(audit_snapshot_json) GROUP BY key HAVING COUNT(*) > 1) OR
+      (type = 'maintenance_record_updated' AND (
+        COALESCE(json_type(audit_snapshot_json, '$.before'), 'missing') <> 'object' OR
+        COALESCE(json_type(audit_snapshot_json, '$.after'), 'missing') <> 'object' OR
+        COALESCE(json_type(audit_snapshot_json, '$.before.title'), 'missing') <> 'text' OR
+        trim(json_extract(audit_snapshot_json, '$.before.title')) = '' OR
+        json_extract(audit_snapshot_json, '$.before.title') <> trim(json_extract(audit_snapshot_json, '$.before.title')) OR
+        length(json_extract(audit_snapshot_json, '$.before.title')) > 100 OR
+        COALESCE(json_type(audit_snapshot_json, '$.before.performedAt'), 'missing') <> 'text' OR
+        length(json_extract(audit_snapshot_json, '$.before.performedAt')) <> 10 OR
+        json_extract(audit_snapshot_json, '$.before.performedAt') NOT GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]' OR
+        COALESCE(date(json_extract(audit_snapshot_json, '$.before.performedAt')), 'invalid') <> json_extract(audit_snapshot_json, '$.before.performedAt') OR
+        COALESCE(json_type(audit_snapshot_json, '$.before.notes'), 'missing') NOT IN ('text', 'null') OR
+        (json_type(audit_snapshot_json, '$.before.notes') = 'text' AND (trim(json_extract(audit_snapshot_json, '$.before.notes')) = '' OR json_extract(audit_snapshot_json, '$.before.notes') <> trim(json_extract(audit_snapshot_json, '$.before.notes')) OR length(json_extract(audit_snapshot_json, '$.before.notes')) > 1000)) OR
+        COALESCE(json_type(audit_snapshot_json, '$.after.title'), 'missing') <> 'text' OR
+        trim(json_extract(audit_snapshot_json, '$.after.title')) = '' OR
+        json_extract(audit_snapshot_json, '$.after.title') <> trim(json_extract(audit_snapshot_json, '$.after.title')) OR
+        length(json_extract(audit_snapshot_json, '$.after.title')) > 100 OR
+        COALESCE(json_type(audit_snapshot_json, '$.after.performedAt'), 'missing') <> 'text' OR
+        length(json_extract(audit_snapshot_json, '$.after.performedAt')) <> 10 OR
+        json_extract(audit_snapshot_json, '$.after.performedAt') NOT GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]' OR
+        COALESCE(date(json_extract(audit_snapshot_json, '$.after.performedAt')), 'invalid') <> json_extract(audit_snapshot_json, '$.after.performedAt') OR
+        COALESCE(json_type(audit_snapshot_json, '$.after.notes'), 'missing') NOT IN ('text', 'null') OR
+        (json_type(audit_snapshot_json, '$.after.notes') = 'text' AND (trim(json_extract(audit_snapshot_json, '$.after.notes')) = '' OR json_extract(audit_snapshot_json, '$.after.notes') <> trim(json_extract(audit_snapshot_json, '$.after.notes')) OR length(json_extract(audit_snapshot_json, '$.after.notes')) > 1000)) OR
+        EXISTS (SELECT 1 FROM json_each(json_extract(audit_snapshot_json, '$.before')) WHERE key NOT IN ('title', 'performedAt', 'notes')) OR
+        EXISTS (SELECT 1 FROM json_each(json_extract(audit_snapshot_json, '$.after')) WHERE key NOT IN ('title', 'performedAt', 'notes')) OR
+        EXISTS (SELECT 1 FROM json_each(json_extract(audit_snapshot_json, '$.before')) GROUP BY key HAVING COUNT(*) > 1) OR
+        EXISTS (SELECT 1 FROM json_each(json_extract(audit_snapshot_json, '$.after')) GROUP BY key HAVING COUNT(*) > 1) OR
+        COALESCE(json_type(audit_snapshot_json, '$.deleted'), 'missing') <> 'missing' OR
+        EXISTS (SELECT 1 FROM json_each(audit_snapshot_json) WHERE key NOT IN ('recordId', 'taskId', 'createdAt', 'before', 'after')))) OR
+      (type = 'maintenance_record_deleted' AND (
+        COALESCE(json_type(audit_snapshot_json, '$.deleted'), 'missing') <> 'object' OR
+        COALESCE(json_type(audit_snapshot_json, '$.deleted.title'), 'missing') <> 'text' OR
+        trim(json_extract(audit_snapshot_json, '$.deleted.title')) = '' OR
+        json_extract(audit_snapshot_json, '$.deleted.title') <> trim(json_extract(audit_snapshot_json, '$.deleted.title')) OR
+        length(json_extract(audit_snapshot_json, '$.deleted.title')) > 100 OR
+        COALESCE(json_type(audit_snapshot_json, '$.deleted.performedAt'), 'missing') <> 'text' OR
+        length(json_extract(audit_snapshot_json, '$.deleted.performedAt')) <> 10 OR
+        json_extract(audit_snapshot_json, '$.deleted.performedAt') NOT GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]' OR
+        COALESCE(date(json_extract(audit_snapshot_json, '$.deleted.performedAt')), 'invalid') <> json_extract(audit_snapshot_json, '$.deleted.performedAt') OR
+        COALESCE(json_type(audit_snapshot_json, '$.deleted.notes'), 'missing') NOT IN ('text', 'null') OR
+        (json_type(audit_snapshot_json, '$.deleted.notes') = 'text' AND (trim(json_extract(audit_snapshot_json, '$.deleted.notes')) = '' OR json_extract(audit_snapshot_json, '$.deleted.notes') <> trim(json_extract(audit_snapshot_json, '$.deleted.notes')) OR length(json_extract(audit_snapshot_json, '$.deleted.notes')) > 1000)) OR
+        EXISTS (SELECT 1 FROM json_each(json_extract(audit_snapshot_json, '$.deleted')) WHERE key NOT IN ('title', 'performedAt', 'notes')) OR
+        EXISTS (SELECT 1 FROM json_each(json_extract(audit_snapshot_json, '$.deleted')) GROUP BY key HAVING COUNT(*) > 1) OR
+        COALESCE(json_type(audit_snapshot_json, '$.before'), 'missing') <> 'missing' OR
+        COALESCE(json_type(audit_snapshot_json, '$.after'), 'missing') <> 'missing' OR
+        EXISTS (SELECT 1 FROM json_each(audit_snapshot_json) WHERE key NOT IN ('recordId', 'taskId', 'createdAt', 'deleted'))))
+    )) AS invalid_activity_audits,
+    (SELECT COUNT(*) FROM activity_entries WHERE type NOT IN ('maintenance_record_updated', 'maintenance_record_deleted') AND audit_snapshot_json IS NOT NULL) AS unexpected_activity_audits;
+  ```
+
+  The command must return one row with all seven integer columns equal to `0`; a missing table/column,
+  a second row, or any nonzero value is a failed gate. The notification bootstrap validation is a
+  second command with the same single-row/zero-value contract. `NOTIFICATION_BOOTSTRAP_VALIDATION_SQL`
+  is exactly:
+
+  ```sql
+  SELECT
+    (SELECT COUNT(*) FROM notification_migration_anomalies WHERE resolved_at IS NULL) AS unresolved_anomalies,
+    (SELECT COUNT(*) FROM maintenance_tasks t JOIN assets a ON a.id = t.asset_id LEFT JOIN notification_task_heads h ON h.maintenance_task_id = t.id WHERE a.archived_at IS NULL AND (h.id IS NULL OR h.status IS NOT 'active' OR h.current_next_due IS NOT t.next_due)) AS invalid_active_heads,
+    (SELECT COUNT(*) FROM notification_sweep_runs WHERE status = 'running') AS incomplete_sweep_runs;
+  ```
+
+  The second command must return exactly one row with columns `unresolved_anomalies`,
+  `invalid_active_heads`, and `incomplete_sweep_runs`, all equal to integer `0`.
+
+  A sweep creates its run row, items, fired transitions, notifications, batches, and outbox rows
+  in one D1 transaction and marks the run `completed` in that same transaction. A D1/transaction
+  failure rolls back the run row and all work; the next invocation retries the same deterministic
+  `sweepRunId`. There is no normal `failed` sweep status or manual status-transition repair path. A
+  committed `running` row is an incomplete migration anomaly and blocks deployment; the only
+  recovery is an idempotent retry using the same `sweepRunId`, which must complete the run or leave
+  it blocked.
+
+- Old maintenance writers are not allowed to write during the backfill window. The exact rollout is: (1) deploy and health-check a compatibility Worker that checks `maintenance_write_gate` on every task/record create, edit, delete, and link operation; (2) apply `0017` while the gate is still `open` because it is schema expansion only; (3) execute `UPDATE maintenance_write_gate SET mode = 'frozen' WHERE id = 1` and require one affected row; (4) apply `0018` through `0021`; (5) run both single-row validation commands; (6) deploy and health-check the final Worker while the gate remains `frozen`; (7) execute `UPDATE maintenance_write_gate SET mode = 'open' WHERE id = 1` and require one affected row. Reads remain available. A frozen or unavailable gate fails closed for writes with HTTP 503, error code `maintenance_write_frozen`, and a retryable response; the UI shows retryable state. If any migration, validation, deployment, health check, or gate update fails, the gate stays frozen; rollback is permitted only to a compatibility build that understands the gate, never to an un-gated old writer.
+- The existing `.github/workflows/deploy.yml` migration-before-deploy ordering is not an accepted rollout for this slice; the implementation PR must replace it with the seven-step sequence above before enabling the new writers.
+- Wrangler applies every pending migration in its directory, so the seven steps use two release
+  boundaries: Release A contains only `0017` plus the gate-aware compatibility Worker and runs
+  `wrangler d1 migrations apply pineapple --remote`; after the gate is frozen, Release B adds
+  `0018` through `0021`, runs the same migrations command to apply exactly those four files, runs
+  both validation commands, and deploys the final Worker. No release may contain `0018`–`0021`
+  while Release A is applying `0017`; if another migration is pending, the release fails closed
+  before applying anything.
+- Before either migrations command, the workflow runs `pnpm --filter @snaveevans/pineapple-api wrangler d1 migrations list pineapple --remote` and parses the unapplied filenames. Release A proceeds only when the unapplied set is exactly `{0017_maintenance_seed_revision_expand.sql}`; Release B proceeds only when it is exactly `{0018_maintenance_seed_revision_backfill.sql, 0019_activity_history_correction_types.sql, 0020_notification_heads_email_claims.sql, 0021_notification_scheduler_bootstrap.sql}`. An empty set, an extra migration, a missing expected migration, malformed command output, or a list-command failure exits nonzero before `migrations apply` is invoked.
+
 ## Out of Scope
 
 - Mileage/odometer-based intervals (Phase 2)
@@ -272,7 +473,7 @@ Published only when `record.performedAt > task.lastCompletedDate` (i.e. when `ne
   interval enum. Future distance/hour tasks need an explicit discriminator such as
   `type: "time" | "distance"` and separate fields like `lastCompletedOdometer` /
   `nextDueMileage`.
-- Directly setting `lastCompletedDate` or `nextDue` via the edit endpoint — moving the schedule without evidence of completed work is "reschedule," a distinct concern tracked in #178 (snooze + reschedule); the boundary is deliberate so the two features don't collide
+- Directly setting `lastCompletedDate` or `nextDue` via the edit endpoint — moving the schedule without evidence of completed work is "reschedule," a distinct concern tracked in [#235](https://github.com/snaveevans/pineapple/issues/235); the boundary is deliberate so the two features don't collide
 - Dashboard-only detail fields such as estimated duration, location/where, assignee/vendor, and
   task notes. They are not part of the current maintenance-task contract and must be specified
   before the dashboard can render them from live API data.

--- a/docs/specs/features/notifications.md
+++ b/docs/specs/features/notifications.md
@@ -9,7 +9,7 @@ metadata:
 
 **Status:** active
 **Owner:** product and engineering
-**Last Updated:** 2026-07-02
+**Last Updated:** 2026-08-21
 **Related Specs:** [authentication.md](../cross-cutting/authentication.md), [validation.md](../cross-cutting/validation.md), [error-handling.md](../cross-cutting/error-handling.md), [loading-states.md](../cross-cutting/loading-states.md), [permissions.md](../cross-cutting/permissions.md), [telemetry.md](../cross-cutting/telemetry.md), [maintenance-task.md](./maintenance-task.md), [activity-history.md](./activity-history.md), [dashboard.md](./dashboard.md), [user-profile.md](./user-profile.md), [email-verification.md](./email-verification.md)
 
 ---
@@ -26,7 +26,7 @@ email** ([email-verification.md](./email-verification.md)) — also by email.
 This is the **durable scheduler** consumer from
 [ADR-0010](../../decisions/0010-smart-events-for-durable-consumers.md), and it is built the way
 that ADR intends: **event-driven, not by polling the source**. When a task's next-due becomes
-known — a task is created, or a completion advances it — the maintenance-task feature publishes
+known — a task is created, a completion advances it, or a record correction recomputes it — the maintenance-task feature publishes
 an **enriched (Smart) event** carrying the producer-owned conclusion (`nextDue`) plus the asset
 snapshot and task title. Notifications **consumes** those events and records its **own**
 cancelable "scheduled reminder" state, keyed by the source task. The maintenance-task feature
@@ -39,7 +39,7 @@ Two behaviors are load-bearing and called out here because they shape the whole 
 
 - **Reminders reschedule and cancel from later events, not from re-reading the task.** A new
   completion supersedes the pending reminder with one for the new cycle; a task deletion cancels
-  it. The scheduler resolves these by event time/version, tolerating out-of-order and duplicated
+  it. The scheduler resolves these by `(taskRevision, kind, lowercase(eventId))`, tolerating out-of-order and duplicated
   delivery ([ADR-0011](../../decisions/0011-reliable-event-delivery-via-cloudflare-queues.md)).
 - **Email is aggregated per user.** If a single scheduler sweep produces more than one reminder
   for the same owner, they receive **one** email listing all of them — never one email per task.
@@ -108,6 +108,8 @@ capability and behavior.
   can track and clear what needs my attention**
 - As **DIYer Dale who completes or deletes a task before its reminder**, I **don't receive a stale
   reminder** so that **notifications stay trustworthy and relevant**
+- As **DIYer Dale who corrects or deletes a linked maintenance record**, I **don't receive a
+  reminder for the superseded schedule** so that **notifications follow the corrected task state**
 - As a **sys admin**, I can **know whether a reminder email actually went out or failed** so that
   **a silently undelivered reminder is detectable** (the ADR-0012 deliverability concern)
 
@@ -117,29 +119,61 @@ Notifications builds its schedule by **consuming enriched maintenance-task event
 its own cancelable state. It does not poll, sweep, or read the maintenance-task tables — the
 event payload carries everything it needs (Smart Events, ADR-0010).
 
-| Consumed event                                         | Scheduler action                                                                                                         |
-| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------ |
-| `MaintenanceTaskCreated` (carries resulting `nextDue`) | Schedule a pending reminder for `(task, nextDue)`, fireAt = `nextDue − lead`, storing the asset/title/`nextDue` snapshot |
-| `MaintenanceTaskAdvanced` (carries new `nextDue`)      | **Reschedule**: supersede the task's prior pending reminder and schedule a new one for the new `nextDue`                 |
-| `MaintenanceTaskDeleted`                               | **Cancel** the task's pending reminder                                                                                   |
+| Consumed event                                            | Scheduler action                                                                                                         |
+| --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `MaintenanceTaskCreated` (carries resulting `nextDue`)    | Schedule a pending reminder for `(task, nextDue)`, fireAt = `nextDue − lead`, storing the asset/title/`nextDue` snapshot |
+| `MaintenanceTaskAdvanced` (carries new `nextDue`)         | **Reschedule**: supersede the task's prior pending reminder and schedule a new one for the new `nextDue`                 |
+| `MaintenanceTaskUpdated` (carries resulting `nextDue`)    | Refresh the pending snapshot; if `nextDue` changed, supersede the prior cycle and schedule the new one                   |
+| `MaintenanceTaskReconciled` (carries resulting `nextDue`) | **Reschedule**: supersede the task's prior pending reminder after a linked record correction changes the schedule        |
+| `MaintenanceTaskDeleted`                                  | **Cancel** the task's pending reminder                                                                                   |
 
 _Asset archive/unarchive would later add "cancel on suspend / reschedule on reactivate" on these
 same handler paths, but that is **out of scope** for this spec and parked in
 [archive-asset.md (backlog)](../backlog/archive-asset.md)._
 
 - **Requires `nextDue` on the event.** For the scheduler to work without reading back,
-  `MaintenanceTaskCreated` and `MaintenanceTaskAdvanced` must carry the resulting `nextDue` as a
+  `MaintenanceTaskCreated`, `MaintenanceTaskUpdated`, `MaintenanceTaskAdvanced`, and
+  `MaintenanceTaskReconciled` must carry the resulting `nextDue` as a
   producer-owned conclusion, alongside the asset snapshot and title they already carry. ADR-0010
   already sanctions `nextDue` as an on-event domain date; the payloads must include it.
 - **Own cancelable state, keyed by task.** Notifications keeps one pending scheduled reminder per
   task, with the snapshot, `nextDue`, computed `fireAt`, a status (`pending` / `fired` /
   `canceled` / `superseded`), and the ordering marker below. This is the "mutable, cancelable
   state keyed by the source entity" of the ADR-0010 durable scheduler.
+- **Task heads are terminal and orderable.** A `notification_task_heads` row stores the latest
+  accepted `(taskRevision, kind, lowercase(eventId))`, `currentNextDue`, and an `active`/`deleted` terminal state for each task. A
+  delete advances the head and marks it `deleted`; this marker remains even when every scheduled
+  cycle row is canceled, so an older or duplicated event cannot recreate a reminder. Maintenance
+  task ids are never reused, so a terminal head cannot be confused with a later task.
+- **Revision and bootstrap ordering.** A new task starts at `taskRevision = 0`; the launch bootstrap
+  writes a marker with `kind = bootstrap` and the deterministic id
+  `bootstrap:<lowercase-taskId>:<nextDue>` at revision 0 only when no newer marker exists. A real
+  event has `kind = real` and always outranks a bootstrap marker at revision 0. Otherwise compare
+  `(taskRevision, kind, lowercase(eventId))` lexicographically: higher revision wins, `real` wins
+  over `bootstrap` at a tie, and the higher canonical event id wins among equal kinds. An equal id
+  is a duplicate and is ignored. An incoming event with a lower revision than the stored task head
+  is stale and is ignored. `MaintenanceTaskDeleted` is a terminal marker, not merely another kind:
+  a real delete uses its incremented revision, while a legacy delete lacking a revision is accepted
+  at revision 0 when no higher-revision head exists and outranks legacy/bootstrap revision-0
+  markers. Once a delete head is accepted, no later event may reactivate that task, including a
+  late real revision-0 marker. A legacy delete never overrides an already accepted higher-revision
+  head.
+- **Legacy message cutover.** A queued pre-cutover message that lacks `taskRevision` or `kind` is
+  normalized to `taskRevision = 0`, `kind = legacy`, and its canonical lowercase event id. A
+  legacy non-delete message has precedence `legacy < bootstrap < real`, so it cannot overwrite a
+  bootstrap head while a real revision-0 event can. A legacy `MaintenanceTaskDeleted` follows the
+  terminal-delete rule above instead of that ordinary kind precedence. This keeps the queue live
+  during deployment; no manual queue drain is required.
 - **Idempotent and order-tolerant** ([ADR-0011](../../decisions/0011-reliable-event-delivery-via-cloudflare-queues.md)):
   each event is deduped on its stable event id (redelivery is a no-op), and schedule-vs-cancel is
-  resolved by **event time/version**, not arrival order — a late-arriving older event never
-  overrides a newer one (e.g. a delete that occurred after an advance always wins, whatever order
-  they are received in).
+  resolved by `(taskRevision, kind, lowercase(eventId))` lexicographically, not arrival order — a late-arriving older
+  event never overrides a newer one (e.g. a delete that occurred after an advance always wins,
+  whatever order they are received in). `taskRevision` is incremented atomically by every
+  task-affecting mutation and is carried on the task event.
+- **Atomic ingestion:** The consumer compares the incoming marker with the task head and updates
+  the head, cycle statuses, and target cycle in one D1 transaction. A losing marker makes no cycle
+  change; a winning marker is committed before the message is acknowledged. The event-id dedupe
+  row and cycle transition are part of that same transaction.
 - **The reminder sweep is notifications' own cron.** Per
   [ADR-0013](../../decisions/0013-reminder-scheduler-via-cron-sweeps.md), a scheduled sweep scans **notifications'
   scheduled-reminder state** for `pending` reminders whose `fireAt` has arrived
@@ -154,6 +188,21 @@ same handler paths, but that is **out of scope** for this spec and parked in
   event, both the scheduled-reminder row and the resulting notification render on their own — even
   after the task is deleted or the asset archived — exactly like
   [activity-history.md](./activity-history.md).
+
+- **Cycle transitions are explicit.** The cycle key is `(taskId, nextDue)`. A new `nextDue`
+  supersedes the current active cycle and creates or reuses one pending row for the new cycle. The
+  current active cycle is the `currentNextDue` stored on the task head. If an accepted event's
+  `nextDue` equals it, the cycle keeps its current status; a winning event replaces the snapshot
+  only when that status is `pending`, and leaves `fired`, `superseded`, and `canceled` rows unchanged.
+  If it differs, the old pending cycle becomes `superseded` and the target cycle is created or
+  reused. A
+  previously seen cycle whose reminder has not fired (`pending` or `superseded`) is reused or
+  reactivated instead of inserted again. Only `superseded` cycles can reactivate; `canceled` means
+  task deletion and is terminal. A cycle whose reminder already fired remains `fired`; it cannot
+  create another in-app notification or email. An event with the current `nextDue` does not create
+  a new cycle or change its fire status. If the current cycle is `pending`, the winning event
+  replaces its asset/title/task snapshot in the same transaction; if the cycle is `fired`,
+  `superseded`, or `canceled`, the cycle row and its historical snapshot are unchanged.
 - **Bootstrapping the existing fleet (one-time backfill).** The scheduler learns tasks from
   events, so at launch a **one-time bootstrap** seeds the scheduled-reminder state from the tasks
   that already exist (tasks on active assets, keyed and deduped the same `(taskId, nextDue)` way).
@@ -214,17 +263,25 @@ same handler paths, but that is **out of scope** for this spec and parked in
       `nextDue` snapshot copied from the scheduled-reminder state, so the inbox row is
       self-contained
 - [ ] A reminder whose task was canceled (`MaintenanceTaskDeleted`) or superseded
-      (`MaintenanceTaskAdvanced`) before the sweep is **not** fired
+      (`MaintenanceTaskAdvanced` or `MaintenanceTaskReconciled`) before the sweep is **not** fired
+- [ ] A `MaintenanceTaskReconciled` event whose `nextDue` is unchanged creates no new reminder cycle or fire-status change; if it wins `(taskRevision, kind, lowercase(eventId))` ordering, it replaces the pending snapshot and marker, while fired/superseded/canceled cycle rows remain unchanged
+- [ ] A reconciliation to a previously seen cycle updates or reactivates an unfired scheduled-reminder row; a cycle that already fired remains fired and never creates a duplicate in-app notification or email
+- [ ] Reconciliation, task-update, advance, and delete ingestion is idempotent by source event id and task cycle, and resolves duplicate or out-of-order delivery using `(taskRevision, kind, lowercase(eventId))` ordering
 - [ ] The lead time is a single shared constant with the dashboard `soon` threshold
       ([dashboard.md](./dashboard.md)); the two are defined once, not independently
 
 ### Email delivery (aggregated per user)
 
-- [ ] When a sweep fires one or more reminders for the same owner, that owner receives **at most
-      one** email covering all of them — **never one email per notification**
+- [ ] When a sweep fires one or more reminders for the same owner, that owner receives **one
+      logical email batch** covering all of them — **never one logical email per notification**;
+      `email_batches` contains one logical batch row and only one send attempt is in flight at a
+      time
 - [ ] The aggregation unit is **a single sweep per owner**: reminders fired in the same sweep are
       combined; reminders fired in different sweeps (e.g. tasks due on different dates) are separate
-      emails
+      emails. Each scheduled invocation derives the canonical string
+      `sweepRunId = "maintenance-reminders:" + cronName + ":" + String(scheduledTimeEpochMs)`;
+      due reminders are claimed for that run in the same transaction, and the unique key
+      `(sweepRunId, ownerId)` guarantees one logical batch even if the invocation is retried.
 - [ ] Aggregation applies to **email only** — the in-app inbox still receives one notification per
       task
 - [ ] The aggregated email is sent only when the owner has a **verified** contact email
@@ -238,13 +295,45 @@ same handler paths, but that is **out of scope** for this spec and parked in
 - [ ] Email delivery is **at-least-once and decoupled** via the notifications queue + DLQ, on the
       same reliability pattern as [activity-history.md](./activity-history.md)
       ([ADR-0011](../../decisions/0011-reliable-event-delivery-via-cloudflare-queues.md)): the
-      aggregated send job is enqueued atomically with the reminders it covers, the consumer is
-      **idempotent on the batch id** so a redelivery cannot re-send, transient failures retry with
-      backoff, and a permanently failing send is dead-lettered and durably persisted rather than
-      left to expire
-- [ ] The **outcome** of every aggregated send (`sent`, `suppressed`, `failed`) and the number of
-      notifications it covered are recorded and observable, so a silently undelivered reminder is
-      detectable — the deliverability requirement
+      aggregated send outbox row is committed atomically with the reminders it covers; publication
+      to the outbound queue is eventual and idempotent, and the consumer is
+      **idempotent on the batch id** so queue redelivery or concurrent consumers cannot claim two
+      sends at once. The consumer atomically claims `pending -> sending` with a lease; a confirmed
+      pre-acceptance transient failure releases it to `pending` for exponential backoff, up to
+      three additional attempts, while
+      a confirmed provider acceptance becomes `sent`, a permanent rejection becomes `failed`, and
+      a timeout/unknown outcome becomes `unknown` and is never retried. A `sending` claim has a
+      five-minute lease; if it expires without a confirmed provider result, the next consumer
+      atomically marks the batch `unknown` and never retries it. A provider acceptance followed by
+      a Worker crash can still produce a physical duplicate in v1; this edge is observable as one
+      batch id and is not retried deliberately.
+- [ ] Email state transitions are fenced by a claim token: `pending -> sending` stores a unique
+      token and a five-minute lease; confirmed pre-acceptance transient failures move back to
+      `pending` with retry delays of 1, 2, and 4 minutes for retries 1, 2, and 3; a fourth such
+      failure moves to `failed` and a durable DLQ record; confirmed acceptance moves to `sent`;
+      permanent rejection moves to `failed`; timeout or unknown outcome moves to terminal
+      `unknown`. A scheduled lease reaper atomically changes expired `sending` rows to `unknown`.
+      A late provider result whose claim token no longer matches, or whose row is terminal, is
+      recorded as an observation only and cannot change state or trigger another send. Every
+      provider-result update is conditional on `status = 'sending'`, the matching claim token,
+      and `lease_expires_at > now`; a result that arrives after lease expiry cannot mark the batch
+      `sent`. The lease reaper is the only recovery path for an abandoned claim and marks it
+      terminal `unknown`.
+- [ ] The durable email transition table is:
+      `pending -> sending` only when `next_attempt_at` is null or due, storing a fresh token and
+      `lease_expires_at = now + 5 minutes`; `sending -> pending` only for the worker holding that
+      token after a confirmed pre-acceptance transient failure, incrementing `retry_count` and
+      setting `next_attempt_at` to `now + 1/2/4 minutes` for retries 1/2/3; the same failure when
+      `retry_count = 3` becomes terminal `failed` and writes a durable DLQ row; `sending -> sent`
+      and `sending -> failed` for provider results require the same token and an unexpired lease;
+      the lease reaper alone performs `sending -> unknown` after expiry; `pending -> suppressed`
+      is used when send-time contact-email verification fails. `sent`, `suppressed`, `failed`, and
+      `unknown` are terminal and all terminal transitions clear the token, lease, and retry time.
+- [ ] The **outcome** of every aggregated send (`sent`, `suppressed`, `failed`, `unknown`) and the number of
+      notifications it covered are recorded in the durable `email_batches` row and emit exactly one
+      `ReminderEmailDispatched` observation after the terminal transition. Operators can query the
+      internal row and telemetry observation; no public email-delivery endpoint is required in v1,
+      so a silently undelivered reminder is still detectable — the deliverability requirement
       [ADR-0012](../../decisions/0012-transactional-email-via-cloudflare-email-sending.md) makes a
       condition of running the open-beta email provider
 
@@ -278,31 +367,34 @@ arithmetic, not timestamp subtraction.
 
 ## Edge Cases & Error States
 
-| Scenario                                                    | Expected Behavior                                                                                                                                                 |
-| ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| No valid session on inbox/mark-read                         | 401; client redirects to `/login`                                                                                                                                 |
-| Caller has no notifications                                 | Empty list, unread count 0; client shows an empty inbox state                                                                                                     |
-| `MaintenanceTaskCreated` received, `nextDue` > 7 days out   | A pending reminder is scheduled; nothing fires until its `fireAt` arrives                                                                                         |
-| `MaintenanceTaskCreated` received already inside the window | Pending reminder with `fireAt` in the past; the next sweep fires it (no retroactive firing before the event)                                                      |
-| Reminder `fireAt` arrives                                   | One `maintenance_due_soon` notification created for that cycle                                                                                                    |
-| Sweep runs again before the task advances                   | No duplicate — creation idempotent on (taskId, nextDue)                                                                                                           |
-| `MaintenanceTaskAdvanced` received                          | Prior pending reminder superseded; a new one scheduled for the new `nextDue`; no reminder for the old cycle                                                       |
-| `MaintenanceTaskDeleted` received before the reminder fires | Pending reminder canceled; nothing fires for that task                                                                                                            |
-| Advance and delete events arrive out of order               | Resolved by event time/version — the later-occurring event wins regardless of arrival order                                                                       |
-| A maintenance event is redelivered                          | No-op — deduped on the event id                                                                                                                                   |
-| Several of one owner's reminders fire in the same sweep     | One aggregated email listing all of them; one inbox notification per task                                                                                         |
-| Owner has a **verified** contact email                      | Aggregated email dispatched to that address                                                                                                                       |
-| Owner has **no**/**unverified** contact email               | Per-task notifications created; **no email**; batch recorded `suppressed`; UI prompts to verify an email                                                          |
-| Owner verifies an email after some suppressed reminders     | Future reminders email; already-suppressed past notifications are not retroactively emailed (v1)                                                                  |
-| Aggregated email send transiently fails                     | Retried with backoff via the queue; not lost                                                                                                                      |
-| Aggregated email send permanently fails                     | Dead-lettered and durably persisted; outcome recorded as `failed`; detectable, not silently dropped                                                               |
-| Redelivery of the same aggregated send job                  | Idempotent on the batch id — the email is not sent twice                                                                                                          |
-| Task on an asset that was archived                          | Until archive is a live action, a reminder may still fire — accepted, currently-unreachable gap; deferred design parked in [backlog](../backlog/archive-asset.md) |
-| Mark-read on an already-read notification                   | Idempotent success                                                                                                                                                |
-| Mark-read on a foreign or unknown `notificationId`          | 404; existence not revealed                                                                                                                                       |
-| New notification arrives while the user views the inbox     | Appears on the next fetch/refresh; the inbox is not real-time                                                                                                     |
-| `limit`/`cursor` out of range or malformed                  | 422 validation error                                                                                                                                              |
-| Non-401 API error on the inbox (e.g. 500)                   | Client shows an inbox-level error state with retry                                                                                                                |
+| Scenario                                                    | Expected Behavior                                                                                                                                                                          |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| No valid session on inbox/mark-read                         | 401; client redirects to `/login`                                                                                                                                                          |
+| Caller has no notifications                                 | Empty list, unread count 0; client shows an empty inbox state                                                                                                                              |
+| `MaintenanceTaskCreated` received, `nextDue` > 7 days out   | A pending reminder is scheduled; nothing fires until its `fireAt` arrives                                                                                                                  |
+| `MaintenanceTaskCreated` received already inside the window | Pending reminder with `fireAt` in the past; the next sweep fires it (no retroactive firing before the event)                                                                               |
+| Reminder `fireAt` arrives                                   | One `maintenance_due_soon` notification created for that cycle                                                                                                                             |
+| Sweep runs again before the task advances                   | No duplicate — creation idempotent on (taskId, nextDue)                                                                                                                                    |
+| `MaintenanceTaskAdvanced` received                          | Prior pending reminder superseded; a new one scheduled for the new `nextDue`; no reminder for the old cycle                                                                                |
+| `MaintenanceTaskDeleted` received before the reminder fires | Pending reminder canceled; nothing fires for that task                                                                                                                                     |
+| Advance and delete events arrive out of order               | Resolved by `(taskRevision, kind, lowercase(eventId))` — the higher task revision wins regardless of arrival order                                                                         |
+| A maintenance event is redelivered                          | No-op — deduped on the event id                                                                                                                                                            |
+| Several of one owner's reminders fire in the same sweep     | One aggregated email listing all of them; one inbox notification per task                                                                                                                  |
+| Two cron invocations share a scheduled timestamp            | Unique `(cronName, scheduledTimeEpochMs)` reuses one `sweepRunId`; reminder claims, notifications, batches, and outbox rows are not duplicated                                             |
+| Sweep crashes before its D1 transaction commits             | No reminder is marked fired; the next invocation reuses the run/items and performs the complete transaction                                                                                |
+| Sweep crashes after its D1 transaction commits              | Fired reminders, sweep items, notifications, email batch, and outbox row are durable; only queue relay remains to retry                                                                    |
+| Owner has a **verified** contact email                      | Aggregated email dispatched to that address                                                                                                                                                |
+| Owner has **no**/**unverified** contact email               | Per-task notifications created; **no email**; batch recorded `suppressed`; UI prompts to verify an email                                                                                   |
+| Owner verifies an email after some suppressed reminders     | Future reminders email; already-suppressed past notifications are not retroactively emailed (v1)                                                                                           |
+| Aggregated email send transiently fails                     | Retried with backoff via the queue; not lost                                                                                                                                               |
+| Aggregated email send permanently fails                     | Dead-lettered and durably persisted; outcome recorded as `failed`; detectable, not silently dropped                                                                                        |
+| Redelivery of the same aggregated send job                  | Idempotent on the batch id — no second in-flight claim; only confirmed pre-acceptance transient failures are retried; provider crash-after-accept duplicates remain the documented v1 edge |
+| Task on an asset that was archived                          | An existing scheduled reminder fires in v1; archiving does not cancel a task or reminder in this slice, and archive suspension remains deferred to [backlog](../backlog/archive-asset.md)  |
+| Mark-read on an already-read notification                   | Idempotent success                                                                                                                                                                         |
+| Mark-read on a foreign or unknown `notificationId`          | 404; existence not revealed                                                                                                                                                                |
+| New notification arrives while the user views the inbox     | Appears on the next fetch/refresh; the inbox is not real-time                                                                                                                              |
+| `limit`/`cursor` out of range or malformed                  | 422 validation error                                                                                                                                                                       |
+| Non-401 API error on the inbox (e.g. 500)                   | Client shows an inbox-level error state with retry                                                                                                                                         |
 
 ## Telemetry
 
@@ -320,7 +412,8 @@ scheduler, the sweep, and email delivery run outside the HTTP request path, so t
 as the domain events below, not request telemetry.
 
 **Domain events consumed:** Notifications is a durable consumer of the existing enriched
-`MaintenanceTaskCreated`, `MaintenanceTaskAdvanced`, and `MaintenanceTaskDeleted` events
+`MaintenanceTaskCreated`, `MaintenanceTaskUpdated`, `MaintenanceTaskAdvanced`,
+`MaintenanceTaskReconciled`, and `MaintenanceTaskDeleted` events
 ([maintenance-task.md](./maintenance-task.md)). Delivery is durable (its own queue), idempotent on
 the event id, and order-tolerant — the same posture as [activity-history.md](./activity-history.md).
 Those events must carry `nextDue` for this consumer.
@@ -357,29 +450,104 @@ One per notification (per task/cycle).
 One per aggregated send (per owner per sweep). Records the outcome and how many notifications the
 email covered — this is the deliverability signal ADR-0012 requires.
 
-| Field        | Name                 | Value                                             |
-| ------------ | -------------------- | ------------------------------------------------- |
-| `indexes[0]` | —                    | `owner_id`                                        |
-| `blobs[0]`   | `event_type`         | `"ReminderEmailDispatched"`                       |
-| `blobs[1]`   | `aggregate_type`     | `"Notification"`                                  |
-| `blobs[2]`   | `email_batch_id`     | Aggregated-send UUID (idempotency key)            |
-| `blobs[3]`   | `owner_id`           | Owner UUID                                        |
-| `blobs[4]`   | `schema_version`     | `"v1"`                                            |
-| `blobs[5]`   | `result`             | `"sent"`, `"suppressed"`, or `"failed"`           |
-| `blobs[6]`   | `suppress_reason`    | `"no_contact_email"`, `"unverified"`, or `"none"` |
-| `doubles[0]` | `count`              | Always `1`                                        |
-| `doubles[1]` | `event_time_ms`      | Event timestamp (ms since epoch)                  |
-| `doubles[2]` | `notification_count` | Number of notifications covered by this email     |
+| Field        | Name                 | Value                                                |
+| ------------ | -------------------- | ---------------------------------------------------- |
+| `indexes[0]` | —                    | `owner_id`                                           |
+| `blobs[0]`   | `event_type`         | `"ReminderEmailDispatched"`                          |
+| `blobs[1]`   | `aggregate_type`     | `"Notification"`                                     |
+| `blobs[2]`   | `email_batch_id`     | Aggregated-send UUID (idempotency key)               |
+| `blobs[3]`   | `owner_id`           | Owner UUID                                           |
+| `blobs[4]`   | `schema_version`     | `"v1"`                                               |
+| `blobs[5]`   | `result`             | `"sent"`, `"suppressed"`, `"failed"`, or `"unknown"` |
+| `blobs[6]`   | `suppress_reason`    | `"no_contact_email"`, `"unverified"`, or `"none"`    |
+| `doubles[0]` | `count`              | Always `1`                                           |
+| `doubles[1]` | `event_time_ms`      | Event timestamp (ms since epoch)                     |
+| `doubles[2]` | `notification_count` | Number of notifications covered by this email        |
 
 ## Implementation Requirements
 
-- Populate `nextDue` on the enriched `MaintenanceTaskCreated` and `MaintenanceTaskAdvanced` event
-  payloads where they are constructed in the application layer. The thin telemetry blobs stay
-  PII-free and unchanged.
+- Populate `nextDue` and `taskRevision` on every enriched `MaintenanceTaskCreated`,
+  `MaintenanceTaskUpdated`, `MaintenanceTaskAdvanced`, and `MaintenanceTaskReconciled` event
+  payload where it is constructed in the application layer. The thin telemetry blobs stay PII-free
+  and unchanged.
 - Add two dedicated queues, each with its own DLQ: one inbound queue for the `MaintenanceTask*`
   notification consumer, and one outbound queue for aggregated email delivery. The split provides
   per-role isolation per [ADR-0011](../../decisions/0011-reliable-event-delivery-via-cloudflare-queues.md):
   a stuck email send cannot block event ingestion.
+- The email provider port returns one of `accepted`, `permanent_rejection`,
+  `pre_acceptance_transient_failure`, or `unknown`. The Cloudflare adapter must distinguish a
+  confirmed rejection before provider acceptance from a timeout/transport result whose acceptance
+  is unknown; the former becomes `failed` and the latter becomes terminal `unknown`.
+  `ReminderEmailDispatched` and its telemetry result union include `unknown` as a first-class
+  outcome, while the stored claim transition still requires the token/lease CAS above.
+- Every queue DLQ write uses the provider/queue message's stable `message.id` as its idempotency key
+  (`queue`, `message.id` unique); it never generates a random persistence id as the dedupe key. If
+  D1 is unavailable while persisting an exhausted message, the consumer throws so the queue retry
+  remains available; once D1 accepts the row, later redelivery is an insert-or-ignore observation.
+- `notification_email_outbox` is a separate relay state machine: `pending -> sending -> sent` on a
+  confirmed `Queue.send`, with a claim token/lease and at most three pre-publication retries.
+  Exhausted confirmed pre-publication failures become a durable DLQ row, terminal `failed` outbox
+  state, terminal `failed` `email_batches` state, and exactly one `ReminderEmailDispatched`
+  observation. A queue publication whose result is unknown leaves the claim to the lease reaper;
+  the reaper records the relay failure durably, marks the outbox `failed`, marks the batch terminal
+  `unknown`, and emits the same single terminal observation. The outbound consumer remains
+  idempotent on `batchId` and ignores a message that arrives after a terminal batch state.
+- If queue publication succeeds but the outbox `sending -> sent` update fails, the queue message is
+  allowed to redeliver and the relay lease can later record a duplicate publication; the outbound
+  consumer dedupes on `batchId`, so the provider-facing batch claim still permits only one logical
+  send. If D1 cannot persist the terminal relay/DLQ row, the relay throws and retains the message for
+  retry rather than acknowledging it. A pre-publication relay DLQ has no Cloudflare queue message
+  id, so it uses stable `queue_message_id = "outbox:" + outboxId`; after publication it uses the
+  actual queue `message.id`.
+- Migration `0020_notification_heads_email_claims.sql` adds nullable `queue_message_id` to
+  `notification_dead_letters`, backfills existing rows to deterministic `legacy:<id>` values, and
+  adds a unique `(queue, queue_message_id)` index. It also rebuilds `notification_email_outbox` so
+  its status check permits `pending | sending | sent | failed`, copies every existing row, preserves
+  `batch_id` uniqueness and claimable indexes, and aborts on any count/key/index mismatch. Existing
+  `sending` rows from the pre-claim schema are normalized to `pending` with a null token/lease and
+  an immediately due retry; `sent` rows remain terminal. New queue
+  consumers persist the actual stable Cloudflare `message.id`; the old generated `id` remains only
+  the row identity.
+- Add `notification_task_heads` and backfill it from existing `scheduled_reminders` in a new
+  idempotent migration; existing heads start at revision `0` with the deterministic bootstrap
+  marker, and the task row's current `nextDue` is authoritative for every active task. Before
+  selecting the target, mark every pending historical cycle with a different `nextDue` as
+  `superseded` so it cannot fire or block the pending-task unique index. A stale pending cycle is
+  never silently dropped: its status transition is recorded before the target is selected. Ensure the
+  `(taskId, task.nextDue)` cycle exists: reuse it when pending, reactivate it only when superseded,
+  preserve it as fired when already fired, and never reactivate a canceled cycle. Historical cycles
+  with a different `nextDue` never determine `currentNextDue`; canceled rows are preserved as
+  terminal history and never deleted or reactivated. If an active task
+  has no candidate row, create/reuse the target pending cycle and point the active head at it. For
+  an active task whose target cycle is already canceled, preserve the terminal row and record a
+  migration anomaly instead of creating a duplicate or silently reactivating it; the bootstrap
+  migration must fail closed with the task id and the blocking validation must surface that anomaly
+  for repair. For
+  a task row that no longer exists, mark the head `deleted`, set `currentNextDue` to the greatest
+  existing row's `nextDue` or `null` when no cycle exists, and cancel every non-fired cycle. Existing
+  `scheduled_reminders.last_event_id` values beginning with `bootstrap:` become `kind = bootstrap`;
+  all other existing messages/rows without a marker kind are `legacy`; a legacy delete source is
+  marked terminal rather than being ranked below bootstrap. The migration must not rely
+  on editing the already-applied `0011_bootstrap_scheduled_reminders.sql`.
+- `notification_task_heads` is the sole authority for event ordering, task terminal deletion, and
+  `(taskRevision, kind, lowercase(eventId))` acceptance. `scheduled_reminders.last_event_id` and
+  `last_task_revision` are retained only as cycle provenance/debug snapshots and are never used to
+  accept or reject an event. `notification_migration_anomalies` stores unresolved bootstrap repair
+  rows (`task_id`, anomaly code, details, `resolved_at`); any unresolved row blocks deployment.
+- Add `sweep_run_id` to `email_batches` and a unique index on `(sweep_run_id, owner_id)`. The sweep
+  writes a single durable `notification_sweep_runs` row per derived `sweepRunId`; a rerun of the
+  same scheduled timestamp reuses that row and cannot claim the same fired reminders into a second
+  batch.
+- `notification_sweep_runs` has `id` (the canonical `sweepRunId`), `cron_name`,
+  `scheduled_time_epoch_ms`, `status` (`running` / `completed`), `created_at`, and `completed_at`,
+  with a unique `(cron_name, scheduled_time_epoch_ms)`. `notification_sweep_items` has
+  `(sweep_run_id, reminder_id)` as its primary key, `owner_id`, `claimed_at`, and `email_batch_id`;
+  the sweep inserts/reuses one item per due reminder, creates the in-app notification, marks the
+  reminder `fired`, and creates/links the owner batch and email outbox row in one D1 transaction.
+  Concurrent invocations use `INSERT ... ON CONFLICT (cron_name, scheduled_time_epoch_ms) DO
+NOTHING` and then read the existing run; a concurrent or retried invocation first reuses the
+  existing run and items, so a crash cannot
+  leave a fired reminder without its batch/outbox or claim it into a second batch.
 - Add both queue bindings/consumers to `apps/api/wrangler.jsonc` and the matching idempotent queue
   creation entries to `.github/workflows/deploy.yml`, then regenerate the Worker binding types
   (`cf-typegen`) and give each producer binding its message type in `BindingOverrides` in
@@ -431,9 +599,8 @@ email covered — this is the deliverability signal ADR-0012 requires.
 - **Channels other than in-app + email** — no SMS, push, or webhooks
 - **Real-time/live inbox updates** — the inbox refreshes on fetch, not via push
 - **Retroactively emailing suppressed past reminders** after a later verification
-- **Cancel-on-archive** — archive is currently a dormant field with no action or event. Until
-  archive becomes a real action, a reminder for a task on an out-of-band archived asset may still
-  fire; the worked-out cascade is parked in [archive-asset.md](../backlog/archive-asset.md).
+- **Cancel-on-archive** — existing scheduled reminders for archived assets fire in v1; archive
+  cancellation and the worked-out cascade are parked in [archive-asset.md](../backlog/archive-asset.md).
 - **The contact-email value, its endpoints, and the verification flow** — owned by
   [user-profile.md](./user-profile.md) and [email-verification.md](./email-verification.md)
 - **Cross-user or team-wide notifications** — single-owner scope in v1
@@ -442,8 +609,6 @@ email covered — this is the deliverability signal ADR-0012 requires.
 
 - Team/delegate notifications. v1 records `actorId` (`"system"`) separately from `ownerId` for
   future attribution, but does not display an actor or support cross-user inboxes.
-- Harden reminder-email dispatch with an atomic claim step before calling the email provider. v1
-  accepts the at-least-once queue edge for aggregated reminder emails; a future pass could add a
-  `pending` -> `sending` transition on `email_batches` so concurrent redeliveries do not both send.
-  This reduces duplicate sends but does not fully eliminate the crash-after-send edge without
-  provider-level idempotency.
+- Add provider-level idempotency keyed by `emailBatchId` if the selected email provider offers it;
+  until then, the documented v1 crash-after-accept edge remains the only path to a physical
+  duplicate, and no application retry intentionally repeats a claimed batch.

--- a/docs/specs/features/teams-foundation.md
+++ b/docs/specs/features/teams-foundation.md
@@ -74,10 +74,11 @@ _Each criterion carries exactly one slice tag (`S1`…`S5`) from the [Delivery P
 **Member access to shared assets (full parity)**
 
 - [x] `S2` A team member can read an asset shared with their team and its **maintenance tasks and records** (the activity feed is `S3`, below)
-- [x] `S2` A team member can perform the same **write** actions on a shared asset that its owner can — the maintenance actions that exist today: adding and deleting maintenance tasks, and logging maintenance records — with the sole exceptions of changing its sharing and deleting the asset itself, which remain asset-owner-only
+- [x] `S2` A team member can perform the same **maintenance write** actions on a shared asset that its owner can — creating, editing, and deleting maintenance tasks and records, and logging maintenance records — with the sole exceptions of changing its sharing and deleting the asset itself, which remain asset-owner-only
 - [x] `S2` Access to a shared asset's dependent records **follows the asset**: authorization for maintenance task and record operations is determined by whether the requester can access the parent asset (owns it, or is a member of the team it is shared with), replacing the direct `ownerId === requesterId` check on those operations
+- [x] `S2` Shared-member access does not bypass feature validation: archived assets remain readable but reject new records/tasks and record corrections with the same 409 rules as for the asset owner; editing or deleting an existing task remains permitted for both owner and member, while editing or deleting a record remains blocked; sharing grants access, not an archive override
 - [x] `S3` Access to the **activity feed** for shared assets follows the asset the same way — specified in [activity-history.md](./activity-history.md) (team visibility of shared-asset activity, with actor attribution)
-- [x] `S2` When an asset is unshared, or a member's access otherwise ends, subsequent requests by that member for the asset or its records behave as if the asset does not exist for them
+- [x] `S2` When an asset is unshared, or a member's access otherwise ends, subsequent collection requests omit the asset and its records; a direct request for an existing but inaccessible asset or child returns 403 under the current canonical error rule
 
 **Read-path integration**
 
@@ -104,23 +105,25 @@ _Each criterion carries exactly one slice tag (`S1`…`S5`) from the [Delivery P
 
 ## Edge Cases & Error States
 
-| Scenario                                                      | Expected Behavior                                                                              |
-| ------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| Create team while already in a team (owner or member)         | 409 Conflict; no team created                                                                  |
-| Create team with empty/whitespace name                        | 422 Validation error mapped to the name field                                                  |
-| Create team with an over-length name                          | 422 Validation error mapped to the name field                                                  |
-| Read "my team" when the user has no team                      | 200 with an explicit "no team" result; client shows create-team prompt                         |
-| Share an asset the requester does not own                     | 403 Forbidden (owner-only), or 404 if the asset is not visible to the requester at all         |
-| Share an asset when the requester has no team                 | 409 Conflict (nothing to share into)                                                           |
-| Share an asset already shared to the caller's team            | Idempotent success (no duplicate)                                                              |
-| Unshare an asset that is already personal                     | Idempotent success                                                                             |
-| Non-owner member tries to unshare a shared asset              | 403 Forbidden (only the asset owner controls sharing)                                          |
-| Member reads/edits an asset shared with their team            | Succeeds; changes are visible to the owner and other members                                   |
-| Member deletes a maintenance task on a shared asset           | Succeeds (full parity)                                                                         |
-| Member tries to delete the shared asset itself                | Not permitted — asset deletion is asset-owner-only (and asset deletion is not yet implemented) |
-| Request an asset shared to a team the requester is **not** in | Treated as not visible (see Flags: 403-vs-404 inherits the permissions.md known issue)         |
-| Asset is unshared while a member has it open                  | The member's next request behaves as if the asset does not exist for them                      |
-| Unauthenticated request to any endpoint here                  | 401 Unauthorized → client redirects to `/login`                                                |
+| Scenario                                                                 | Expected Behavior                                                                              |
+| ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------- |
+| Create team while already in a team (owner or member)                    | 409 Conflict; no team created                                                                  |
+| Create team with empty/whitespace name                                   | 422 Validation error mapped to the name field                                                  |
+| Create team with an over-length name                                     | 422 Validation error mapped to the name field                                                  |
+| Read "my team" when the user has no team                                 | 200 with an explicit "no team" result; client shows create-team prompt                         |
+| Share an asset the requester does not own                                | 403 Forbidden (owner-only), or 404 if the asset is not visible to the requester at all         |
+| Share an asset when the requester has no team                            | 409 Conflict (nothing to share into)                                                           |
+| Share an asset already shared to the caller's team                       | Idempotent success (no duplicate)                                                              |
+| Unshare an asset that is already personal                                | Idempotent success                                                                             |
+| Non-owner member tries to unshare a shared asset                         | 403 Forbidden (only the asset owner controls sharing)                                          |
+| Member reads/edits an asset shared with their team                       | Succeeds; changes are visible to the owner and other members                                   |
+| Member creates or edits a maintenance task on a shared asset             | Succeeds (full maintenance parity)                                                             |
+| Member deletes a maintenance task on a shared asset                      | Succeeds (full maintenance parity)                                                             |
+| Member creates, edits, or deletes a maintenance record on a shared asset | Succeeds; the asset owner remains the record owner and the member is the actor                 |
+| Member tries to delete the shared asset itself                           | Not permitted — asset deletion is asset-owner-only (and asset deletion is not yet implemented) |
+| Request an asset shared to a team the requester is **not** in            | Direct resource request returns 403; collection requests omit it (the current canonical rule)  |
+| Asset is unshared while a member has it open                             | The member's next request behaves as if the asset does not exist for them                      |
+| Unauthenticated request to any endpoint here                             | 401 Unauthorized → client redirects to `/login`                                                |
 
 ## API Shape (design target)
 

--- a/docs/specs/prompts/mutation-kill.md
+++ b/docs/specs/prompts/mutation-kill.md
@@ -1,0 +1,157 @@
+# Prompt: Kill mutation survivors (test-only)
+
+Reusable process for issues that raise the mutation baseline by tightening
+assertions — backlog [#91](https://github.com/snaveevans/pineapple/issues/91)–[#98](https://github.com/snaveevans/pineapple/issues/98).
+Policy: [docs/specs/cross-cutting/testing.md](../cross-cutting/testing.md),
+[ADR-0016](../../decisions/0016-mutation-testing-as-the-ci-trust-boundary.md).
+
+---
+
+## Hard constraints (do not violate)
+
+1. **Tests only.** Edit or create `*.test.ts` under `apps/api/src/domain/**` or
+   `apps/api/src/application/**`. Do **not** change production source, Stryker
+   config, `thresholds.break`, mutators, or `mutate` globs.
+2. **One issue = one branch = one PR.** No drive-by refactors, renames, or
+   unrelated coverage.
+3. **Assert outcomes, not execution.** Returned values, error **types** +
+   `field`, event **payloads**, computed numbers, status/retryable contracts.
+4. **Never pin error-message prose.** `StringLiteral` survivors on error copy
+   are expected — kill type/field/behavior mutants only.
+5. **Do not raise `thresholds.break`.** Concurrent kill-PRs race on the floor;
+   a separate ratchet lands after several merge.
+6. **Pure unit tests.** In-memory fakes for ports; no D1, no Workers runtime.
+7. **Match existing style.** Co-located `Foo.test.ts`, vitest, branded IDs via
+   `.from()` / `.generate()`, `Result` via `result.ok` then value/error, fake
+   repos like neighboring tests.
+
+## Inputs (fill per issue)
+
+| Field               | Value                  |
+| ------------------- | ---------------------- |
+| Issue               | `#N` — title           |
+| Target files        | (from issue body)      |
+| Acceptance criteria | (checklist from issue) |
+| Sample survivors    | (from issue body)      |
+| Worktree (if any)   | absolute path          |
+
+## Process
+
+### 0. Isolate
+
+```bash
+# Prefer a dedicated worktree so parallel agents never thrash the same checkout.
+git fetch origin main
+git worktree add -b test/N-short-slug /path/to/worktree origin/main
+cd /path/to/worktree
+pnpm install
+```
+
+Branch regex: `test/{issue}-{slug}` e.g. `test/91-cover-get-asset-list-activity`.
+
+### 1. Orient (read before writing)
+
+1. Full issue body + acceptance criteria.
+2. Each target **source** file (understand branches under test).
+3. Existing co-located `*.test.ts` and 1–2 sibling use-case/domain tests for
+   fake/assert patterns.
+4. `docs/specs/cross-cutting/testing.md` mutator policy (status strings **are**
+   contract; error prose is **not**).
+5. Relevant feature/cross-cutting specs only if needed for intended behavior
+   (e.g. permissions for #95, Smart Events ADR-0010 for #97).
+
+### 2. Write tests that kill high-signal mutants
+
+For each acceptance criterion and each sample survivor:
+
+| Mutant class                             | What the test must prove                             |
+| ---------------------------------------- | ---------------------------------------------------- |
+| `ConditionalExpression` → `true`/`false` | Both sides of the guard (grant **and** deny)         |
+| `EqualityOperator` `>` ↔ `>=` etc.       | Exact boundary: in-bound valid, out-of-bound invalid |
+| `BooleanLiteral` flip                    | The flag’s real value matters to the caller          |
+| `ObjectLiteral` → `{}`                   | Every required payload field is present and correct  |
+| `ArrayDeclaration` → `[]` / filler       | Empty vs non-empty branch outcomes differ            |
+| `UpdateOperator` `++` → `--`             | Exact counts, not “key exists”                       |
+| `ArithmeticOperator`                     | Direction and clamping with concrete dates/numbers   |
+| `NoCoverage`                             | At least one test executes the path **and** asserts  |
+
+Patterns that **fail** this work:
+
+- `expect(result.ok).toBe(true)` with no value checks
+- Asserting only `events[0].type` without payload fields
+- Asserting error `.message` strings
+- Happy-path only when the survivor is a removed deny guard
+
+### 3. Verify
+
+```bash
+# Fast loop while writing (scope to touched tests / units)
+pnpm --filter @snaveevans/pineapple-api exec vitest run path/to/File.test.ts
+
+# Full package tests before PR
+pnpm --filter @snaveevans/pineapple-api test
+
+# Optional but preferred: confirm target files lost NoCoverage / high-signal survivors
+# Full suite ~80s+. If too heavy, at least ensure new tests fail when you
+# temporarily invert the production guard, then revert the guard (do not commit
+# production edits).
+pnpm --filter @snaveevans/pineapple-api test:mutation
+```
+
+Also run when practical:
+
+```bash
+pnpm lint && pnpm type-check
+```
+
+### 4. Ship
+
+```bash
+git status   # only *.test.ts (and nothing else)
+git log origin/main..HEAD --oneline
+# commit — end with Co-Authored-By trailer per AGENTS.md
+git push -u origin HEAD
+
+gh pr create --base main --title "test: …" --body "$(cat <<'EOF'
+## Summary
+
+- <what assertions were added and which mutants they target>
+
+## Related
+
+Closes #N
+
+## Test plan
+
+- [x] `pnpm --filter @snaveevans/pineapple-api test` green
+- [x] New/updated tests assert values, error types, payloads — not merely execution
+- [ ] CI `verify` + `mutation` green
+
+## Spec / AC
+
+Issue #N acceptance criteria:
+
+- [x] …
+EOF
+)"
+```
+
+PR title style: `test: <issue slug>` matching the issue intent.
+Do **not** merge. Stop after the PR URL is printed.
+
+## Done definition
+
+- [ ] Every issue AC checked off in the PR body with evidence in tests
+- [ ] Diff is test-only
+- [ ] Branch `test/N-…`, PR `Closes #N`
+- [ ] No change to `stryker.conf.json` / production sources
+- [ ] Agent final message: PR URL + brief list of files touched
+
+## Anti-collusion / honesty
+
+- Do not weaken production code to make tests easier.
+- Do not delete or skip existing tests to green the suite.
+- If an AC cannot be met without a production change, **stop**, open a comment
+  on the issue explaining why, and leave the PR as draft or do not open one.
+- If two target files share helpers, keep helpers inside the test file or a
+  test-only pattern already used nearby — still no production edits.

--- a/docs/web/FEATURES.md
+++ b/docs/web/FEATURES.md
@@ -419,12 +419,19 @@ Success is a navigate-away transition (updates the asset query cache, invalidate
 - `pending` (create record) — inline or modal form validates date and description; submits to API
 - `pending` (create task) — inline form validates title and due date
 - `pending` (edit task) — drawer/sheet form (title + interval only, no last-completed-date field) opened from an edit button on the task card; submits `PATCH` and updates the task in place
+- `pending` (edit record) — prefilled title/date/notes form on a record; submits `PATCH` and refreshes the record list and linked task
+- `pending` (delete record) — confirmation dialog, then a disabled/pending delete action; success removes the record and refreshes any linked task
 - `pending` (share/unshare, owner only) — sheet/drawer to share the asset to the caller's team or unshare it back to personal
-- `error` — inline field errors; 401 redirects to `/login`
+- `error` — inline field errors; mutation errors distinguish 401, 403, 404, 409, and 503; 401 redirects to `/login`
+- `frozen-write` (503 `maintenance_write_frozen`) — preserves the current form and displayed data,
+  shows "Changes are temporarily paused" with a retry action, and never treats the mutation as
+  successful
 
 **Local UI states (not async):**
 
 - Delete-task confirm — local "Delete task?" confirm dialog with Delete/Cancel buttons, distinct from any mutation `isPending` (the deletion is a direct async call, not a `useMutation`)
+- Edit-record form — local form prefilled from the selected record; `taskId` is not editable
+- Delete-record confirm — local "Delete maintenance record?" confirm dialog with Delete/Cancel buttons; archived assets hide or disable correction controls
 
 **Content stress:** long asset name in header; long record description; long task title; long owner display name in sharing badge
 
@@ -439,6 +446,9 @@ Success is a navigate-away transition (updates the asset query cache, invalidate
 - Share/unshare are idempotent on the API; the sheet closes on success and refreshes the asset query
 - An edit button (owner only, gated on `sharing.isOwner` like the share control) links to `/app/assets/:id/edit` — see [Edit Asset](#edit-asset)
 - Task edit does not offer a last-completed-date field — that value only ever changes by logging a maintenance record against the task; editing lets the user correct the title or interval without losing it (unlike the old delete-and-recreate workaround)
+- Record edit changes only title, performed date, or notes; changing the performed date refreshes the linked task from the server-computed schedule, and the client never recomputes `lastCompletedDate` or `nextDue`
+- Record deletion is a hard delete from the maintenance list but leaves an immutable correction entry in Activity History; the UI does not attempt to remove or rewrite History entries
+- Corrections are available to users with the same active-asset access as record creation, including shared teammates; archived assets remain readable but correction controls are hidden or disabled
 
 **Spec:** [`docs/specs/features/maintenance-record.md`](../specs/features/maintenance-record.md), [`docs/specs/features/maintenance-task.md`](../specs/features/maintenance-task.md), [`docs/specs/features/teams-foundation.md`](../specs/features/teams-foundation.md)
 

--- a/migrations/0017_maintenance_seed_revision_expand.sql
+++ b/migrations/0017_maintenance_seed_revision_expand.sql
@@ -1,0 +1,20 @@
+-- Expand maintenance_tasks and maintenance_records with schedule seed and revision fields.
+-- Expand maintenance_write_gate for zero-downtime migration rollouts.
+
+ALTER TABLE maintenance_tasks ADD COLUMN schedule_seed_date TEXT;
+ALTER TABLE maintenance_tasks ADD COLUMN initial_last_completed_date TEXT;
+ALTER TABLE maintenance_tasks ADD COLUMN revision INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE maintenance_records ADD COLUMN revision INTEGER NOT NULL DEFAULT 0;
+
+CREATE TABLE IF NOT EXISTS maintenance_write_gate (
+  id INTEGER PRIMARY KEY CHECK (id = 1),
+  mode TEXT NOT NULL CHECK (mode IN ('open', 'frozen')) DEFAULT 'open'
+);
+
+INSERT OR IGNORE INTO maintenance_write_gate (id, mode) VALUES (1, 'open');
+
+CREATE TABLE IF NOT EXISTS mutation_guards (
+  name TEXT PRIMARY KEY,
+  assertion INTEGER NOT NULL CHECK (assertion = 1)
+);

--- a/migrations/0018_maintenance_seed_revision_backfill.sql
+++ b/migrations/0018_maintenance_seed_revision_backfill.sql
@@ -1,0 +1,7 @@
+-- Backfill schedule_seed_date and initial_last_completed_date on legacy maintenance_tasks.
+
+UPDATE maintenance_tasks
+SET
+  schedule_seed_date = COALESCE(last_completed_date, substr(created_at, 1, 10)),
+  initial_last_completed_date = last_completed_date
+WHERE schedule_seed_date IS NULL;

--- a/migrations/0019_activity_history_correction_types.sql
+++ b/migrations/0019_activity_history_correction_types.sql
@@ -1,0 +1,51 @@
+-- Widen activity_entries.type to include maintenance_record_updated and maintenance_record_deleted
+-- and add nullable audit_snapshot_json for full correction audit history (issue #181).
+
+CREATE TABLE activity_entries_new (
+  id                  TEXT NOT NULL PRIMARY KEY,
+  source_event_id     TEXT NOT NULL UNIQUE,
+  owner_id            TEXT NOT NULL REFERENCES users(id),
+  actor_id            TEXT NOT NULL REFERENCES users(id),
+  type                TEXT NOT NULL CHECK (
+    type IN (
+      'asset_added',
+      'maintenance_logged',
+      'maintenance_record_updated',
+      'maintenance_record_deleted',
+      'task_completed',
+      'task_scheduled',
+      'task_updated',
+      'task_deleted'
+    )
+  ),
+  occurred_at         TEXT NOT NULL,
+  asset_id            TEXT NOT NULL,
+  asset_name          TEXT NOT NULL,
+  asset_type          TEXT NOT NULL CHECK (asset_type IN ('vehicle', 'property', 'equipment')),
+  title               TEXT,
+  performed_at        TEXT,
+  created_at          TEXT NOT NULL,
+  actor_display_name  TEXT,
+  audit_snapshot_json TEXT
+);
+
+INSERT INTO activity_entries_new (
+  id, source_event_id, owner_id, actor_id, type, occurred_at, asset_id,
+  asset_name, asset_type, title, performed_at, created_at, actor_display_name
+)
+SELECT
+  id, source_event_id, owner_id, actor_id, type, occurred_at, asset_id,
+  asset_name, asset_type, title, performed_at, created_at, actor_display_name
+FROM activity_entries;
+
+DROP TABLE activity_entries;
+ALTER TABLE activity_entries_new RENAME TO activity_entries;
+
+CREATE INDEX IF NOT EXISTS idx_activity_entries_owner_order
+  ON activity_entries(owner_id, occurred_at DESC, id DESC);
+
+CREATE INDEX IF NOT EXISTS idx_activity_entries_owner_type_order
+  ON activity_entries(owner_id, type, occurred_at DESC, id DESC);
+
+CREATE INDEX IF NOT EXISTS idx_activity_entries_owner_asset_order
+  ON activity_entries(owner_id, asset_id, occurred_at DESC, id DESC);

--- a/packages/shared/errors.ts
+++ b/packages/shared/errors.ts
@@ -18,6 +18,16 @@ export class UnauthorizedError extends DomainError {}
 /** A domain invariant was violated — indicates a programming error, not a user error. */
 export class InvariantError extends DomainError {}
 
+/** A service or write gate is temporarily unavailable/frozen. */
+export class ServiceUnavailableError extends DomainError {
+  constructor(
+    message: string,
+    public readonly code?: string,
+  ) {
+    super(message);
+  }
+}
+
 export class ValidationError extends DomainError {
   constructor(
     message: string,

--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -24,6 +24,7 @@ export {
   TooManyRequestsError,
   UnauthorizedError,
   InvariantError,
+  ServiceUnavailableError,
   ValidationError,
 } from "./errors.ts";
 export {


### PR DESCRIPTION
## Summary

- Implemented `PATCH /api/assets/{assetId}/maintenance-records/{recordId}` and `DELETE /api/assets/{assetId}/maintenance-records/{recordId}` with optimistic concurrency control (CAS) and frozen write gate enforcement.
- Added automatic maintenance task schedule reconciliation rewinding/advancing `lastCompletedDate` and `nextDue` based on remaining records and schedule seeds, with `MaintenanceTaskReconciled` smart event publication.
- Added Activity History audit snapshot capture (`maintenance_record_updated`, `maintenance_record_deleted`) with `audit_snapshot_json` before/after tracking.
- Implemented Web UI edit modal and delete dialog with optimistic UI updates and archived-asset / permission protection.

## Related

Closes #181

## Risk

**Level:** C

**Why:**
Touches migrations (`migrations/0017_*`, `0018_*`, `0019_*`), schema expand/contract backfill rules, core maintenance domain invariants, and public API mutation endpoints with D1 transactional CAS guards (`mutation_guards`).

**Human validation budget:**
Stop if plan was not human-approved; deep review required.

## Evidence

- Unit test suites for use cases, domain entities, repositories, and UI components:
  - `apps/api/src/application/usecases/UpdateMaintenanceRecord.test.ts` (10 tests)
  - `apps/api/src/application/usecases/DeleteMaintenanceRecord.test.ts` (11 tests)
  - `apps/api/src/domain/maintenance/MaintenanceRecord.test.ts` (21 tests)
  - `apps/api/src/domain/maintenance/MaintenanceTask.test.ts` (15 tests)
  - `apps/api/src/infrastructure/persistence/D1MaintenanceRecordRepository.test.ts` (5 tests)
  - `apps/web/src/app/AppMaintenanceRecords.test.tsx` (5 tests)
- Full local test suite passing (86 API files / 593 tests, 24 Web files / 133 tests).

## Test plan

- [x] Automated test suites covering CAS conflicts, task schedule rewinding/advancement, write-freeze gate, audit snapshots, and schema validation.
- [x] OpenAPI schema generation and web type sync verification.
- [x] Migration scope and PR diff size budget selftests.

## Spec / AC

- [docs/specs/features/maintenance-record.md](docs/specs/features/maintenance-record.md)
- [docs/specs/features/maintenance-task.md](docs/specs/features/maintenance-task.md)

## Validation gate

- [x] Rebased on latest `main`
- [x] Lint / type-check / tests green locally
- [x] Adversarial review run (`pr-review`)
- [x] Safe findings self-fixed; product escalations listed below
- [x] Docs / spec AC / FEATURES.md updated if required
- [x] OpenAPI + web `api:types` regenerated if contract changed

**Escalations (need human decision):**
None.