### PR TITLE
docs: ADR-0018 — risk-tiered autonomous merge policy

### DIFF
--- a/.agents/skills/validation-gate/SKILL.md
+++ b/.agents/skills/validation-gate/SKILL.md
@@ -8,9 +8,10 @@ description: Take finished branch work through a no-mistakes-inspired gate — r
 Semi-automated quality gate between "agent says done" and "human judges the PR."
 
 Inspired by Kun Chen's **no-mistakes** pipeline, but built on this repo's existing
-skills (`pr-review`, `pr-respond`, `/pr`) rather than a separate push remote. Automation
-will deepen over time; today the human owns the **merge** — the agent commits and
-pushes its own branch autonomously, and stops at merge for explicit approval.
+skills (`pr-review`, `pr-respond`, `/pr`) rather than a separate push remote.
+Merge authority follows [ADR-0018](../../docs/decisions/0018-risk-tiered-autonomous-merge-policy.md):
+while that policy is `proposed`/unactivated, the human owns the **merge** — the agent
+commits and pushes its own branch autonomously, and stops at merge for explicit approval.
 
 **Phone-friendly by design.** Outputs live in the PR body (risk, evidence, escalations) —
 not in a desktop-only UI. Lavish is optional laptop polish for planning; it is not part of
@@ -19,8 +20,10 @@ this gate.
 ## What this skill is not
 
 - Not a replacement for `pr-review` or `pr-respond` — it **orchestrates** them.
-- Not a license to merge without explicit user approval.
-- Not full unattended merge. Human validation budget still scales with **Risk**.
+- Not a license to merge H/C work. Human-only at any risk level: merging H/C PRs,
+  accepting an ADR, `breaking-api`/`large-diff` labels, secrets/credentials.
+- Not full unattended merge while ADR-0018 is unactivated. Once active: L/M merge
+  autonomously per the policy table; H/C never without explicit approval.
 
 ## When to run
 
@@ -179,18 +182,21 @@ Push path depends on whether the branch is already on the remote:
   on your own feature branch. This is the one force-push the gate performs; it follows
   from the step-1 rebase, not a separate ask. Never force-push `main` or a protected branch.
 
-**Gate:** Commit and push the branch autonomously. Do not **merge** without explicit
-user approval.
+**Gate:** Commit and push the branch autonomously. Merge only per ADR-0018: while
+unactivated, stop and wait for explicit user approval; once activated, L/M may merge
+per the policy table with the required evidence in the PR body. H/C: never without
+explicit user approval, activated or not.
 
 ### 8. Babysit CI (optional pass)
 
 After the PR exists and CI has run:
 
-- Green → report URL + risk + what the human should do per budget.
+- Green → report URL + risk + what the human should do per budget (or merge autonomously
+  per ADR-0018 if the policy is active and the tier permits).
 - Red → invoke `pr-respond` for failing checks only (same ownership rules).
 - Re-score risk if the fix round materially grew scope.
 
-Do not merge unless the user asks.
+Do not merge outside the ADR-0018 policy table, ever.
 
 ## Report shape
 
@@ -219,5 +225,7 @@ Next: <what you need from the human, if anything>
 ## Evolution
 
 v1 (this file): orchestrated checklist + hybrid risk + PR template audit trail.
+v2: merge authority aligned with [ADR-0018](../../docs/decisions/0018-risk-tiered-autonomous-merge-policy.md) —
+the hard-stop became policy-following; the Risk budget contract itself is unchanged.
 Later: deeper automation (isolated worktree, push gate, richer evidence upload) without
 changing the human-facing Risk budget contract.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -268,6 +268,17 @@ Work on a branch → open a PR → CI must pass → merge → auto-deploys to Cl
 Don't commit to `main` directly. End commit messages with the Co-Authored-By
 trailer.
 
