### PR TITLE
ci: post-deploy smoke check for the API worker + rollback runbook

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -166,6 +166,35 @@ jobs:
         working-directory: apps/api
         run: pnpm wrangler deploy
 
+      # Post-deploy smoke: this deploy just took 100% of traffic, so prove the
+      # worker actually serves before the job goes green. `/health` does a real
+      # D1 round trip and reports migration status (503 + status:"error" on
+      # genuine failure); `/openapi.json` proves the contract route serves.
+      # Retries absorb brief propagation lag right after deploy — a genuinely
+      # broken worker still fails all five attempts.
+      #
+      # On red: roll back per docs/runbooks/rollback.md, then investigate.
+      # Do not re-deploy over a red smoke.
+      - name: Post-deploy smoke check
+        run: |
+          base="https://pineapple.tylerevans.co"
+          for attempt in 1 2 3 4 5; do
+            health_code="$(curl -fsS -o /tmp/health.json -w '%{http_code}' --max-time 15 "$base/health" || true)"
+            spec_code="$(curl -fsS -o /tmp/openapi.json -w '%{http_code}' --max-time 15 "$base/openapi.json" || true)"
+            if [ "$health_code" = "200" ] \
+              && jq -e '.status == "ok" and .database == "reachable"' /tmp/health.json > /dev/null \
+              && [ "$spec_code" = "200" ] \
+              && jq -e 'has("openapi") and has("paths")' /tmp/openapi.json > /dev/null; then
+              echo "Smoke green (attempt $attempt): /health 200 ok+reachable, /openapi.json 200 valid"
+              exit 0
+            fi
+            echo "Attempt $attempt failed (health=$health_code spec=$spec_code) — retrying in 10s"
+            sleep 10
+          done
+          echo "::error::Post-deploy smoke failed after 5 attempts — the deployed API worker is not serving correctly."
+          echo "::error::Roll back now per docs/runbooks/rollback.md, then investigate. Do not re-deploy over a red smoke."
+          exit 1
+
   deploy-web:
     needs: [verify, changes]
     if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.web == 'true' }}

