### PR TITLE
feat: goal-driven development layer — docs/goals, goal-author, goal-executor

### DIFF
--- a/.agents/skills/goal-author/SKILL.md
+++ b/.agents/skills/goal-author/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: goal-author
+description: Turn a one-paragraph outcome into a hardened, executable goal doc — decomposed into slices/specs/issues, with live-verified validation commands, before any autonomous goal loop starts. Use when starting milestone work, authoring a goal, or preparing a /goal run.
+---
+
+Goal hardening pre-flight. The autonomous loop is only as safe as the goal doc
+it pins: weak criteria and unverified checks are where reward hacking enters
+(see `docs/goals/README.md` and the
+[goal epic](https://github.com/snaveevans/pineapple/issues/261)). This skill
+spends human attention where it compounds — before the run, not during it.
+
+**Input:** a one-paragraph outcome from the user, or an existing goal doc to
+revise (only when no loop is running — docs are hash-pinned mid-loop).
+
+**Output:** `docs/goals/<yyyy-mm>-<name>.md` at `status: review`, a GitHub
+Milestone with slice issues, and a baseline verification the user approves.
+You do NOT start the loop — the user runs `/goal` after approving.
+
+## 1. Interrogate the outcome
+
+Work conversationally; do not draft until this is complete.
+
+- **End state in one sentence.** What is true when this goal is done? Push back
+  on verbs like "support" / "improve" — demand the observable state.
+- **Personas & scenarios (light).** Goals span features; deep persona work
+  belongs to `spec-author` per feature. Here: who notices the goal is done,
+  and what can they do that they couldn't before?
+- **Non-goals.** Ask explicitly: "what should this goal NOT touch?" Non-goals
+  are what stops the loop absorbing drift.
+- **Known risks.** Anything the user already knows is H/C-risk (auth, schema,
+  contracts)? It goes in Risk & merge policy up front.
+
+## 2. Map the landscape
+
+```!
+echo "── Feature specs ──"
+ls docs/specs/features/*.md 2>/dev/null | xargs -I{} basename {}
+echo "── Existing goals ──"
+ls docs/goals/*.md 2>/dev/null | grep -v template | grep -v README
+echo "── Open milestones ──"
+gh api repos/:owner/:repo/milestones --jq '.[] | "\(.number) \(.title) (open: \(.open_issues))"' 2>/dev/null || echo "(gh unavailable)"
+```
+
+- Which behaviors already have specs? Reference them — do not duplicate.
+- Which need new or revised specs? Each becomes a `spec-author` delegation
+  (Greenfield or Revise) before the goal doc reaches `review`. A slice without
+  a spec is fine only for pure chore/test/infra work with no product behavior.
+- Does an active goal overlap this one? Two loops editing the same area is a
+  conflict machine — flag it and resolve before proceeding.
+
+## 3. Decompose into slices
+
+Partition into **independently-landable slices** (scope budget per CLAUDE.md:
+~40 files / ~800 net lines is the signal to split). For each: scope, the spec
+it lives in, dependencies. Mechanisms (tables, queues, migrations) land as
+their own slice **before** the feature that uses them — scope discipline
+applies to goals doubly, because the loop will otherwise absorb the split.
+
+Create the tracking shell:
+
+- GitHub Milestone titled after the goal
+- One issue per slice (`Refs #<epic-or-milestone>`, `ready-for-dev` label when
+  the spec slice is unblocked)
+
+## 4. Author done-when + the checks block
+
+**Criteria:** EARS-style ("When X, the system shall Y"), each tagged with one
+slice. Derive from scenarios, not implementation. A criterion that resists a
+validation command gets split or moved to a spec — never left vague.
+
+**Checks block** (format contract with the `/goal` plugin):
+
+- **Line 1: the enforced milestone check.** Default `pnpm verify`. This is what
+  the loop itself runs on every completion claim — it must be repo-universal,
+  fast enough to run every ~5 iterations, and impossible to satisfy vacuously.
+- **Then, one commented line per criterion:** `# S1: <short criterion> → <command>`
+- Commands must be **deterministic and self-contained** (test files, scripts,
+  `pnpm` commands). No curl-to-prod, no manual steps, no "ask the user".
+
+**Live-verify every command — this step is the point of the skill:**
+
+1. **Green today:** run each command on a clean tree. Record the result.
+2. **Fails when broken:** for criteria pinning existing behavior, demonstrate
+   the command _fails_ when the behavior breaks — invert a condition, delete a
+   line, or point the command at a mutated copy. If you can't break it without
+   breaking the command itself, the command is too weak — replace it. (This is
+   the testing spec's "a mutation would break it" standard, applied to goals.)
+3. **Pending by design:** criteria for unimplemented slices get their commands
+   written now and marked `# pending (S2 not yet implemented)` — but the
+   milestone check (line 1) must be green _today_.
+
+## 5. Escalation classes, protected paths, risk
+
+Fill the template sections from the defaults; adjust per goal:
+
+- **Escalation classes** — copy template defaults; remove entries the goal
+  genuinely doesn't need; add goal-specific ones (e.g. "touching the
+  notification outbox schema").
+- **Protected paths** — built-in defaults only unless the goal truly needs
+  extras (e.g. `migrations/**` for a schema goal). Extras are justified in one
+  line each.
+- **Risk & merge policy** — state the policy in force (human merge until
+  ADR-0018 activates) and pre-declare expected H/C slices.
+
+## 6. Baseline + approval gate
+
+```bash
+pnpm verify
+```
+
+Record the result in the verification log as the kickoff baseline. Set
+`status: review`.
+
+**Present the goal doc to the user.** This is the one human gate worth its
+cost: they read the outcome, non-goals, done-when, and checks block — not the
+scaffolding. Apply their edits, re-verify anything that changed, and only then
+hand off:
+
+> Goal doc ready: `docs/goals/<name>.md` (review). Milestone #N, slices S1–Sn
+> filed. Approve, then start the loop:
+> `/goal Execute docs/goals/<name>.md per goal-executor --max <N>`
+
+The loop hash-pins the doc at start — later revisions mean blocking and
+restarting, so this approval is deliberate, not ceremonial.

--- a/.agents/skills/goal-executor/SKILL.md
+++ b/.agents/skills/goal-executor/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: goal-executor
+description: Execute a goal doc slice by slice — test-first implementation, validation gate, PR, verification log — stopping only at the goal's escalation classes. Use when a goal doc is approved (status: review/active) and the loop should run, or when resuming one.
+---
+
+The per-slice pipeline a goal loop runs. The `/goal` plugin owns the loop
+discipline (re-prompting, the pinned check, tamper audit); **this skill owns
+what one iteration of real work looks like**. The goal doc is the destination;
+deterministic gates are the only evidence.
+
+**Input:** a goal doc path (e.g. `docs/goals/2026-09-<name>.md`), or detect the
+single doc under `docs/goals/` with unchecked criteria. If `status` is not
+`review`/`active`, stop — `goal-author` hasn't finished.
+
+## 0. Orient
+
+Read the goal doc end to end. Restate in one block: goal, slices with status
+(from Done-when tags + the Delivery Plan + the verification log), the enforced
+check, escalation classes, and the merge policy in force. A cold agent must be
+able to do exactly this — never resume from memory of a previous session.
+
+Confirm the loop context: if the session is not running under `/goal`, say so
+and suggest the kickoff command; still proceed slice-by-slice either way.
+
+## 1. Pick the next slice
+
+The next `Sn` whose Done-when boxes are all `[ ]`, whose Delivery Plan
+dependencies are all landed (log shows their PRs), and whose spec — if any —
+has no unchecked boxes in _earlier_ slices. If two are eligible, take the lower
+number; if the goal author left the order genuinely ambiguous, decide and say
+why in the log.
+
+## 2. Blind acceptance tests — mandatory, first
+
+Invoke the `test-author` skill **before** any implementation exists in context:
+produce the failing tests for this slice's criteria from the goal doc + spec
+alone.
+
+- The implementer (you, next step) may **add** tests but must never modify,
+  delete, or narrow these assertions regardless of outcome — the tamper audit
+  surfaces violations and this skill treats hiding one as an escalation.
+- If `test-author` finds a criterion untestable as written, that is a **stop**:
+  the criterion is defective (can't name a live-verified command and a test).
+  Emit `[[GOAL_BLOCKED]]` under `/goal` — the doc is pinned; it needs a human
+  revision.
+
+## 3. Implement the slice
+
+Invoke `spec-implement` for the slice (or follow `layer-checklist.md` directly
+for pure chore/test/infra slices): dependency order, `pnpm verify` after each
+layer, generated-artifact regen when verify flags staleness. Scope discipline:
+implement exactly this slice's criteria; growth past it is an explicit
+decision, not an absorption.
+
+## 4. Certify against the checks block
+
+For each of the slice's criteria, run its validation command from the checks
+block. All must be green **and** the enforced milestone check green:
+
+```bash
+pnpm verify
+```
+
+A criterion without a green command is not certified — fix the work or stop.
+
+## 5. Gate and land the PR
+
+Invoke the `validation-gate` skill: rebase, fresh-context `pr-review`, verify,
+docs pass, risk score, evidence, PR. Carry **every** tamper-audit flag from the
+current iteration into the PR description with a one-line justification each —
+an unexplained flag treated as hidden is an escalation.
+
+Merge per the policy in force on the goal doc:
+
+- **Human merge (default until ADR-0018 activates):** push, shepherd CI
+  (`pr-shepherd`), report, and wait for the human. While waiting, do not start
+  a dependent slice — start an independent one if any exists.
+- **ADR-0018 active:** L → merge after green CI + clean review; M → merge +
+  next-day digest entry; H/C → same as human-merge path.
+
+## 6. Log and advance
+
+On merge, append to the goal doc's verification log:
+
+`| date | Sn | PR url | commands run + results | tamper flags (or none) | pr-respond rounds | notes |`
+
+Then check off the slice's Done-when boxes and the spec's tagged AC boxes
+(only when covered by a test on `main`), update spec/Milestone status, and
+proceed to §1 for the next slice.
+
+## Stopping: escalation classes
+
+Stop and emit `[[GOAL_BLOCKED]]` (with `DECISION NEEDED:` + 2–3 options) when
+the goal doc's escalation classes trigger. Additionally, without exception:
+
+- A test assertion must be modified/deleted/narrowed to make progress
+- A criterion's validation command is wrong or weak in practice (doc is pinned;
+  say what to change and why)
+- The enforced check is red for 3+ consecutive rounds with no fixable cause
+- Two slices turn out to be one (scope split was wrong) — propose the split,
+  don't absorb it
+
+## Goal completion
+
+When the last slice lands: run the full checks block one final time, confirm
+every Done-when box is `[x]` with tests, set the goal doc `status: complete`,
+close the Milestone, and report the evidence summary. Under `/goal`, this
+report precedes `[[GOAL_COMPLETE]]` — the plugin re-runs the milestone check
+and rejects the marker if it is red.

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,15 +11,16 @@ this repo.
 
 ## The doc types
 
-| Type            | Lives in                                 | Source of truth                 | Primarily serves           |
-| --------------- | ---------------------------------------- | ------------------------------- | -------------------------- |
-| Front door      | `README.md`, `CLAUDE.md`                 | hand-written                    | newcomers · AI agents      |
-| Decisions (ADR) | `docs/decisions/`                        | hand-written                    | engineers (the _why_)      |
-| Specs           | `docs/specs/`                            | hand-written                    | everyone (the _what_)      |
-| API reference   | `docs/reference/api.md` + `openapi.json` | **generated from Zod**          | UI/integration devs · LLMs |
-| Data model      | `docs/reference/data-model.md`           | hand-written, mirrors `domain/` | designers · devs           |
-| Roadmap         | `docs/product/roadmap.md`                | hand-written                    | PM · marketing             |
-| Guides          | `docs/guides/`                           | hand-written                    | operators · contributors   |
+| Type            | Lives in                                 | Source of truth                 | Primarily serves                                                               |
+| --------------- | ---------------------------------------- | ------------------------------- | ------------------------------------------------------------------------------ |
+| Front door      | `README.md`, `CLAUDE.md`                 | hand-written                    | newcomers · AI agents                                                          |
+| Decisions (ADR) | `docs/decisions/`                        | hand-written                    | engineers (the _why_)                                                          |
+| Specs           | `docs/specs/`                            | hand-written                    | everyone (the _what_)                                                          |
+| Goals           | `docs/goals/`                            | hand-written                    | maintainers · AI agents (the milestone _what next_, with executable done-when) |
+| API reference   | `docs/reference/api.md` + `openapi.json` | **generated from Zod**          | UI/integration devs · LLMs                                                     |
+| Data model      | `docs/reference/data-model.md`           | hand-written, mirrors `domain/` | designers · devs                                                               |
+| Roadmap         | `docs/product/roadmap.md`                | hand-written                    | PM · marketing                                                                 |
+| Guides          | `docs/guides/`                           | hand-written                    | operators · contributors                                                       |
 
 ### Who reads what
 

--- a/docs/goals/README.md
+++ b/docs/goals/README.md
@@ -1,0 +1,74 @@
+> **Audience:** maintainers · AI agents · **Purpose:** how goal-driven milestone work is defined and executed · **Source of truth:** this file · **Last reviewed:** 2026-09-04
+
+# Goals
+
+A **goal** is a milestone-sized outcome driven end-to-end by an autonomous loop:
+the maintainer writes (or revises) one goal doc, an agent decomposes it into
+slices and specs, then executes slice after slice — implementing, validating,
+and landing PRs — stopping only at defined escalation classes.
+
+Goals sit **above specs**: a spec says what one feature should do; a goal says
+what set of features/changes constitutes a finished milestone, and — critically —
+**what deterministic evidence proves it**. Goals never duplicate spec content;
+they reference specs and add the executable layer.
+
+## Why goals exist
+
+Specs alone don't make autonomous loops safe. The failure mode documented across
+the 2025–26 agent literature is reward hacking: a long-running loop optimizes
+for "look done" instead of "be done" — gutting assertions, weakening checks,
+narrowing criteria. The defense is layering (see the
+[epic](https://github.com/snaveevans/pineapple/issues/261)):
+
+1. **The goal doc is hash-pinned** by the goal loop when `/goal` starts — editing
+   it mid-loop stops the loop. If a criterion is genuinely wrong, block and
+   restart with a revised doc.
+2. **The `checks` block is the enforced stop condition.** The loop runs the
+   milestone check itself (first non-comment line) on every completion claim and
+   periodically. Agent-pasted output is never evidence.
+3. **Per-criterion validation commands** (the rest of the checks block) are what
+   `goal-executor` runs when certifying each slice — each must be verified live
+   by `goal-author`: green on a clean tree, and provably failing when the
+   behavior breaks.
+4. **Protected paths are audited** — test files, vitest configs, stryker config,
+   workflows, root `package.json`, and the goal doc itself. Changes are allowed
+   in v1 but always surfaced; narrowing or deleting assertions is prohibited
+   regardless of outcome.
+
+## The goal doc
+
+Copy [`goal.template.md`](goal.template.md) to `docs/goals/<yyyy-mm>-<name>.md`.
+Section by section:
+
+| Section             | Purpose                                                                                                                                                            |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Outcome             | One paragraph: the end state, for whom, and why now                                                                                                                |
+| Scope               | In/out boundary; non-goals are load-bearing — they stop the loop from absorbing drift                                                                              |
+| Done-when           | Acceptance criteria in EARS-style phrasing, each tagged with one slice and one validation command                                                                  |
+| Delivery plan       | Slices (`S1`…), the spec each lives in, its issue, and dependencies — normally rolled up under a GitHub Milestone                                                  |
+| Checks              | The ` ```checks ` fenced block: **line 1 is the enforced milestone check** (default `pnpm verify`); following lines map criteria to validation commands (comments) |
+| Escalation classes  | What stops the loop vs. what the agent decides alone                                                                                                               |
+| Risk & merge policy | Per-slice risk floor and the merge rule in force (human merge until ADR-0018 activates)                                                                            |
+| Verification log    | Appended per slice: PR, evidence, tamper flags, rework rounds — the durable memory a cold agent or the next session resumes from                                   |
+
+A criterion that cannot name a validation command is not done-when material —
+it's either a non-goal, a spec-level detail, or not yet automatable; say so
+explicitly rather than faking a check.
+
+## Lifecycle
+
+`draft` (being authored) → `review` (checks live-verified, awaiting maintainer
+approval) → `active` (approved; the loop may run) → `complete` (all criteria
+green, verification log complete). A goal doc is never edited after the loop
+starts — see pinning above.
+
+## Commands
+
+```bash
+/goal Execute docs/goals/<yyyy-mm>-<name>.md per goal-executor --max 50
+```
+
+The opencode `/goal` plugin (maintainer config, documented in
+[#260](https://github.com/snaveevans/pineapple/issues/260)) provides the loop;
+`goal-executor` provides the per-slice pipeline; the goal doc provides the
+destination and the evidence standard.

--- a/docs/goals/goal.template.md
+++ b/docs/goals/goal.template.md
@@ -1,0 +1,103 @@
+> **Audience:** maintainers · AI agents · **Purpose:** blank starting point for a goal doc · **Source of truth:** this file · **Last reviewed:** 2026-09-04
+
+# Goal: <kebab-name>
+
+**Status:** `draft` <!-- draft → review → active → complete -->
+**Milestone:** <!-- GitHub Milestone number/URL, created by goal-author -->
+**Created:** <!-- yyyy-mm-dd -->
+**Last reviewed:** <!-- yyyy-mm-dd -->
+
+## Outcome
+
+<!-- One paragraph. The end state, for whom, and why now. If it takes more than
+     one paragraph, it is probably two goals. -->
+
+## Scope
+
+**In:**
+
+<!-- Concrete capabilities/changes included. -->
+
+**Out (non-goals):**
+
+<!-- Explicit exclusions. These are load-bearing: they are what stops the loop
+     from absorbing scope drift mid-run. -->
+
+## Done-when
+
+<!-- EARS-style criteria: observable, testable, unambiguous. Each criterion
+     carries exactly one slice tag and one validation command (mirrored in the
+     checks block below). A criterion that cannot name a validation command
+     doesn't belong here. -->
+
+- [ ] When <trigger>, the system shall <observable behavior>. — validation: `<command>` `S1`
+- [ ] <criterion> — validation: `<command>` `S2`
+
+## Delivery plan
+
+<!-- Slices map to specs' Delivery Plans where features exist; goal-author
+     creates the Milestone and one issue per slice. -->
+
+| Slice | Scope | Spec                     | Issue | Depends on |
+| ----- | ----- | ------------------------ | ----- | ---------- |
+| `S1`  |       | docs/specs/features/….md | #     | —          |
+| `S2`  |       | docs/specs/features/….md | #     | `S1`       |
+
+## Checks
+
+<!-- The goal loop parses this block: LINE 1 is the enforced milestone check —
+     the plugin runs it on every completion claim and every 5th iteration.
+     Remaining lines map criteria to validation commands (goal-executor runs
+     them when certifying a slice). Comments are conventions, not enforcement. -->
+
+```checks
+pnpm verify
+# S1: <criterion> → <command>
+# S2: <criterion> → <command>
+```
+
+## Escalation classes
+
+<!-- What stops the loop (agent must emit [[GOAL_BLOCKED]] with DECISION NEEDED
+     + options) vs. what the agent decides alone. Defaults below; edit per goal. -->
+
+**Stops the loop:**
+
+- Product choice not derivable from this doc or linked specs
+- Unresolvable merge conflict needing a product decision
+- H/C-risk change (per validation-gate's hybrid risk score)
+- A red gate unfixable in ~3 rounds
+- Any tamper flag the agent cannot justify in writing
+
+**Agent decides alone:**
+
+- Implementation details within a slice's scope
+- Mechanical conflict resolution
+- L/M-risk merge per the policy in force
+- Test _additions_ (never narrowing/deleting existing assertions)
+
+## Protected paths
+
+<!-- Audited every iteration; changes surfaced, each must be justified in the
+     PR description. Built-in defaults (do not remove): all `**/*.test.ts(x)`,
+     vitest configs, `apps/api/stryker.conf.json`, `.github/workflows/**`, root
+     `package.json`, and this goal doc (hash-pinned — edits stop the loop). -->
+
+**Goal-specific extras:** <!-- none, or paths -->
+
+## Risk & merge policy
+
+<!-- Default: validation-gate's risk table; human merge on every PR until
+     ADR-0018 activates, then L auto / M batched / H-C human. State the policy
+     in force at authoring time so a cold agent doesn't guess. -->
+
+- Policy in force: human merge on every PR (ADR-0018 pending)
+- Known H/C-risk slices: <!-- list, or "none expected" -->
+
+## Verification log
+
+<!-- goal-executor appends one row per landed slice. This is the durable memory
+     a cold agent resumes from and the batch review digest reads from. -->
+
+| Date | Slice | PR  | Evidence | Tamper flags | Rework rounds | Notes |
+| ---- | ----- | --- | -------- | ------------ | ------------- | ----- |


### PR DESCRIPTION
## Summary

- `docs/goals/` — the goal doc format: outcome, non-goals, EARS-style done-when criteria each carrying a validation command, a `checks` block whose **first line is the enforced milestone check** (parsed by the `/goal` plugin per #260), escalation classes, protected paths, and a verification log (durable memory).
- `goal-author` skill — the pre-flight: interrogate outcome, decompose into slices/specs under a GitHub Milestone + issues, then **live-verify every validation command** (green today; provably fails when the behavior breaks), baseline `pnpm verify`, one human approval gate.
- `goal-executor` skill — the per-slice pipeline: blind `test-author` first (mandatory), `spec-implement`, `validation-gate`, PR with every tamper flag justified, verification log row, next slice. Stops only at escalation classes; test assertions may never be narrowed or deleted.
- `docs/README.md` — Goals row in the doc-types table.

## Related

Closes #257
Refs #261

## Risk

**Level:** L

**Why:** docs + new skill files only — no app code, no CI, no contract. Path-glob floor L; no semantic elevations. The skills reference existing skills (`spec-author`, `test-author`, `spec-implement`, `validation-gate`, `pr-shepherd`) without changing them.

**Human validation budget:**
L — Glance evidence. Do not read the diff.

## Evidence

- [x] `checks`-block format contract verified against the plugin implementation: `extractCheckFromDoc` parses the first non-comment line of a ` ```checks ` block (validated in #260's smoke test — kickoff extracted `echo check-ok` from a doc with exactly this format)
- [x] Template's protected-path defaults match the plugin's built-in audit list (test files, vitest configs, stryker config, workflows, root `package.json`, the hash-pinned goal doc)
- [x] `pnpm lint && pnpm type-check && pnpm -r test` green (docs-only change; `pnpm verify` lands via #262)

## Test plan

- [x] Plugin mechanics against a template-format doc already validated in #260's smoke suite (pin, extract, loop, block-on-edit)
- [ ] First real goal run via `goal-author` → `goal-executor` — an epic acceptance criterion, exercised after merge

## Spec / AC

Delivers #257's template + skills; the live-verification and end-to-end-slice ACs are exercised by the first real goal run (tracked on epic #261).