+### Merge policy (ADR-0018)
+
+Merge authority is risk-tiered per
+[ADR-0018](docs/decisions/0018-risk-tiered-autonomous-merge-policy.md):
+**L** merges autonomously after green CI + clean adversarial review; **M** same,
+plus next-day batch digest the human samples; **H/C** human merges, no exceptions.
+The policy is `proposed` — until it is accepted and its activation gate passes,
+the human merges every PR. **Always human-only, at any risk level:** merging H/C
+PRs, accepting an ADR, `breaking-api` / `large-diff` labels, and anything
+touching secrets or credentials.
+
 ### Branch naming
 
 ```

--- a/docs/decisions/0018-risk-tiered-autonomous-merge-policy.md
+++ b/docs/decisions/0018-risk-tiered-autonomous-merge-policy.md
@@ -1,0 +1,139 @@
+# Risk-tiered autonomous merge policy
+
+- Status: proposed
+- Date: 2026-09-04
+
+## Context and Problem Statement
+
+The repository's branch protection already permits autonomous merges: `main` auto-merges
+on green CI with `required_approving_review_count: 0`. What actually withholds merges is
+agent-side policy — `validation-gate` and `issue-implement` both hard-stop at "do not
+merge without explicit user approval." The maintainer is the merge bottleneck for every
+PR, including trivial docs changes.
+
+Goal-driven development (epic [#261](https://github.com/snaveevans/pineapple/issues/261))
+needs the opposite: a milestone of slices delivered with the human reviewing by exception,
+not by keystroke. But autonomy without back-pressure is how reward-hacking agents land
+regressions — published analyses of SWE-bench agents show them silently weakening tests
+to pass. The deterministic back-pressure this repo already has or is building — CI verify
+with generated-artifact drift checks, mutation testing as the CI trust boundary
+([ADR-0016](0016-mutation-testing-as-the-ci-trust-boundary.md)), D1 integration tests
+(#120), and the post-deploy smoke check (#89) — is what makes a bounded amount of
+autonomy defensible.
+
+The decision: **what may reach production without a human keystroke, and on what
+evidence.**
+
+## Decision Drivers
+
+- **Goal-driven autonomy** — per-PR merge interrupts break the autonomous loop; a
+  policy that still requires a click per PR delivers none of the milestone-scale benefit.
+- **Blast-radius-proportional scrutiny** — a docs edit and a migration should not
+  demand the same human attention; scarce review time must concentrate where damage is
+  hardest to undo.
+- **Reward-hacking resistance** — an agent optimizing for green checks can weaken tests
+  or contracts; what auto-merges must pass gates the agent cannot quietly subvert.
+- **Auditability** — every autonomous merge must leave evidence (risk score, adversarial
+  review result) so post-hoc human sampling is cheap and findings are actionable.
+- **Detectability** — production deploys are verified by the post-deploy smoke check and
+  reversible per the rollback runbook, so a bad low-risk merge is observable at deploy time.
+- **One-person team** — the human is the scarcest resource in the system.
+
+## Considered Options
+
+- **Option A — Status quo (implicit human-merge):** keep the current hard-stop; every
+  PR waits for a click.
+- **Option B — Full auto-merge on green CI:** any green PR merges, no tiering, no
+  adversarial review requirement.
+- **Option C — Risk-tiered autonomous merge:** merge authority follows the PR's risk
+  score, with different evidence required per tier and an immutable high-risk floor.
+
+## Decision Outcome
+
+Chosen option: **Option C — risk-tiered autonomous merge**, because it is the only
+option that reconciles milestone-scale autonomous delivery with blast-radius-proportional
+scrutiny. Option A caps delivery at human typing speed and wastes review attention on
+trivial diffs. Option B removes the human from exactly the merges that can end careers of
+this project (migrations, auth, contracts) and offers reward-hacking agents a single
+uniform gate to game.
+
+The policy, once **activated** (see Activation gate below):
+
+| Risk          | Merge authority             | Required evidence                                                                                                        |
+| ------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| **L**         | Agent merges autonomously   | Green CI **and** clean fresh-context adversarial review (`pr-review` with no unresolved high-confidence findings)        |
+| **M**         | Agent merges autonomously   | Same as L, **plus** the PR lands in the next-day batch digest the human samples; findings trigger `pr-respond` or revert |
+| **H** / **C** | Human merges, no exceptions | The validation-gate human budget for that level applies in full                                                          |
+
+- Risk scoring and its override rules stay owned by `validation-gate` (path-glob
+  baseline, semantic elevations, "never override below C") — this ADR only consumes the
+  resulting score.
+- **Human-only actions, always, regardless of risk:** merging H/C PRs, accepting an ADR,
+  applying the `breaking-api` / `large-diff` labels, and any secret or credential
+  operation.
+- Every autonomous merge records the tier, the review outcome, and the CI run in the PR
+  body — the merge itself is part of the audit trail.
+
+### Activation gate
+
+The policy does **not** take effect until **all** of the following hold:
+
+1. The deterministic back-pressure is complete: mutation gate extended to `api/**`
+   (#126), D1 integration tests (#120), post-deploy smoke check (#89 — landed).
+2. Two consecutive weeks of green telemetry under the current human-merge regime:
+   rework rounds, review findings, and escaped defects all trending stable or down.
+
+Until activation, the human continues to merge (today's behavior). Activation is
+declared by the human, not the agent — flipping this ADR to `accepted` and announcing
+the digest convention are the same act.
+
+### Positive Consequences
+
+- Milestone-scale autonomous delivery becomes possible without lowering the bar for
+  dangerous changes; H/C scrutiny is untouched.
+- Human attention concentrates on the diffs that need judgment, sampled via the digest
+  rather than demanded per PR.
+- The policy is explicit and auditable where today it is implicit ("the human happens
+  to click"), so it can be reasoned about, tightened, or rolled back deliberately.
+- Builds directly on the trust boundary of [ADR-0016](0016-mutation-testing-as-the-ci-trust-boundary.md):
+  autonomous merges inherit mutation-tested test suites, not agent-editable ones alone.
+
+### Negative Consequences
+
+- Bad L/M merges can reach production without human eyes. Mitigated — post-deploy
+  smoke, rollback runbook, digest sampling — but not eliminated; fast revert discipline
+  becomes load-bearing.
+- Digest findings arrive **after** merge; the human is reviewing to catch patterns, not
+  to prevent individual regressions.
+- Adversarial review is LLM-based and non-deterministic; it supplements the deterministic
+  gates, never substitutes for them.
+- The two-week telemetry gate delays autonomy; urgency does not waive it.
+
+---
+
+## Pros and Cons of the Options
+
+### Option A — Status quo
+
+- ✅ Good, because zero new risk; the human sees every diff before it lands.
+- ❌ Bad, because it contradicts the goal-driven operating model — the loop still
+  interrupts per PR, and the human's attention does not scale with slice count.
+- ❌ Bad, because the current per-PR review is already shallow-by-necessity (one person,
+  many PRs) — uniform attention is an illusion.
+
+### Option B — Full auto-merge on green CI
+
+- ✅ Good, because maximum delivery speed and no tier bookkeeping.
+- ❌ Bad, because green CI is exactly the thing a reward-hacking agent controls; with no
+  adversarial review and no risk floor, a gutted test suite merges as easily as a real fix.
+- ❌ Bad, because it treats a typo fix and a schema migration identically.
+
+### Option C — Risk-tiered autonomous merge (chosen)
+
+- ✅ Good, because autonomy is granted exactly where evidence is strongest and blast
+  radius smallest, and withheld exactly where it is not.
+- ✅ Good, because every tier's evidence requirement is checkable after the fact.
+- ❌ Bad, because two review regimes now exist (autonomous and human), and the digest
+  convention must actually be worked or M-tier findings rot unread.
+- ❌ Bad, because the agent both scores risk and merges at L/M — the score is
+  agent-asserted, so the semantic-elevation rules and the C floor must stay sharp.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -69,3 +69,4 @@ Use [`0000-template.md`](0000-template.md) as your starting point.
 | [0015](0015-teams-as-opt-in-sharing-scope.md)                    | Teams as an opt-in sharing scope                 | proposed                                                    |
 | [0016](0016-mutation-testing-as-the-ci-trust-boundary.md)        | Mutation testing as the CI trust boundary        | accepted                                                    |
 | [0017](0017-expand-contract-schema-migrations.md)                | Expand/contract schema migrations                | accepted                                                    |
+| [0018](0018-risk-tiered-autonomous-merge-policy.md)              | Risk-tiered autonomous merge policy              | proposed                                                    |


### PR DESCRIPTION
## Summary

- **ADR-0018: risk-tiered autonomous merge policy** (status: `proposed`). Merge authority follows risk: **L** auto-merges after green CI + clean fresh-context adversarial review; **M** same + next-day batch digest the human samples; **H/C** human merges, no exceptions. Activation is gated on the deterministic back-pressure being complete (#126, #120, #89 — #89 landed) **plus two consecutive weeks of green telemetry**. Until activation, nothing changes: the human merges every PR.
- Wires the policy into its two consumers: **CLAUDE.md** gains a "Merge policy (ADR-0018)" section under Workflow; **validation-gate**'s hard-stop becomes policy-following (4 spots), with the Risk budget contract itself unchanged. ADR stays at decision altitude — the scoring algorithm remains validation-gate's, the digest convention remains convention docs.

## Related

Refs #258 (this PR is the ADR; the issue closes when it's accepted + ACs ticked)
Refs #261

## Risk

**Level:** L

**Why:** docs-only (path-glob floor L). No code, no CI, no enforcement change — the policy is `proposed` and cannot activate itself; flipping it on is your act (accepting the ADR = the human-only action this policy defines).

**One deliberate note on what "merge" means here:** accepting an ADR is human-only at any risk level — **your review and merge of this PR is that acceptance act.** Read the policy table, the human-only actions, and the activation gate as the decision.

**Human validation budget:** L — glance evidence, but read the ADR body: it's the decision itself.

## Evidence

- [x] Full-form ADR with honest options (status-quo / full-auto / tiered) and stated trade-offs (bad L/M merges can reach prod; digest findings arrive post-merge; LLM review is non-deterministic and never substitutes for deterministic gates)
- [x] Builds on ADR-0016's trust boundary; no existing ADR contradicted → no supersede
- [x] `pnpm verify` green
- [x] Policy table + human-only actions + activation gate match the plan approved in the #258 issue and our planning session

## Test plan

- [x] Links resolve (README index row added; CLAUDE.md and validation-gate link repo-relative)
- [x] validation-gate edits: header, "what this is not", step-7 gate, step-8 babysit, evolution — all four consistent with "unactivated = human merge, activated = table"
- [ ] Your acceptance review (the one human gate this policy defines)

## Spec / AC

Partially addresses #258 ACs: `S1` (ADR authored — acceptance pending your merge), `S2` (validation-gate + CLAUDE.md updated). The issue closes once the ADR is accepted and the digest convention has a home.

**Escalations:** none.