--- a/docs/runbooks/rollback.md
+++ b/docs/runbooks/rollback.md
@@ -1,0 +1,72 @@
+> **Audience:** on-call (both of us) · **Purpose:** what to do when production is broken after a deploy · **Source of truth:** this file · **Last reviewed:** 2026-09-04
+
+# Rollback runbook
+
+## When to roll back
+
+- The **post-deploy smoke check** in `deploy.yml` fails (`deploy-api` job red
+  after Deploy Worker) — the deployed API worker is not serving correctly.
+- A user reports the app broken immediately after a merge to `main`.
+- Analytics Engine telemetry shows a sustained error-rate spike following a
+  deploy.
+
+Roll back first, investigate second. A rollback is cheap and reversible; a
+broken production is not.
+
+## How: roll back a Worker
+
+`wrangler rollback` re-activates the most recent **stable** version (one that
+was previously deployed at 100% of traffic). It prompts for a reason — always
+write one; it lands in the deployment history as the audit trail.
+
+```bash
+# API worker (serves /api/*, /openapi.json, /health, and the SPA catch-all —
+# the API worker is almost always the one to roll back)
+cd apps/api
+pnpm wrangler rollback              # most recent stable version
+pnpm wrangler versions list         # to pick a specific version instead
+pnpm wrangler rollback <VERSION-ID> # that specific version
+
+# Web worker (serves the built SPA assets)
+cd apps/web
+pnpm wrangler rollback
+```
+
+**Rollback can be blocked.** Per the Cloudflare docs, you cannot roll back to a
+version if platform resources (KV, D1, R2, secrets) were **added, deleted, or
+modified** since that version was deployed — the error names what changed. If
+the bad deploy changed `wrangler.jsonc` bindings or secrets, the rollback
+target may be out of reach; in that case fix-forward (revert the commit and
+push, letting the deploy pipeline re-verify and re-deploy) and say so in the
+incident notes.
+
+## What a rollback does NOT undo
+
+| Change                   | Survives rollback because                                                                                                                                                                                       |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Applied D1 migrations    | Migrations are applied before the deploy and never auto-revert. Schema safety comes from [expand/contract](../specs/cross-cutting/schema-migrations.md): new schema stays compatible with the rolled-back code. |
+| In-flight queue messages | Queues are provisioned infrastructure, not part of a version.                                                                                                                                                   |
+| Sent email               | Already sent.                                                                                                                                                                                                   |
+
+This is why the [change-safety epic](https://github.com/snaveevans/pineapple/issues/129)
+frames rollback as one layer of several, not a full undo.
+
+## Verify the rollback worked
+
+```bash
+curl -fsS https://pineapple.tylerevans.co/health | jq -e '.status == "ok" and .database == "reachable"'
+curl -fsS https://pineapple.tylerevans.co/openapi.json | jq -e 'has("openapi") and has("paths")'
+```
+
+Both green = the previous version is serving. These are the same assertions the
+deploy workflow's smoke check makes.
+
+## After the rollback
+
+1. Open a `bug` issue with the smoke failure output (or user report) and the
+   rollback reason from the deployment history.
+2. Investigate before re-deploying — merging to `main` auto-deploys, so a fix
+   lands through the normal pipeline (branch → PR → green CI → merge), at which
+   point the new deploy supersedes the rollback.
+3. If the failure was found by smoke rather than by a user, the blast radius was
+   zero-traffic-visible — note that in the issue; it means the gate worked.


### PR DESCRIPTION
## Summary

- `deploy.yml` `deploy-api`: after Deploy Worker, a **post-deploy smoke check** proves the deployed worker serves before the job goes green — `GET /health` (asserts `status:"ok"` and `database:"reachable"`, which includes a real D1 round trip + migration status) and `GET /openapi.json` (asserts a valid spec shape). 5 retries at 10s absorb propagation lag; a genuinely broken worker fails all five and the job goes red with rollback instructions.
- `docs/runbooks/rollback.md`: the responder runbook — when to roll back, `wrangler rollback` mechanics (validated against current Cloudflare docs: no ID = most recent stable 100%-traffic version), what rollback does **not** undo (applied D1 migrations, in-flight queue messages, sent email), verification after rollback, and the fix-forward path.

## Related

Closes #89
Refs #261

## Risk

**Level:** M

**Why:** path-glob floor H (`.github/workflows/**`) per validation-gate, agent **down-overridden to M** with reason: the change is purely additive after the existing Deploy step — it cannot alter the deploy itself, only verify its result and fail the job. No auth, contract, or schema surface. (Human may bump back to H; the budget below assumes M.)

**Human validation budget:**
M — Evidence + escalations; spot-check 1–2 hot files (the smoke step in deploy.yml).

## Evidence

- [x] Both smoke assertions executed against live production right now: `/health` → 200 with `status:"ok"`/`database:"reachable"`; `/openapi.json` → 200 with `openapi`+`paths` — the exact jq checks the step runs (`jq -e 'has("openapi") and has("paths")'`)
- [x] `wrangler rollback` semantics validated against current Cloudflare docs (rollbacks page + wrangler command reference): no-ID rollback targets most recent stable version; explicit ID via `versions list`; documented caveat that resource/secret changes since the target version block rollback
- [x] `pnpm lint && pnpm type-check && pnpm -r test` green
- [ ] The step's failure path fires in CI — observed on first real deploy after merge (or a `workflow_dispatch` run)

## Test plan

- [x] Smoke assertions live-tested against prod (read-only GETs)
- [x] Retry loop semantics: per-attempt failure message, final `::error::` with runbook pointer
- [ ] Watch the next push-to-main deploy run green through the new step

## Spec / AC

Closes both #89 ACs (`S1`): a failing post-deploy health check fails the `deploy-api` job; rollback steps documented where a responder will find them (linked from the failure output itself).

**Escalations (need human decision):**

- None in this diff. Out-of-scope follow-ups from #89 remain open as separate issues: gradual deployments (#122) and error-rate alerting (#123).
