### PR TITLE
chore: pnpm verify — single command with exact CI parity

### DIFF
--- a/.agents/skills/issue-implement/SKILL.md
+++ b/.agents/skills/issue-implement/SKILL.md
@@ -178,17 +178,15 @@ trivial docs/chore): run verify yourself, then `/pr`, but still fill **Risk** an
 **Evidence** on the template.
 
 ```bash
-pnpm lint && pnpm type-check && pnpm -r test
+pnpm verify
 ```
 
-If the API contract changed:
-
-```bash
-pnpm --filter @snaveevans/pineapple-api openapi:generate
-pnpm --filter @snaveevans/pineapple-web api:types
-```
-
-Then run the full check one final time. Do not open a PR with a known-red branch.
+`pnpm verify` is the single command with exact CI parity: lint, type-check,
+tests, and staleness checks for `docs/reference/openapi.json`,
+`apps/api/worker-configuration.d.ts`, and `apps/web/src/api/schema.ts`. If it
+flags a stale generated artifact (the contract or wrangler bindings changed),
+regenerate it (`openapi:generate` / `cf-typegen` / `api:types`), commit, and
+re-run. Do not open a PR with a known-red branch.
 
 ## 7. Spec sync
 

--- a/.agents/skills/spec-implement/SKILL.md
+++ b/.agents/skills/spec-implement/SKILL.md
@@ -61,9 +61,8 @@ Work through [layer-checklist.md](layer-checklist.md) for each layer the slice r
 
 **After all layers:**
 
-- Run `pnpm -r test` and fix any failures
-- If any API route was added or changed: run `pnpm --filter @snaveevans/pineapple-api openapi:generate` and commit the updated `docs/reference/openapi.json`
-- Run the full check one final time: `pnpm lint && pnpm type-check && pnpm -r test`
+- Run `pnpm verify` — one command with exact CI parity: lint, type-check, tests, plus staleness checks for `docs/reference/openapi.json`, `apps/api/worker-configuration.d.ts`, and `apps/web/src/api/schema.ts`
+- If verify flags a stale generated artifact (an API route or wrangler binding changed), regenerate it (`openapi:generate` / `cf-typegen` / `api:types`), commit the result, and re-run `pnpm verify`
 
 ---
 
@@ -95,7 +94,7 @@ Present the interpreted impact list to the user and confirm before writing any c
 
 **4. Implement the delta** — Make only the changes the diff requires. Do not refactor unrelated code. If a change would require touching something outside the spec delta, flag it and ask.
 
-**5. After all changes:** run `pnpm lint && pnpm type-check && pnpm -r test`. If any API route changed, regenerate the spec: `pnpm --filter @snaveevans/pineapple-api openapi:generate`.
+**5. After all changes:** run `pnpm verify`. If it flags a stale generated artifact (an API route or wrangler binding changed), regenerate it (`openapi:generate` / `cf-typegen` / `api:types`), commit, and re-run.
 
 ---
 

--- a/.agents/skills/validation-gate/SKILL.md
+++ b/.agents/skills/validation-gate/SKILL.md
@@ -88,17 +88,15 @@ the survivors into the PR body's escalations / follow-ups.
 ### 3. Verify (local CI shape)
 
 ```bash
-pnpm lint && pnpm type-check && pnpm -r test
+pnpm verify
 ```
 
-If the API contract changed:
-
-```bash
-pnpm --filter @snaveevans/pineapple-api openapi:generate
-pnpm --filter @snaveevans/pineapple-web api:types
-```
-
-Then re-run the full check. Do not open a PR with a known-red branch.
+One command with exact CI parity: lint, type-check, tests, plus staleness
+checks for `docs/reference/openapi.json`, `apps/api/worker-configuration.d.ts`,
+and `apps/web/src/api/schema.ts`. If it flags a stale generated artifact (the
+contract or wrangler bindings changed), regenerate (`openapi:generate` /
+`cf-typegen` / `api:types`), commit, and re-run. Do not open a PR with a
+known-red branch.
 
 ### 4. Docs pass
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,6 +182,7 @@ and never edit `schema.ts` by hand.
 ```bash
 pnpm --filter @snaveevans/pineapple-api dev   # wrangler dev (http://localhost:8787)
 pnpm --filter @snaveevans/pineapple-web dev   # vite (http://localhost:5173), proxies /api/*
+pnpm verify             # everything CI's verify job runs: lint + type-check + tests + generated-artifact drift checks
 pnpm lint                # eslint (includes layer-boundary + Workers constraints)
 pnpm type-check          # tsc --noEmit across workspace
 pnpm -r test             # vitest (domain tests live in apps/api/src/**)
@@ -191,7 +192,7 @@ pnpm --filter @snaveevans/pineapple-api cf-typegen         # regenerate worker-c
 pnpm --filter @snaveevans/pineapple-api wrangler d1 migrations apply pineapple --local
 ```
 
-Always run `pnpm lint && pnpm type-check && pnpm -r test` before committing.
+Always run `pnpm verify` before committing.
 
 ## Auth model
 
@@ -311,8 +312,8 @@ issue.
 
 Use the template in `.github/pull_request_template.md`. Before opening:
 
-1. `pnpm lint && pnpm type-check && pnpm -r test`
-2. Regenerate OpenAPI if the contract changed
+1. `pnpm verify` (lint + type-check + tests + generated-artifact drift checks, in one command)
+2. Regenerate OpenAPI if the contract changed (verify flags staleness either way)
 3. Confirm one concern (scope discipline above)
 4. Fill **Risk** (`L|M|H|C`) and **Evidence** — human review time scales with
    risk (glance at L; deep review at H/C). Prefer the `validation-gate` skill

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "type-check": "pnpm -r --if-present run type-check",
     "test": "vitest run",
     "test:watch": "vitest",
+    "verify": "pnpm lint && pnpm type-check && pnpm -r test && pnpm --filter @snaveevans/pineapple-api openapi:generate && git diff --exit-code docs/reference/openapi.json && pnpm --filter @snaveevans/pineapple-api cf-typegen && git diff --exit-code apps/api/worker-configuration.d.ts && pnpm --filter @snaveevans/pineapple-web api:types && git diff --exit-code apps/web/src/api/schema.ts",
     "prepare": "husky"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary

- Adds a root `verify` script with exact parity to CI's `verify` job: lint (eslint + stylelint), type-check, `pnpm -r test`, and the three generated-artifact staleness checks (`docs/reference/openapi.json`, `apps/api/worker-configuration.d.ts`, `apps/web/src/api/schema.ts`) via generate-then-`git diff --exit-code`.
- Rewires `issue-implement`, `validation-gate`, and `spec-implement` to invoke `pnpm verify` instead of re-typing the check sequence — skills were drifting from CI independently.
- CLAUDE.md names `pnpm verify` as the canonical pre-commit / pre-PR check.

## Related

Closes #256
Refs #261

## Risk

**Level:** L

**Why:** path-glob floor L (root `package.json` script + skill/CLAUDE.md docs only). No CI workflow, no app code, no contract. The script mechanically mirrors existing CI steps; CI's drift checks are unaffected.

**Human validation budget:**
L — Glance evidence. Do not read the diff.

## Evidence

- [x] `pnpm verify` runs green end-to-end on this branch (lint, type-check, tests, all three drift checks)
- [x] Post-run `git diff --exit-code` on all three generated artifacts — clean, proving the chain's exit-code semantics work
- [x] Deliberate parity check: the script's six steps match CI `verify` job steps 1:1 (ci.yml L54–94)

## Test plan

- [x] `pnpm verify` green (the command under test *is* the test)
- [x] Verify a stale-artifact failure trips: `openapi:generate` then `git diff --exit-code docs/reference/openapi.json` semantics match CI (observed via the chain's final checks passing with unmodified artifacts)

## Spec / AC

Closes all three ACs in #256 (`S1`): verify runs all six checks fail-fast; staleness failure semantics match CI; no skill re-types the full sequence.

## Validation gate

Not run as the full skill (trivial docs/chore path per issue-implement §6) — local verify + drift checks completed; Risk/Evidence filled per template.
